### PR TITLE
verifier_program_storage: Allow to store more messages

### DIFF
--- a/light-sdk-ts/src/idls/verifier_program_storage.ts
+++ b/light-sdk-ts/src/idls/verifier_program_storage.ts
@@ -101,6 +101,16 @@ export type VerifierProgramStorage = {
       "code": 6000,
       "name": "NoopProgram",
       "msg": "The provided program is not the noop program."
+    },
+    {
+      "code": 6001,
+      "name": "MsgTooLarge",
+      "msg": "Message too large, the limit per one method call is 1024 bytes."
+    },
+    {
+      "code": 6002,
+      "name": "VerifierStateNoSpace",
+      "msg": "Cannot allocate more space for the verifier state account (message too large)."
     }
   ]
 };
@@ -208,6 +218,16 @@ export const IDL: VerifierProgramStorage = {
       "code": 6000,
       "name": "NoopProgram",
       "msg": "The provided program is not the noop program."
+    },
+    {
+      "code": 6001,
+      "name": "MsgTooLarge",
+      "msg": "Message too large, the limit per one method call is 1024 bytes."
+    },
+    {
+      "code": 6002,
+      "name": "VerifierStateNoSpace",
+      "msg": "Cannot allocate more space for the verifier state account (message too large)."
     }
   ]
 };

--- a/light-system-programs/programs/verifier_program_storage/Cargo.toml
+++ b/light-system-programs/programs/verifier_program_storage/Cargo.toml
@@ -16,7 +16,7 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "0.26.0"
+anchor-lang = { version = "0.26.0", features = ["init-if-needed"] }
 
 # Light deps
 light-verifier-sdk = { path = "../../../light-verifier-sdk" }

--- a/light-system-programs/tests/functional_tests.ts
+++ b/light-system-programs/tests/functional_tests.ts
@@ -72,7 +72,7 @@ describe("verifier_program", () => {
   const merkleTreeProgram: anchor.Program<MerkleTreeProgram> =
     new anchor.Program(IDL_MERKLE_TREE_PROGRAM, merkleTreeProgramId);
 
-  const msg = Buffer.alloc(887).fill(1);
+  const msg = Buffer.alloc(877).fill(1);
   const verifierProgram = new anchor.Program(
     IDL_VERIFIER_PROGRAM_STORAGE,
     verifierStorageProgramId,
@@ -162,20 +162,32 @@ describe("verifier_program", () => {
     assert.equal(accountInfo, null);
   });
 
-  it("shielded transfer 1 & 2", async () => {
-    let tx0 = await verifierProgram.methods
-      .shieldedTransferFirst(msg)
-      .accounts({
-        signingAddress: ADMIN_AUTH_KEYPAIR.publicKey,
-        systemProgram: solana.SystemProgram.programId,
-        verifierState: verifierState,
-      })
-      .signers([ADMIN_AUTH_KEYPAIR])
-      .rpc(confirmConfig);
+  it.only("shielded transfer 1 & 2", async () => {
+    await provider.connection.confirmTransaction(
+      await provider.connection.requestAirdrop(verifierState, 1_000_000_000),
+      "confirmed",
+    );
+    await provider.connection.confirmTransaction(
+      await provider.connection.requestAirdrop(ADMIN_AUTH_KEYPAIR.publicKey, 1_000_000_000),
+      "confirmed",
+    );
 
-    console.log(tx0);
+    for (var i = 0; i < 2; i++) {
+      let msg_i = Buffer.alloc(877).fill(i);
+      let tx = await verifierProgram.methods
+        .shieldedTransferFirst(msg_i)
+        .accounts({
+          signingAddress: ADMIN_AUTH_KEYPAIR.publicKey,
+          systemProgram: solana.SystemProgram.programId,
+          verifierState: verifierState,
+        })
+        .signers([ADMIN_AUTH_KEYPAIR])
+        .rpc(confirmConfig);
 
-    let tx1 = await verifierProgram.methods
+      console.log("tx" + i + ": " + tx);
+    }
+
+    let tx = await verifierProgram.methods
       .shieldedTransferSecond()
       .accounts({
         signingAddress: ADMIN_AUTH_KEYPAIR.publicKey,
@@ -185,7 +197,7 @@ describe("verifier_program", () => {
       .signers([ADMIN_AUTH_KEYPAIR])
       .rpc(confirmConfig);
 
-    console.log(tx1);
+    console.log(tx);
 
     let accountInfo = await provider.connection.getAccountInfo(
       verifierState,
@@ -457,7 +469,7 @@ describe("verifier_program", () => {
       // relayer,
     });
     console.log(inputUtxos);
-    
+
     let txParams = new TransactionParameters({
       inputUtxos,
       // outputUtxos: [new Utxo({poseidon: POSEIDON})],


### PR DESCRIPTION
Use the `init_if_needed` annotation and `resize()` function to allow storing longer messages up to 8KB.