### PR TITLE
[WIP] verifier: Use `light_verifier_accounts` macro

### DIFF
--- a/light-system-programs/Anchor.toml
+++ b/light-system-programs/Anchor.toml
@@ -36,5 +36,5 @@ wallet = "~/.config/solana/id.json"
 [scripts]
 test = "yarn run ts-mocha -t 100000000 tests/functional_tests.ts --exit"
 
-[workspace]
-types = "../light-sdk-ts/src/idls"
+# [workspace]
+# types = "../light-sdk-ts/src/idls"

--- a/light-system-programs/Cargo.lock
+++ b/light-system-programs/Cargo.lock
@@ -2228,6 +2228,7 @@ dependencies = [
 name = "light-macros"
 version = "0.1.0"
 dependencies = [
+ "anchor-syn",
  "bs58 0.4.0",
  "proc-macro2 1.0.49",
  "quote 1.0.18",

--- a/light-system-programs/programs/verifier_program_one/src/lib.rs
+++ b/light-system-programs/programs/verifier_program_one/src/lib.rs
@@ -14,13 +14,9 @@ pub use processor::*;
 
 use crate::processor::TransactionConfig;
 use anchor_lang::prelude::*;
-use anchor_spl::token::Token;
+use light_macros::light_verifier_accounts;
 use light_verifier_sdk::light_transaction::VERIFIER_STATE_SEED;
 use light_verifier_sdk::state::VerifierState10Ins;
-use merkle_tree_program::{
-    poseidon_merkle_tree::state::MerkleTree, program::MerkleTreeProgram,
-    utils::constants::TOKEN_AUTHORITY_SEED, RegisteredVerifier,
-};
 
 declare_id!("3KS2k14CmtnuVv2fvYcvdrNgC94Y11WETBpMUGgXyWZL");
 
@@ -96,42 +92,13 @@ pub struct LightInstructionFirst<'info> {
 }
 
 /// Executes light transaction with state created in the first instruction.
-#[derive(Accounts)]
+#[light_verifier_accounts]
 pub struct LightInstructionSecond<'info> {
     #[account(mut, address=verifier_state.signer)]
     pub signing_address: Signer<'info>,
     #[account(mut, seeds = [&signing_address.key().to_bytes(), VERIFIER_STATE_SEED], bump, close=signing_address )]
     pub verifier_state: Box<Account<'info, VerifierState10Ins<TransactionConfig>>>,
     pub system_program: Program<'info, System>,
-    pub program_merkle_tree: Program<'info, MerkleTreeProgram>,
-    /// CHECK: Is the same as in integrity hash.
-    #[account(mut)]
-    pub merkle_tree: AccountLoader<'info, MerkleTree>,
-    /// CHECK: This is the cpi authority and will be enforced in the Merkle tree program.
-    #[account(mut, seeds= [MerkleTreeProgram::id().to_bytes().as_ref()], bump)]
-    pub authority: UncheckedAccount<'info>,
-    pub token_program: Program<'info, Token>,
-    /// CHECK:` Is checked depending on deposit or withdrawal.
-    #[account(mut)]
-    pub sender: UncheckedAccount<'info>,
-    /// CHECK:` Is checked depending on deposit or withdrawal.
-    #[account(mut)]
-    pub recipient: UncheckedAccount<'info>,
-    /// CHECK:` Is checked depending on deposit or withdrawal.
-    #[account(mut)]
-    pub sender_fee: UncheckedAccount<'info>,
-    /// CHECK:` Is checked depending on deposit or withdrawal.
-    #[account(mut)]
-    pub recipient_fee: UncheckedAccount<'info>,
-    /// CHECK:` Is not checked the relayer has complete freedom.
-    #[account(mut)]
-    pub relayer_recipient: UncheckedAccount<'info>,
-    /// CHECK:` Is checked when it is used during spl withdrawals.
-    #[account(mut, seeds=[TOKEN_AUTHORITY_SEED], bump, seeds::program= MerkleTreeProgram::id())]
-    pub token_authority: UncheckedAccount<'info>,
-    /// Verifier config pda which needs ot exist Is not checked the relayer has complete freedom.
-    #[account(mut, seeds= [program_id.key().to_bytes().as_ref()], bump, seeds::program= MerkleTreeProgram::id())]
-    pub registered_verifier_pda: Account<'info, RegisteredVerifier>,
 }
 
 #[derive(Accounts)]

--- a/light-system-programs/programs/verifier_program_two/src/lib.rs
+++ b/light-system-programs/programs/verifier_program_two/src/lib.rs
@@ -15,9 +15,11 @@ use crate::processor::process_shielded_transfer;
 use anchor_lang::prelude::*;
 use anchor_spl::token::Token;
 
+use light_macros::light_verifier_accounts;
 use merkle_tree_program::program::MerkleTreeProgram;
 use merkle_tree_program::utils::constants::TOKEN_AUTHORITY_SEED;
 use merkle_tree_program::{poseidon_merkle_tree::state::MerkleTree, RegisteredVerifier};
+
 declare_id!("GFDwN8PXuKZG2d2JLxRhbggXYe9eQHoGYoYK5K3G5tV8");
 #[error_code]
 pub enum ErrorCode {
@@ -42,7 +44,7 @@ pub mod verifier_program_two {
     }
 }
 
-#[derive(Accounts)]
+#[light_verifier_accounts]
 pub struct LightInstruction<'info> {
     /// CHECK: Cannot be checked with Account because it assumes this program to be the owner
     // CHECK: Signer check to acertain the invoking program ID to be used as a public input.
@@ -52,35 +54,4 @@ pub struct LightInstruction<'info> {
     pub signing_address: Signer<'info>,
     /// CHECK: Is the same as in integrity hash.
     pub system_program: Program<'info, System>,
-    /// CHECK: Is the same as in integrity hash.
-    pub program_merkle_tree: Program<'info, MerkleTreeProgram>,
-    /// CHECK: Is the same as in integrity hash.
-    #[account(mut)]
-    pub merkle_tree: AccountLoader<'info, MerkleTree>,
-    /// CHECK: This is the cpi authority and will be enforced in the Merkle tree program.
-    #[account(mut, seeds= [MerkleTreeProgram::id().to_bytes().as_ref()], bump)]
-    pub authority: UncheckedAccount<'info>,
-    pub token_program: Program<'info, Token>,
-    /// CHECK:` Is checked depending on deposit or withdrawal.
-    #[account(mut)]
-    pub sender: UncheckedAccount<'info>,
-    /// CHECK:` Is checked depending on deposit or withdrawal.
-    #[account(mut)]
-    pub recipient: UncheckedAccount<'info>,
-    /// CHECK:` Is checked depending on deposit or withdrawal.
-    #[account(mut)]
-    pub sender_fee: UncheckedAccount<'info>,
-    /// CHECK:` Is checked depending on deposit or withdrawal.
-    #[account(mut)]
-    pub recipient_fee: UncheckedAccount<'info>,
-    /// CHECK:` Is not checked the relayer has complete freedom.
-    #[account(mut)]
-    pub relayer_recipient: UncheckedAccount<'info>,
-    /// CHECK:` Is not checked the relayer has complete freedom.
-    #[account(mut, seeds=[TOKEN_AUTHORITY_SEED], bump, seeds::program= MerkleTreeProgram::id())]
-    pub token_authority: UncheckedAccount<'info>,
-    /// Verifier config pda which needs ot exist Is not checked the relayer has complete freedom.
-    /// CHECK: Is the same as in integrity hash.
-    #[account(mut, seeds= [program_id.key().to_bytes().as_ref()], bump, seeds::program= MerkleTreeProgram::id())]
-    pub registered_verifier_pda: Account<'info, RegisteredVerifier>,
 }

--- a/light-system-programs/programs/verifier_program_zero/src/lib.rs
+++ b/light-system-programs/programs/verifier_program_zero/src/lib.rs
@@ -13,6 +13,8 @@ pub use processor::*;
 
 use anchor_lang::prelude::*;
 use anchor_spl::token::Token;
+
+use light_macros::light_verifier_accounts;
 use merkle_tree_program::{
     poseidon_merkle_tree::state::MerkleTree, program::MerkleTreeProgram,
     utils::constants::TOKEN_AUTHORITY_SEED, RegisteredVerifier,
@@ -63,38 +65,9 @@ pub mod verifier_program_zero {
     }
 }
 
-#[derive(Accounts)]
+#[light_verifier_accounts]
 pub struct LightInstruction<'info> {
     #[account(mut)]
     pub signing_address: Signer<'info>,
     pub system_program: Program<'info, System>,
-    pub program_merkle_tree: Program<'info, MerkleTreeProgram>,
-    /// CHECK: Is the same as in integrity hash.
-    #[account(mut)]
-    pub merkle_tree: AccountLoader<'info, MerkleTree>,
-    /// CHECK: This is the cpi authority and will be enforced in the Merkle tree program.
-    #[account(mut, seeds= [MerkleTreeProgram::id().to_bytes().as_ref()], bump)]
-    pub authority: UncheckedAccount<'info>,
-    pub token_program: Program<'info, Token>,
-    /// CHECK:` Is checked depending on deposit or withdrawal.
-    #[account(mut)]
-    pub sender: UncheckedAccount<'info>,
-    /// CHECK:` Is checked depending on deposit or withdrawal.
-    #[account(mut)]
-    pub recipient: UncheckedAccount<'info>,
-    /// CHECK:` Is checked depending on deposit or withdrawal.
-    #[account(mut)]
-    pub sender_fee: UncheckedAccount<'info>,
-    /// CHECK:` Is checked depending on deposit or withdrawal.
-    #[account(mut)]
-    pub recipient_fee: UncheckedAccount<'info>,
-    /// CHECK:` Is not checked the relayer has complete freedom.
-    #[account(mut)]
-    pub relayer_recipient: UncheckedAccount<'info>,
-    /// CHECK:` Is checked when it is used during spl withdrawals.
-    #[account(mut, seeds=[TOKEN_AUTHORITY_SEED], bump, seeds::program= MerkleTreeProgram::id())]
-    pub token_authority: AccountInfo<'info>,
-    /// Verifier config pda which needs ot exist Is not checked the relayer has complete freedom.
-    #[account(mut, seeds= [program_id.key().to_bytes().as_ref()], bump, seeds::program= MerkleTreeProgram::id())]
-    pub registered_verifier_pda: Account<'info, RegisteredVerifier>,
 }

--- a/mock-app-verifier/Cargo.lock
+++ b/mock-app-verifier/Cargo.lock
@@ -1336,6 +1336,7 @@ dependencies = [
 name = "light-macros"
 version = "0.1.0"
 dependencies = [
+ "anchor-syn",
  "bs58 0.4.0",
  "proc-macro2",
  "quote",


### PR DESCRIPTION
That macro adds all common accounts related to Light Protocol verifiers, so we can make our instruction context structs less repeatable.