### PR TITLE
CI: Make sure PAT_TOKEN is not used on pull requests from fork

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,9 +15,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-        with:
-          submodules: true
-          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Install stable Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,11 @@ jobs:
           submodules: true
 
       - name: Log in to the container registry
+        # NOTE(vadorovsky): We don't want to push the cache image if the PR is
+        # from the needed PAT_TOKEN. That's not ideal (because external
+        # contributions are not going to be cached immediately), but for now
+        # that's the best we can do.
+        if: github.event.pull_request.head.repo.fork == false
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
@@ -41,6 +46,8 @@ jobs:
           password: ${{ secrets.PAT_TOKEN }}
 
       - name: Pre-build dev container image
+        # Same here.
+        if: github.event.pull_request.head.repo.fork == false
         uses: devcontainers/ci@v0.3
         with:
           imageName: ghcr.io/lightprotocol/devcontainer-cache


### PR DESCRIPTION
* Remove the usage of PAT_TOKEN in the checkout job - we don't have any private submodules, so there is no need for that.
* Push cache devcontainer image only when pull request is not coming from a fork.