### PR TITLE
Exclude more files from the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 */.coderrect
 /program/dist/program/*.so
 */*.so
-*/test-ledger
+test-ledger
 /program/dist/
 /program/docker-target
 


### PR DESCRIPTION
* Actually remove the `lookUpTable.txt` file, which was already present in `.gitignore`, but not removed from the repo.
* Ignore `test-ledger` in the main directory as well.