### PR TITLE
Fix formatting in relayer readme

### DIFF
--- a/relayer/readme.md
+++ b/relayer/readme.md
@@ -1,6 +1,7 @@
 1. Start validator (see other readme)
 
-```../solana/validator/solana-test-validator \
+```
+../solana/validator/solana-test-validator \
     --reset \
     --limit-ledger-size 500000000 \
     --bpf-program J1RRetZ4ujphU75LP8RadjXMf3sA12yC2R44CF7PmU7i ./light-system-programs/target/deploy/verifier_program_zero.so \
@@ -12,8 +13,8 @@
 
 2. Airdrop cmd (might have to fund your own idjson keypair)
 
-```solana airdrop 100000 ZBUKxVWviAJBy12edp5H6kvhcatGYW3BV4ijbgxpVSq && solana airdrop 100000 ALA2cnz41Wa2v2EYUdkYHsg7VnKsbH1j7secM5aiP8k && solana airdrop 100000 8Ers2bBEWExdrh7KDFTrRbauPbFeEvsHz3UX4vxcK9xY && solana airdrop 10000 BEKmoiPHRUxUPik2WQuKqkoFLLkieyNPrTDup5h8c9S7
-
+```
+solana airdrop 100000 ZBUKxVWviAJBy12edp5H6kvhcatGYW3BV4ijbgxpVSq && solana airdrop 100000 ALA2cnz41Wa2v2EYUdkYHsg7VnKsbH1j7secM5aiP8k && solana airdrop 100000 8Ers2bBEWExdrh7KDFTrRbauPbFeEvsHz3UX4vxcK9xY && solana airdrop 10000 BEKmoiPHRUxUPik2WQuKqkoFLLkieyNPrTDup5h8c9S7
 ```
 
 3. `yarn` && `yarn tsc` in /relayer


### PR DESCRIPTION
Currently the airdrop command is rendered as an empty box, need to have a newline after backticks