### PR TITLE
light-verifier-sdk: Provide program keys in bs58 format

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "market-place-verifier"]
 path = market-place-verifier
 	url = git@github.com:Lightprotocol/market-place-verifier.git
+[submodule "light-macros"]
+	path = light-macros
+	url = git@github.com:Lightprotocol/light-macros.git

--- a/light-system-programs/Cargo.lock
+++ b/light-system-programs/Cargo.lock
@@ -2225,6 +2225,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-macros"
+version = "0.1.0"
+dependencies = [
+ "bs58 0.4.0",
+ "proc-macro2 1.0.49",
+ "quote 1.0.18",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "light-verifier-sdk"
 version = "0.1.0"
 dependencies = [
@@ -5324,6 +5334,7 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "groth16-solana",
+ "light-macros",
  "light-verifier-sdk",
  "merkle_tree_program",
  "solana-security-txt",
@@ -5344,6 +5355,7 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "groth16-solana",
+ "light-macros",
  "light-verifier-sdk",
  "merkle_tree_program",
  "solana-security-txt",
@@ -5356,6 +5368,7 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "groth16-solana",
+ "light-macros",
  "light-verifier-sdk",
  "merkle_tree_program",
  "solana-security-txt",

--- a/light-system-programs/programs/verifier_program_one/Cargo.toml
+++ b/light-system-programs/programs/verifier_program_one/Cargo.toml
@@ -23,4 +23,5 @@ merkle_tree_program = { path = "../merkle_tree_program", features = ["cpi"] }
 
 # Light Deps
 groth16-solana = "0.0.1"
+light-macros = {path = "../../../light-macros"}
 light-verifier-sdk = {path = "../../../light-verifier-sdk"}

--- a/light-system-programs/programs/verifier_program_one/src/processor.rs
+++ b/light-system-programs/programs/verifier_program_one/src/processor.rs
@@ -1,5 +1,6 @@
 use crate::verifying_key::VERIFYINGKEY;
 use anchor_lang::prelude::*;
+use light_macros::pubkey;
 use light_verifier_sdk::{
     accounts::Accounts,
     light_transaction::{Config, Transaction},
@@ -15,11 +16,8 @@ impl Config for TransactionConfig {
     const NR_LEAVES: usize = 2;
     /// Number of checked public inputs.
     const NR_CHECKED_PUBLIC_INPUTS: usize = 0;
-    /// ProgramId in bytes.
-    const ID: [u8; 32] = [
-        34, 112, 33, 68, 178, 147, 230, 193, 113, 82, 213, 107, 154, 193, 174, 159, 246, 190, 23,
-        138, 211, 16, 120, 183, 7, 91, 10, 173, 20, 245, 75, 167,
-    ];
+    /// ProgramId.
+    const ID: Pubkey = pubkey!("3KS2k14CmtnuVv2fvYcvdrNgC94Y11WETBpMUGgXyWZL");
 }
 
 pub fn process_transfer_10_ins_2_outs_first<'a, 'b, 'c, 'info>(

--- a/light-system-programs/programs/verifier_program_two/Cargo.toml
+++ b/light-system-programs/programs/verifier_program_two/Cargo.toml
@@ -23,4 +23,5 @@ merkle_tree_program = { path = "../merkle_tree_program", features = ["cpi"] }
 
 # Light Deps
 groth16-solana = "0.0.1"
+light-macros = { path = "../../../light-macros" }
 light-verifier-sdk = {path = "../../../light-verifier-sdk"}

--- a/light-system-programs/programs/verifier_program_two/src/processor.rs
+++ b/light-system-programs/programs/verifier_program_two/src/processor.rs
@@ -1,5 +1,6 @@
 use crate::verifying_key::VERIFYINGKEY;
 use anchor_lang::prelude::*;
+use light_macros::pubkey;
 use light_verifier_sdk::{
     accounts::Accounts,
     light_transaction::{Config, Transaction},
@@ -18,11 +19,8 @@ impl Config for TransactionConfig {
     const NR_LEAVES: usize = 4;
     /// Number of checked public inputs, Invoking Verifier, connecting hash.
     const NR_CHECKED_PUBLIC_INPUTS: usize = 2;
-    /// ProgramId in bytes.
-    const ID: [u8; 32] = [
-        252, 178, 75, 149, 78, 219, 142, 17, 53, 237, 47, 4, 42, 105, 173, 204, 248, 16, 209, 38,
-        219, 222, 123, 242, 5, 68, 240, 131, 3, 211, 184, 81,
-    ];
+    /// ProgramId.
+    const ID: Pubkey = pubkey!("GFDwN8PXuKZG2d2JLxRhbggXYe9eQHoGYoYK5K3G5tV8");
 }
 
 pub fn process_shielded_transfer<'a, 'b, 'c, 'info>(

--- a/light-system-programs/programs/verifier_program_zero/Cargo.toml
+++ b/light-system-programs/programs/verifier_program_zero/Cargo.toml
@@ -23,4 +23,5 @@ merkle_tree_program = { path = "../merkle_tree_program", features = ["cpi"] }
 
 # Light Deps
 groth16-solana = "0.0.1"
+light-macros = { path = "../../../light-macros" }
 light-verifier-sdk = {path = "../../../light-verifier-sdk"}

--- a/light-system-programs/programs/verifier_program_zero/src/processor.rs
+++ b/light-system-programs/programs/verifier_program_zero/src/processor.rs
@@ -1,5 +1,6 @@
 use crate::verifying_key::VERIFYINGKEY;
 use anchor_lang::prelude::*;
+use light_macros::pubkey;
 use light_verifier_sdk::{
     accounts::Accounts,
     light_transaction::{Config, Transaction},
@@ -15,10 +16,7 @@ impl Config for TransactionConfig {
     /// Number of checked public inputs.
     const NR_CHECKED_PUBLIC_INPUTS: usize = 0;
     /// ProgramId in bytes.
-    const ID: [u8; 32] = [
-        252, 178, 75, 149, 78, 219, 142, 17, 53, 237, 47, 4, 42, 105, 173, 204, 248, 16, 209, 38,
-        219, 222, 123, 242, 5, 68, 240, 131, 3, 211, 184, 81,
-    ];
+    const ID: Pubkey = pubkey!("J1RRetZ4ujphU75LP8RadjXMf3sA12yC2R44CF7PmU7i");
 }
 
 pub fn process_shielded_transfer_2_in_2_out<'a, 'b, 'c, 'info>(

--- a/light-verifier-sdk/src/light_transaction.rs
+++ b/light-verifier-sdk/src/light_transaction.rs
@@ -43,7 +43,7 @@ pub trait Config {
     /// Number of checked public inputs.
     const NR_CHECKED_PUBLIC_INPUTS: usize;
     /// Program ID of the verifier program.
-    const ID: [u8; 32];
+    const ID: Pubkey;
 }
 
 #[derive(Clone)]

--- a/light-verifier-sdk/src/state.rs
+++ b/light-verifier-sdk/src/state.rs
@@ -50,8 +50,7 @@ impl<T: Config> anchor_lang::AccountSerialize for VerifierState10Ins<T> {
 
 impl<T: Config> anchor_lang::Owner for VerifierState10Ins<T> {
     fn owner() -> Pubkey {
-        #[allow(deprecated)]
-        Pubkey::new(&T::ID[..])
+        T::ID
     }
 }
 

--- a/mock-app-verifier/Cargo.lock
+++ b/mock-app-verifier/Cargo.lock
@@ -1333,6 +1333,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-macros"
+version = "0.1.0"
+dependencies = [
+ "bs58 0.4.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "light-verifier-sdk"
 version = "0.1.0"
 dependencies = [
@@ -2502,6 +2512,7 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "groth16-solana",
+ "light-macros",
  "light-verifier-sdk",
  "merkle_tree_program",
  "solana-security-txt 1.1.0",


### PR DESCRIPTION
Use our light-macros crate to provide program IDs to light-verifier-sdk in bs58 format (which gets converted to bytes during compilation time).

Thanks to that, we also don't have to use the deprecated `Pubkey::new()` associated method.