### PR TITLE
merkle tree program - merkle tree update: removed logs

### DIFF
--- a/light-system-programs/programs/merkle_tree_program/src/transaction_merkle_tree/update_merkle_tree_lib/instructions.rs
+++ b/light-system-programs/programs/merkle_tree_program/src/transaction_merkle_tree/update_merkle_tree_lib/instructions.rs
@@ -12,18 +12,6 @@ pub fn insert_0_double(
     update_state_data.current_index = (merkle_tree_account.next_index as u64
         + update_state_data.insert_leaves_index as u64 * 2)
         / 2;
-    msg!(
-        "current index hash bytes: {}",
-        update_state_data.current_index
-    );
-    msg!(
-        "update_state_data.node_left: {:?}",
-        update_state_data.node_left
-    );
-    msg!(
-        "update_state_data.node_right: {:?}",
-        update_state_data.node_right
-    );
 
     if update_state_data.current_index == 262144 {
         msg!("Merkle tree full");
@@ -33,22 +21,11 @@ pub fn insert_0_double(
         [usize::try_from(update_state_data.insert_leaves_index).unwrap()][0];
     update_state_data.node_right = update_state_data.leaves
         [usize::try_from(update_state_data.insert_leaves_index).unwrap()][1];
-    msg!(
-        "update_state_data.node_left {:?}",
-        update_state_data.node_left
-    );
-    msg!(
-        "update_state_data.node_right {:?}",
-        update_state_data.node_right
-    );
 
     update_state_data.current_level = 1;
     // increase insert leaves index to insert the next leaf
     update_state_data.insert_leaves_index += 1;
-    msg!(
-        "update_state_data.insert_leaves_index {}",
-        update_state_data.insert_leaves_index
-    );
+
     update_state_data.tmp_leaves_index += 2;
 
     //zeroing out prior state since the account was used for prior computation
@@ -63,27 +40,10 @@ pub fn insert_1_inner_loop(
     merkle_tree_account: &mut RefMut<'_, TransactionMerkleTree>,
     update_state_data: &mut MerkleTreeUpdateState,
 ) -> Result<(), ProgramError> {
-    msg!(
-        "insert_1_inner_loop_0 level {:?}",
-        update_state_data.current_level
-    );
-    msg!(
-        "current_level_hash {:?}",
-        update_state_data.current_level_hash
-    );
     if update_state_data.current_level != 0 {
         update_state_data.current_level_hash = update_state_data.state[0..32].try_into().unwrap();
     }
-    msg!(
-        "update_state_data.current_index {}",
-        update_state_data.current_index
-    );
     if update_state_data.current_index % 2 == 0 {
-        msg!(
-            "updating subtree: {:?}",
-            update_state_data.current_level_hash
-        );
-
         update_state_data.node_left = update_state_data.current_level_hash;
         update_state_data.node_right =
             ZERO_BYTES_MERKLE_TREE_18[usize::try_from(update_state_data.current_level).unwrap()];
@@ -92,12 +52,6 @@ pub fn insert_1_inner_loop(
             update_state_data.current_level_hash;
         // check if there is another queued leaves pair
         if update_state_data.insert_leaves_index < update_state_data.number_of_leaves {
-            msg!(
-                "\n\nresetting current_instruction_index {} < {}\n\n",
-                update_state_data.insert_leaves_index,
-                update_state_data.number_of_leaves
-            );
-
             // reset current_instruction_index to 1 since the lock is already taken
             update_state_data.current_instruction_index = 1;
 
@@ -114,16 +68,6 @@ pub fn insert_1_inner_loop(
     }
     update_state_data.current_index /= 2;
     update_state_data.current_level += 1;
-    msg!("current_index {:?}", update_state_data.current_index);
-
-    msg!(
-        "update_state_data.node_left: {:?}",
-        update_state_data.node_left
-    );
-    msg!(
-        "update_state_data.node_right: {:?}",
-        update_state_data.node_right
-    );
     Ok(())
 }
 
@@ -134,19 +78,7 @@ pub fn insert_last_double(
     merkle_tree_account.current_root_index = (merkle_tree_account.current_root_index + 1)
         % u64::try_from(merkle_tree_account.roots.len()).unwrap();
 
-    msg!(
-        "merkle_tree_account.current_root_index {}",
-        merkle_tree_account.current_root_index
-    );
     merkle_tree_account.next_index = update_state_data.tmp_leaves_index;
-    msg!(
-        "merkle_tree_account.next_index {:?}",
-        merkle_tree_account.next_index
-    );
-    msg!(
-        "update_state_data.state[0..32].to_vec() {:?}",
-        update_state_data.state[0..32].to_vec()
-    );
     let index: usize = merkle_tree_account.current_root_index.try_into().unwrap();
 
     merkle_tree_account.roots[index] = update_state_data.state[0..32].try_into().unwrap();

--- a/light-system-programs/programs/merkle_tree_program/src/transaction_merkle_tree/update_merkle_tree_lib/instructions_poseidon.rs
+++ b/light-system-programs/programs/merkle_tree_program/src/transaction_merkle_tree/update_merkle_tree_lib/instructions_poseidon.rs
@@ -186,7 +186,6 @@ pub fn prepare_inputs(
         .chain(right_input.iter())
         .copied()
         .collect();
-    msg!("chained: {:?}", chained);
     let f_inputs = utils::to_field_elements(&chained).unwrap();
     if f_inputs.len() >= PoseidonCircomRounds3::WIDTH {
         panic!(


### PR DESCRIPTION
Problem:
- https://github.com/Lightprotocol/light-protocol/actions/runs/5281318114/jobs/9554721727?pr=145 ci tests failed because it ran out of compute units during merkle tree update
Solution:
- removed logs, which is lowest hanging fruit to save compute units