### PR TITLE
cli: Fix the download mechanism

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -1,7 +1,7 @@
 import type { Arguments, CommandBuilder } from "yargs";
 import { execSync } from "child_process";
 import { Options } from "yargs-parser";
-import { anchorBinUrlMap, downloadFileIfNotExists } from "../utils/downloadBin";
+import { downloadFileIfNotExists } from "../utils/downloadBin";
 
 const path = require("path");
 export const command: string = "init [name]";
@@ -26,7 +26,12 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   const anchorPath = path.resolve(__dirname, "../../bin/light-anchor");
   const dirPath = path.resolve(__dirname, "../../bin/");
 
-  await downloadFileIfNotExists(anchorBinUrlMap, anchorPath, dirPath, "anchor");
+  await downloadFileIfNotExists({
+    filePath: anchorPath,
+    dirPath,
+    repoName: "anchor",
+    fileName: "light-anchor",
+  });
 
   execSync(`${anchorPath} init-psp ${name}`);
 

--- a/cli/src/utils/buildPSP.ts
+++ b/cli/src/utils/buildPSP.ts
@@ -6,7 +6,7 @@ import { randomBytes } from "tweetnacl";
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
 import { utils } from "@coral-xyz/anchor";
 import { sleep } from "@lightprotocol/zk.js";
-import { downloadFileIfNotExists, macroCircomBinUrlMap } from "./downloadBin";
+import { downloadFileIfNotExists } from "./downloadBin";
 
 /**
  * Generates a zk-SNARK circuit given a circuit name.
@@ -147,19 +147,17 @@ export async function buildPSP(
   programName: string
 ) {
   let circuitFileName = findLightFile(circuitDir);
-  // let programName = "verifier"
   console.log("Creating circom files");
   const macroCircomBinPath = path.resolve(__dirname, "../../bin/macro-circom");
-  // TODO: check whether macro circom binary exists if not fetch it
   // TODO: check whether circom binary exists if not load it
   const dirPath = path.resolve(__dirname, "../../bin/");
 
-  await downloadFileIfNotExists(
-    macroCircomBinUrlMap,
-    macroCircomBinPath,
+  await downloadFileIfNotExists({
+    filePath: macroCircomBinPath,
     dirPath,
-    "macro-circom"
-  );
+    repoName: "macro-circom",
+    fileName: "macro-circom",
+  });
 
   let stdout = execSync(
     `${macroCircomBinPath} ./${circuitDir}/${circuitFileName} ${programName}`

--- a/cli/src/utils/downloadBin.ts
+++ b/cli/src/utils/downloadBin.ts
@@ -5,55 +5,19 @@ import * as os from "os";
 
 const fileExists = promisify(fs.exists);
 
-export const anchorBinUrlMap = new Map([
-  [
-    "linux-amd64",
-    "https://github.com/Lightprotocol/anchor/releases/download/v0.27.0/light-anchor-linux-amd64",
-  ],
-  [
-    "macos-amd64",
-    "https://github.com/Lightprotocol/anchor/releases/download/v0.27.0/light-anchor-macos-amd64",
-  ],
-  [
-    "macos-arm64",
-    "https://github.com/Lightprotocol/anchor/releases/download/v0.27.0/light-anchor-macos-arm64",
-  ],
-  [
-    "linux-arm64",
-    "https://github.com/Lightprotocol/anchor/releases/download/v0.27.0/light-anchor-linux-arm64",
-  ],
-]);
-
-export const macroCircomBinUrlMap = new Map([
-  [
-    "linux-amd64",
-    "https://github.com/Lightprotocol/macro-circom/releases/download/v0.1.1/macro-circom-linux-amd64",
-  ],
-  [
-    "macos-amd64",
-    "https://github.com/Lightprotocol/macro-circom/releases/download/v0.1.1/macro-circom-macos-amd64",
-  ],
-  [
-    "macos-arm64",
-    "https://github.com/Lightprotocol/macro-circom/releases/download/v0.1.1/macro-circom-linux-arm64",
-  ],
-  [
-    "linux-arm64",
-    "https://github.com/Lightprotocol/macro-circom/releases/download/v0.1.1/macro-circom-macos-arm64",
-  ],
-]);
-function replaceVersionTagInUrl(url: string, newTag: string): string {
-  // Matches the version pattern (e.g., v0.1.1) in the URL
-  const versionPattern = /v\d+\.\d+\.\d+/g;
-  return url.replace(versionPattern, newTag);
-}
 async function latestRelease(owner: string, repo: string) {
-  const GITHUB = "https://api.github.com";
-  console.log(`${GITHUB}/repos/${owner}/${repo}/releases/latest`);
+  const github = "https://api.github.com";
+  console.log(
+    `Checking the latest release of ${github}/repos/${owner}/${repo}/releases/latest`
+  );
 
   const response = await axios.get(
-    `${GITHUB}/repos/${owner}/${repo}/releases/latest`
+    `${github}/repos/${owner}/${repo}/releases/latest`
   );
+  const tag_name = response.data.tag_name;
+
+  console.log(`The newest release of ${repo} is ${tag_name}`);
+
   return response.data.tag_name;
 }
 
@@ -87,12 +51,17 @@ function makeExecutable(filePath: string): void {
   fs.chmodSync(filePath, "755");
 }
 
-export async function downloadFileIfNotExists(
-  urlMap: Map<string, string>,
-  filePath: string,
-  dirPath: string,
-  name: string
-) {
+export async function downloadFileIfNotExists({
+  filePath,
+  dirPath,
+  repoName,
+  fileName,
+}: {
+  filePath: string;
+  dirPath: string;
+  repoName: string;
+  fileName: string;
+}) {
   if (!fs.existsSync(dirPath)) {
     fs.mkdirSync(dirPath, { recursive: true });
   }
@@ -103,18 +72,16 @@ export async function downloadFileIfNotExists(
   }
 
   const system = getSystem();
-  var url = urlMap.get(system);
-  const tag = await latestRelease("lightprotocol", name);
+  const tag = await latestRelease("lightprotocol", repoName);
 
-  url = replaceVersionTagInUrl(url, tag);
-  console.log(url);
+  const url = `https://github.com/Lightprotocol/${repoName}/releases/download/${tag}/${fileName}-${system}`;
 
   if (!url) {
     throw new Error(`No binary found for the detected system ${system}`);
   }
 
   // Download the file
-  console.log(` ${name} binary does not exist, starting download...`);
+  console.log(`Downloading ${fileName} from ${url}...`);
   const { data } = await axios({
     url,
     method: "GET",

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -1144,11 +1144,6 @@ hoopy@^0.1.4:
   resolved "https://registry.yarnpkg.com/hoopy/-/hoopy-0.1.4.tgz#609207d661100033a9a9402ad3dea677381c1b1d"
   integrity sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==
 
-https@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/https/-/https-1.0.0.tgz#3c37c7ae1a8eeb966904a2ad1e975a194b7ed3a4"
-  integrity sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==
-
 humanize-ms@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"


### PR DESCRIPTION
First of all, make it simplier by removing the maps and building URLs just with string concatenation. Simplier to read and less error-prone.

The original issue was that we were fetching light-anchor-linux-arm64 on macos-arm64 platforms (and vice versa), due to a typo in the map.