### PR TITLE
[WIP] Update solana-test-validator command in READMEs and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ solana-test-validator \
     --bpf-program JA5cjkRJ1euVi9xLWsCJVzsRzEkT8vcC4rqw9sVAo5d6 ./light-system-programs/target/deploy/merkle_tree_program.so \
     --bpf-program 3KS2k14CmtnuVv2fvYcvdrNgC94Y11WETBpMUGgXyWZL ./light-system-programs/target/deploy/verifier_program_one.so \
     --bpf-program GFDwN8PXuKZG2d2JLxRhbggXYe9eQHoGYoYK5K3G5tV8  ./light-system-programs/target/deploy/verifier_program_two.so  \
+    --bpf-program DJpbogMSrK94E1zvvJydtkqoE4sknuzmMRoutd6B7TKj ./light-system-programs/target/deploy/verifier_program_storage.so \
     --bpf-program noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV ../solana/web3.js/test/fixtures/noop-program/solana_sbf_rust_noop.so \
     --bpf-program Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS ./mock-app-verifier/target/deploy/mock_verifier.so
 ```

--- a/light-system-programs/runTest.sh
+++ b/light-system-programs/runTest.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -e
-../../solana/validator/solana-test-validator     --reset     --limit-ledger-size 500000000     --bpf-program J1RRetZ4ujphU75LP8RadjXMf3sA12yC2R44CF7PmU7i ./target/deploy/verifier_program_zero.so     --bpf-program JA5cjkRJ1euVi9xLWsCJVzsRzEkT8vcC4rqw9sVAo5d6 ./target/deploy/merkle_tree_program.so     --bpf-program 3KS2k14CmtnuVv2fvYcvdrNgC94Y11WETBpMUGgXyWZL ./target/deploy/verifier_program_one.so --bpf-program noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV ../../solana/web3.js/test/fixtures/noop-program/solana_sbf_rust_noop.so --bpf-program Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS ./target/deploy/verifier_program.so --quiet &
+solana-test-validator \
+    --reset \
+    --limit-ledger-size 500000000 \
+    --bpf-program J1RRetZ4ujphU75LP8RadjXMf3sA12yC2R44CF7PmU7i ./target/deploy/verifier_program_zero.so \
+    --bpf-program JA5cjkRJ1euVi9xLWsCJVzsRzEkT8vcC4rqw9sVAo5d6 ./target/deploy/merkle_tree_program.so \
+    --bpf-program 3KS2k14CmtnuVv2fvYcvdrNgC94Y11WETBpMUGgXyWZL ./target/deploy/verifier_program_one.so \
+    --bpf-program noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV ../../solana/web3.js/test/fixtures/noop-program/solana_sbf_rust_noop.so \
+    --bpf-program DJpbogMSrK94E1zvvJydtkqoE4sknuzmMRoutd6B7TKj ./target/deploy/verifier_program_storage.so \
+    --quiet &
 sleep 7
 PID=$!
 $1;

--- a/mock-app-verifier/README.md
+++ b/mock-app-verifier/README.md
@@ -1,5 +1,12 @@
-./validator/solana-test-validator --reset --limit-ledger-size 500000000     --bpf-program J1RRetZ4ujphU75LP8RadjXMf3sA12yC2R44CF7PmU7i         /home/ananas/test_light/light-protocol-onchain/light-system-programs/target/deploy/verifier_program_zero.so --bpf-program JA5cjkRJ1euVi9xLWsCJVzsRzEkT8vcC4rqw9sVAo5d6         /home/ananas/test_light/light-protocol-onchain/light-system-programs/target/deploy/merkle_tree_program.so --bpf-program GFDwN8PXuKZG2d2JLxRhbggXYe9eQHoGYoYK5K3G5tV8  /home/ananas/test_light/light-protocol-onchain/light-system-programs/target/deploy/verifier_program_two.so --bpf-program Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS /home/ananas/test_light/light-protocol-onchain/market-place-verifier/target/deploy/market_place_verifier.so
-
+```
+solana-test-validator \
+    --reset \
+    --limit-ledger-size 500000000 \
+    --bpf-program J1RRetZ4ujphU75LP8RadjXMf3sA12yC2R44CF7PmU7i ../light-system-programs/target/deploy/verifier_program_zero.so \
+    --bpf-program JA5cjkRJ1euVi9xLWsCJVzsRzEkT8vcC4rqw9sVAo5d6 ../light-system-programs/target/deploy/merkle_tree_program.so \
+    --bpf-program GFDwN8PXuKZG2d2JLxRhbggXYe9eQHoGYoYK5K3G5tV8 ../light-system-programs/target/deploy/verifier_program_two.so \
+    --bpf-program Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS ../market-place-verifier/target/deploy/market_place_verifier.so
+```
 
 TODO:
 - Change Utxos

--- a/mock-app-verifier/runTest.sh
+++ b/mock-app-verifier/runTest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-../../solana/validator/solana-test-validator \
+solana-test-validator \
     --reset \
     --limit-ledger-size 500000000 \
     --bpf-program J1RRetZ4ujphU75LP8RadjXMf3sA12yC2R44CF7PmU7i ../light-system-programs/target/deploy/verifier_program_zero.so \


### PR DESCRIPTION
We don't have to use a cloned Solana repo anymore, the newest testnet versions of Solana CLI tools are working fine.