### PR TITLE
tests: Fix connection to validator container on macOS hosts

### DIFF
--- a/light-system-programs/runTest.sh
+++ b/light-system-programs/runTest.sh
@@ -33,8 +33,22 @@ else
     docker rm -f solana-validator || true
     docker run -d \
         --name solana-validator \
-        --net=host \
         --pull=always \
+        -p 8899:8899 \
+        -p 8900:8900 \
+        -p 8901:8901 \
+        -p 8902:8902 \
+        -p 9900:9900 \
+        -p 8000:8000 \
+        -p 8001:8001 \
+        -p 8002:8002 \
+        -p 8003:8003 \
+        -p 8004:8004 \
+        -p 8005:8005 \
+        -p 8006:8006 \
+        -p 8007:8007 \
+        -p 8008:8008 \
+        -p 8009:8009 \
         -v $HOME/.config/solana/id.json:/home/node/.config/solana/id.json \
         -v $(pwd)/target/deploy:/home/node/.local/light-protocol/lib/light-protocol \
         -v $(pwd)/../accounts:/home/node/.local/light-protocol/lib/accounts \

--- a/light-system-programs/runTestNoAccounts.sh
+++ b/light-system-programs/runTestNoAccounts.sh
@@ -32,8 +32,22 @@ else
     docker rm -f solana-validator || true
     docker run -d \
         --name solana-validator \
-        --net=host \
         --pull=always \
+        -p 8899:8899 \
+        -p 8900:8900 \
+        -p 8901:8901 \
+        -p 8902:8902 \
+        -p 9900:9900 \
+        -p 8000:8000 \
+        -p 8001:8001 \
+        -p 8002:8002 \
+        -p 8003:8003 \
+        -p 8004:8004 \
+        -p 8005:8005 \
+        -p 8006:8006 \
+        -p 8007:8007 \
+        -p 8008:8008 \
+        -p 8009:8009 \
         -v $HOME/.config/solana/id.json:/home/node/.config/solana/id.json \
         -v $(pwd)/target/deploy:/home/node/.local/light-protocol/lib/light-protocol \
         ghcr.io/lightprotocol/solana-test-validator:main \

--- a/mock-app-verifier/runTest.sh
+++ b/mock-app-verifier/runTest.sh
@@ -37,8 +37,22 @@ else
     docker rm -f solana-validator || true
     docker run -d \
         --name solana-validator \
-        --net=host \
         --pull=always \
+        -p 8899:8899 \
+        -p 8900:8900 \
+        -p 8901:8901 \
+        -p 8902:8902 \
+        -p 9900:9900 \
+        -p 8000:8000 \
+        -p 8001:8001 \
+        -p 8002:8002 \
+        -p 8003:8003 \
+        -p 8004:8004 \
+        -p 8005:8005 \
+        -p 8006:8006 \
+        -p 8007:8007 \
+        -p 8008:8008 \
+        -p 8009:8009 \
         -v $HOME/.config/solana/id.json:/root/.config/solana/id.json \
         -v $(git rev-parse --show-toplevel)/light-system-programs/target/deploy:/home/node/.local/light-protocol/lib/light-protocol-onchain \
         -v $(pwd)/target/deploy:/home/node/.local/light-protocol/lib/mock-app-verifier \

--- a/relayer/runTest.sh
+++ b/relayer/runTest.sh
@@ -32,8 +32,22 @@ else
     docker rm -f solana-validator || true
     docker run -d \
         --name solana-validator \
-        --net=host \
         --pull=always \
+        -p 8899:8899 \
+        -p 8900:8900 \
+        -p 8901:8901 \
+        -p 8902:8902 \
+        -p 9900:9900 \
+        -p 8000:8000 \
+        -p 8001:8001 \
+        -p 8002:8002 \
+        -p 8003:8003 \
+        -p 8004:8004 \
+        -p 8005:8005 \
+        -p 8006:8006 \
+        -p 8007:8007 \
+        -p 8008:8008 \
+        -p 8009:8009 \
         -v $HOME/.config/solana/id.json:/home/node/.config/solana/id.json \
         -v $(git rev-parse --show-toplevel)/light-system-programs/target/deploy:/home/node/.local/light-protocol/lib/light-protocol-onchain \
         ghcr.io/lightprotocol/solana-test-validator:main \


### PR DESCRIPTION
Docker on macOS doesn't support the `--net=host` option. And using it is a bad practice anyway. Instead of doing that, map all the ports that solana-test-validator listens to directly to the host.