### PR TITLE
cli: Do not inclue `bin/` folder, bump the version to 0.1.1-alpha.12

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightprotocol/cli",
-  "version": "0.1.1-alpha.11",
+  "version": "0.1.1-alpha.12",
   "description": "",
   "main": "build/cli.js",
   "scripts": {
@@ -31,7 +31,6 @@
   },
   "files": [
     "build/**/*",
-    "bin/*",
     "scripts/*"
   ]
 }


### PR DESCRIPTION
Binaries should be downloaded by each user for their system and architecture. We publish NPM packages from Linux x86_64 hosts usually, so publishing bin/ in the package usually results in shipping that binary to all users. That's a parial reason why it didn't work on macOS arm64.