### PR TITLE
zk-js: utils - fetchNullifierAccountInfo - fixes getBalance

### DIFF
--- a/light-zk.js/src/utils.ts
+++ b/light-zk.js/src/utils.ts
@@ -182,7 +182,7 @@ export const fetchNullifierAccountInfo = async (
 ) => {
   const nullifierPubkey = PublicKey.findProgramAddressSync(
     [
-      Buffer.from(new anchor.BN(nullifier.toString()).toArray()),
+      Buffer.from(new anchor.BN(nullifier.toString()).toArray("be", 32)),
       anchor.utils.bytes.utf8.encode("nf"),
     ],
     merkleTreeProgramId,

--- a/light-zk.js/src/utils.ts
+++ b/light-zk.js/src/utils.ts
@@ -182,7 +182,7 @@ export const fetchNullifierAccountInfo = async (
 ) => {
   const nullifierPubkey = PublicKey.findProgramAddressSync(
     [
-      Buffer.from(new anchor.BN(nullifier.toString()).toArray("be", 32)),
+      new anchor.BN(nullifier.toString()).toBuffer("be", 32),
       anchor.utils.bytes.utf8.encode("nf"),
     ],
     merkleTreeProgramId,


### PR DESCRIPTION
Problem:
- balance fetch does not categorize spent utxos in all cases
- ci tests fail and seem flaky

Solution:
- force nullifier serialization during nullifier pubkey derivation to always be 32 bytes