### PR TITLE
verifier-sdk: Simplify input arguments and structs

### DIFF
--- a/light-sdk-ts/src/idls/verifier_program_one.ts
+++ b/light-sdk-ts/src/idls/verifier_program_one.ts
@@ -67,7 +67,9 @@ export type VerifierProgramOne = {
         },
         {
           name: "rootIndex";
-          type: "u64";
+          type: {
+            defined: "usize";
+          };
         },
         {
           name: "relayerFee";
@@ -273,7 +275,9 @@ export const IDL: VerifierProgramOne = {
         },
         {
           name: "rootIndex",
-          type: "u64",
+          type: {
+            defined: "usize",
+          },
         },
         {
           name: "relayerFee",

--- a/light-system-programs/programs/verifier_program_one/src/lib.rs
+++ b/light-system-programs/programs/verifier_program_one/src/lib.rs
@@ -38,7 +38,7 @@ pub mod verifier_program_one {
         nullifiers: [[u8; 32]; 10],
         leaves: [[u8; 32]; 2],
         public_amount_sol: [u8; 32],
-        root_index: u64,
+        root_index: usize,
         relayer_fee: u64,
         encrypted_utxos: Vec<u8>,
     ) -> Result<()> {
@@ -92,7 +92,7 @@ pub struct LightInstructionFirst<'info> {
     pub signing_address: Signer<'info>,
     pub system_program: Program<'info, System>,
     #[account(init, seeds = [&signing_address.key().to_bytes(), VERIFIER_STATE_SEED], bump, space= 3000/*8 + 32 * 6 + 10 * 32 + 2 * 32 + 512 + 16 + 128*/, payer = signing_address )]
-    pub verifier_state: Box<Account<'info, VerifierState10Ins<TransactionConfig>>>,
+    pub verifier_state: Box<Account<'info, VerifierState10Ins<TransactionConfig, 1>>>,
 }
 
 /// Executes light transaction with state created in the first instruction.
@@ -101,7 +101,7 @@ pub struct LightInstructionSecond<'info> {
     #[account(mut, address=verifier_state.signer)]
     pub signing_address: Signer<'info>,
     #[account(mut, seeds = [&signing_address.key().to_bytes(), VERIFIER_STATE_SEED], bump, close=signing_address )]
-    pub verifier_state: Box<Account<'info, VerifierState10Ins<TransactionConfig>>>,
+    pub verifier_state: Box<Account<'info, VerifierState10Ins<TransactionConfig, 1>>>,
     pub system_program: Program<'info, System>,
     pub program_merkle_tree: Program<'info, MerkleTreeProgram>,
     /// CHECK: Is the same as in integrity hash.
@@ -139,5 +139,5 @@ pub struct CloseVerifierState<'info> {
     #[account(mut, address=verifier_state.signer)]
     pub signing_address: Signer<'info>,
     #[account(mut, seeds = [&signing_address.key().to_bytes(), VERIFIER_STATE_SEED], bump, close=signing_address )]
-    pub verifier_state: Box<Account<'info, VerifierState10Ins<TransactionConfig>>>,
+    pub verifier_state: Box<Account<'info, VerifierState10Ins<TransactionConfig, 1>>>,
 }

--- a/light-system-programs/programs/verifier_program_one/src/processor.rs
+++ b/light-system-programs/programs/verifier_program_one/src/processor.rs
@@ -30,29 +30,24 @@ pub fn process_transfer_10_ins_2_outs_first<'a, 'b, 'c, 'info>(
     leaves: &'a [[[u8; 32]; 2]; 1],
     public_amount_sol: &'a [u8; 32],
     encrypted_utxos: &'a Vec<u8>,
-    root_index: &'a u64,
+    merkle_root_index: &'a usize,
     relayer_fee: &'a u64,
 ) -> Result<()> {
     let checked_public_inputs = Vec::<Vec<u8>>::new();
-    let pool_type = [0u8; 32];
-    let tx = Transaction::<1, 10, TransactionConfig>::new(
-        proof_a,
-        proof_b,
-        proof_c,
-        public_amount_spl,
-        public_amount_sol,
-        &checked_public_inputs, // checked_public_inputs
-        nullifiers,
+    ctx.accounts.verifier_state.init(
+        *ctx.accounts.signing_address.key,
+        nullifiers.to_vec(),
         leaves,
-        &encrypted_utxos,
-        *relayer_fee,
-        (*root_index).try_into().unwrap(),
-        &pool_type, //pool_type
-        None,
-        &VERIFYINGKEY,
+        public_amount_spl.to_owned(),
+        public_amount_sol.to_owned(),
+        relayer_fee.to_owned(),
+        encrypted_utxos.to_owned(),
+        merkle_root_index.to_owned(),
+        checked_public_inputs,
+        proof_a.to_owned(),
+        proof_b.to_owned(),
+        proof_c.to_owned(),
     );
-    ctx.accounts.verifier_state.set_inner(tx.into());
-    ctx.accounts.verifier_state.signer = *ctx.accounts.signing_address.key;
     Ok(())
 }
 
@@ -111,7 +106,7 @@ pub fn process_transfer_10_ins_2_outs_second<'a, 'b, 'c, 'info>(
             .try_into()
             .unwrap(),
         &pool_type,
-        Some(&accounts),
+        &accounts,
         &VERIFYINGKEY,
     );
     tx.transact()

--- a/light-system-programs/programs/verifier_program_two/src/processor.rs
+++ b/light-system-programs/programs/verifier_program_two/src/processor.rs
@@ -30,7 +30,7 @@ pub fn process_shielded_transfer<'a, 'b, 'c, 'info>(
     proof_c: &'a [u8; 64],
     connecting_hash: &[u8; 32],
 ) -> Result<()> {
-    let verifier_state = VerifierState10Ins::<TransactionConfig>::deserialize(
+    let verifier_state = VerifierState10Ins::<TransactionConfig, 1>::deserialize(
         &mut &*ctx.accounts.verifier_state.to_account_info().data.take(),
     )?;
 
@@ -84,7 +84,7 @@ pub fn process_shielded_transfer<'a, 'b, 'c, 'info>(
         verifier_state.relayer_fee,
         verifier_state.merkle_root_index.try_into().unwrap(),
         &pool_type, //verifier_state.pool_type,
-        Some(&accounts),
+        &accounts,
         &VERIFYINGKEY,
     );
 

--- a/light-system-programs/programs/verifier_program_zero/src/processor.rs
+++ b/light-system-programs/programs/verifier_program_zero/src/processor.rs
@@ -65,7 +65,7 @@ pub fn process_shielded_transfer_2_in_2_out<'a, 'b, 'c, 'info>(
         relayer_fee,
         merkle_tree_index.try_into().unwrap(),
         pool_type,
-        Some(&accounts),
+        &accounts,
         &VERIFYINGKEY,
     );
 

--- a/light-verifier-sdk/src/cpi_instructions.rs
+++ b/light-verifier-sdk/src/cpi_instructions.rs
@@ -1,130 +1,129 @@
 use anchor_lang::prelude::*;
 
-pub fn insert_nullifiers_cpi<'a, 'b>(
-    program_id: &Pubkey,
-    merkle_tree_program_id: &'b AccountInfo<'a>,
-    authority: &'b AccountInfo<'a>,
-    system_program: &'b AccountInfo<'a>,
-    registered_verifier_pda: &'b AccountInfo<'a>,
-    nullifiers: Vec<[u8; 32]>,
-    nullifier_pdas: Vec<AccountInfo<'a>>,
-) -> Result<()> {
-    let (seed, bump) = get_seeds(program_id, merkle_tree_program_id)?;
-    let bump = &[bump];
-    let seeds = &[&[seed.as_slice(), bump][..]];
-    let accounts = merkle_tree_program::cpi::accounts::InitializeNullifiers {
-        authority: authority.clone(),
-        system_program: system_program.clone(),
-        registered_verifier_pda: registered_verifier_pda.clone(),
-    };
+use crate::light_transaction::{Config, Transaction};
 
-    let mut cpi_ctx = CpiContext::new_with_signer(merkle_tree_program_id.clone(), accounts, seeds);
-    cpi_ctx = cpi_ctx.with_remaining_accounts(nullifier_pdas);
+impl<T: Config, const NR_LEAVES: usize, const NR_NULLIFIERS: usize>
+    Transaction<'_, '_, '_, NR_LEAVES, NR_NULLIFIERS, T>
+{
+    pub fn insert_nullifiers_cpi(&self) -> Result<()> {
+        let (seed, bump) = self.get_seeds()?;
+        let bump = &[bump];
+        let seeds = &[&[seed.as_slice(), bump][..]];
+        let accounts = merkle_tree_program::cpi::accounts::InitializeNullifiers {
+            authority: self.accounts.authority.to_account_info().clone(),
+            system_program: self.accounts.system_program.to_account_info(),
+            registered_verifier_pda: self.accounts.registered_verifier_pda.to_account_info(),
+        };
 
-    merkle_tree_program::cpi::initialize_nullifiers(cpi_ctx, nullifiers)
-}
+        let mut cpi_ctx = CpiContext::new_with_signer(
+            self.accounts.program_merkle_tree.to_account_info(),
+            accounts,
+            seeds,
+        );
+        cpi_ctx = cpi_ctx.with_remaining_accounts(self.accounts.remaining_accounts.to_vec());
 
-pub fn withdraw_sol_cpi<'a, 'b>(
-    program_id: &Pubkey,
-    merkle_tree_program_id: &'b AccountInfo<'a>,
-    authority: &'b AccountInfo<'a>,
-    merkle_tree_token: &'b AccountInfo<'a>,
-    recipient: &'b AccountInfo<'a>,
-    registered_verifier_pda: &'b AccountInfo<'a>,
-    pub_amount_checked: u64,
-) -> Result<()> {
-    let (seed, bump) = get_seeds(program_id, merkle_tree_program_id)?;
-    let bump = &[bump];
-    let seeds = &[&[seed.as_slice(), bump][..]];
+        merkle_tree_program::cpi::initialize_nullifiers(cpi_ctx, self.verifier_state.nullifiers.to_vec())
+    }
 
-    let accounts = merkle_tree_program::cpi::accounts::WithdrawSol {
-        authority: authority.clone(),
-        merkle_tree_token: merkle_tree_token.clone(),
-        registered_verifier_pda: registered_verifier_pda.clone(),
-        recipient: recipient.clone(),
-    };
+    pub fn withdraw_sol_cpi<'a, 'b>(&self, pub_amount_checked: u64) -> Result<()> {
+        let (seed, bump) = self.get_seeds()?;
+        let bump = &[bump];
+        let seeds = &[&[seed.as_slice(), bump][..]];
 
-    let cpi_ctx = CpiContext::new_with_signer(merkle_tree_program_id.clone(), accounts, seeds);
-    merkle_tree_program::cpi::withdraw_sol(cpi_ctx, pub_amount_checked)
-}
+        let accounts = merkle_tree_program::cpi::accounts::WithdrawSol {
+            authority: self.accounts.authority.to_account_info(),
+            merkle_tree_token: self.accounts.sender_sol.as_ref().unwrap().clone(),
+            registered_verifier_pda: self.accounts.registered_verifier_pda.to_account_info(),
+            recipient: self.accounts.recipient_sol.as_ref().unwrap().clone(),
+        };
 
-#[allow(clippy::too_many_arguments)]
-pub fn withdraw_spl_cpi<'a, 'b>(
-    program_id: &Pubkey,
-    merkle_tree_program_id: &'b AccountInfo<'a>,
-    authority: &'b AccountInfo<'a>,
-    merkle_tree_token: &'b AccountInfo<'a>,
-    recipient: &'b AccountInfo<'a>,
-    token_authority: &'b AccountInfo<'a>,
-    token_program: &'b AccountInfo<'a>,
-    registered_verifier_pda: &'b AccountInfo<'a>,
-    pub_amount_checked: u64,
-) -> Result<()> {
-    let (seed, bump) = get_seeds(program_id, merkle_tree_program_id)?;
-    let bump = &[bump];
-    let seeds = &[&[seed.as_slice(), bump][..]];
+        let cpi_ctx = CpiContext::new_with_signer(
+            self.accounts.program_merkle_tree.to_account_info(),
+            accounts,
+            seeds,
+        );
+        merkle_tree_program::cpi::withdraw_sol(cpi_ctx, pub_amount_checked)
+    }
 
-    let accounts = merkle_tree_program::cpi::accounts::WithdrawSpl {
-        authority: authority.clone(),
-        merkle_tree_token: merkle_tree_token.clone(),
-        token_authority: token_authority.clone(),
-        token_program: token_program.clone(),
-        registered_verifier_pda: registered_verifier_pda.clone(),
-        recipient: recipient.clone(),
-    };
+    #[allow(clippy::too_many_arguments)]
+    pub fn withdraw_spl_cpi<'a, 'b>(&self, pub_amount_checked: u64) -> Result<()> {
+        let (seed, bump) = self.get_seeds()?;
+        let bump = &[bump];
+        let seeds = &[&[seed.as_slice(), bump][..]];
 
-    let cpi_ctx = CpiContext::new_with_signer(merkle_tree_program_id.clone(), accounts, seeds);
-    merkle_tree_program::cpi::withdraw_spl(cpi_ctx, pub_amount_checked)
-}
+        let accounts = merkle_tree_program::cpi::accounts::WithdrawSpl {
+            authority: self.accounts.authority.to_account_info(),
+            merkle_tree_token: self.accounts.sender_spl.as_ref().unwrap().clone(),
+            token_authority: self.accounts.token_authority.as_ref().unwrap().clone(),
+            token_program: self.accounts.token_program.unwrap().to_account_info(),
+            registered_verifier_pda: self.accounts.registered_verifier_pda.to_account_info(),
+            recipient: self
+                .accounts
+                .recipient_spl
+                .as_ref()
+                .unwrap()
+                .to_account_info(),
+        };
 
-#[allow(clippy::too_many_arguments)]
-pub fn insert_two_leaves_cpi<'a, 'b>(
-    program_id: &Pubkey,
-    merkle_tree_program_id: &'b AccountInfo<'a>,
-    authority: &'b AccountInfo<'a>,
-    two_leaves_pda: &'b AccountInfo<'a>,
-    transaction_merkle_tree_account: &'b AccountInfo<'a>,
-    system_program: &'b AccountInfo<'a>,
-    registered_verifier_pda: &'b AccountInfo<'a>,
-    leaf_left: [u8; 32],
-    leaf_right: [u8; 32],
-    encrypted_utxos: Vec<u8>,
-) -> Result<()> {
-    let (seed, bump) = get_seeds(program_id, merkle_tree_program_id)?;
-    let bump = &[bump];
-    let seeds = &[&[seed.as_slice(), bump][..]];
+        let cpi_ctx = CpiContext::new_with_signer(
+            self.accounts.program_merkle_tree.to_account_info(),
+            accounts,
+            seeds,
+        );
+        merkle_tree_program::cpi::withdraw_spl(cpi_ctx, pub_amount_checked)
+    }
 
-    let accounts = merkle_tree_program::cpi::accounts::InsertTwoLeaves {
-        authority: authority.clone(),
-        two_leaves_pda: two_leaves_pda.clone(),
-        system_program: system_program.clone(),
-        transaction_merkle_tree: transaction_merkle_tree_account.clone(),
-        registered_verifier_pda: registered_verifier_pda.clone(),
-    };
+    #[allow(clippy::too_many_arguments)]
+    pub fn insert_two_leaves_cpi<'info, 'a, 'c>(
+        &self,
+        two_leaves_pda_i: usize,
+        leaf_left: [u8; 32],
+        leaf_right: [u8; 32],
+        encrypted_utxos: Vec<u8>,
+    ) -> Result<()> {
+        let (seed, bump) = self.get_seeds()?;
+        let bump = &[bump];
+        let seeds = &[&[seed.as_slice(), bump][..]];
 
-    let cpi_ctx = CpiContext::new_with_signer(merkle_tree_program_id.clone(), accounts, seeds);
-    merkle_tree_program::cpi::insert_two_leaves(
-        cpi_ctx,
-        leaf_left,
-        leaf_right,
-        [
-            encrypted_utxos.to_vec(),
-            vec![0u8; 256 - encrypted_utxos.len()],
-        ]
-        .concat()
-        .try_into()
-        .unwrap(),
-    )
-}
+        let accounts = merkle_tree_program::cpi::accounts::InsertTwoLeaves {
+            authority: self.accounts.authority.to_account_info(),
+            two_leaves_pda: self.accounts.remaining_accounts[T::NR_NULLIFIERS + two_leaves_pda_i]
+                .to_account_info(),
+            system_program: self.accounts.system_program.to_account_info(),
+            transaction_merkle_tree: self.accounts.transaction_merkle_tree.to_account_info(),
+            registered_verifier_pda: self.accounts.registered_verifier_pda.to_account_info(),
+        };
 
-pub fn get_seeds<'a>(
-    program_id: &'a Pubkey,
-    merkle_tree_program_id: &'a AccountInfo,
-) -> Result<([u8; 32], u8)> {
-    let (_, bump) = anchor_lang::prelude::Pubkey::find_program_address(
-        &[merkle_tree_program_id.key().to_bytes().as_ref()],
-        program_id,
-    );
-    let seed = merkle_tree_program_id.key().to_bytes();
-    Ok((seed, bump))
+        let cpi_ctx = CpiContext::new_with_signer(
+            self.accounts.program_merkle_tree.to_account_info(),
+            accounts,
+            seeds,
+        );
+        merkle_tree_program::cpi::insert_two_leaves(
+            cpi_ctx,
+            leaf_left,
+            leaf_right,
+            [
+                encrypted_utxos.to_vec(),
+                vec![0u8; 256 - encrypted_utxos.len()],
+            ]
+            .concat()
+            .try_into()
+            .unwrap(),
+        )
+    }
+
+    pub fn get_seeds<'a>(&self) -> Result<([u8; 32], u8)> {
+        let (_, bump) = anchor_lang::prelude::Pubkey::find_program_address(
+            &[self.accounts.program_id.key().to_bytes().as_ref()],
+            self.accounts.program_id,
+        );
+        let seed = self
+            .accounts
+            .program_merkle_tree
+            .to_account_info()
+            .key()
+            .to_bytes();
+        Ok((seed, bump))
+    }
 }

--- a/light-verifier-sdk/src/state.rs
+++ b/light-verifier-sdk/src/state.rs
@@ -1,4 +1,4 @@
-use crate::light_transaction::{Config, Transaction};
+use crate::light_transaction::Config;
 use anchor_lang::prelude::*;
 use borsh::{BorshDeserialize, BorshSerialize};
 use std::marker::PhantomData;
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 /// Verifier state is a boiler plate struct which should be versatile enough to serve many use cases.
 /// For specialized use cases with less
 #[derive(AnchorDeserialize, AnchorSerialize, Clone, Debug)]
-pub struct VerifierState10Ins<T: Config> {
+pub struct VerifierState10Ins<T: Config, const NR_LEAVES: usize> {
     pub signer: Pubkey,
     pub nullifiers: Vec<[u8; 32]>,
     pub leaves: Vec<[u8; 32]>,
@@ -25,11 +25,92 @@ pub struct VerifierState10Ins<T: Config> {
     pub e_phantom: PhantomData<T>,
 }
 
-impl<T: Config> VerifierState10Ins<T> {
+impl<T: Config, const NR_LEAVES: usize> VerifierState10Ins<T, NR_LEAVES> {
     pub const LEN: usize = 2048;
+
+    pub fn new(
+        nullifiers: Vec<[u8; 32]>,
+        leaves: Vec<[u8; 32]>,
+        public_amount_spl: [u8; 32],
+        public_amount_sol: [u8; 32],
+        relayer_fee: u64,
+        encrypted_utxos: Vec<u8>,
+        merkle_root_index: usize,
+        checked_public_inputs: Vec<Vec<u8>>,
+        proof_a: [u8; 64],
+        proof_b: [u8; 128],
+        proof_c: [u8; 64],
+    ) -> Self {
+        Self {
+            signer: Pubkey::default(),
+            nullifiers,
+            leaves,
+            public_amount_spl,
+            public_amount_sol,
+            mint_pubkey: [0u8; 32],
+            merkle_root: [0u8; 32],
+            tx_integrity_hash: [0u8; 32],
+            relayer_fee,
+            encrypted_utxos,
+            merkle_root_index: merkle_root_index as u64,
+            checked_public_inputs,
+            proof_a,
+            proof_b,
+            proof_c,
+            e_phantom: PhantomData,
+        }
+    }
+
+    pub fn init(
+        &mut self,
+        signer: Pubkey,
+        nullifiers: Vec<[u8; 32]>,
+        // leaves: Vec<[u8; 32]>,
+        leaves: &[[[u8; 32]; 2]; NR_LEAVES],
+        public_amount_spl: [u8; 32],
+        public_amount_sol: [u8; 32],
+        relayer_fee: u64,
+        encrypted_utxos: Vec<u8>,
+        merkle_root_index: usize,
+        checked_public_inputs: Vec<Vec<u8>>,
+        proof_a: [u8; 64],
+        proof_b: [u8; 128],
+        proof_c: [u8; 64],
+    ) {
+        self.signer = signer;
+        self.nullifiers = nullifiers;
+        self.leaves = leaves.iter().flat_map(|pair| [pair[0], pair[1]]).collect();
+        self.public_amount_spl = public_amount_spl;
+        self.public_amount_sol = public_amount_sol;
+        self.mint_pubkey = [0u8; 32];
+        self.merkle_root = [0u8; 32];
+        self.tx_integrity_hash = [0u8; 32];
+        self.relayer_fee = relayer_fee;
+        self.encrypted_utxos = encrypted_utxos;
+        self.merkle_root_index = merkle_root_index as u64;
+        self.checked_public_inputs = checked_public_inputs;
+        self.proof_a = proof_a;
+        self.proof_b = proof_b;
+        self.proof_c = proof_c;
+    }
+
+    /// Returns the merkle root index (as usize).
+    pub fn merkle_root_index(&self) -> usize {
+        self.merkle_root_index as usize
+    }
+
+    /// Returns an iterator over the pairs of leaves.
+    pub fn leaves(&self) -> impl Iterator<Item = (&[u8; 32], &[u8; 32])> {
+        self.leaves
+            .iter()
+            .step_by(2)
+            .zip(self.leaves.iter().skip(1).step_by(2))
+    }
 }
 
-impl<T: Config> anchor_lang::AccountDeserialize for VerifierState10Ins<T> {
+impl<T: Config, const NR_LEAVES: usize> anchor_lang::AccountDeserialize
+    for VerifierState10Ins<T, NR_LEAVES>
+{
     fn try_deserialize_unchecked(buf: &mut &[u8]) -> Result<Self> {
         match VerifierState10Ins::deserialize(buf) {
             Ok(v) => Ok(v),
@@ -38,7 +119,9 @@ impl<T: Config> anchor_lang::AccountDeserialize for VerifierState10Ins<T> {
     }
 }
 
-impl<T: Config> anchor_lang::AccountSerialize for VerifierState10Ins<T> {
+impl<T: Config, const NR_LEAVES: usize> anchor_lang::AccountSerialize
+    for VerifierState10Ins<T, NR_LEAVES>
+{
     fn try_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<()> {
         self.serialize(writer).unwrap();
         match self.serialize(writer) {
@@ -48,48 +131,8 @@ impl<T: Config> anchor_lang::AccountSerialize for VerifierState10Ins<T> {
     }
 }
 
-impl<T: Config> anchor_lang::Owner for VerifierState10Ins<T> {
+impl<T: Config, const NR_LEAVES: usize> anchor_lang::Owner for VerifierState10Ins<T, NR_LEAVES> {
     fn owner() -> Pubkey {
         T::ID
-    }
-}
-
-impl<const NR_LEAVES: usize, const NR_NULLIFIERS: usize, T: Config>
-    From<Transaction<'_, '_, '_, NR_LEAVES, NR_NULLIFIERS, T>> for VerifierState10Ins<T>
-{
-    fn from(
-        light_tx: Transaction<'_, '_, '_, NR_LEAVES, NR_NULLIFIERS, T>,
-    ) -> VerifierState10Ins<T> {
-        assert_eq!(T::NR_LEAVES / 2, light_tx.leaves.len());
-        assert_eq!(T::NR_NULLIFIERS, light_tx.nullifiers.len());
-        // assert_eq!(T::NR_CHECKED_PUBLIC_INPUTS, light_tx.checked_public_inputs.len());
-
-        // need to remove one nested layer because serde cannot handle three layered nesting
-        let mut leaves = Vec::new();
-        for pair in light_tx.leaves.iter() {
-            leaves.push(pair[0].clone());
-            leaves.push(pair[1].clone());
-        }
-
-        #[allow(deprecated)]
-        VerifierState10Ins {
-            merkle_root_index: <usize as TryInto<u64>>::try_into(light_tx.merkle_root_index)
-                .unwrap(),
-            signer: Pubkey::new(&[0u8; 32]),
-            nullifiers: light_tx.nullifiers.to_vec(),
-            leaves,
-            public_amount_spl: *light_tx.public_amount_spl,
-            public_amount_sol: *light_tx.public_amount_sol,
-            mint_pubkey: light_tx.mint_pubkey,
-            relayer_fee: light_tx.relayer_fee,
-            encrypted_utxos: light_tx.encrypted_utxos.to_vec(),
-            proof_a: light_tx.proof_a,
-            proof_b: *light_tx.proof_b,
-            proof_c: *light_tx.proof_c,
-            merkle_root: light_tx.merkle_root,
-            tx_integrity_hash: light_tx.tx_integrity_hash,
-            checked_public_inputs: light_tx.checked_public_inputs.to_vec(),
-            e_phantom: PhantomData,
-        }
     }
 }

--- a/mock-app-verifier/programs/verifier/src/lib.rs
+++ b/mock-app-verifier/programs/verifier/src/lib.rs
@@ -50,7 +50,7 @@ pub mod mock_verifier {
         nullifiers: [[u8; 32]; 4],
         leaves: [[[u8; 32]; 2]; 2],
         public_amount_sol: [u8; 32],
-        root_index: u64,
+        root_index: usize,
         relayer_fee: u64,
         encrypted_utxos: Vec<u8>,
     ) -> Result<()> {
@@ -129,7 +129,7 @@ pub struct LightInstructionFirst<'info> {
     pub signing_address: Signer<'info>,
     pub system_program: Program<'info, System>,
     #[account(init, seeds = [&signing_address.key().to_bytes(), VERIFIER_STATE_SEED], bump, space= 3000/*8 + 32 * 6 + 10 * 32 + 2 * 32 + 512 + 16 + 128*/, payer = signing_address )]
-    pub verifier_state: Box<Account<'info, VerifierState10Ins<TransactionsConfig>>>,
+    pub verifier_state: Box<Account<'info, VerifierState10Ins<TransactionsConfig, 2>>>,
 }
 
 /// Executes light transaction with state created in the first instruction.
@@ -138,7 +138,7 @@ pub struct LightInstructionSecond<'info> {
     #[account(mut, address=verifier_state.signer)]
     pub signing_address: Signer<'info>,
     #[account(mut, seeds = [&signing_address.key().to_bytes(), VERIFIER_STATE_SEED], bump, close=signing_address )]
-    pub verifier_state: Box<Account<'info, VerifierState10Ins<TransactionsConfig>>>,
+    pub verifier_state: Box<Account<'info, VerifierState10Ins<TransactionsConfig, 2>>>,
     pub system_program: Program<'info, System>,
     pub program_merkle_tree: Program<'info, MerkleTreeProgram>,
     /// CHECK: Is the same as in integrity hash.
@@ -177,5 +177,5 @@ pub struct CloseVerifierState<'info> {
     #[account(mut, address=verifier_state.signer)]
     pub signing_address: Signer<'info>,
     #[account(mut, seeds = [&signing_address.key().to_bytes(), VERIFIER_STATE_SEED], bump, close=signing_address )]
-    pub verifier_state: Box<Account<'info, VerifierState10Ins<TransactionsConfig>>>,
+    pub verifier_state: Box<Account<'info, VerifierState10Ins<TransactionsConfig, 2>>>,
 }

--- a/mock-app-verifier/programs/verifier/src/processor.rs
+++ b/mock-app-verifier/programs/verifier/src/processor.rs
@@ -4,10 +4,7 @@ use crate::LightInstructionSecond;
 use anchor_lang::prelude::*;
 use light_macros::pubkey;
 use light_verifier_sdk::light_transaction::VERIFIER_STATE_SEED;
-use light_verifier_sdk::{
-    light_app_transaction::AppTransaction,
-    light_transaction::{Config, Transaction},
-};
+use light_verifier_sdk::{light_app_transaction::AppTransaction, light_transaction::Config};
 
 #[derive(Clone)]
 pub struct TransactionsConfig;
@@ -33,28 +30,24 @@ pub fn process_transfer_4_ins_4_outs_4_checked_first<'a, 'b, 'c, 'info>(
     public_amount_sol: &'a [u8; 32],
     checked_public_inputs: &'a Vec<Vec<u8>>,
     encrypted_utxos: &'a Vec<u8>,
-    pool_type: &'a [u8; 32],
-    root_index: &'a u64,
+    _pool_type: &'a [u8; 32],
+    merkle_root_index: &'a usize,
     relayer_fee: &'a u64,
 ) -> Result<()> {
-    let tx = Transaction::<2, 4, TransactionsConfig>::new(
-        proof_a,
-        proof_b,
-        proof_c,
-        public_amount_spl,
-        public_amount_sol,
-        checked_public_inputs,
-        nullifiers,
+    ctx.accounts.verifier_state.init(
+        *ctx.accounts.signing_address.key,
+        nullifiers.to_vec(),
         leaves,
-        encrypted_utxos,
-        *relayer_fee,
-        (*root_index).try_into().unwrap(),
-        pool_type, //pool_type
-        None,
-        &VERIFYINGKEY,
+        public_amount_spl.to_owned(),
+        public_amount_sol.to_owned(),
+        relayer_fee.to_owned(),
+        encrypted_utxos.to_owned(),
+        merkle_root_index.to_owned(),
+        checked_public_inputs.to_owned(),
+        proof_a.to_owned(),
+        proof_b.to_owned(),
+        proof_c.to_owned(),
     );
-    ctx.accounts.verifier_state.set_inner(tx.into());
-    ctx.accounts.verifier_state.signer = *ctx.accounts.signing_address.key;
     Ok(())
 }
 


### PR DESCRIPTION
verifier-sdk arguments and struct fields were quite repetitive. Here they get simplified by:

* Removing all fields which exist in `VerifierState10Ins` from `Transaction`.
* Including `VerifierState10Ins` as a field of `Transaction` instead.
  * The only difference between commmon fields in those structs was different way of storing leaves. `VerifierState10Ins` stores them as a flat vector of `[u8; 32]`. `Transaction` stored them as an array of `[[u8; 32]; 2]`, so it aggregated them in pairs. But the flat vector can be converted to an iterator of pairs in a lazy manner. It's done here by adding the `leaves()` method which does that.
* Changing all the CPI functions to methods of `Transaction`. Thanks to that, accounts don't have to be passed as arguments
* Initializing only `VerifierState*` in `*_first` methods, without creating the whole `Transaction` just yet. That way, `*_first` methods got simplified and `Transaction::accounts` can be changed from `Option<Accounts>` just to `Accounts` type.