### PR TITLE
chore: Fix rustc warnings

### DIFF
--- a/light-system-programs/programs/merkle_tree_program/src/lib.rs
+++ b/light-system-programs/programs/merkle_tree_program/src/lib.rs
@@ -26,42 +26,11 @@ pub mod utils;
 pub mod config_accounts;
 pub use config_accounts::*;
 
-use crate::config_accounts::{
-    init_asset_pda::{RegisterSolPool, RegisterSplPool},
-    merkle_tree_authority::{
-        InitializeMerkleTreeAuthority, UpdateMerkleTreeAuthority, UpdateMerkleTreeAuthorityConfig,
-    },
-    register_verifier::RegisterVerifier,
-};
-
 use crate::errors::ErrorCode;
-
-use crate::transaction_merkle_tree::update_merkle_tree_lib::merkle_tree_update_state::MerkleTreeUpdateState;
 
 use crate::utils::{
     config::{self, ZERO_BYTES_MERKLE_TREE_18},
     constants::MESSAGE_MERKLE_TREE_HEIGHT,
-};
-
-use crate::verifier_invoked_instructions::{
-    insert_nullifier::{process_insert_nullifiers, InitializeNullifiers},
-    insert_two_leaves_transaction::{process_insert_two_leaves, InsertTwoLeaves},
-    sol_transfer::{process_sol_transfer, WithdrawSol},
-    spl_transfer::{process_spl_transfer, WithdrawSpl},
-};
-
-use crate::{
-    message_merkle_tree::InitializeNewMessageMerkleTree,
-    transaction_merkle_tree::{
-        initialize_new_merkle_tree_18::{
-            process_initialize_new_merkle_tree_18, InitializeNewTransactionMerkleTree,
-        },
-        update_instructions::{
-            initialize_update_state::{process_initialize_update_state, InitializeUpdateState},
-            insert_root::{process_insert_root, InsertRoot},
-            update_merkle_tree::{process_update_merkle_tree, UpdateTransactionMerkleTree},
-        },
-    },
 };
 
 #[program]

--- a/light-system-programs/programs/merkle_tree_program/src/transaction_merkle_tree/update_merkle_tree_lib/instructions_poseidon.rs
+++ b/light-system-programs/programs/merkle_tree_program/src/transaction_merkle_tree/update_merkle_tree_lib/instructions_poseidon.rs
@@ -215,7 +215,7 @@ pub fn permute_custom_split(
 
     for r in nr_start..nr_end {
         state.iter_mut().enumerate().for_each(|(i, a)| {
-            let c = params.round_keys[((r - nr_start) * PoseidonCircomRounds3::WIDTH + i)];
+            let c = params.round_keys[(r - nr_start) * PoseidonCircomRounds3::WIDTH + i];
             a.add_assign(c);
         });
 

--- a/light-system-programs/programs/verifier_program_one/src/lib.rs
+++ b/light-system-programs/programs/verifier_program_one/src/lib.rs
@@ -12,7 +12,6 @@ pub mod verifying_key;
 
 pub use processor::*;
 
-use crate::processor::TransactionConfig;
 use anchor_lang::prelude::*;
 use anchor_spl::token::Token;
 use light_verifier_sdk::light_transaction::VERIFIER_STATE_SEED;

--- a/light-system-programs/programs/verifier_program_two/src/lib.rs
+++ b/light-system-programs/programs/verifier_program_two/src/lib.rs
@@ -11,7 +11,6 @@ pub mod processor;
 pub mod verifying_key;
 pub use processor::*;
 
-use crate::processor::process_shielded_transfer;
 use anchor_lang::prelude::*;
 use anchor_spl::token::Token;
 


### PR DESCRIPTION
Fix Rust compiler warnings about:

* Redundant parenthesis.
* Redundant imports (`use something::` after `pub use::something::*`).