### PR TITLE
zk.js: make provider reusable

### DIFF
--- a/light-system-programs/tests/user_tests.ts
+++ b/light-system-programs/tests/user_tests.ts
@@ -36,7 +36,7 @@ import {
 import { BN } from "@coral-xyz/anchor";
 
 var POSEIDON;
-var RELAYER: TestRelayer, provider: Provider;
+var RELAYER: TestRelayer, provider: Provider, user: User;
 
 // TODO: remove deprecated function calls
 describe("Test User", () => {
@@ -50,7 +50,7 @@ describe("Test User", () => {
   );
   anchor.setProvider(anchorProvider);
   const userKeypair = ADMIN_AUTH_KEYPAIR;
-
+  
   before("init test setup Merkle tree lookup table etc ", async () => {
     await createTestAccounts(anchorProvider.connection);
     POSEIDON = await circomlibjs.buildPoseidonOpt();
@@ -67,6 +67,13 @@ describe("Test User", () => {
       relayerRecipientSol,
       new BN(100000),
     );
+    provider = await Provider.init({
+      wallet: userKeypair,
+      relayer: RELAYER,
+    });
+    await airdropSol({provider: anchorProvider,amount: 2_000_000_000, recipientPublicKey: userKeypair.publicKey })
+
+    user = await User.init({ provider });
   });
 
   it.skip("(user class) shield SPL random infinite", async () => {
@@ -138,19 +145,7 @@ describe("Test User", () => {
       expectedSpentUtxosLength,
     };
 
-    const provider = await Provider.init({
-      wallet: userKeypair,
-      relayer: RELAYER,
-    });
 
-    let res = await provider.provider.connection.requestAirdrop(
-      userKeypair.publicKey,
-      2_000_000_000,
-    );
-
-    await provider.provider.connection.confirmTransaction(res, "confirmed");
-
-    const user: User = await User.init({ provider });
 
     const testStateValidator = new TestStateValidator({
       userSender: user,
@@ -180,20 +175,6 @@ describe("Test User", () => {
       type: Action.SHIELD,
       expectedUtxoHistoryLength: 1,
     };
-
-    const provider = await Provider.init({
-      wallet: userKeypair,
-      relayer: RELAYER,
-    }); // userKeypair
-
-    let res = await provider.provider.connection.requestAirdrop(
-      userKeypair.publicKey,
-      4_000_000_000,
-    );
-
-    await provider.provider.connection.confirmTransaction(res, "confirmed");
-
-    const user: User = await User.init({ provider });
 
     const testStateValidator = new TestStateValidator({
       userSender: user,
@@ -227,19 +208,6 @@ describe("Test User", () => {
       recipientSpl: solRecipient.publicKey,
       expectedUtxoHistoryLength: 1,
     };
-
-    const provider = await Provider.init({
-      wallet: userKeypair,
-      relayer: RELAYER,
-    }); // userKeypair
-
-    let res = await provider.provider.connection.requestAirdrop(
-      userKeypair.publicKey,
-      2_000_000_000,
-    );
-
-    await provider.provider.connection.confirmTransaction(res, "confirmed");
-
     // TODO: add test case for if recipient doesnt have account yet -> relayer must create it
     await newAccountWithTokens({
       connection: provider.provider.connection,
@@ -248,8 +216,6 @@ describe("Test User", () => {
       userAccount: solRecipient,
       amount: new anchor.BN(0),
     });
-
-    const user: User = await User.init({ provider });
 
     const testStateValidator = new TestStateValidator({
       userSender: user,
@@ -282,17 +248,11 @@ describe("Test User", () => {
       expectedRecipientUtxoLength: 1,
     };
 
-    const provider = await Provider.init({
-      wallet: userKeypair,
-      relayer: RELAYER,
-    });
-
     const recipientAccount = new Account({
       poseidon: POSEIDON,
       seed: testInputs.recipientSeed,
     });
 
-    const user: User = await User.init({ provider });
     const userRecipient: User = await User.init({
       provider,
       seed: testInputs.recipientSeed,
@@ -328,12 +288,6 @@ describe("Test User", () => {
       storage: true,
       message: Buffer.alloc(512).fill(1),
     };
-    provider = await Provider.init({
-      wallet: userKeypair,
-      relayer: RELAYER,
-    });
-
-    const user: User = await User.init({ provider });
 
     const testStateValidator = new TestStateValidator({
       userSender: user,
@@ -361,19 +315,9 @@ describe("Test User", () => {
       message: Buffer.alloc(672).fill(2),
     };
 
-    provider = await Provider.init({
-      wallet: userKeypair,
-      relayer: RELAYER,
-    });
     const seed = bs58.encode(new Uint8Array(32).fill(4));
     await airdropShieldedSol({ provider, amount: 1, seed });
 
-    let res = await provider.provider.connection.requestAirdrop(
-      userKeypair.publicKey,
-      4_000_000_000,
-    );
-
-    await provider.provider.connection.confirmTransaction(res, "confirmed");
     await provider.latestMerkleTree();
     const user: User = await User.init({ provider, seed });
 

--- a/light-system-programs/tests/user_tests.ts
+++ b/light-system-programs/tests/user_tests.ts
@@ -50,7 +50,7 @@ describe("Test User", () => {
   );
   anchor.setProvider(anchorProvider);
   const userKeypair = ADMIN_AUTH_KEYPAIR;
-  
+
   before("init test setup Merkle tree lookup table etc ", async () => {
     await createTestAccounts(anchorProvider.connection);
     POSEIDON = await circomlibjs.buildPoseidonOpt();
@@ -71,7 +71,11 @@ describe("Test User", () => {
       wallet: userKeypair,
       relayer: RELAYER,
     });
-    await airdropSol({provider: anchorProvider,amount: 2_000_000_000, recipientPublicKey: userKeypair.publicKey })
+    await airdropSol({
+      provider: anchorProvider,
+      amount: 2_000_000_000,
+      recipientPublicKey: userKeypair.publicKey,
+    });
 
     user = await User.init({ provider });
   });
@@ -144,8 +148,6 @@ describe("Test User", () => {
       expectedUtxoHistoryLength,
       expectedSpentUtxosLength,
     };
-
-
 
     const testStateValidator = new TestStateValidator({
       userSender: user,

--- a/light-zk.js/src/test-utils/testRelayer.ts
+++ b/light-zk.js/src/test-utils/testRelayer.ts
@@ -34,6 +34,8 @@ export class TestRelayer extends Relayer {
 
   async updateMerkleTree(provider: Provider): Promise<any> {
     if (!provider.provider) throw new Error("Provider.provider is undefined.");
+    if (!provider.url) throw new Error("Provider.provider is undefined.");
+
     await airdropSol({
       provider: provider.provider,
       amount: 1_000_000_000,
@@ -42,7 +44,7 @@ export class TestRelayer extends Relayer {
     try {
       const response = await updateMerkleTreeForTest(
         this.relayerKeypair,
-        provider.provider,
+        provider.url,
       );
       return response;
     } catch (e) {

--- a/light-zk.js/src/test-utils/updateMerkleTree.ts
+++ b/light-zk.js/src/test-utils/updateMerkleTree.ts
@@ -3,32 +3,39 @@ import {
   executeUpdateMerkleTreeTransactions,
   SolMerkleTree,
 } from "../merkleTree/index";
-import { merkleTreeProgramId, TRANSACTION_MERKLE_TREE_KEY } from "../constants";
+import {
+  confirmConfig,
+  merkleTreeProgramId,
+  TRANSACTION_MERKLE_TREE_KEY,
+} from "../constants";
 import { IDL_MERKLE_TREE_PROGRAM, MerkleTreeProgram } from "../idls/index";
 const circomlibjs = require("circomlibjs");
 import { ADMIN_AUTH_KEYPAIR } from "./constants_system_verifier";
 import { Provider, Wallet } from "../wallet";
 import { Connection, Keypair } from "@solana/web3.js";
 
-export async function updateMerkleTreeForTest(
-  payer: Keypair,
-  provider: anchor.Provider,
-) {
+export async function updateMerkleTreeForTest(payer: Keypair, url: string) {
+  const connection = new Connection(url, confirmConfig);
+  const anchorProvider = new anchor.AnchorProvider(
+    connection,
+    new anchor.Wallet(Keypair.generate()),
+    confirmConfig,
+  );
   try {
     const merkleTreeProgram = new anchor.Program(
       IDL_MERKLE_TREE_PROGRAM,
       merkleTreeProgramId,
-      provider && provider,
+      anchorProvider && anchorProvider,
     );
 
     // fetch uninserted utxos from chain
     let leavesPdas = await SolMerkleTree.getUninsertedLeavesRelayer(
       TRANSACTION_MERKLE_TREE_KEY,
-      provider && provider,
+      anchorProvider && anchorProvider,
     );
 
     await executeUpdateMerkleTreeTransactions({
-      connection: provider.connection,
+      connection,
       signer: payer,
       merkleTreeProgram,
       leavesPdas,

--- a/relayer/src/services/merkleTreeService.ts
+++ b/relayer/src/services/merkleTreeService.ts
@@ -41,7 +41,7 @@ export const initMerkleTree = async (req: any, res: any) => {
 export const updateMerkleTree = async (req: any, res: any) => {
   try {
     const provider = await getLightProvider();
-    await updateMerkleTreeForTest(getKeyPairFromEnv("KEY_PAIR"), provider.provider!);
+    await updateMerkleTreeForTest(getKeyPairFromEnv("KEY_PAIR"), provider.url!);
     return res.status(200).json({ status: "ok" });
   } catch (e) {
     return res.status(500).json({ status: "error", message: e.message });


### PR DESCRIPTION
this pr builds on  https://github.com/Lightprotocol/light-protocol/pull/143 and should be merged after

Problem:
- one anchor provider cannot be used to instantiate a merkle tree twice because it will send the same transactions again
- in case of the compute transactions the exact same transaction since the different data is just saved in the temporary account

Solution:
- instantiate a new connection and provider when updating the Merkle tree with the test relayer
- changed the user_test to test the new changes by only instantiating the provider and user once

Comment:
- this is somewhat a quick fix, we should think about a better solution maybe change the Merkle tree program to make transactions unique