### PR TITLE
cli: Use cargo-generate for initializing new projects

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -23,8 +23,12 @@
     "@solana/web3.js": "1.76.0",
     "circomlibjs": "^0.1.7",
     "node-fetch": "^3.3.1",
+    "progress-stream": "^2.0.0",
+    "snake-case": "^3.0.4",
+    "tar": "^6.1.15",
     "tweetnacl": "^1.0.3",
-    "yargs": "^17.6.2"
+    "yargs": "^17.6.2",
+    "zlib": "^1.0.5"
   },
   "bin": {
     "light": "./build/cli.js"

--- a/cli/src/utils/buildPSP.ts
+++ b/cli/src/utils/buildPSP.ts
@@ -6,7 +6,7 @@ import { randomBytes } from "tweetnacl";
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
 import { utils } from "@coral-xyz/anchor";
 import { sleep } from "@lightprotocol/zk.js";
-import { downloadFileIfNotExists } from "./downloadBin";
+import { downloadLightBinIfNotExists } from "./downloadBin";
 
 /**
  * Generates a zk-SNARK circuit given a circuit name.
@@ -152,11 +152,11 @@ export async function buildPSP(
   // TODO: check whether circom binary exists if not load it
   const dirPath = path.resolve(__dirname, "../../bin/");
 
-  await downloadFileIfNotExists({
-    filePath: macroCircomBinPath,
+  await downloadLightBinIfNotExists({
+    localFilePath: macroCircomBinPath,
     dirPath,
     repoName: "macro-circom",
-    fileName: "macro-circom",
+    remoteFileName: "macro-circom",
   });
 
   let stdout = execSync(

--- a/cli/src/utils/downloadBin.ts
+++ b/cli/src/utils/downloadBin.ts
@@ -1,7 +1,13 @@
 import axios from "axios";
 import * as fs from "fs";
 import { promisify } from "util";
+const progress = require("progress-stream");
 import * as os from "os";
+import * as path from "path";
+const tar = require("tar");
+import * as zlib from "zlib";
+import { AnyNaptrRecord } from "dns";
+import { ENCRYPTED_UNCOMPRESSED_UTXO_BYTES_LENGTH } from "@lightprotocol/zk.js";
 
 const fileExists = promisify(fs.exists);
 
@@ -21,82 +27,221 @@ async function latestRelease(owner: string, repo: string) {
   return response.data.tag_name;
 }
 
-function getSystem(): string {
+enum System {
+  MacOsAmd64,
+  MacOsArm64,
+  LinuxAmd64,
+  LinuxArm64,
+}
+
+function getSystem(): System {
   const arch = os.arch();
   const platform = os.platform();
 
-  let platformName: string;
-  let archName: string;
-
-  if (platform === "darwin") {
-    platformName = "macos";
-  } else if (platform === "linux") {
-    platformName = "linux";
-  } else {
-    throw new Error(`Platform ${platform} is not supported.`);
+  switch (platform) {
+    case "darwin":
+      switch (arch) {
+        case "x64":
+          return System.MacOsAmd64;
+        case "arm":
+        // fallthrough
+        case "arm64":
+          return System.MacOsArm64;
+        default:
+          throw new Error(`Architecture ${arch} is not supported.`);
+      }
+    case "linux":
+      switch (arch) {
+        case "x64":
+          return System.LinuxAmd64;
+        case "arm":
+        // fallthrough
+        case "arm64":
+          return System.LinuxArm64;
+        default:
+          throw new Error(`Architecture ${arch} is not supported.`);
+      }
   }
 
-  if (arch === "x64") {
-    archName = "amd64";
-  } else if (arch === "arm" || arch === "arm64") {
-    archName = "arm64";
-  } else {
-    throw new Error(`Architecture ${arch} is not supported.`);
-  }
-
-  return `${platformName}-${archName}`;
+  throw new Error(`Platform ${platform} is not supported.`);
 }
 
 function makeExecutable(filePath: string): void {
   fs.chmodSync(filePath, "755");
 }
 
-export async function downloadFileIfNotExists({
-  filePath,
+/**
+ * Download a binary from the given release artifact of the GitHub repository,
+ * if it was not already downloaded.
+ * @param localFilePath - The path to the local file (which either already
+ * exists or will be created).
+ * @param dirPath - The path to the directory where the file will be created.
+ * @param owner - The owner of the GitHub repository.
+ * @param repoName - The name of the GitHub repository.
+ * @param remoteFileName - The name of the file in the GitHub release artifact.
+ * @returns {Promise<void>}
+ */
+export async function downloadBinIfNotExists({
+  localFilePath,
   dirPath,
+  owner,
   repoName,
-  fileName,
+  remoteFileName,
 }: {
-  filePath: string;
+  localFilePath: string;
   dirPath: string;
+  owner: string;
   repoName: string;
-  fileName: string;
+  remoteFileName: string;
 }) {
   if (!fs.existsSync(dirPath)) {
     fs.mkdirSync(dirPath, { recursive: true });
   }
 
   // Check if file exists
-  if (await fileExists(filePath)) {
+  if (await fileExists(localFilePath)) {
     return;
   }
 
-  const system = getSystem();
-  const tag = await latestRelease("lightprotocol", repoName);
-
-  const url = `https://github.com/Lightprotocol/${repoName}/releases/download/${tag}/${fileName}-${system}`;
-
-  if (!url) {
-    throw new Error(`No binary found for the detected system ${system}`);
-  }
+  const tag = await latestRelease(owner, repoName);
+  const url = `https://github.com/${owner}/${repoName}/releases/download/${tag}/${remoteFileName}`;
 
   // Download the file
-  console.log(`Downloading ${fileName} from ${url}...`);
-  const { data } = await axios({
+  console.log(`Downloading ${remoteFileName} from ${url}...`);
+  const { data, headers } = await axios({
     url,
     method: "GET",
     responseType: "stream",
   });
 
-  // Save the file
-  const writer = fs.createWriteStream(filePath);
-  data.pipe(writer);
+  const totalLength = headers["content-length"];
 
-  return new Promise<void>((resolve, reject) => {
-    writer.on("finish", () => {
-      makeExecutable(filePath); // Make the file executable after it has been written.
-      resolve();
+  let progressStream = progress({
+    length: totalLength,
+    time: 100 /* ms */,
+  });
+
+  progressStream.on("progress", (progress: any) => {
+    console.log(`Progress: ${progress.percentage.toFixed(2)}%`);
+  });
+
+  // If the file is a tar.gz file, unzip and untar it while it's being written.
+  if (remoteFileName.endsWith(".tar.gz")) {
+    console.log(`Extracting ${remoteFileName}...`);
+    const gunzip = zlib.createGunzip();
+    const parser = new tar.Parse();
+    data.pipe(progressStream).pipe(gunzip).pipe(parser);
+
+    // Sadly, `tar` doesn't expose any interface which would describe all
+    // properties we need, so we have to use `any` here.
+    parser.on("entry", (entry: any) => {
+      if (entry.path === path.parse(localFilePath).base) {
+        entry.pipe(fs.createWriteStream(localFilePath));
+      } else {
+        entry.resume();
+      }
     });
-    writer.on("error", reject);
+
+    return new Promise<void>((resolve, reject) => {
+      parser.on("end", () => {
+        // Make the file executable after it has been written.
+        makeExecutable(localFilePath);
+        resolve();
+      });
+      parser.on("error", reject);
+    });
+  } else {
+    let writeStream = fs.createWriteStream(localFilePath);
+    data.pipe(progressStream).pipe(writeStream);
+
+    return new Promise<void>((resolve, reject) => {
+      writeStream.on("finish", () => {
+        // Make the file executable after it has been written.
+        makeExecutable(localFilePath);
+        resolve();
+      });
+      writeStream.on("error", reject);
+    });
+  }
+}
+
+/**
+ * Download a binary of a Light Protocol associated project. They all share
+ * common properties (e.g. the owner, the OS and CPU architecture suffix, etc.).
+ * @param localFilePath - The path to the local file (which either already
+ * exists or will be created).
+ * @param dirPath - The path to the directory where the file will be created.
+ * @param repoName - The name of the GitHub repository.
+ * @param remoteFileName - The name of the file in the GitHub release artifact.
+ * @returns {Promise<void>}
+ */
+export async function downloadLightBinIfNotExists({
+  localFilePath,
+  dirPath,
+  repoName,
+  remoteFileName,
+}: {
+  localFilePath: string;
+  dirPath: string;
+  repoName: string;
+  remoteFileName: string;
+}) {
+  let systemSuffix: string;
+  switch (getSystem()) {
+    case System.LinuxAmd64:
+      systemSuffix = "linux-amd64";
+      break;
+    case System.LinuxArm64:
+      systemSuffix = "linux-arm64";
+      break;
+    case System.MacOsAmd64:
+      systemSuffix = "macos-amd64";
+      break;
+    case System.MacOsArm64:
+      systemSuffix = "macos-arm64";
+      break;
+  }
+
+  const fullRemoteFileName = `${remoteFileName}-${systemSuffix}`;
+  await downloadBinIfNotExists({
+    localFilePath,
+    dirPath,
+    owner: "Lightprotocol",
+    repoName,
+    remoteFileName: fullRemoteFileName,
+  });
+}
+
+export async function downloadCargoGenerateIfNotExists({
+  localFilePath,
+  dirPath,
+}: {
+  localFilePath: string;
+  dirPath: string;
+}) {
+  const tag = await latestRelease("cargo-generate", "cargo-generate");
+  let remoteFileName: string;
+  switch (getSystem()) {
+    case System.LinuxAmd64:
+      remoteFileName = `cargo-generate-${tag}-x86_64-unknown-linux-musl.tar.gz`;
+      break;
+    case System.LinuxArm64:
+      remoteFileName =
+        "cargo-generate-${tag}-aarch64-unknown-linux-musl.tar.gz";
+      break;
+    case System.MacOsAmd64:
+      remoteFileName = "cargo-generate-${tag}-x86_64-apple-darwin.tar.gz";
+      break;
+    case System.MacOsArm64:
+      remoteFileName = "cargo-generate-${tag}-aarch64-apple-darwin.tar.gz";
+      break;
+  }
+
+  await downloadBinIfNotExists({
+    localFilePath,
+    dirPath,
+    owner: "cargo-generate",
+    repoName: "cargo-generate",
+    remoteFileName,
   });
 }

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -815,6 +815,11 @@ check-types@^11.1.1:
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-11.2.2.tgz#7afc0b6a860d686885062f2dba888ba5710335b4"
   integrity sha512-HBiYvXvn9Z70Z88XKjz3AEKd4HJhBXsa3j7xFnITAzoS8+q6eIGi8qDB8FKPBAjtuxjI/zFpwuiCb8oDtKOYrA==
 
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
 circom_runtime@0.1.21:
   version "0.1.21"
   resolved "https://registry.yarnpkg.com/circom_runtime/-/circom_runtime-0.1.21.tgz#0ee93bb798b5afb8ecec30725ed14d94587a999b"
@@ -874,6 +879,11 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cross-fetch@^3.1.5:
   version "3.1.6"
@@ -1099,6 +1109,13 @@ formdata-polyfill@^4.0.10:
   dependencies:
     fetch-blob "^3.1.2"
 
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
+
 fs@^0.0.1-security:
   version "0.0.1-security"
   resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
@@ -1156,7 +1173,7 @@ ieee754@^1.2.1:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-inherits@^2.0.3, inherits@^2.0.4:
+inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1165,6 +1182,11 @@ is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
 
 isomorphic-ws@^4.0.1:
   version "4.0.1"
@@ -1280,6 +1302,31 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
+minipass@^3.0.0:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.3.6.tgz#7bba384db3a1520d18c9c0e5251c3444e95dd94a"
+  integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
+  dependencies:
+    yallist "^4.0.0"
+
+minipass@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
+  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
+
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
+mkdirp@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -1339,10 +1386,23 @@ pako@^2.0.3:
   resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
   integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
 process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+
+progress-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress-stream/-/progress-stream-2.0.0.tgz#fac63a0b3d11deacbb0969abcc93b214bce19ed5"
+  integrity sha512-xJwOWR46jcXUq6EH9yYyqp+I52skPySOeHfkxOZ2IY1AiBi/sFJhbhAKHoV3OTw/omQ45KTio9215dRJ2Yxd3Q==
+  dependencies:
+    speedometer "~1.0.0"
+    through2 "~2.0.3"
 
 proxy-from-env@^1.1.0:
   version "1.1.0"
@@ -1367,6 +1427,19 @@ readable-stream@^3.6.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readable-stream@~2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
+  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 regenerator-runtime@^0.13.11:
   version "0.13.11"
@@ -1395,6 +1468,11 @@ safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 scrypt-js@3.0.1:
   version "3.0.1"
@@ -1425,6 +1503,11 @@ snarkjs@^0.5.0:
     logplease "^1.2.15"
     r1csfile "0.0.41"
 
+speedometer@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/speedometer/-/speedometer-1.0.0.tgz#cd671cb06752c22bca3370e2f334440be4fc62e2"
+  integrity sha512-lgxErLl/7A5+vgIIXsh9MbeukOaCb2axgQ+bKCdIE+ibNT4XNYGNCR1qFEGq6F+YDASXK3Fh/c5FgtZchFolxw==
+
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -1440,6 +1523,13 @@ string_decoder@^1.1.1:
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -1465,10 +1555,30 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+tar@^6.1.15:
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.15.tgz#c9738b0b98845a3b344d334b8fa3041aaba53a69"
+  integrity sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^5.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
 text-encoding-utf-8@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz#585b62197b0ae437e3c7b5d0af27ac1021e10d13"
   integrity sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==
+
+through2@~2.0.3:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
+  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
+  dependencies:
+    readable-stream "~2.3.6"
+    xtend "~4.0.1"
 
 "through@>=2.2.7 <3":
   version "2.3.8"
@@ -1517,7 +1627,7 @@ utf-8-validate@^5.0.2:
   dependencies:
     node-gyp-build "^4.3.0"
 
-util-deprecate@^1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
@@ -1586,10 +1696,20 @@ ws@^8.5.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
   integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
 
+xtend@~4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@^21.1.1:
   version "21.1.1"
@@ -1608,3 +1728,8 @@ yargs@^17.6.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+zlib@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/zlib/-/zlib-1.0.5.tgz#6e7c972fc371c645a6afb03ab14769def114fcc0"
+  integrity sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w==

--- a/light-circuits/yarn.lock
+++ b/light-circuits/yarn.lock
@@ -394,7 +394,7 @@
     ffjavascript "^0.2.48"
 
 "@lightprotocol/zk.js@file:../light-zk.js":
-  version "0.3.0"
+  version "0.3.2-alpha.8"
   dependencies:
     "@coral-xyz/anchor" "0.27.0"
     "@coral-xyz/borsh" "^0.27.0"

--- a/light-system-programs/yarn.lock
+++ b/light-system-programs/yarn.lock
@@ -394,7 +394,7 @@
     ffjavascript "^0.2.48"
 
 "@lightprotocol/zk.js@file:../light-zk.js":
-  version "0.3.0"
+  version "0.3.2-alpha.8"
   dependencies:
     "@coral-xyz/anchor" "0.27.0"
     "@coral-xyz/borsh" "^0.27.0"

--- a/mock-app-verifier/yarn.lock
+++ b/mock-app-verifier/yarn.lock
@@ -394,7 +394,7 @@
     ffjavascript "^0.2.48"
 
 "@lightprotocol/zk.js@file:../light-zk.js":
-  version "0.3.0"
+  version "0.3.2-alpha.8"
   dependencies:
     "@coral-xyz/anchor" "0.27.0"
     "@coral-xyz/borsh" "^0.27.0"

--- a/relayer/yarn.lock
+++ b/relayer/yarn.lock
@@ -419,7 +419,7 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@lightprotocol/zk.js@file:../light-zk.js":
-  version "0.3.0"
+  version "0.3.2-alpha.8"
   dependencies:
     "@coral-xyz/anchor" "0.27.0"
     "@coral-xyz/borsh" "^0.27.0"


### PR DESCRIPTION
Lightprotocol/psp-template#1 introduces a project template which can be used by cargo-generate[0] for creating new projects. Instead of using light-anchor for that, let's just use that template.

The advantage of cargo-generate is making the template independent from our toolchain releases and better readability.

[0] https://crates.io/crates/cargo-generate