### PR TITLE
zk.js: merkle tree update added retry logic

### DIFF
--- a/light-system-programs/tests/merkle_tree_tests.ts
+++ b/light-system-programs/tests/merkle_tree_tests.ts
@@ -807,6 +807,7 @@ describe("Merkle Tree Tests", () => {
       connection: provider.connection,
       merkleTreeUpdateState,
       numberOfTransactions: 10,
+      interrupt: true
     });
     console.log("checkMerkleTreeUpdateStateCreated 22");
 
@@ -843,8 +844,9 @@ describe("Merkle Tree Tests", () => {
         connection: provider.connection,
         merkleTreeUpdateState,
         numberOfTransactions: 1,
+        interrupt: true
       });
-    } catch (err) {
+    } catch (err) {      
       error = err;
     }
     assert(

--- a/light-system-programs/tests/merkle_tree_tests.ts
+++ b/light-system-programs/tests/merkle_tree_tests.ts
@@ -807,7 +807,7 @@ describe("Merkle Tree Tests", () => {
       connection: provider.connection,
       merkleTreeUpdateState,
       numberOfTransactions: 10,
-      interrupt: true
+      interrupt: true,
     });
     console.log("checkMerkleTreeUpdateStateCreated 22");
 
@@ -844,9 +844,9 @@ describe("Merkle Tree Tests", () => {
         connection: provider.connection,
         merkleTreeUpdateState,
         numberOfTransactions: 1,
-        interrupt: true
+        interrupt: true,
       });
-    } catch (err) {      
+    } catch (err) {
       error = err;
     }
     assert(


### PR DESCRIPTION
Problem:
- merkle tree update is still flaky

Solution Attempt:
- did not crash during a 6h test in ci so hopefully this is a sustainable solution

- refactored merkle tree update compute instruction execution function
  - send 28 transactions (the exact amount of transactions to update the Merkle tree when inserting 1 pair of leaves)
  - check whether Merkle tree update is complete
  - if not send another 10 transactions
  - the update might not be complete after 28 transactions because it is a batched update the update (for more insertions we need to compute more hashes -> more transactions) or transactions failed
  - if a limit of 120 transactions is reached an error is thrown