### PR TITLE
zk.js: user - unshield unified sol and spl recipient

### DIFF
--- a/light-system-programs/tests/user_tests.ts
+++ b/light-system-programs/tests/user_tests.ts
@@ -7,15 +7,9 @@ const chaiAsPromised = require("chai-as-promised");
 chai.use(chaiAsPromised);
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
 let circomlibjs = require("circomlibjs");
-
-// TODO: add and use  namespaces in SDK
 import {
-  setUpMerkleTree,
-  initLookUpTableFromFile,
   ADMIN_AUTH_KEYPAIR,
-  MINT,
   Provider,
-  newAccountWithTokens,
   createTestAccounts,
   confirmConfig,
   User,
@@ -38,7 +32,6 @@ import { BN } from "@coral-xyz/anchor";
 var POSEIDON;
 var RELAYER: TestRelayer, provider: Provider, user: User;
 
-// TODO: remove deprecated function calls
 describe("Test User", () => {
   // Configure the client to use the local cluster.
   process.env.ANCHOR_WALLET = process.env.HOME + "/.config/solana/id.json";
@@ -81,10 +74,6 @@ describe("Test User", () => {
   });
 
   it.skip("(user class) shield SPL random infinite", async () => {
-    const getRandomElement = () => {
-      const randomIndex = parseInt(Math.floor(Math.random() * 7).toString());
-      return randomIndex;
-    };
     var expectedSpentUtxosLength = 0;
     var expectedUtxoHistoryLength = 1;
     var totalSplAmount = 0;
@@ -137,6 +126,7 @@ describe("Test User", () => {
       expectedUtxoHistoryLength++;
     }
   });
+
   it("(user class) shield SPL", async () => {
     var expectedSpentUtxosLength = 0;
     var expectedUtxoHistoryLength = 1;
@@ -210,14 +200,6 @@ describe("Test User", () => {
       recipientSpl: solRecipient.publicKey,
       expectedUtxoHistoryLength: 1,
     };
-    // TODO: add test case for if recipient doesnt have account yet -> relayer must create it
-    await newAccountWithTokens({
-      connection: provider.provider.connection,
-      MINT,
-      ADMIN_AUTH_KEYPAIR: userKeypair,
-      userAccount: solRecipient,
-      amount: new anchor.BN(0),
-    });
 
     const testStateValidator = new TestStateValidator({
       userSender: user,
@@ -231,7 +213,7 @@ describe("Test User", () => {
     await user.unshield({
       publicAmountSpl: testInputs.amountSpl,
       token: testInputs.token,
-      recipientSpl: testInputs.recipientSpl,
+      recipient: testInputs.recipientSpl,
     });
 
     await user.provider.latestMerkleTree();

--- a/light-zk.js/src/constants.ts
+++ b/light-zk.js/src/constants.ts
@@ -95,12 +95,11 @@ export const DEFAULT_PROGRAMS = {
   clock: SYSVAR_CLOCK_PUBKEY,
 };
 
-// TODO: adjust according to relayer fees
 // recommented minimum amount of lamports to be able to pay for transaction fees
-// needs to be more than 100k to be rentexempt
-export const MINIMUM_LAMPORTS = 150_000;
+// needs to be more than 890_880 to be rentexempt
+export const MINIMUM_LAMPORTS = new anchor.BN(890_880 + 150_000);
 
-export const TOKEN_ACCOUNT_FEE = 500_000;
+export const TOKEN_ACCOUNT_FEE = new anchor.BN(1_461_600 + 5000);
 
 // TODO: make account object with important accounts
 export const MESSAGE_MERKLE_TREE_KEY = new PublicKey(

--- a/light-zk.js/src/relayer.ts
+++ b/light-zk.js/src/relayer.ts
@@ -32,7 +32,7 @@ export class Relayer {
     lookUpTable: PublicKey,
     relayerRecipientSol?: PublicKey,
     relayerFee: BN = new BN(0),
-    highRelayerFee: BN = new BN(TOKEN_ACCOUNT_FEE),
+    highRelayerFee: BN = TOKEN_ACCOUNT_FEE,
   ) {
     if (!relayerPubkey) {
       throw new RelayerError(

--- a/light-zk.js/src/test-utils/airdrop.ts
+++ b/light-zk.js/src/test-utils/airdrop.ts
@@ -122,7 +122,7 @@ export async function airdropShieldedMINTSpl({
     await airdropSplToAssociatedTokenAccount(
       provider.provider!.connection,
       1_000_000_000_000 ? amount : 1_000_000_000_000,
-      ADMIN_AUTH_KEYPAIR.publicKey,
+      ADMIN_AUTH_KEYPAIR,
     );
   }
 
@@ -135,23 +135,23 @@ export async function airdropShieldedMINTSpl({
   });
 }
 
-async function airdropSplToAssociatedTokenAccount(
+export async function airdropSplToAssociatedTokenAccount(
   connection: Connection,
   amount: number,
-  authorityPublicKey: PublicKey,
+  payer: Keypair,
 ) {
   let tokenAccount = await getOrCreateAssociatedTokenAccount(
     connection,
     ADMIN_AUTH_KEYPAIR,
     MINT,
-    authorityPublicKey,
+    payer.publicKey,
   );
   await mintTo(
     connection,
     ADMIN_AUTH_KEYPAIR,
     MINT,
     tokenAccount.address,
-    authorityPublicKey,
+    ADMIN_AUTH_KEYPAIR.publicKey,
     amount,
     [],
   );

--- a/light-zk.js/src/wallet/provider.ts
+++ b/light-zk.js/src/wallet/provider.ts
@@ -27,6 +27,7 @@ import {
   RELAYER_RECIPIENT_KEYPAIR,
   IndexedTransaction,
   MINT,
+  MINIMUM_LAMPORTS,
 } from "../index";
 
 const axios = require("axios");
@@ -72,7 +73,7 @@ export class Provider {
     confirmConfig,
     connection,
     url = "http://127.0.0.1:8899",
-    minimumLamports = new BN(5000 * 30),
+    minimumLamports = MINIMUM_LAMPORTS,
     relayer,
     verifierProgramLookupTable,
     assetLookupTable,

--- a/light-zk.js/src/wallet/user.ts
+++ b/light-zk.js/src/wallet/user.ts
@@ -657,14 +657,12 @@ export class User {
   async unshield({
     token,
     publicAmountSpl,
-    recipientSpl = AUTHORITY,
     publicAmountSol,
-    recipientSol = AUTHORITY,
+    recipient = AUTHORITY,
     minimumLamports = true,
   }: {
     token: string;
-    recipientSpl?: PublicKey;
-    recipientSol?: PublicKey;
+    recipient?: PublicKey;
     publicAmountSpl?: number | BN | string;
     publicAmountSol?: number | BN | string;
     minimumLamports?: boolean;
@@ -672,9 +670,8 @@ export class User {
     await this.createUnshieldTransactionParameters({
       token,
       publicAmountSpl,
-      recipientSpl,
       publicAmountSol,
-      recipientSol,
+      recipient,
       minimumLamports,
     });
 
@@ -696,14 +693,12 @@ export class User {
   async createUnshieldTransactionParameters({
     token,
     publicAmountSpl,
-    recipientSpl = AUTHORITY,
     publicAmountSol,
-    recipientSol = AUTHORITY,
+    recipient = AUTHORITY,
     minimumLamports = true,
   }: {
     token: string;
-    recipientSpl?: PublicKey;
-    recipientSol?: PublicKey;
+    recipient?: PublicKey;
     publicAmountSpl?: number | BN | string;
     publicAmountSol?: number | BN | string;
     minimumLamports?: boolean;
@@ -722,13 +717,13 @@ export class User {
         "unshield",
         "Need to provide at least one amount for an unshield",
       );
-    if (publicAmountSol && recipientSol.toBase58() == AUTHORITY.toBase58())
+    if (publicAmountSol && recipient.toBase58() == AUTHORITY.toBase58())
       throw new UserError(
         TransactionErrorCode.SOL_RECIPIENT_UNDEFINED,
         "getTxParams",
         "no recipient provided for sol unshield",
       );
-    if (publicAmountSpl && recipientSpl.toBase58() == AUTHORITY.toBase58())
+    if (publicAmountSpl && recipient.toBase58() == AUTHORITY.toBase58())
       throw new UserError(
         TransactionErrorCode.SPL_RECIPIENT_UNDEFINED,
         "getTxParams",
@@ -736,10 +731,10 @@ export class User {
       );
 
     let ataCreationFee = false;
-
-    if (!tokenCtx.isNative && publicAmountSpl) {
+    let recipientSpl = undefined;
+    if (publicAmountSpl) {
       let tokenBalance = await this.provider.connection?.getTokenAccountBalance(
-        recipientSpl,
+        recipient,
       );
       if (!tokenBalance?.value.uiAmount) {
         /** Signal relayer to create the ATA and charge an extra fee for it */
@@ -747,7 +742,7 @@ export class User {
       }
       recipientSpl = splToken.getAssociatedTokenAddressSync(
         tokenCtx!.mint,
-        recipientSpl,
+        recipient,
       );
     }
 
@@ -785,7 +780,7 @@ export class User {
       account: this.account,
       utxos,
       publicAmountSol: _publicSolAmount,
-      recipientSol: recipientSol,
+      recipientSol: recipient,
       recipientSplAddress: recipientSpl,
       provider: this.provider,
       relayer: this.provider.relayer,

--- a/light-zk.js/tests/relayer.test.ts
+++ b/light-zk.js/tests/relayer.test.ts
@@ -4,7 +4,12 @@ import { Keypair as SolanaKeypair } from "@solana/web3.js";
 import * as anchor from "@coral-xyz/anchor";
 import { it } from "mocha";
 
-import { Relayer, RelayerError, RelayerErrorCode } from "../src";
+import {
+  Relayer,
+  RelayerError,
+  RelayerErrorCode,
+  TOKEN_ACCOUNT_FEE,
+} from "../src";
 
 process.env.ANCHOR_PROVIDER_URL = "http://127.0.0.1:8899";
 process.env.ANCHOR_WALLET = process.env.HOME + "/.config/solana/id.json";
@@ -53,7 +58,7 @@ describe("Test Relayer Functional", () => {
     let relayer = new Relayer(mockKeypair.publicKey, mockKeypair1.publicKey);
     assert.equal(relayer.relayerFee.toString(), "0");
     assert.equal(
-      new anchor.BN(500000).toNumber(),
+      TOKEN_ACCOUNT_FEE.toNumber(),
       relayer.getRelayerFee(true).toNumber(),
     );
     assert.equal(

--- a/relayer/tests/functional_test.ts
+++ b/relayer/tests/functional_test.ts
@@ -282,7 +282,7 @@ describe("API tests", () => {
     await user.unshield({
       publicAmountSol: amount,
       token,
-      recipientSol: recipient,
+      recipient,
     });
 
     await user.provider.latestMerkleTree();


### PR DESCRIPTION
Problem:
- unshield recipient arguments were confusing

Solution:
- take a recipient sol account and use the associated token account as destination for the spl unshield