### PR TITLE
light-sdk-ts: Autogenerate IDL with light-anchor

### DIFF
--- a/.github/workflows/programs-test.yml
+++ b/.github/workflows/programs-test.yml
@@ -20,12 +20,6 @@ jobs:
           submodules: true
           token: ${{ secrets.PAT_TOKEN }}
 
-      # - name: Checkout Solana sources
-      #   uses: actions/checkout@v2
-      #   with:
-      #     path: solana
-      #     repository: solana-labs/solana
-
       - name: Install stable Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -33,6 +27,8 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v1
 
       - name: Install Node.js
         uses: actions/setup-node@v2
@@ -43,14 +39,13 @@ jobs:
         run: |
           npm i -g typescript
 
-      - name: Install Solana and Anchor
+      - name: Install Light Protocol toolchain
         run: |
-          docker run -d --name solana-install --entrypoint=/bin/sleep vadorovsky/solana:audit inf
-          docker cp solana-install:/usr/local/bin/. /usr/local/bin
-          docker cp solana-install:/usr/local/cargo/bin/anchor /usr/local/bin
-          docker rm -f solana-install
-          solana-keygen new --no-bip39-passphrase
-          
+          curl -s \
+            https://raw.githubusercontent.com/Lightprotocol/install/main/light-protocol-install.sh | \
+            bash -s -- --no-prompt
+          echo "$HOME/.local/light-protocol/bin" >> $GITHUB_PATH
+
       - name: Create env file
         working-directory: light-protocol-onchain
         run: |

--- a/build.sh
+++ b/build.sh
@@ -13,12 +13,12 @@ popd
 
 pushd light-system-programs
 yarn install --force
-anchor build
+light-anchor build
 popd
 
 pushd mock-app-verifier
 yarn install --force
-anchor build
+light-anchor build
 popd
 
 pushd light-circuits

--- a/light-sdk-ts/src/idls/merkle_tree_program.ts
+++ b/light-sdk-ts/src/idls/merkle_tree_program.ts
@@ -1,120 +1,6 @@
 export type MerkleTreeProgram = {
   version: "0.1.0";
   name: "merkle_tree_program";
-  constants: [
-    {
-      name: "ENCRYPTED_UTXOS_LENGTH";
-      type: {
-        defined: "usize";
-      };
-      value: "174";
-    },
-    {
-      name: "MERKLE_TREE_TMP_PDA_SIZE";
-      type: {
-        defined: "usize";
-      };
-      value: "2048";
-    },
-    {
-      name: "MERKLE_TREE_HISTORY_SIZE";
-      type: "u64";
-      value: "256";
-    },
-    {
-      name: "MERKLE_TREE_HEIGHT";
-      type: "u64";
-      value: "18";
-    },
-    {
-      name: "INITIAL_MERKLE_TREE_AUTHORITY";
-      type: {
-        array: ["u8", 32];
-      };
-      value: "[2 , 99 , 226 , 251 , 88 , 66 , 92 , 33 , 25 , 216 , 211 , 185 , 112 , 203 , 212 , 238 , 105 , 144 , 72 , 121 , 176 , 253 , 106 , 168 , 115 , 158 , 154 , 188 , 62 , 255 , 166 , 81 ,]";
-    },
-    {
-      name: "ZERO_BYTES_MERKLE_TREE_18";
-      type: {
-        array: [
-          {
-            array: ["u8", 32];
-          },
-          19,
-        ];
-      };
-      value: "[[40 , 66 , 58 , 227 , 48 , 224 , 249 , 227 , 188 , 18 , 133 , 168 , 156 , 214 , 220 , 144 , 244 , 144 , 67 , 82 , 76 , 6 , 135 , 78 , 64 , 186 , 52 , 113 , 234 , 47 , 27 , 32 ,] , [227 , 42 , 164 , 149 , 188 , 70 , 170 , 8 , 197 , 44 , 134 , 162 , 211 , 186 , 50 , 238 , 97 , 71 , 25 , 130 , 77 , 70 , 37 , 128 , 172 , 154 , 54 , 111 , 93 , 193 , 105 , 27 ,] , [25 , 241 , 255 , 33 , 65 , 214 , 48 , 229 , 38 , 116 , 134 , 103 , 44 , 146 , 163 , 214 , 31 , 238 , 148 , 206 , 34 , 137 , 144 , 221 , 184 , 11 , 5 , 213 , 10 , 188 , 143 , 18 ,] , [211 , 61 , 251 , 33 , 128 , 34 , 4 , 100 , 229 , 47 , 99 , 121 , 109 , 204 , 224 , 90 , 200 , 149 , 219 , 20 , 48 , 206 , 210 , 177 , 161 , 66 , 44 , 10 , 169 , 56 , 248 , 8 ,] , [200 , 15 , 65 , 80 , 151 , 74 , 72 , 69 , 229 , 131 , 25 , 215 , 86 , 36 , 195 , 74 , 67 , 59 , 117 , 179 , 51 , 60 , 181 , 13 , 242 , 192 , 228 , 228 , 189 , 238 , 70 , 8 ,] , [171 , 62 , 122 , 81 , 181 , 197 , 22 , 238 , 224 , 40 , 154 , 231 , 127 , 202 , 201 , 169 , 196 , 109 , 244 , 175 , 117 , 101 , 23 , 67 , 103 , 57 , 127 , 200 , 37 , 43 , 111 , 7 ,] , [59 , 78 , 126 , 104 , 199 , 143 , 213 , 10 , 2 , 158 , 64 , 78 , 153 , 25 , 107 , 190 , 32 , 122 , 123 , 211 , 116 , 179 , 175 , 172 , 70 , 54 , 175 , 59 , 201 , 120 , 64 , 44 ,] , [110 , 91 , 92 , 81 , 205 , 89 , 122 , 223 , 55 , 163 , 42 , 227 , 109 , 54 , 38 , 22 , 110 , 217 , 29 , 148 , 107 , 99 , 128 , 106 , 146 , 47 , 239 , 41 , 55 , 157 , 155 , 22 ,] , [18 , 231 , 42 , 5 , 245 , 159 , 211 , 227 , 239 , 89 , 35 , 142 , 223 , 69 , 166 , 224 , 14 , 114 , 128 , 14 , 123 , 123 , 215 , 2 , 241 , 185 , 191 , 60 , 252 , 61 , 146 , 12 ,] , [231 , 0 , 84 , 227 , 127 , 64 , 158 , 7 , 171 , 179 , 137 , 231 , 92 , 87 , 25 , 221 , 156 , 229 , 53 , 208 , 194 , 201 , 12 , 165 , 105 , 150 , 41 , 142 , 29 , 205 , 136 , 29 ,] , [195 , 2 , 103 , 231 , 62 , 207 , 214 , 105 , 214 , 210 , 108 , 23 , 28 , 151 , 77 , 100 , 78 , 194 , 210 , 29 , 227 , 14 , 17 , 242 , 211 , 50 , 33 , 194 , 106 , 18 , 246 , 45 ,] , [131 , 178 , 24 , 157 , 251 , 247 , 103 , 69 , 101 , 229 , 194 , 14 , 167 , 57 , 158 , 128 , 212 , 19 , 140 , 234 , 69 , 37 , 10 , 156 , 249 , 96 , 152 , 52 , 97 , 96 , 119 , 41 ,] , [30 , 223 , 20 , 181 , 108 , 110 , 112 , 102 , 234 , 54 , 99 , 29 , 213 , 3 , 55 , 225 , 125 , 185 , 223 , 234 , 188 , 108 , 83 , 89 , 27 , 3 , 100 , 6 , 65 , 107 , 3 , 24 ,] , [167 , 32 , 85 , 233 , 205 , 253 , 154 , 214 , 236 , 82 , 147 , 75 , 252 , 144 , 109 , 73 , 63 , 167 , 77 , 233 , 12 , 201 , 150 , 242 , 103 , 15 , 158 , 83 , 137 , 24 , 170 , 16 ,] , [45 , 98 , 238 , 69 , 136 , 141 , 101 , 226 , 94 , 209 , 58 , 215 , 212 , 14 , 210 , 135 , 110 , 96 , 52 , 16 , 101 , 177 , 121 , 109 , 134 , 81 , 189 , 146 , 113 , 243 , 97 , 42 ,] , [71 , 51 , 251 , 48 , 95 , 193 , 94 , 26 , 180 , 17 , 124 , 203 , 48 , 98 , 55 , 17 , 60 , 104 , 186 , 175 , 213 , 189 , 7 , 239 , 92 , 175 , 16 , 5 , 220 , 168 , 70 , 21 ,] , [35 , 92 , 72 , 197 , 23 , 142 , 16 , 200 , 136 , 38 , 44 , 255 , 162 , 115 , 11 , 1 , 248 , 182 , 236 , 78 , 90 , 24 , 128 , 245 , 168 , 17 , 130 , 2 , 73 , 51 , 196 , 6 ,] , [89 , 178 , 154 , 246 , 236 , 130 , 30 , 100 , 27 , 230 , 24 , 196 , 8 , 172 , 176 , 196 , 197 , 13 , 157 , 194 , 169 , 106 , 207 , 70 , 66 , 117 , 69 , 53 , 56 , 154 , 78 , 0 ,] , [231 , 174 , 226 , 37 , 211 , 160 , 187 , 178 , 149 , 82 , 17 , 60 , 110 , 116 , 28 , 61 , 58 , 145 , 58 , 71 , 25 , 42 , 67 , 46 , 189 , 214 , 248 , 234 , 182 , 251 , 238 , 34 ,] ,]";
-    },
-    {
-      name: "IX_ORDER";
-      type: {
-        array: ["u8", 57];
-      };
-      value: "[34 , 14 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 241 ,]";
-    },
-    {
-      name: "AUTHORITY_SEED";
-      type: "bytes";
-      value: "[65, 85, 84, 72, 79, 82, 73, 84, 89, 95, 83, 69, 69, 68]";
-    },
-    {
-      name: "MERKLE_TREE_AUTHORITY_SEED";
-      type: "bytes";
-      value: "[77, 69, 82, 75, 76, 69, 95, 84, 82, 69, 69, 95, 65, 85, 84, 72, 79, 82, 73, 84, 89]";
-    },
-    {
-      name: "TREE_ROOT_SEED";
-      type: "bytes";
-      value: "[84, 82, 69, 69, 95, 82, 79, 79, 84, 95, 83, 69, 69, 68]";
-    },
-    {
-      name: "STORAGE_SEED";
-      type: "bytes";
-      value: "[115, 116, 111, 114, 97, 103, 101]";
-    },
-    {
-      name: "LEAVES_SEED";
-      type: "bytes";
-      value: "[108, 101, 97, 118, 101, 115]";
-    },
-    {
-      name: "NULLIFIER_SEED";
-      type: "bytes";
-      value: "[110, 102]";
-    },
-    {
-      name: "POOL_TYPE_SEED";
-      type: "bytes";
-      value: "[112, 111, 111, 108, 116, 121, 112, 101]";
-    },
-    {
-      name: "POOL_CONFIG_SEED";
-      type: "bytes";
-      value: "[112, 111, 111, 108, 45, 99, 111, 110, 102, 105, 103]";
-    },
-    {
-      name: "POOL_SEED";
-      type: "bytes";
-      value: "[112, 111, 111, 108]";
-    },
-    {
-      name: "TOKEN_AUTHORITY_SEED";
-      type: "bytes";
-      value: "[115, 112, 108]";
-    },
-    {
-      name: "MESSSAGE_MERKLE_TREE_SEED";
-      type: "bytes";
-      value: "[109, 101, 115, 115, 97, 103, 101, 95, 109, 101, 114, 107, 108, 101, 95, 116, 114, 101, 101]";
-    },
-    {
-      name: "MESSAGE_MERKLE_TREE_HEIGHT";
-      type: {
-        defined: "usize";
-      };
-      value: "8";
-    },
-  ];
   instructions: [
     {
       name: "initializeNewTransactionMerkleTree";
@@ -853,6 +739,39 @@ export type MerkleTreeProgram = {
       };
     },
     {
+      name: "messageMerkleTree";
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "merkleTree";
+            type: {
+              defined: "MerkleTree";
+            };
+          },
+        ];
+      };
+    },
+    {
+      name: "merkleTreePdaToken";
+      type: {
+        kind: "struct";
+        fields: [];
+      };
+    },
+    {
+      name: "preInsertedLeavesIndex";
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "nextIndex";
+            type: "u64";
+          },
+        ];
+      };
+    },
+    {
       name: "merkleTreeAuthority";
       docs: [
         "Configures the authority of the merkle tree which can:",
@@ -888,148 +807,6 @@ export type MerkleTreeProgram = {
           {
             name: "enablePermissionlessMerkleTreeRegistration";
             type: "bool";
-          },
-        ];
-      };
-    },
-    {
-      name: "registeredVerifier";
-      docs: [""];
-      type: {
-        kind: "struct";
-        fields: [
-          {
-            name: "pubkey";
-            type: "publicKey";
-          },
-        ];
-      };
-    },
-    {
-      name: "messageMerkleTree";
-      type: {
-        kind: "struct";
-        fields: [
-          {
-            name: "merkleTree";
-            type: {
-              defined: "MerkleTree<Sha256,MessageMerkleTreeConfig>";
-            };
-          },
-        ];
-      };
-    },
-    {
-      name: "merkleTreePdaToken";
-      type: {
-        kind: "struct";
-        fields: [];
-      };
-    },
-    {
-      name: "preInsertedLeavesIndex";
-      type: {
-        kind: "struct";
-        fields: [
-          {
-            name: "nextIndex";
-            type: "u64";
-          },
-        ];
-      };
-    },
-    {
-      name: "transactionMerkleTree";
-      type: {
-        kind: "struct";
-        fields: [
-          {
-            name: "filledSubtrees";
-            type: {
-              array: [
-                {
-                  array: ["u8", 32];
-                },
-                18,
-              ];
-            };
-          },
-          {
-            name: "currentRootIndex";
-            type: "u64";
-          },
-          {
-            name: "nextIndex";
-            type: "u64";
-          },
-          {
-            name: "roots";
-            type: {
-              array: [
-                {
-                  array: ["u8", 32];
-                },
-                256,
-              ];
-            };
-          },
-          {
-            name: "pubkeyLocked";
-            type: "publicKey";
-          },
-          {
-            name: "timeLocked";
-            type: "u64";
-          },
-          {
-            name: "height";
-            type: "u64";
-          },
-          {
-            name: "merkleTreeNr";
-            type: "u64";
-          },
-          {
-            name: "lockDuration";
-            type: "u64";
-          },
-          {
-            name: "nextQueuedIndex";
-            type: "u64";
-          },
-        ];
-      };
-    },
-    {
-      name: "twoLeavesBytesPda";
-      type: {
-        kind: "struct";
-        fields: [
-          {
-            name: "nodeLeft";
-            type: {
-              array: ["u8", 32];
-            };
-          },
-          {
-            name: "nodeRight";
-            type: {
-              array: ["u8", 32];
-            };
-          },
-          {
-            name: "merkleTreePubkey";
-            type: "publicKey";
-          },
-          {
-            name: "encryptedUtxos";
-            type: {
-              array: ["u8", 256];
-            };
-          },
-          {
-            name: "leftLeafIndex";
-            type: "u64";
           },
         ];
       };
@@ -1145,10 +922,119 @@ export type MerkleTreeProgram = {
         ];
       };
     },
+    {
+      name: "registeredVerifier";
+      docs: [""];
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "pubkey";
+            type: "publicKey";
+          },
+        ];
+      };
+    },
+    {
+      name: "transactionMerkleTree";
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "filledSubtrees";
+            type: {
+              array: [
+                {
+                  array: ["u8", 32];
+                },
+                18,
+              ];
+            };
+          },
+          {
+            name: "currentRootIndex";
+            type: "u64";
+          },
+          {
+            name: "nextIndex";
+            type: "u64";
+          },
+          {
+            name: "roots";
+            type: {
+              array: [
+                {
+                  array: ["u8", 32];
+                },
+                256,
+              ];
+            };
+          },
+          {
+            name: "pubkeyLocked";
+            type: "publicKey";
+          },
+          {
+            name: "timeLocked";
+            type: "u64";
+          },
+          {
+            name: "height";
+            type: "u64";
+          },
+          {
+            name: "merkleTreeNr";
+            type: "u64";
+          },
+          {
+            name: "lockDuration";
+            type: "u64";
+          },
+          {
+            name: "nextQueuedIndex";
+            type: "u64";
+          },
+        ];
+      };
+    },
+    {
+      name: "twoLeavesBytesPda";
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "nodeLeft";
+            type: {
+              array: ["u8", 32];
+            };
+          },
+          {
+            name: "nodeRight";
+            type: {
+              array: ["u8", 32];
+            };
+          },
+          {
+            name: "merkleTreePubkey";
+            type: "publicKey";
+          },
+          {
+            name: "encryptedUtxos";
+            type: {
+              array: ["u8", 256];
+            };
+          },
+          {
+            name: "leftLeafIndex";
+            type: "u64";
+          },
+        ];
+      };
+    },
   ];
   types: [
     {
-      name: "MerkleTree<Sha256,MessageMerkleTreeConfig>";
+      name: "MerkleTree";
       type: {
         kind: "struct";
         fields: [
@@ -1321,125 +1207,6 @@ export type MerkleTreeProgram = {
 export const IDL: MerkleTreeProgram = {
   version: "0.1.0",
   name: "merkle_tree_program",
-  constants: [
-    {
-      name: "ENCRYPTED_UTXOS_LENGTH",
-      type: {
-        defined: "usize",
-      },
-      value: "174",
-    },
-    {
-      name: "MERKLE_TREE_TMP_PDA_SIZE",
-      type: {
-        defined: "usize",
-      },
-      value: "2048",
-    },
-    {
-      name: "MERKLE_TREE_HISTORY_SIZE",
-      type: "u64",
-      value: "256",
-    },
-    {
-      name: "MERKLE_TREE_HEIGHT",
-      type: "u64",
-      value: "18",
-    },
-    {
-      name: "INITIAL_MERKLE_TREE_AUTHORITY",
-      type: {
-        array: ["u8", 32],
-      },
-      value:
-        "[2 , 99 , 226 , 251 , 88 , 66 , 92 , 33 , 25 , 216 , 211 , 185 , 112 , 203 , 212 , 238 , 105 , 144 , 72 , 121 , 176 , 253 , 106 , 168 , 115 , 158 , 154 , 188 , 62 , 255 , 166 , 81 ,]",
-    },
-    {
-      name: "ZERO_BYTES_MERKLE_TREE_18",
-      type: {
-        array: [
-          {
-            array: ["u8", 32],
-          },
-          19,
-        ],
-      },
-      value:
-        "[[40 , 66 , 58 , 227 , 48 , 224 , 249 , 227 , 188 , 18 , 133 , 168 , 156 , 214 , 220 , 144 , 244 , 144 , 67 , 82 , 76 , 6 , 135 , 78 , 64 , 186 , 52 , 113 , 234 , 47 , 27 , 32 ,] , [227 , 42 , 164 , 149 , 188 , 70 , 170 , 8 , 197 , 44 , 134 , 162 , 211 , 186 , 50 , 238 , 97 , 71 , 25 , 130 , 77 , 70 , 37 , 128 , 172 , 154 , 54 , 111 , 93 , 193 , 105 , 27 ,] , [25 , 241 , 255 , 33 , 65 , 214 , 48 , 229 , 38 , 116 , 134 , 103 , 44 , 146 , 163 , 214 , 31 , 238 , 148 , 206 , 34 , 137 , 144 , 221 , 184 , 11 , 5 , 213 , 10 , 188 , 143 , 18 ,] , [211 , 61 , 251 , 33 , 128 , 34 , 4 , 100 , 229 , 47 , 99 , 121 , 109 , 204 , 224 , 90 , 200 , 149 , 219 , 20 , 48 , 206 , 210 , 177 , 161 , 66 , 44 , 10 , 169 , 56 , 248 , 8 ,] , [200 , 15 , 65 , 80 , 151 , 74 , 72 , 69 , 229 , 131 , 25 , 215 , 86 , 36 , 195 , 74 , 67 , 59 , 117 , 179 , 51 , 60 , 181 , 13 , 242 , 192 , 228 , 228 , 189 , 238 , 70 , 8 ,] , [171 , 62 , 122 , 81 , 181 , 197 , 22 , 238 , 224 , 40 , 154 , 231 , 127 , 202 , 201 , 169 , 196 , 109 , 244 , 175 , 117 , 101 , 23 , 67 , 103 , 57 , 127 , 200 , 37 , 43 , 111 , 7 ,] , [59 , 78 , 126 , 104 , 199 , 143 , 213 , 10 , 2 , 158 , 64 , 78 , 153 , 25 , 107 , 190 , 32 , 122 , 123 , 211 , 116 , 179 , 175 , 172 , 70 , 54 , 175 , 59 , 201 , 120 , 64 , 44 ,] , [110 , 91 , 92 , 81 , 205 , 89 , 122 , 223 , 55 , 163 , 42 , 227 , 109 , 54 , 38 , 22 , 110 , 217 , 29 , 148 , 107 , 99 , 128 , 106 , 146 , 47 , 239 , 41 , 55 , 157 , 155 , 22 ,] , [18 , 231 , 42 , 5 , 245 , 159 , 211 , 227 , 239 , 89 , 35 , 142 , 223 , 69 , 166 , 224 , 14 , 114 , 128 , 14 , 123 , 123 , 215 , 2 , 241 , 185 , 191 , 60 , 252 , 61 , 146 , 12 ,] , [231 , 0 , 84 , 227 , 127 , 64 , 158 , 7 , 171 , 179 , 137 , 231 , 92 , 87 , 25 , 221 , 156 , 229 , 53 , 208 , 194 , 201 , 12 , 165 , 105 , 150 , 41 , 142 , 29 , 205 , 136 , 29 ,] , [195 , 2 , 103 , 231 , 62 , 207 , 214 , 105 , 214 , 210 , 108 , 23 , 28 , 151 , 77 , 100 , 78 , 194 , 210 , 29 , 227 , 14 , 17 , 242 , 211 , 50 , 33 , 194 , 106 , 18 , 246 , 45 ,] , [131 , 178 , 24 , 157 , 251 , 247 , 103 , 69 , 101 , 229 , 194 , 14 , 167 , 57 , 158 , 128 , 212 , 19 , 140 , 234 , 69 , 37 , 10 , 156 , 249 , 96 , 152 , 52 , 97 , 96 , 119 , 41 ,] , [30 , 223 , 20 , 181 , 108 , 110 , 112 , 102 , 234 , 54 , 99 , 29 , 213 , 3 , 55 , 225 , 125 , 185 , 223 , 234 , 188 , 108 , 83 , 89 , 27 , 3 , 100 , 6 , 65 , 107 , 3 , 24 ,] , [167 , 32 , 85 , 233 , 205 , 253 , 154 , 214 , 236 , 82 , 147 , 75 , 252 , 144 , 109 , 73 , 63 , 167 , 77 , 233 , 12 , 201 , 150 , 242 , 103 , 15 , 158 , 83 , 137 , 24 , 170 , 16 ,] , [45 , 98 , 238 , 69 , 136 , 141 , 101 , 226 , 94 , 209 , 58 , 215 , 212 , 14 , 210 , 135 , 110 , 96 , 52 , 16 , 101 , 177 , 121 , 109 , 134 , 81 , 189 , 146 , 113 , 243 , 97 , 42 ,] , [71 , 51 , 251 , 48 , 95 , 193 , 94 , 26 , 180 , 17 , 124 , 203 , 48 , 98 , 55 , 17 , 60 , 104 , 186 , 175 , 213 , 189 , 7 , 239 , 92 , 175 , 16 , 5 , 220 , 168 , 70 , 21 ,] , [35 , 92 , 72 , 197 , 23 , 142 , 16 , 200 , 136 , 38 , 44 , 255 , 162 , 115 , 11 , 1 , 248 , 182 , 236 , 78 , 90 , 24 , 128 , 245 , 168 , 17 , 130 , 2 , 73 , 51 , 196 , 6 ,] , [89 , 178 , 154 , 246 , 236 , 130 , 30 , 100 , 27 , 230 , 24 , 196 , 8 , 172 , 176 , 196 , 197 , 13 , 157 , 194 , 169 , 106 , 207 , 70 , 66 , 117 , 69 , 53 , 56 , 154 , 78 , 0 ,] , [231 , 174 , 226 , 37 , 211 , 160 , 187 , 178 , 149 , 82 , 17 , 60 , 110 , 116 , 28 , 61 , 58 , 145 , 58 , 71 , 25 , 42 , 67 , 46 , 189 , 214 , 248 , 234 , 182 , 251 , 238 , 34 ,] ,]",
-    },
-    {
-      name: "IX_ORDER",
-      type: {
-        array: ["u8", 57],
-      },
-      value:
-        "[34 , 14 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 0 , 1 , 2 , 241 ,]",
-    },
-    {
-      name: "AUTHORITY_SEED",
-      type: "bytes",
-      value: "[65, 85, 84, 72, 79, 82, 73, 84, 89, 95, 83, 69, 69, 68]",
-    },
-    {
-      name: "MERKLE_TREE_AUTHORITY_SEED",
-      type: "bytes",
-      value:
-        "[77, 69, 82, 75, 76, 69, 95, 84, 82, 69, 69, 95, 65, 85, 84, 72, 79, 82, 73, 84, 89]",
-    },
-    {
-      name: "TREE_ROOT_SEED",
-      type: "bytes",
-      value: "[84, 82, 69, 69, 95, 82, 79, 79, 84, 95, 83, 69, 69, 68]",
-    },
-    {
-      name: "STORAGE_SEED",
-      type: "bytes",
-      value: "[115, 116, 111, 114, 97, 103, 101]",
-    },
-    {
-      name: "LEAVES_SEED",
-      type: "bytes",
-      value: "[108, 101, 97, 118, 101, 115]",
-    },
-    {
-      name: "NULLIFIER_SEED",
-      type: "bytes",
-      value: "[110, 102]",
-    },
-    {
-      name: "POOL_TYPE_SEED",
-      type: "bytes",
-      value: "[112, 111, 111, 108, 116, 121, 112, 101]",
-    },
-    {
-      name: "POOL_CONFIG_SEED",
-      type: "bytes",
-      value: "[112, 111, 111, 108, 45, 99, 111, 110, 102, 105, 103]",
-    },
-    {
-      name: "POOL_SEED",
-      type: "bytes",
-      value: "[112, 111, 111, 108]",
-    },
-    {
-      name: "TOKEN_AUTHORITY_SEED",
-      type: "bytes",
-      value: "[115, 112, 108]",
-    },
-    {
-      name: "MESSSAGE_MERKLE_TREE_SEED",
-      type: "bytes",
-      value:
-        "[109, 101, 115, 115, 97, 103, 101, 95, 109, 101, 114, 107, 108, 101, 95, 116, 114, 101, 101]",
-    },
-    {
-      name: "MESSAGE_MERKLE_TREE_HEIGHT",
-      type: {
-        defined: "usize",
-      },
-      value: "8",
-    },
-  ],
   instructions: [
     {
       name: "initializeNewTransactionMerkleTree",
@@ -2178,6 +1945,39 @@ export const IDL: MerkleTreeProgram = {
       },
     },
     {
+      name: "messageMerkleTree",
+      type: {
+        kind: "struct",
+        fields: [
+          {
+            name: "merkleTree",
+            type: {
+              defined: "MerkleTree",
+            },
+          },
+        ],
+      },
+    },
+    {
+      name: "merkleTreePdaToken",
+      type: {
+        kind: "struct",
+        fields: [],
+      },
+    },
+    {
+      name: "preInsertedLeavesIndex",
+      type: {
+        kind: "struct",
+        fields: [
+          {
+            name: "nextIndex",
+            type: "u64",
+          },
+        ],
+      },
+    },
+    {
       name: "merkleTreeAuthority",
       docs: [
         "Configures the authority of the merkle tree which can:",
@@ -2213,148 +2013,6 @@ export const IDL: MerkleTreeProgram = {
           {
             name: "enablePermissionlessMerkleTreeRegistration",
             type: "bool",
-          },
-        ],
-      },
-    },
-    {
-      name: "registeredVerifier",
-      docs: [""],
-      type: {
-        kind: "struct",
-        fields: [
-          {
-            name: "pubkey",
-            type: "publicKey",
-          },
-        ],
-      },
-    },
-    {
-      name: "messageMerkleTree",
-      type: {
-        kind: "struct",
-        fields: [
-          {
-            name: "merkleTree",
-            type: {
-              defined: "MerkleTree<Sha256,MessageMerkleTreeConfig>",
-            },
-          },
-        ],
-      },
-    },
-    {
-      name: "merkleTreePdaToken",
-      type: {
-        kind: "struct",
-        fields: [],
-      },
-    },
-    {
-      name: "preInsertedLeavesIndex",
-      type: {
-        kind: "struct",
-        fields: [
-          {
-            name: "nextIndex",
-            type: "u64",
-          },
-        ],
-      },
-    },
-    {
-      name: "transactionMerkleTree",
-      type: {
-        kind: "struct",
-        fields: [
-          {
-            name: "filledSubtrees",
-            type: {
-              array: [
-                {
-                  array: ["u8", 32],
-                },
-                18,
-              ],
-            },
-          },
-          {
-            name: "currentRootIndex",
-            type: "u64",
-          },
-          {
-            name: "nextIndex",
-            type: "u64",
-          },
-          {
-            name: "roots",
-            type: {
-              array: [
-                {
-                  array: ["u8", 32],
-                },
-                256,
-              ],
-            },
-          },
-          {
-            name: "pubkeyLocked",
-            type: "publicKey",
-          },
-          {
-            name: "timeLocked",
-            type: "u64",
-          },
-          {
-            name: "height",
-            type: "u64",
-          },
-          {
-            name: "merkleTreeNr",
-            type: "u64",
-          },
-          {
-            name: "lockDuration",
-            type: "u64",
-          },
-          {
-            name: "nextQueuedIndex",
-            type: "u64",
-          },
-        ],
-      },
-    },
-    {
-      name: "twoLeavesBytesPda",
-      type: {
-        kind: "struct",
-        fields: [
-          {
-            name: "nodeLeft",
-            type: {
-              array: ["u8", 32],
-            },
-          },
-          {
-            name: "nodeRight",
-            type: {
-              array: ["u8", 32],
-            },
-          },
-          {
-            name: "merkleTreePubkey",
-            type: "publicKey",
-          },
-          {
-            name: "encryptedUtxos",
-            type: {
-              array: ["u8", 256],
-            },
-          },
-          {
-            name: "leftLeafIndex",
-            type: "u64",
           },
         ],
       },
@@ -2470,10 +2128,119 @@ export const IDL: MerkleTreeProgram = {
         ],
       },
     },
+    {
+      name: "registeredVerifier",
+      docs: [""],
+      type: {
+        kind: "struct",
+        fields: [
+          {
+            name: "pubkey",
+            type: "publicKey",
+          },
+        ],
+      },
+    },
+    {
+      name: "transactionMerkleTree",
+      type: {
+        kind: "struct",
+        fields: [
+          {
+            name: "filledSubtrees",
+            type: {
+              array: [
+                {
+                  array: ["u8", 32],
+                },
+                18,
+              ],
+            },
+          },
+          {
+            name: "currentRootIndex",
+            type: "u64",
+          },
+          {
+            name: "nextIndex",
+            type: "u64",
+          },
+          {
+            name: "roots",
+            type: {
+              array: [
+                {
+                  array: ["u8", 32],
+                },
+                256,
+              ],
+            },
+          },
+          {
+            name: "pubkeyLocked",
+            type: "publicKey",
+          },
+          {
+            name: "timeLocked",
+            type: "u64",
+          },
+          {
+            name: "height",
+            type: "u64",
+          },
+          {
+            name: "merkleTreeNr",
+            type: "u64",
+          },
+          {
+            name: "lockDuration",
+            type: "u64",
+          },
+          {
+            name: "nextQueuedIndex",
+            type: "u64",
+          },
+        ],
+      },
+    },
+    {
+      name: "twoLeavesBytesPda",
+      type: {
+        kind: "struct",
+        fields: [
+          {
+            name: "nodeLeft",
+            type: {
+              array: ["u8", 32],
+            },
+          },
+          {
+            name: "nodeRight",
+            type: {
+              array: ["u8", 32],
+            },
+          },
+          {
+            name: "merkleTreePubkey",
+            type: "publicKey",
+          },
+          {
+            name: "encryptedUtxos",
+            type: {
+              array: ["u8", 256],
+            },
+          },
+          {
+            name: "leftLeafIndex",
+            type: "u64",
+          },
+        ],
+      },
+    },
   ],
   types: [
     {
-      name: "MerkleTree<Sha256,MessageMerkleTreeConfig>",
+      name: "MerkleTree",
       type: {
         kind: "struct",
         fields: [

--- a/light-sdk-ts/src/idls/verifier_program_one.ts
+++ b/light-sdk-ts/src/idls/verifier_program_one.ts
@@ -1,13 +1,6 @@
 export type VerifierProgramOne = {
   version: "0.1.0";
   name: "verifier_program_one";
-  constants: [
-    {
-      name: "PROGRAM_ID";
-      type: "string";
-      value: '"3KS2k14CmtnuVv2fvYcvdrNgC94Y11WETBpMUGgXyWZL"';
-    },
-  ];
   instructions: [
     {
       name: "shieldedTransferFirst";
@@ -160,40 +153,80 @@ export type VerifierProgramOne = {
   ];
   accounts: [
     {
-      name: "zKtransactionMasp10PublicInputs";
+      name: "instructionDataShieldedTransferFirst";
       type: {
         kind: "struct";
         fields: [
           {
-            name: "root";
-            type: "u8";
-          },
-          {
             name: "publicAmountSpl";
-            type: "u8";
-          },
-          {
-            name: "txIntegrityHash";
-            type: "u8";
-          },
-          {
-            name: "publicAmountSol";
-            type: "u8";
-          },
-          {
-            name: "publicMintPubkey";
-            type: "u8";
+            type: {
+              array: ["u8", 32];
+            };
           },
           {
             name: "inputNullifier";
             type: {
-              array: ["u8", 10];
+              array: [
+                {
+                  array: ["u8", 32];
+                },
+                10,
+              ];
             };
           },
           {
             name: "outputCommitment";
             type: {
-              array: ["u8", 2];
+              array: [
+                {
+                  array: ["u8", 32];
+                },
+                2,
+              ];
+            };
+          },
+          {
+            name: "publicAmountSol";
+            type: {
+              array: ["u8", 32];
+            };
+          },
+          {
+            name: "rootIndex";
+            type: "u64";
+          },
+          {
+            name: "relayerFee";
+            type: "u64";
+          },
+          {
+            name: "encryptedUtxos";
+            type: "bytes";
+          },
+        ];
+      };
+    },
+    {
+      name: "instructionDataShieldedTransferSecond";
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "proofA";
+            type: {
+              array: ["u8", 64];
+            };
+          },
+          {
+            name: "proofB";
+            type: {
+              array: ["u8", 128];
+            };
+          },
+          {
+            name: "proofC";
+            type: {
+              array: ["u8", 64];
             };
           },
         ];
@@ -385,80 +418,40 @@ export type VerifierProgramOne = {
       };
     },
     {
-      name: "instructionDataShieldedTransferFirst";
+      name: "zKtransactionMasp10PublicInputs";
       type: {
         kind: "struct";
         fields: [
           {
+            name: "root";
+            type: "u8";
+          },
+          {
             name: "publicAmountSpl";
-            type: {
-              array: ["u8", 32];
-            };
+            type: "u8";
+          },
+          {
+            name: "txIntegrityHash";
+            type: "u8";
+          },
+          {
+            name: "publicAmountSol";
+            type: "u8";
+          },
+          {
+            name: "publicMintPubkey";
+            type: "u8";
           },
           {
             name: "inputNullifier";
             type: {
-              array: [
-                {
-                  array: ["u8", 32];
-                },
-                10,
-              ];
+              array: ["u8", 10];
             };
           },
           {
             name: "outputCommitment";
             type: {
-              array: [
-                {
-                  array: ["u8", 32];
-                },
-                2,
-              ];
-            };
-          },
-          {
-            name: "publicAmountSol";
-            type: {
-              array: ["u8", 32];
-            };
-          },
-          {
-            name: "rootIndex";
-            type: "u64";
-          },
-          {
-            name: "relayerFee";
-            type: "u64";
-          },
-          {
-            name: "encryptedUtxos";
-            type: "bytes";
-          },
-        ];
-      };
-    },
-    {
-      name: "instructionDataShieldedTransferSecond";
-      type: {
-        kind: "struct";
-        fields: [
-          {
-            name: "proofA";
-            type: {
-              array: ["u8", 64];
-            };
-          },
-          {
-            name: "proofB";
-            type: {
-              array: ["u8", 128];
-            };
-          },
-          {
-            name: "proofC";
-            type: {
-              array: ["u8", 64];
+              array: ["u8", 2];
             };
           },
         ];
@@ -470,13 +463,6 @@ export type VerifierProgramOne = {
 export const IDL: VerifierProgramOne = {
   version: "0.1.0",
   name: "verifier_program_one",
-  constants: [
-    {
-      name: "PROGRAM_ID",
-      type: "string",
-      value: '"3KS2k14CmtnuVv2fvYcvdrNgC94Y11WETBpMUGgXyWZL"',
-    },
-  ],
   instructions: [
     {
       name: "shieldedTransferFirst",
@@ -629,40 +615,80 @@ export const IDL: VerifierProgramOne = {
   ],
   accounts: [
     {
-      name: "zKtransactionMasp10PublicInputs",
+      name: "instructionDataShieldedTransferFirst",
       type: {
         kind: "struct",
         fields: [
           {
-            name: "root",
-            type: "u8",
-          },
-          {
             name: "publicAmountSpl",
-            type: "u8",
-          },
-          {
-            name: "txIntegrityHash",
-            type: "u8",
-          },
-          {
-            name: "publicAmountSol",
-            type: "u8",
-          },
-          {
-            name: "publicMintPubkey",
-            type: "u8",
+            type: {
+              array: ["u8", 32],
+            },
           },
           {
             name: "inputNullifier",
             type: {
-              array: ["u8", 10],
+              array: [
+                {
+                  array: ["u8", 32],
+                },
+                10,
+              ],
             },
           },
           {
             name: "outputCommitment",
             type: {
-              array: ["u8", 2],
+              array: [
+                {
+                  array: ["u8", 32],
+                },
+                2,
+              ],
+            },
+          },
+          {
+            name: "publicAmountSol",
+            type: {
+              array: ["u8", 32],
+            },
+          },
+          {
+            name: "rootIndex",
+            type: "u64",
+          },
+          {
+            name: "relayerFee",
+            type: "u64",
+          },
+          {
+            name: "encryptedUtxos",
+            type: "bytes",
+          },
+        ],
+      },
+    },
+    {
+      name: "instructionDataShieldedTransferSecond",
+      type: {
+        kind: "struct",
+        fields: [
+          {
+            name: "proofA",
+            type: {
+              array: ["u8", 64],
+            },
+          },
+          {
+            name: "proofB",
+            type: {
+              array: ["u8", 128],
+            },
+          },
+          {
+            name: "proofC",
+            type: {
+              array: ["u8", 64],
             },
           },
         ],
@@ -854,80 +880,40 @@ export const IDL: VerifierProgramOne = {
       },
     },
     {
-      name: "instructionDataShieldedTransferFirst",
+      name: "zKtransactionMasp10PublicInputs",
       type: {
         kind: "struct",
         fields: [
           {
+            name: "root",
+            type: "u8",
+          },
+          {
             name: "publicAmountSpl",
-            type: {
-              array: ["u8", 32],
-            },
+            type: "u8",
+          },
+          {
+            name: "txIntegrityHash",
+            type: "u8",
+          },
+          {
+            name: "publicAmountSol",
+            type: "u8",
+          },
+          {
+            name: "publicMintPubkey",
+            type: "u8",
           },
           {
             name: "inputNullifier",
             type: {
-              array: [
-                {
-                  array: ["u8", 32],
-                },
-                10,
-              ],
+              array: ["u8", 10],
             },
           },
           {
             name: "outputCommitment",
             type: {
-              array: [
-                {
-                  array: ["u8", 32],
-                },
-                2,
-              ],
-            },
-          },
-          {
-            name: "publicAmountSol",
-            type: {
-              array: ["u8", 32],
-            },
-          },
-          {
-            name: "rootIndex",
-            type: "u64",
-          },
-          {
-            name: "relayerFee",
-            type: "u64",
-          },
-          {
-            name: "encryptedUtxos",
-            type: "bytes",
-          },
-        ],
-      },
-    },
-    {
-      name: "instructionDataShieldedTransferSecond",
-      type: {
-        kind: "struct",
-        fields: [
-          {
-            name: "proofA",
-            type: {
-              array: ["u8", 64],
-            },
-          },
-          {
-            name: "proofB",
-            type: {
-              array: ["u8", 128],
-            },
-          },
-          {
-            name: "proofC",
-            type: {
-              array: ["u8", 64],
+              array: ["u8", 2],
             },
           },
         ],

--- a/light-sdk-ts/src/idls/verifier_program_storage.ts
+++ b/light-sdk-ts/src/idls/verifier_program_storage.ts
@@ -1,13 +1,6 @@
 export type VerifierProgramStorage = {
   version: "0.1.0";
   name: "verifier_program_storage";
-  constants: [
-    {
-      name: "PROGRAM_ID";
-      type: "string";
-      value: '"DJpbogMSrK94E1zvvJydtkqoE4sknuzmMRoutd6B7TKj"';
-    },
-  ];
   instructions: [
     {
       name: "shieldedTransferFirst";
@@ -31,7 +24,7 @@ export type VerifierProgramStorage = {
       ];
       args: [
         {
-          name: "message";
+          name: "inputs";
           type: "bytes";
         },
       ];
@@ -87,7 +80,6 @@ export type VerifierProgramStorage = {
           name: "logWrapper";
           isMut: false;
           isSigner: false;
-          docs: ["CHECK"];
         },
         {
           name: "messageMerkleTree";
@@ -143,6 +135,86 @@ export type VerifierProgramStorage = {
           {
             name: "msg";
             type: "bytes";
+          },
+        ];
+      };
+    },
+    {
+      name: "instructionDataShieldedTransferFirst";
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "message";
+            type: "bytes";
+          },
+        ];
+      };
+    },
+    {
+      name: "instructionDataShieldedTransferSecond";
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "proofA";
+            type: {
+              array: ["u8", 64];
+            };
+          },
+          {
+            name: "proofB";
+            type: {
+              array: ["u8", 128];
+            };
+          },
+          {
+            name: "proofC";
+            type: {
+              array: ["u8", 64];
+            };
+          },
+          {
+            name: "inputNullifier";
+            type: {
+              array: [
+                {
+                  array: ["u8", 32];
+                },
+                2,
+              ];
+            };
+          },
+          {
+            name: "outputCommitment";
+            type: {
+              array: [
+                {
+                  array: ["u8", 32];
+                },
+                2,
+              ];
+            };
+          },
+          {
+            name: "publicAmountSol";
+            type: {
+              array: ["u8", 32];
+            };
+          },
+          {
+            name: "rootIndex";
+            type: "u64";
+          },
+          {
+            name: "relayerFee";
+            type: "u64";
+          },
+          {
+            name: "encryptedUtxos";
+            type: {
+              array: ["u8", 256];
+            };
           },
         ];
       };
@@ -372,86 +444,6 @@ export type VerifierProgramStorage = {
         ];
       };
     },
-    {
-      name: "instructionDataShieldedTransferFirst";
-      type: {
-        kind: "struct";
-        fields: [
-          {
-            name: "message";
-            type: "bytes";
-          },
-        ];
-      };
-    },
-    {
-      name: "instructionDataShieldedTransferSecond";
-      type: {
-        kind: "struct";
-        fields: [
-          {
-            name: "proofA";
-            type: {
-              array: ["u8", 64];
-            };
-          },
-          {
-            name: "proofB";
-            type: {
-              array: ["u8", 128];
-            };
-          },
-          {
-            name: "proofC";
-            type: {
-              array: ["u8", 64];
-            };
-          },
-          {
-            name: "inputNullifier";
-            type: {
-              array: [
-                {
-                  array: ["u8", 32];
-                },
-                2,
-              ];
-            };
-          },
-          {
-            name: "outputCommitment";
-            type: {
-              array: [
-                {
-                  array: ["u8", 32];
-                },
-                2,
-              ];
-            };
-          },
-          {
-            name: "publicAmountSol";
-            type: {
-              array: ["u8", 32];
-            };
-          },
-          {
-            name: "rootIndex";
-            type: "u64";
-          },
-          {
-            name: "relayerFee";
-            type: "u64";
-          },
-          {
-            name: "encryptedUtxos";
-            type: {
-              array: ["u8", 256];
-            };
-          },
-        ];
-      };
-    },
   ];
   errors: [
     {
@@ -475,13 +467,6 @@ export type VerifierProgramStorage = {
 export const IDL: VerifierProgramStorage = {
   version: "0.1.0",
   name: "verifier_program_storage",
-  constants: [
-    {
-      name: "PROGRAM_ID",
-      type: "string",
-      value: '"DJpbogMSrK94E1zvvJydtkqoE4sknuzmMRoutd6B7TKj"',
-    },
-  ],
   instructions: [
     {
       name: "shieldedTransferFirst",
@@ -505,7 +490,7 @@ export const IDL: VerifierProgramStorage = {
       ],
       args: [
         {
-          name: "message",
+          name: "inputs",
           type: "bytes",
         },
       ],
@@ -561,7 +546,6 @@ export const IDL: VerifierProgramStorage = {
           name: "logWrapper",
           isMut: false,
           isSigner: false,
-          docs: ["CHECK"],
         },
         {
           name: "messageMerkleTree",
@@ -617,6 +601,86 @@ export const IDL: VerifierProgramStorage = {
           {
             name: "msg",
             type: "bytes",
+          },
+        ],
+      },
+    },
+    {
+      name: "instructionDataShieldedTransferFirst",
+      type: {
+        kind: "struct",
+        fields: [
+          {
+            name: "message",
+            type: "bytes",
+          },
+        ],
+      },
+    },
+    {
+      name: "instructionDataShieldedTransferSecond",
+      type: {
+        kind: "struct",
+        fields: [
+          {
+            name: "proofA",
+            type: {
+              array: ["u8", 64],
+            },
+          },
+          {
+            name: "proofB",
+            type: {
+              array: ["u8", 128],
+            },
+          },
+          {
+            name: "proofC",
+            type: {
+              array: ["u8", 64],
+            },
+          },
+          {
+            name: "inputNullifier",
+            type: {
+              array: [
+                {
+                  array: ["u8", 32],
+                },
+                2,
+              ],
+            },
+          },
+          {
+            name: "outputCommitment",
+            type: {
+              array: [
+                {
+                  array: ["u8", 32],
+                },
+                2,
+              ],
+            },
+          },
+          {
+            name: "publicAmountSol",
+            type: {
+              array: ["u8", 32],
+            },
+          },
+          {
+            name: "rootIndex",
+            type: "u64",
+          },
+          {
+            name: "relayerFee",
+            type: "u64",
+          },
+          {
+            name: "encryptedUtxos",
+            type: {
+              array: ["u8", 256],
+            },
           },
         ],
       },
@@ -841,86 +905,6 @@ export const IDL: VerifierProgramStorage = {
             name: "outputCommitment",
             type: {
               array: ["u8", 2],
-            },
-          },
-        ],
-      },
-    },
-    {
-      name: "instructionDataShieldedTransferFirst",
-      type: {
-        kind: "struct",
-        fields: [
-          {
-            name: "message",
-            type: "bytes",
-          },
-        ],
-      },
-    },
-    {
-      name: "instructionDataShieldedTransferSecond",
-      type: {
-        kind: "struct",
-        fields: [
-          {
-            name: "proofA",
-            type: {
-              array: ["u8", 64],
-            },
-          },
-          {
-            name: "proofB",
-            type: {
-              array: ["u8", 128],
-            },
-          },
-          {
-            name: "proofC",
-            type: {
-              array: ["u8", 64],
-            },
-          },
-          {
-            name: "inputNullifier",
-            type: {
-              array: [
-                {
-                  array: ["u8", 32],
-                },
-                2,
-              ],
-            },
-          },
-          {
-            name: "outputCommitment",
-            type: {
-              array: [
-                {
-                  array: ["u8", 32],
-                },
-                2,
-              ],
-            },
-          },
-          {
-            name: "publicAmountSol",
-            type: {
-              array: ["u8", 32],
-            },
-          },
-          {
-            name: "rootIndex",
-            type: "u64",
-          },
-          {
-            name: "relayerFee",
-            type: "u64",
-          },
-          {
-            name: "encryptedUtxos",
-            type: {
-              array: ["u8", 256],
             },
           },
         ],

--- a/light-sdk-ts/src/idls/verifier_program_two.ts
+++ b/light-sdk-ts/src/idls/verifier_program_two.ts
@@ -1,13 +1,6 @@
 export type VerifierProgramTwo = {
   version: "0.1.0";
   name: "verifier_program_two";
-  constants: [
-    {
-      name: "PROGRAM_ID";
-      type: "string";
-      value: '"GFDwN8PXuKZG2d2JLxRhbggXYe9eQHoGYoYK5K3G5tV8"';
-    },
-  ];
   instructions: [
     {
       name: "shieldedTransferInputs";
@@ -377,13 +370,6 @@ export type VerifierProgramTwo = {
 export const IDL: VerifierProgramTwo = {
   version: "0.1.0",
   name: "verifier_program_two",
-  constants: [
-    {
-      name: "PROGRAM_ID",
-      type: "string",
-      value: '"GFDwN8PXuKZG2d2JLxRhbggXYe9eQHoGYoYK5K3G5tV8"',
-    },
-  ],
   instructions: [
     {
       name: "shieldedTransferInputs",

--- a/light-sdk-ts/src/idls/verifier_program_zero.ts
+++ b/light-sdk-ts/src/idls/verifier_program_zero.ts
@@ -1,13 +1,6 @@
 export type VerifierProgramZero = {
   version: "0.1.0";
   name: "verifier_program_zero";
-  constants: [
-    {
-      name: "PROGRAM_ID";
-      type: "string";
-      value: '"J1RRetZ4ujphU75LP8RadjXMf3sA12yC2R44CF7PmU7i"';
-    },
-  ];
   instructions: [
     {
       name: "shieldedTransferFirst";
@@ -170,6 +163,104 @@ export type VerifierProgramZero = {
           {
             name: "encryptedUtxos";
             type: "bytes";
+          },
+        ];
+      };
+    },
+    {
+      name: "u256";
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "x";
+            type: {
+              array: ["u8", 32];
+            };
+          },
+        ];
+      };
+    },
+    {
+      name: "utxo";
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "amounts";
+            type: {
+              array: ["u64", 2];
+            };
+          },
+          {
+            name: "splAssetIndex";
+            type: "u64";
+          },
+          {
+            name: "verifierAddressIndex";
+            type: "u64";
+          },
+          {
+            name: "blinding";
+            type: "u256";
+          },
+          {
+            name: "appDataHash";
+            type: "u256";
+          },
+          {
+            name: "accountShieldedPublicKey";
+            type: "u256";
+          },
+          {
+            name: "accountEncryptionPublicKey";
+            type: {
+              array: ["u8", 32];
+            };
+          },
+        ];
+      };
+    },
+    {
+      name: "transactionParameters";
+      type: {
+        kind: "struct";
+        fields: [
+          {
+            name: "message";
+            type: "bytes";
+          },
+          {
+            name: "inputUtxosBytes";
+            type: {
+              vec: "bytes";
+            };
+          },
+          {
+            name: "outputUtxosBytes";
+            type: {
+              vec: "bytes";
+            };
+          },
+          {
+            name: "recipientSpl";
+            type: "publicKey";
+          },
+          {
+            name: "recipientSol";
+            type: "publicKey";
+          },
+          {
+            name: "relayerPubkey";
+            type: "publicKey";
+          },
+          {
+            name: "relayerFee";
+            type: "u64";
+          },
+          {
+            name: "transactionNonce";
+            type: "u64";
           },
         ];
       };
@@ -399,113 +490,12 @@ export type VerifierProgramZero = {
         ];
       };
     },
-    {
-      name: "u256";
-      type: {
-        kind: "struct";
-        fields: [
-          {
-            name: "x";
-            type: {
-              array: ["u8", 32];
-            };
-          },
-        ];
-      };
-    },
-    {
-      name: "utxo";
-      type: {
-        kind: "struct";
-        fields: [
-          {
-            name: "amounts";
-            type: {
-              array: ["u64", 2];
-            };
-          },
-          {
-            name: "splAssetIndex";
-            type: "u64";
-          },
-          {
-            name: "verifierAddressIndex";
-            type: "u64";
-          },
-          {
-            name: "blinding";
-            type: "u256";
-          },
-          {
-            name: "appDataHash";
-            type: "u256";
-          },
-          {
-            name: "accountShieldedPublicKey";
-            type: "u256";
-          },
-          {
-            name: "accountEncryptionPublicKey";
-            type: {
-              array: ["u8", 32];
-            };
-          },
-        ];
-      };
-    },
-    {
-      name: "transactionParameters";
-      type: {
-        kind: "struct";
-        fields: [
-          {
-            name: "inputUtxosBytes";
-            type: {
-              vec: "bytes";
-            };
-          },
-          {
-            name: "outputUtxosBytes";
-            type: {
-              vec: "bytes";
-            };
-          },
-          {
-            name: "recipientSpl";
-            type: "publicKey";
-          },
-          {
-            name: "recipientSol";
-            type: "publicKey";
-          },
-          {
-            name: "relayerPubkey";
-            type: "publicKey";
-          },
-          {
-            name: "relayerFee";
-            type: "u64";
-          },
-          {
-            name: "transactionNonce";
-            type: "u64";
-          },
-        ];
-      };
-    },
   ];
 };
 
 export const IDL: VerifierProgramZero = {
   version: "0.1.0",
   name: "verifier_program_zero",
-  constants: [
-    {
-      name: "PROGRAM_ID",
-      type: "string",
-      value: '"J1RRetZ4ujphU75LP8RadjXMf3sA12yC2R44CF7PmU7i"',
-    },
-  ],
   instructions: [
     {
       name: "shieldedTransferFirst",
@@ -668,6 +658,104 @@ export const IDL: VerifierProgramZero = {
           {
             name: "encryptedUtxos",
             type: "bytes",
+          },
+        ],
+      },
+    },
+    {
+      name: "u256",
+      type: {
+        kind: "struct",
+        fields: [
+          {
+            name: "x",
+            type: {
+              array: ["u8", 32],
+            },
+          },
+        ],
+      },
+    },
+    {
+      name: "utxo",
+      type: {
+        kind: "struct",
+        fields: [
+          {
+            name: "amounts",
+            type: {
+              array: ["u64", 2],
+            },
+          },
+          {
+            name: "splAssetIndex",
+            type: "u64",
+          },
+          {
+            name: "verifierAddressIndex",
+            type: "u64",
+          },
+          {
+            name: "blinding",
+            type: "u256",
+          },
+          {
+            name: "appDataHash",
+            type: "u256",
+          },
+          {
+            name: "accountShieldedPublicKey",
+            type: "u256",
+          },
+          {
+            name: "accountEncryptionPublicKey",
+            type: {
+              array: ["u8", 32],
+            },
+          },
+        ],
+      },
+    },
+    {
+      name: "transactionParameters",
+      type: {
+        kind: "struct",
+        fields: [
+          {
+            name: "message",
+            type: "bytes",
+          },
+          {
+            name: "inputUtxosBytes",
+            type: {
+              vec: "bytes",
+            },
+          },
+          {
+            name: "outputUtxosBytes",
+            type: {
+              vec: "bytes",
+            },
+          },
+          {
+            name: "recipientSpl",
+            type: "publicKey",
+          },
+          {
+            name: "recipientSol",
+            type: "publicKey",
+          },
+          {
+            name: "relayerPubkey",
+            type: "publicKey",
+          },
+          {
+            name: "relayerFee",
+            type: "u64",
+          },
+          {
+            name: "transactionNonce",
+            type: "u64",
           },
         ],
       },
@@ -893,100 +981,6 @@ export const IDL: VerifierProgramZero = {
             type: {
               array: ["u8", 2],
             },
-          },
-        ],
-      },
-    },
-    {
-      name: "u256",
-      type: {
-        kind: "struct",
-        fields: [
-          {
-            name: "x",
-            type: {
-              array: ["u8", 32],
-            },
-          },
-        ],
-      },
-    },
-    {
-      name: "utxo",
-      type: {
-        kind: "struct",
-        fields: [
-          {
-            name: "amounts",
-            type: {
-              array: ["u64", 2],
-            },
-          },
-          {
-            name: "splAssetIndex",
-            type: "u64",
-          },
-          {
-            name: "verifierAddressIndex",
-            type: "u64",
-          },
-          {
-            name: "blinding",
-            type: "u256",
-          },
-          {
-            name: "appDataHash",
-            type: "u256",
-          },
-          {
-            name: "accountShieldedPublicKey",
-            type: "u256",
-          },
-          {
-            name: "accountEncryptionPublicKey",
-            type: {
-              array: ["u8", 32],
-            },
-          },
-        ],
-      },
-    },
-    {
-      name: "transactionParameters",
-      type: {
-        kind: "struct",
-        fields: [
-          {
-            name: "inputUtxosBytes",
-            type: {
-              vec: "bytes",
-            },
-          },
-          {
-            name: "outputUtxosBytes",
-            type: {
-              vec: "bytes",
-            },
-          },
-          {
-            name: "recipientSpl",
-            type: "publicKey",
-          },
-          {
-            name: "recipientSol",
-            type: "publicKey",
-          },
-          {
-            name: "relayerPubkey",
-            type: "publicKey",
-          },
-          {
-            name: "relayerFee",
-            type: "u64",
-          },
-          {
-            name: "transactionNonce",
-            type: "u64",
           },
         ],
       },

--- a/light-system-programs/Anchor.toml
+++ b/light-system-programs/Anchor.toml
@@ -35,3 +35,6 @@ wallet = "~/.config/solana/id.json"
 
 [scripts]
 test = "yarn run ts-mocha -t 100000000 tests/functional_tests.ts --exit"
+
+[workspace]
+types = "../light-sdk-ts/src/idls"

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,7 @@ set -e
 ./build-sdk.sh
 
 pushd light-system-programs
-anchor build
+light-anchor build
 yarn test
 popd
 
@@ -15,7 +15,7 @@ sleep 1
 popd
 
 pushd mock-app-verifier
-anchor build
+light-anchor build
 yarn test
 popd
 


### PR DESCRIPTION
Thanks to recent changes in our Anchor fork, we are able to autogenerate IDL for account structs which use types from external crates.