### PR TITLE
zk.js: added confirm options

### DIFF
--- a/light-zk.js/src/relayer.ts
+++ b/light-zk.js/src/relayer.ts
@@ -1,4 +1,10 @@
-import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  RpcResponseAndContext,
+  SignatureResult,
+} from "@solana/web3.js";
 import { BN } from "@coral-xyz/anchor";
 import axios from "axios";
 import {
@@ -8,7 +14,15 @@ import {
   IndexedTransaction,
   TOKEN_ACCOUNT_FEE,
   LOOK_UP_TABLE,
+  ConfirmOptions,
+  SendVersionedTransactionsResult,
 } from "./index";
+
+export type RelayerSendTransactionsResponse =
+  SendVersionedTransactionsResult & {
+    transactionStatus: string;
+    rpcResponse?: RpcResponseAndContext<SignatureResult>;
+  };
 
 export class Relayer {
   accounts: {
@@ -88,10 +102,13 @@ export class Relayer {
     }
   }
 
-  async sendTransaction(instruction: any, provider: Provider): Promise<any> {
+  async sendTransactions(
+    instructions: any[],
+    provider: Provider,
+  ): Promise<RelayerSendTransactionsResponse> {
     try {
       const response = await axios.post(this.url + "/relayInstruction", {
-        instruction,
+        instructions,
       });
       return response.data.data;
     } catch (err) {

--- a/light-zk.js/src/test-utils/airdrop.ts
+++ b/light-zk.js/src/test-utils/airdrop.ts
@@ -10,6 +10,7 @@ import {
 import { Connection, Keypair, PublicKey } from "@solana/web3.js";
 import {
   ADMIN_AUTH_KEYPAIR,
+  ConfirmOptions,
   MINT,
   Provider,
   RELAYER_FEES,
@@ -132,6 +133,7 @@ export async function airdropShieldedMINTSpl({
     token: TOKEN_PUBKEY_SYMBOL.get(MINT.toBase58())!,
     recipient: recipientPublicKey,
     skipDecimalConversions: true,
+    confirmOptions: ConfirmOptions.spendable,
   });
 }
 

--- a/light-zk.js/src/test-utils/testRelayer.ts
+++ b/light-zk.js/src/test-utils/testRelayer.ts
@@ -1,15 +1,26 @@
-import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import {
+  BlockheightBasedTransactionConfirmationStrategy,
+  Connection,
+  Keypair,
+  PublicKey,
+  TransactionSignature,
+} from "@solana/web3.js";
 import { BN, BorshAccountsCoder } from "@coral-xyz/anchor";
-import { Relayer } from "../relayer";
+import { Relayer, RelayerSendTransactionsResponse } from "../relayer";
 import { updateMerkleTreeForTest } from "./updateMerkleTree";
-import { Provider } from "../wallet";
+import { ConfirmOptions, Provider } from "../wallet";
 import {
   indexRecentTransactions,
   sendVersionedTransaction,
+  sendVersionedTransactions,
 } from "../transaction";
 import { IndexedTransaction } from "../types";
 import { airdropSol } from "./airdrop";
-import { TRANSACTION_MERKLE_TREE_KEY, IDL_MERKLE_TREE_PROGRAM } from "../index";
+import {
+  TRANSACTION_MERKLE_TREE_KEY,
+  IDL_MERKLE_TREE_PROGRAM,
+  confirmConfig,
+} from "../index";
 
 export class TestRelayer extends Relayer {
   indexedTransactions: IndexedTransaction[] = [];
@@ -53,15 +64,13 @@ export class TestRelayer extends Relayer {
     }
   }
 
-  async sendTransaction(instruction: any, provider: Provider): Promise<any> {
-    try {
-      if (!provider.provider) throw new Error("no provider set");
-      const response = await sendVersionedTransaction(instruction, provider);
-      return response;
-    } catch (err) {
-      console.error("erorr here =========>", { err });
-      throw err;
-    }
+  async sendTransactions(
+    instructions: any[],
+    provider: Provider,
+  ): Promise<RelayerSendTransactionsResponse> {
+    var res = await sendVersionedTransactions(instructions, provider);
+    if (res.error) return { transactionStatus: "error", ...res };
+    else return { transactionStatus: "confirmed", ...res };
   }
 
   /**

--- a/light-zk.js/src/test-utils/testTransaction.ts
+++ b/light-zk.js/src/test-utils/testTransaction.ts
@@ -269,7 +269,7 @@ export class TestTransaction {
         await this.provider.provider!.connection.getAccountInfo(
           remainingAccounts.nullifierPdaPubkeys[i].pubkey,
           {
-            commitment: "confirmed",
+            commitment: "processed",
           },
         );
 
@@ -284,7 +284,7 @@ export class TestTransaction {
       leavesAccountData =
         await this.merkleTreeProgram.account.twoLeavesBytesPda.fetch(
           remainingAccounts.leavesPdaPubkeys[i / 2].pubkey,
-          "confirmed",
+          "processed",
         );
 
       assert.equal(

--- a/light-zk.js/src/transaction/transactionParameters.ts
+++ b/light-zk.js/src/transaction/transactionParameters.ts
@@ -6,7 +6,6 @@ import {
   AUTHORITY,
   MESSAGE_MERKLE_TREE_KEY,
   TRANSACTION_MERKLE_TREE_KEY,
-  verifierProgramZeroProgramId,
   verifierProgramStorageProgramId,
 } from "../constants";
 import { N_ASSET_PUBKEYS, Utxo } from "../utxo";
@@ -33,9 +32,7 @@ import {
   lightAccounts,
   IDL_VERIFIER_PROGRAM_ZERO,
   AppUtxoConfig,
-  validateUtxoAmounts,
   createOutUtxos,
-  IDL_VERIFIER_PROGRAM_ONE,
 } from "../index";
 import nacl from "tweetnacl";
 import { sha256 } from "@noble/hashes/sha256";
@@ -679,8 +676,8 @@ export class TransactionParameters implements transactionParameters {
 
   static async getTxParams({
     tokenCtx,
-    publicAmountSpl,
-    publicAmountSol,
+    publicAmountSpl = new BN(0),
+    publicAmountSol = new BN(0),
     action,
     userSplAccount = AUTHORITY,
     account,
@@ -728,9 +725,6 @@ export class TransactionParameters implements transactionParameters {
     assetLookupTable: string[];
     verifierProgramLookupTable: string[];
   }): Promise<TransactionParameters> {
-    publicAmountSol = publicAmountSol ? publicAmountSol : new BN(0);
-    publicAmountSpl = publicAmountSpl ? publicAmountSpl : new BN(0);
-
     if (action === Action.TRANSFER && !outUtxos && !mergeUtxos)
       throw new TransactioParametersError(
         UserErrorCode.SHIELDED_RECIPIENT_UNDEFINED,
@@ -772,6 +766,7 @@ export class TransactionParameters implements transactionParameters {
           TransactionParameters.getVerifierConfig(verifierIdl).in,
       });
     }
+
     if (addOutUtxos) {
       outputUtxos = createOutUtxos({
         publicMint: tokenCtx.mint,

--- a/light-zk.js/src/wallet/buildBalance.ts
+++ b/light-zk.js/src/wallet/buildBalance.ts
@@ -63,6 +63,7 @@ export class TokenUtxoBalance {
     this[attribute].set(commitment, utxo);
 
     if (attribute === ("utxos" as VariableType) && !utxoExists) {
+      this.committedUtxos.delete(commitment);
       this.totalBalanceSol = this.totalBalanceSol.add(utxo.amounts[0]);
       if (utxo.amounts[1])
         this.totalBalanceSpl = this.totalBalanceSpl.add(utxo.amounts[1]);
@@ -70,28 +71,13 @@ export class TokenUtxoBalance {
     return !utxoExists;
   }
 
-  // movetToCommittedUtxos(commitment: string) {
-  //   let utxo = this.utxos.get(commitment);
-  //   if (!utxo)
-  //     throw new TokenUtxoBalanceError(
-  //       TokenUtxoBalanceErrorCode.UTXO_UNDEFINED,
-  //       "moveToCommittedUtxos",
-  //       `utxo with committment ${commitment} does not exist in utxos`,
-  //     );
-  //   this.totalBalanceSol = this.totalBalanceSol.sub(utxo.amounts[0]);
-  //   if (utxo.amounts[1])
-  //     this.totalBalanceSpl = this.totalBalanceSpl.sub(utxo.amounts[1]);
-  //   this.committedUtxos.set(commitment, utxo);
-  //   this.utxos.delete(commitment);
-  // }
-
-  movetToSpentUtxos(commitment: string) {
+  moveToSpentUtxos(commitment: string) {
     let utxo = this.utxos.get(commitment);
     if (!utxo)
       throw new TokenUtxoBalanceError(
         TokenUtxoBalanceErrorCode.UTXO_UNDEFINED,
-        "movetToSpentUtxos",
-        `utxo with committment ${commitment} does not exist in committed utxos`,
+        "moveToSpentUtxos",
+        `utxo with committment ${commitment} does not exist in utxos`,
       );
     this.totalBalanceSol = this.totalBalanceSol.sub(utxo.amounts[0]);
     if (utxo.amounts[1])
@@ -272,8 +258,7 @@ export async function decryptAddUtxoToBalance({
         tokenBalanceUsdc,
       );
     }
-    const assetKey =
-      decryptedUtxo.assets[queuedLeavesPdaExists ? 1 : assetIndex].toBase58();
+    const assetKey = decryptedUtxo.assets[assetIndex].toBase58();
     const utxoType = queuedLeavesPdaExists
       ? "committedUtxos"
       : nullifierExists

--- a/light-zk.js/src/wallet/selectInUtxos.ts
+++ b/light-zk.js/src/wallet/selectInUtxos.ts
@@ -111,12 +111,6 @@ const selectBiggestSmallest = (
           // add utxo
           selectedUtxos.push(filteredUtxos[utxo]);
         }
-      } else {
-        if (selectedUtxosAmount.lt(sumOutSpl)) {
-          throw new Error(
-            `Could not find a utxo combination for spl token ${mint} and amount ${sumOutSpl}`,
-          );
-        }
       }
     }
   }
@@ -291,16 +285,13 @@ export function selectInUtxos({
           );
 
         // if a sol utxo was found replace small spl utxo
-        if (selectedUtxo1.length === 0)
-          throw new SelectInUtxosError(
-            SelectInUtxosErrorCode.FAILED_TO_SELECT_SOL_UTXO,
-            "selectInUtxos",
-            `Failed to select a sol utxo sumOutSol ${sumOutSol}, sumInSol ${sumInSol}`,
-          );
-        if (selectedUtxosR.length == numberMaxInUtxos) {
+        if (
+          (selectedUtxo1.length !== 0,
+          selectedUtxosR.length == numberMaxInUtxos)
+        ) {
           // overwrite existing utxo
           selectedUtxosR[1] = selectedUtxo1[0];
-        } else {
+        } else if (selectedUtxo1.length !== 0) {
           // add utxo
           selectedUtxosR.push(selectedUtxo1[0]);
         }

--- a/light-zk.js/tests/balance.test.ts
+++ b/light-zk.js/tests/balance.test.ts
@@ -64,7 +64,7 @@ describe("Utxo Functional", () => {
     });
   });
 
-  it("Test Balance movetToSpentUtxos", async () => {
+  it("Test Balance moveToSpentUtxos", async () => {
     let balance: Balance = {
       tokenBalances: new Map([
         [SystemProgram.programId.toBase58(), TokenUtxoBalance.initSol()],
@@ -109,7 +109,7 @@ describe("Utxo Functional", () => {
 
     balance.tokenBalances
       .get(MINT.toBase58())
-      ?.movetToSpentUtxos(deposit_utxo1.getCommitment(poseidon));
+      ?.moveToSpentUtxos(deposit_utxo1.getCommitment(poseidon));
     assert.equal(
       balance.tokenBalances.get(MINT.toBase58())?.totalBalanceSol.toString(),
       "0",

--- a/relayer/runScript.sh
+++ b/relayer/runScript.sh
@@ -1,4 +1,51 @@
-#!/bin/bash -e
-../../solana/validator/solana-test-validator     --reset     --limit-ledger-size 500000000 --faucet-port 9002 --rpc-port 8899  --bpf-program J1RRetZ4ujphU75LP8RadjXMf3sA12yC2R44CF7PmU7i ../light-system-programs/target/deploy/verifier_program_zero.so     --bpf-program JA5cjkRJ1euVi9xLWsCJVzsRzEkT8vcC4rqw9sVAo5d6 ../light-system-programs/target/deploy/merkle_tree_program.so     --bpf-program 3KS2k14CmtnuVv2fvYcvdrNgC94Y11WETBpMUGgXyWZL ../light-system-programs/target/deploy/verifier_program_one.so --bpf-program noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV ../../solana/web3.js/test/fixtures/noop-program/solana_sbf_rust_noop.so --bpf-program Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS ../light-system-programs/target/deploy/verifier_program_storage.so --quiet & 
-sleep 7
+#!/bin/bash
+
+set -eux
+
+LIMIT_LEDGER_SIZE=500000000
+
+NOOP_PROGRAM_ID="noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV"
+MERKLE_TREE_PROGRAM_ID="JA5cjkRJ1euVi9xLWsCJVzsRzEkT8vcC4rqw9sVAo5d6"
+VERIFIER_PROGRAM_ZERO_ID="J1RRetZ4ujphU75LP8RadjXMf3sA12yC2R44CF7PmU7i"
+VERIFIER_PROGRAM_STORAGE_ID="DJpbogMSrK94E1zvvJydtkqoE4sknuzmMRoutd6B7TKj"
+VERIFIER_PROGRAM_ONE_ID="3KS2k14CmtnuVv2fvYcvdrNgC94Y11WETBpMUGgXyWZL"
+
+solana config set --url http://localhost:8899
+
+if [ -f /.dockerenv ]; then
+    solana-test-validator \
+        --reset \
+        --limit-ledger-size=$LIMIT_LEDGER_SIZE \
+        --quiet \
+        --bpf-program $NOOP_PROGRAM_ID ~/.local/light-protocol/lib/solana-program-library/spl_noop.so \
+        --bpf-program $MERKLE_TREE_PROGRAM_ID ../light-system-programs/target/deploy/merkle_tree_program.so \
+        --bpf-program $VERIFIER_PROGRAM_ZERO_ID ../light-system-programs/target/deploy/verifier_program_zero.so \
+        --bpf-program $VERIFIER_PROGRAM_STORAGE_ID ../light-system-programs/target/deploy/verifier_program_storage.so \
+        --bpf-program $VERIFIER_PROGRAM_ONE_ID ../light-system-programs/target/deploy/verifier_program_one.so \
+        --account-dir ../accounts \
+        &
+    PID=$!
+
+    sleep 7
+else
+    docker rm -f solana-validator || true
+    docker run -d \
+        --name solana-validator \
+        --net=host \
+        --pull=always \
+        -v $HOME/.config/solana/id.json:/home/node/.config/solana/id.json \
+        -v $(git rev-parse --show-toplevel)/light-system-programs/target/deploy:/home/node/.local/light-protocol/lib/light-protocol-onchain \
+        ghcr.io/lightprotocol/solana-test-validator:main \
+        --reset \
+        --limit-ledger-size=$LIMIT_LEDGER_SIZE \
+        --quiet \
+        --bpf-program $NOOP_PROGRAM_ID /home/node/.local/light-protocol/lib/solana-program-library/spl_noop.so \
+        --bpf-program $MERKLE_TREE_PROGRAM_ID /home/node/.local/light-protocol/lib/light-protocol/merkle_tree_program.so \
+        --bpf-program $VERIFIER_PROGRAM_ZERO_ID /home/node/.local/light-protocol/lib/light-protocol/verifier_program_zero.so \
+        --bpf-program $VERIFIER_PROGRAM_STORAGE_ID /home/node/.local/light-protocol/lib/light-protocol/verifier_program_storage.so \
+        --bpf-program $VERIFIER_PROGRAM_ONE_ID /home/node/.local/light-protocol/lib/light-protocol/verifier_program_one.so \
+        --account-dir /home/node/.local/light-protocol/lib/accounts
+
+    sleep 15
+fi
 solana airdrop 100000 ZBUKxVWviAJBy12edp5H6kvhcatGYW3BV4ijbgxpVSq && solana airdrop 100000 ALA2cnz41Wa2v2EYUdkYHsg7VnKsbH1j7secM5aiP8k && solana airdrop 100000 8Ers2bBEWExdrh7KDFTrRbauPbFeEvsHz3UX4vxcK9xY && solana airdrop 10000 BEKmoiPHRUxUPik2WQuKqkoFLLkieyNPrTDup5h8c9S7

--- a/relayer/src/index.ts
+++ b/relayer/src/index.ts
@@ -23,7 +23,7 @@ app.get("/merkletree", initMerkleTree);
 
 app.get("/lookuptable", initLookupTable);
 
-app.post("/relayInstruction", sendTransaction);
+app.post("/relayTransaction", sendTransaction);
 
 app.get("/indexedTransactions", indexedTransactions);
 

--- a/relayer/tests/functional_test.ts
+++ b/relayer/tests/functional_test.ts
@@ -47,7 +47,7 @@ app.use(addCorsHeadersStub);
 app.post("/updatemerkletree", updateMerkleTree);
 app.get("/merkletree", initMerkleTree);
 app.get("/lookuptable", initLookupTable);
-app.post("/relayInstruction", sendTransaction);
+app.post("/relayTransaction", sendTransaction);
 app.get("/indexedTransactions", indexedTransactions);
 
 describe("API tests", () => {
@@ -314,12 +314,12 @@ describe("API tests", () => {
     );
   });
 
-  it("Should fail transaction with empty instruction", (done) => {
-    const instruction = {}; // Replace with a valid instruction object
+  it("Should fail transaction with empty instructions", (done) => {
+    const instructions = [{}]; // Replace with a valid instruction object
     chai
       .request(app)
-      .post("/relayInstruction")
-      .send({ instruction })
+      .post("/relayTransaction")
+      .send({ instructions })
       .end((err, res) => {
         expect(res).to.have.status(500);
         assert.isTrue(


### PR DESCRIPTION
Problem:
- user shield/transfer/unshield wait for merkle tree to update which takes a couple seconds while the transaction is already finalized

Solution:
- add two confirm options:
  - finalized (utxos are spend and new utxos are queued but not inserted into the merkle tree yet)
    -> transaction is final but new utxos are not spendable yet
  - spendable (utxos are spent and new utxos are spendable -> have been inserted into the merkle tree)