### PR TITLE
zk.js - utxo encryption & decryption: set env correctly for aes

### DIFF
--- a/light-zk.js/src/utils.ts
+++ b/light-zk.js/src/utils.ts
@@ -38,6 +38,8 @@ const { keccak_256 } = require("@noble/hashes/sha3");
 import { Decimal } from "decimal.js";
 import { SPL_NOOP_PROGRAM_ID } from "@solana/spl-account-compression";
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
+const crypto = require("@noble/hashes/crypto");
+
 export function hashAndTruncateToCircuit(data: Uint8Array) {
   return new BN(
     keccak_256
@@ -389,4 +391,17 @@ export async function initLookUpTable(
 
 export function toSnakeCase(str: string): string {
   return str.replace(/-/g, "_");
+}
+
+// setting environment correctly for ethereum-crypto
+export function setEnvironment() {
+  if (
+    typeof process !== "undefined" &&
+    process.versions != null &&
+    process.versions.node != null
+  ) {
+    crypto.node = require("crypto");
+  } else {
+    crypto.web = window.crypto;
+  }
 }

--- a/light-zk.js/src/utxo.ts
+++ b/light-zk.js/src/utxo.ts
@@ -13,13 +13,7 @@ import { PublicKey, SystemProgram } from "@solana/web3.js";
 var ffjavascript = require("ffjavascript");
 const { unstringifyBigInts, leInt2Buff } = ffjavascript.utils;
 
-import {
-  AccountClient,
-  ACCOUNT_DISCRIMINATOR_SIZE,
-  BN,
-  BorshAccountsCoder,
-  Idl,
-} from "@coral-xyz/anchor";
+import { BN, BorshAccountsCoder, Idl } from "@coral-xyz/anchor";
 import { assert } from "chai";
 import {
   UtxoError,
@@ -37,6 +31,7 @@ import {
   ENCRYPTED_COMPRESSED_UTXO_BYTES_LENGTH,
   NACL_ENCRYPTED_COMPRESSED_UTXO_BYTES_LENGTH,
   fetchVerifierByIdLookUp,
+  setEnvironment,
 } from "./index";
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
 
@@ -611,6 +606,7 @@ export class Utxo {
           "For aes encryption the transaction index is necessary to derive the viewingkey",
         );
 
+      setEnvironment();
       const iv16 = nonce.slice(0, 16);
       const ciphertext = await encrypt(
         bytes_message,
@@ -689,7 +685,7 @@ export class Utxo {
       if (compressed) {
         encBytes = encBytes.slice(0, ENCRYPTED_COMPRESSED_UTXO_BYTES_LENGTH);
       }
-
+      setEnvironment();
       const iv16 = commitment.slice(0, 16);
 
       try {


### PR DESCRIPTION
Problem:
- ethereum-crypto environment detection is not reliable

Solution:
- detect the environment differently and set env variables such that ethereum-crypto detects the env correctly
- add utils function which sets the crypto variables correctly
- set env in utxo.encrypt and utxo.decrypt

Note:
- this is not tested for a browser env
- let's merge it anyway but keep this in mind

Error:
```
TypeError: Cannot read properties of undefined (reading 'importKey')
      at getBrowserKey (node_modules/@lightprotocol/zk.js/node_modules/ethereum-cryptography/aes.js:33:42)
      at encrypt (node_modules/@lightprotocol/zk.js/node_modules/ethereum-cryptography/aes.js:41:36)
      at Utxo.<anonymous> (node_modules/@lightprotocol/zk.js/src/utxo.ts:615:39)
      at [Generator.next](http://generator.next/) (<anonymous>)
      at fulfilled (node_modules/@lightprotocol/zk.js/lib/utxo.js:28:58)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
```