### PR TITLE
zk.js: remove deprecated sendTransaction method

### DIFF
--- a/light-zk.js/src/merkleTree/merkleTreeUpdater.ts
+++ b/light-zk.js/src/merkleTree/merkleTreeUpdater.ts
@@ -5,14 +5,7 @@ import {
   checkMerkleTreeBatchUpdateSuccess,
 } from "../test-utils/testChecks";
 
-import {
-  confirmConfig,
-  DEFAULT_PROGRAMS,
-  MerkleTreeProgram,
-  Provider,
-  sendTransactionWithConnection,
-  sendVersionedTransaction,
-} from "../index";
+import { confirmConfig, DEFAULT_PROGRAMS, MerkleTreeProgram } from "../index";
 import {
   ComputeBudgetProgram,
   PublicKey,

--- a/light-zk.js/src/test-utils/createAccounts.ts
+++ b/light-zk.js/src/test-utils/createAccounts.ts
@@ -107,7 +107,7 @@ export const newProgramOwnedAccount = async ({
       );
 
       tx.feePayer = payer.publicKey;
-      tx.recentBlockhash = await connection.getRecentBlockhash();
+      tx.recentBlockhash = await connection.getLatestBlockhash();
       let x = await solana.sendAndConfirmTransaction(
         connection,
         tx,

--- a/light-zk.js/src/test-utils/initLookUpTable.ts
+++ b/light-zk.js/src/test-utils/initLookUpTable.ts
@@ -154,7 +154,7 @@ export async function initLookUpTableTest(
     transaction.add(extendInstruction);
     transaction.add(ix0);
     // transaction.add(ix1);
-    let recentBlockhash = await provider.connection.getRecentBlockhash(
+    let recentBlockhash = await provider.connection.getLatestBlockhash(
       "confirmed",
     );
     transaction.feePayer = payerPubkey;

--- a/light-zk.js/src/transaction/sendVersionedTransaction.ts
+++ b/light-zk.js/src/transaction/sendVersionedTransaction.ts
@@ -68,38 +68,3 @@ export const sendVersionedTransaction = async (ix: any, provider: Provider) => {
   }
   return res;
 };
-
-// currently not used
-export const sendTransactionWithConnection = async (
-  instructions: [TransactionInstruction],
-  connection: Connection,
-  signer: Keypair,
-) => {
-  const recentBlockhash = (await connection.getLatestBlockhash(confirmConfig))
-    .blockhash;
-
-  const txMsg = new TransactionMessage({
-    payerKey: signer.publicKey,
-    instructions,
-    recentBlockhash,
-  });
-  const v0Message = txMsg.compileToV0Message();
-
-  var tx = new VersionedTransaction(v0Message);
-  tx.sign([signer]);
-  let retries = 3;
-  let res;
-  while (retries > 0) {
-    try {
-      res = await connection.sendTransaction(tx, confirmConfig);
-      retries = 0;
-    } catch (e: any) {
-      retries--;
-      if (retries == 0 || e.logs !== undefined) {
-        console.log(e);
-        return e;
-      }
-    }
-  }
-  return res;
-};

--- a/light-zk.js/src/transaction/sendVersionedTransaction.ts
+++ b/light-zk.js/src/transaction/sendVersionedTransaction.ts
@@ -1,6 +1,9 @@
 import {
   AddressLookupTableAccount,
   ComputeBudgetProgram,
+  Connection,
+  Keypair,
+  TransactionInstruction,
   TransactionMessage,
   VersionedTransaction,
 } from "@solana/web3.js";
@@ -9,7 +12,7 @@ import { Provider } from "../wallet";
 import { confirmConfig } from "../constants";
 export const sendVersionedTransaction = async (ix: any, provider: Provider) => {
   const recentBlockhash = (
-    await provider.provider!.connection.getRecentBlockhash("confirmed")
+    await provider.provider!.connection.getLatestBlockhash(confirmConfig)
   ).blockhash;
 
   const txMsg = new TransactionMessage({
@@ -50,12 +53,45 @@ export const sendVersionedTransaction = async (ix: any, provider: Provider) => {
   while (retries > 0) {
     tx = await provider.wallet.signTransaction(tx);
     try {
-      let serializedTx = tx.serialize();
-
-      res = await provider.provider!.connection.sendRawTransaction(
-        serializedTx,
+      res = await provider.provider!.connection.sendTransaction(
+        tx,
         confirmConfig,
       );
+      retries = 0;
+    } catch (e: any) {
+      retries--;
+      if (retries == 0 || e.logs !== undefined) {
+        console.log(e);
+        return e;
+      }
+    }
+  }
+  return res;
+};
+
+// currently not used
+export const sendTransactionWithConnection = async (
+  instructions: [TransactionInstruction],
+  connection: Connection,
+  signer: Keypair,
+) => {
+  const recentBlockhash = (await connection.getLatestBlockhash(confirmConfig))
+    .blockhash;
+
+  const txMsg = new TransactionMessage({
+    payerKey: signer.publicKey,
+    instructions,
+    recentBlockhash,
+  });
+  const v0Message = txMsg.compileToV0Message();
+
+  var tx = new VersionedTransaction(v0Message);
+  tx.sign([signer]);
+  let retries = 3;
+  let res;
+  while (retries > 0) {
+    try {
+      res = await connection.sendTransaction(tx, confirmConfig);
       retries = 0;
     } catch (e: any) {
       retries--;

--- a/light-zk.js/src/utils.ts
+++ b/light-zk.js/src/utils.ts
@@ -366,7 +366,7 @@ export async function initLookUpTable(
 
   transaction.add(extendInstruction);
 
-  let recentBlockhash = await provider.connection.getRecentBlockhash(
+  let recentBlockhash = await provider.connection.getLatestBlockhash(
     "confirmed",
   );
   transaction.feePayer = payerPubkey;


### PR DESCRIPTION
Problem:
- sometimes ci tests fail for transaction confirm timeout
- cause could be the use of deprecated the deprecated sendTransction method
Solution:
- replaced deprecated method calls