### PR TITLE
zk.js test: fixed flakyness in aes encryption test

### DIFF
--- a/light-zk.js/tests/account.test.ts
+++ b/light-zk.js/tests/account.test.ts
@@ -245,24 +245,27 @@ describe("Test Account Functional", () => {
     let nonce = newNonce().subarray(0, 16);
     if (!k0.aesSecret) throw new Error("aes secret undefined");
 
-    // removed domain separation
     let cipherText1 = await Account.encryptAes(k0.aesSecret, message, nonce);
-    // let cipherText2 = await Account.encryptAes(k0.aesSecret,message, nonce, "newDomain");
     let cleartext1 = await Account.decryptAes(k0.aesSecret, cipherText1);
-    // let cleartext2 = await Account.decryptAes(k0.aesSecret,cipherText2, "newDomain");
 
-    // assert.notEqual(cipherText1.toString(), cipherText2.toString());
-    // assert.equal(cleartext1.toString(), cleartext2.toString());
     assert.equal(cleartext1.toString(), message.toString());
     assert.notEqual(
       new Uint8Array(32).fill(1).toString(),
       k0.aesSecret.toString(),
     );
+
     // try to decrypt with invalid secret key
-    await chai.assert.isRejected(
-      Account.decryptAes(new Uint8Array(32).fill(1), cipherText1),
-      Error,
-    );
+    // added try catch because in some cases it doesn't decrypt but doesn't throw an error either
+    //TODO: revisit this and possibly switch aes library
+    try {
+      await chai.assert.isRejected(
+        Account.decryptAes(new Uint8Array(32).fill(1), cipherText1),
+        Error,
+      );
+    } catch (error) {
+      const msg = Account.decryptAes(new Uint8Array(32).fill(1), cipherText1);
+      assert.notEqual(msg.toString(), message.toString());
+    }
   });
 });
 


### PR DESCRIPTION
Problem:
- account test functional: aes encryption relies on the assumption that the decryption of an aes cipher text with an invalid secret key throws an error
- In most cases this assumption is correct. However, in some cases the library does not throw an error and just returns a value. This value is of course not the correct clear text since we are using an invalid secret key but the test fails because it expected an error.

Solution:
- add an additional check which asserts the incorrectness of the decrypted value should the decryption not throw an error