### PR TITLE
zk.js - utxo encryption

### DIFF
--- a/light-system-programs/tests/functional_tests.ts
+++ b/light-system-programs/tests/functional_tests.ts
@@ -88,7 +88,6 @@ describe("verifier_program", () => {
     message,
     messageMerkleTreePubkey,
     senderSpl,
-    transactionNonce,
     shuffleEnabled = true,
     verifierIdl,
   }: {
@@ -97,7 +96,6 @@ describe("verifier_program", () => {
     message?: Buffer;
     messageMerkleTreePubkey?: anchor.web3.PublicKey;
     senderSpl: anchor.web3.PublicKey;
-    transactionNonce: number;
     shuffleEnabled: boolean;
     verifierIdl: Idl;
   }) => {
@@ -154,7 +152,6 @@ describe("verifier_program", () => {
       lookUpTable: LOOK_UP_TABLE,
       action: Action.SHIELD,
       poseidon: POSEIDON,
-      transactionNonce,
       verifierIdl: verifierIdl,
     });
     let transactionTester = new TestTransaction({
@@ -189,7 +186,6 @@ describe("verifier_program", () => {
       delegate: AUTHORITY_ONE,
       spl: true,
       senderSpl: userTokenAccount,
-      transactionNonce: TRANSACTION_NONCE,
       shuffleEnabled: true,
       verifierIdl: IDL_VERIFIER_PROGRAM_ONE,
     });
@@ -202,7 +198,6 @@ describe("verifier_program", () => {
       message: Buffer.alloc(900).fill(1),
       messageMerkleTreePubkey: MESSAGE_MERKLE_TREE_KEY,
       senderSpl: null,
-      transactionNonce: TRANSACTION_NONCE,
       shuffleEnabled: false,
       verifierIdl: IDL_VERIFIER_PROGRAM_STORAGE,
     });
@@ -213,7 +208,6 @@ describe("verifier_program", () => {
       delegate: AUTHORITY,
       spl: true,
       senderSpl: userTokenAccount,
-      transactionNonce: TRANSACTION_NONCE,
       shuffleEnabled: true,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
@@ -230,7 +224,6 @@ describe("verifier_program", () => {
     message,
     messageMerkleTreePubkey,
     recipientSpl,
-    transactionNonce,
     shuffleEnabled = true,
     verifierIdl,
   }: {
@@ -239,7 +232,6 @@ describe("verifier_program", () => {
     message?: Buffer;
     messageMerkleTreePubkey?: anchor.web3.PublicKey;
     recipientSpl?: anchor.web3.PublicKey;
-    transactionNonce: number;
     shuffleEnabled: boolean;
     verifierIdl: Idl;
   }) => {
@@ -270,7 +262,6 @@ describe("verifier_program", () => {
       relayer: RELAYER,
       action: Action.UNSHIELD,
       poseidon: POSEIDON,
-      transactionNonce,
       verifierIdl: verifierIdl,
     });
 
@@ -303,7 +294,6 @@ describe("verifier_program", () => {
       outputUtxos: [],
       tokenProgram: MINT,
       recipientSpl: recipientTokenAccount,
-      transactionNonce: TRANSACTION_NONCE,
       shuffleEnabled: false,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
@@ -315,7 +305,6 @@ describe("verifier_program", () => {
       tokenProgram: SystemProgram.programId,
       message: Buffer.alloc(900).fill(1),
       messageMerkleTreePubkey: MESSAGE_MERKLE_TREE_KEY,
-      transactionNonce: TRANSACTION_NONCE,
       shuffleEnabled: false,
       verifierIdl: IDL_VERIFIER_PROGRAM_STORAGE,
     });
@@ -347,7 +336,6 @@ describe("verifier_program", () => {
       ],
       tokenProgram: MINT,
       recipientSpl: recipientTokenAccount,
-      transactionNonce: TRANSACTION_NONCE,
       shuffleEnabled: true,
       verifierIdl: IDL_VERIFIER_PROGRAM_ONE,
     });

--- a/light-system-programs/tests/merkle_tree_tests.ts
+++ b/light-system-programs/tests/merkle_tree_tests.ts
@@ -631,7 +631,6 @@ describe("Merkle Tree Tests", () => {
       action: Action.SHIELD,
       lookUpTable: LOOK_UP_TABLE,
       poseidon: POSEIDON,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
     var transaction = new Transaction({

--- a/light-system-programs/tests/provider.test.ts
+++ b/light-system-programs/tests/provider.test.ts
@@ -159,7 +159,6 @@ describe("verifier_program", () => {
       poseidon: POSEIDON,
       lookUpTable: LOOK_UP_TABLE,
       action: Action.SHIELD,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
     let tx = new Transaction({

--- a/light-system-programs/tests/user_tests.ts
+++ b/light-system-programs/tests/user_tests.ts
@@ -281,7 +281,6 @@ describe("Test User", () => {
       recipient.publicKey,
     );
     assert.equal(recipientBalance, 0.5e9);
-    // user, 13.5e9 - 2* RELAYER.relayerFee.toNumber(), provider,Action.UNSHIELD, transactionNonce, userSeed
     await testStateValidatorUnshield.checkCommittedBalanceSpl();
   });
 

--- a/light-system-programs/tests/verifier_tests.ts
+++ b/light-system-programs/tests/verifier_tests.ts
@@ -131,7 +131,6 @@ describe("Verifier Zero and One Tests", () => {
         poseidon: POSEIDON,
         action: Action.SHIELD,
         lookUpTable: LOOK_UP_TABLE,
-        transactionNonce: 0,
         verifierIdl: VERIFIER_IDLS[verifier],
       });
 
@@ -174,7 +173,6 @@ describe("Verifier Zero and One Tests", () => {
         poseidon: POSEIDON,
         action: Action.SHIELD,
         lookUpTable: LOOK_UP_TABLE,
-        transactionNonce: 1,
         verifierIdl: VERIFIER_IDLS[verifier],
       });
 
@@ -206,7 +204,6 @@ describe("Verifier Zero and One Tests", () => {
         relayer: RELAYER,
         poseidon: POSEIDON,
         action: Action.UNSHIELD,
-        transactionNonce: 2,
         verifierIdl: VERIFIER_IDLS[verifier],
       });
       var tx = new Transaction({

--- a/light-zk.js/src/account.ts
+++ b/light-zk.js/src/account.ts
@@ -265,10 +265,10 @@ export class Account {
    */
   getAesUtxoViewingKey(
     merkleTreePdaPublicKey: PublicKey,
-    index: number,
+    salt: string,
   ): Uint8Array {
     return this.getDomainSeparatedAesSecretKey(
-      merkleTreePdaPublicKey.toBase58() + index.toString(),
+      merkleTreePdaPublicKey.toBase58() + salt.toString(),
     );
   }
 

--- a/light-zk.js/src/test-utils/functionalCircuit.ts
+++ b/light-zk.js/src/test-utils/functionalCircuit.ts
@@ -46,7 +46,6 @@ export async function functionalCircuitTest(
     lookUpTable: mockPubkey,
     action: Action.SHIELD,
     poseidon,
-    transactionNonce: 0,
     verifierIdl: verifierIdl,
   });
 

--- a/light-zk.js/src/test-utils/testStateValidator.ts
+++ b/light-zk.js/src/test-utils/testStateValidator.ts
@@ -891,10 +891,8 @@ export class TestStateValidator {
   async checkCommittedBalanceSpl() {
     if (this.tokenCtx.isNative)
       throw new Error("checkCommittedBalanceSpl is not implemented for sol");
-    let transactionNonce;
     if (this.testInputs.type !== Action.TRANSFER) {
       let balance = await this.sender.user.getBalance();
-      transactionNonce = this.sender.preShieldedBalance!.transactionNonce += 1;
       let numberOfUtxos = balance.tokenBalances.get(
         this.tokenCtx.mint.toBase58(),
       )?.utxos.size
@@ -907,11 +905,8 @@ export class TestStateValidator {
           .size,
         1,
       );
-      assert.equal(balance.transactionNonce, transactionNonce);
     } else {
       let balance = await this.recipient.user.getBalance();
-      transactionNonce =
-        this.recipient.preShieldedBalance!.transactionNonce += 1;
       let numberOfUtxos = balance.tokenBalances.get(
         this.tokenCtx.mint.toBase58(),
       )?.utxos.size
@@ -973,7 +968,6 @@ export class TestStateValidator {
         .size,
       1,
     );
-    assert.equal(balanceSpendable.transactionNonce, transactionNonce);
     if (this.testInputs.type === Action.SHIELD) {
       this.checkTokenShielded();
     } else if (this.testInputs.type === Action.TRANSFER) {

--- a/light-zk.js/src/test-utils/testTransaction.ts
+++ b/light-zk.js/src/test-utils/testTransaction.ts
@@ -312,7 +312,6 @@ export class TestTransaction {
           encBytes: this.params!.encryptedUtxos,
           account: account ? account : this.params!.outputUtxos![0].account,
           index: 0, // this is just a placeholder
-          transactionNonce: this.params!.transactionNonce,
           merkleTreePdaPublicKey: this.params!.accounts.transactionMerkleTree,
           commitment:
             j === 0

--- a/light-zk.js/src/transaction/transactionParameters.ts
+++ b/light-zk.js/src/transaction/transactionParameters.ts
@@ -59,7 +59,6 @@ export class TransactionParameters implements transactionParameters {
   assetPubkeysCircuit: string[];
   action: Action;
   ataCreationFee?: boolean;
-  transactionNonce: number;
   txIntegrityHash?: BN;
   verifierIdl: Idl;
   verifierProgramId: PublicKey;
@@ -81,7 +80,6 @@ export class TransactionParameters implements transactionParameters {
     action,
     lookUpTable,
     ataCreationFee,
-    transactionNonce,
     validateUtxos = true,
     verifierIdl,
   }: {
@@ -101,7 +99,6 @@ export class TransactionParameters implements transactionParameters {
     lookUpTable?: PublicKey;
     provider?: Provider;
     ataCreationFee?: boolean;
-    transactionNonce: number;
     validateUtxos?: boolean;
     verifierIdl: Idl;
   }) {
@@ -154,7 +151,6 @@ export class TransactionParameters implements transactionParameters {
     this.verifierProgramId =
       TransactionParameters.getVerifierProgramId(verifierIdl);
     this.verifierConfig = TransactionParameters.getVerifierConfig(verifierIdl);
-    this.transactionNonce = transactionNonce;
     this.message = message;
     this.verifierIdl = verifierIdl;
     this.poseidon = poseidon;
@@ -493,7 +489,6 @@ export class TransactionParameters implements transactionParameters {
       relayerFee: this.relayer.relayerFee,
       ...this,
       ...this.accounts,
-      transactionNonce: new BN(this.transactionNonce),
     };
     return await coder.encode("transactionParameters", preparedObject);
   }
@@ -691,7 +686,6 @@ export class TransactionParameters implements transactionParameters {
     relayer,
     provider,
     ataCreationFee, // associatedTokenAccount = ata
-    transactionNonce,
     appUtxo,
     addInUtxos = true,
     addOutUtxos = true,
@@ -715,7 +709,6 @@ export class TransactionParameters implements transactionParameters {
     provider: Provider;
     relayer?: Relayer;
     ataCreationFee?: boolean;
-    transactionNonce: number;
     appUtxo?: AppUtxoConfig;
     addInUtxos?: boolean;
     addOutUtxos?: boolean;
@@ -800,7 +793,6 @@ export class TransactionParameters implements transactionParameters {
       lookUpTable: provider.lookUpTable!,
       relayer: relayer,
       ataCreationFee,
-      transactionNonce,
       verifierIdl,
       message,
       messageMerkleTreePubkey: message ? MESSAGE_MERKLE_TREE_KEY : undefined,
@@ -1157,7 +1149,6 @@ export class TransactionParameters implements transactionParameters {
           await this.outputUtxos[utxo].encrypt(
             poseidon,
             this.accounts.transactionMerkleTree,
-            this.transactionNonce,
           ),
         );
       }

--- a/light-zk.js/tests/balance.test.ts
+++ b/light-zk.js/tests/balance.test.ts
@@ -69,9 +69,6 @@ describe("Utxo Functional", () => {
       tokenBalances: new Map([
         [SystemProgram.programId.toBase58(), TokenUtxoBalance.initSol()],
       ]),
-      transactionNonce: 0,
-      committedTransactionNonce: 0,
-      decryptionTransactionNonce: 0,
       totalSolBalance: new anchor.BN(0),
       programBalances: new Map(),
       nftBalances: new Map(),

--- a/light-zk.js/tests/circuits.test.ts
+++ b/light-zk.js/tests/circuits.test.ts
@@ -91,7 +91,6 @@ describe("Masp circuit tests", () => {
       lookUpTable: mockPubkey,
       action: Action.SHIELD,
       poseidon,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
 
@@ -103,7 +102,6 @@ describe("Masp circuit tests", () => {
       lookUpTable: mockPubkey,
       action: Action.SHIELD,
       poseidon,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
     lightProvider.solMerkleTree!.merkleTree = new MerkleTree(18, poseidon, [
@@ -132,7 +130,6 @@ describe("Masp circuit tests", () => {
       recipientSol: lightProvider.wallet.publicKey,
       action: Action.UNSHIELD,
       relayer,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
     appData = { testInput1: new anchor.BN(1), testInput2: new anchor.BN(1) };
@@ -154,7 +151,6 @@ describe("Masp circuit tests", () => {
       action: Action.UNSHIELD,
       poseidon,
       relayer,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_TWO,
     });
     txParamsPoolType = new TransactionParameters({
@@ -174,7 +170,6 @@ describe("Masp circuit tests", () => {
       action: Action.UNSHIELD,
       poseidon,
       relayer,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
     txParamsPoolTypeOut = new TransactionParameters({
@@ -194,7 +189,6 @@ describe("Masp circuit tests", () => {
       action: Action.UNSHIELD,
       poseidon,
       relayer,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
     txParamsOutApp = new TransactionParameters({
@@ -216,7 +210,6 @@ describe("Masp circuit tests", () => {
       poseidon,
       // automatic encryption for app utxos is not implemented
       encryptedUtxos: new Uint8Array(256).fill(1),
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
   });
@@ -708,7 +701,6 @@ describe("App system circuit tests", () => {
       lookUpTable: mockPubkey,
       action: Action.SHIELD,
       poseidon,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_TWO,
     });
 
@@ -736,7 +728,6 @@ describe("App system circuit tests", () => {
       action: Action.UNSHIELD,
       poseidon,
       relayer,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_TWO,
     });
   });

--- a/light-zk.js/tests/prover.test.ts
+++ b/light-zk.js/tests/prover.test.ts
@@ -84,7 +84,6 @@ describe("Test Prover Functional", () => {
       senderSpl: mockPubkey,
       senderSol: lightProvider.wallet?.publicKey,
       action: Action.SHIELD,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
     lightProvider.solMerkleTree!.merkleTree = new MerkleTree(18, poseidon, [
@@ -105,7 +104,6 @@ describe("Test Prover Functional", () => {
       recipientSol: lightProvider.wallet?.publicKey,
       action: Action.UNSHIELD,
       relayer,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
   });
@@ -197,7 +195,6 @@ describe("Test Prover Functional", () => {
       senderSpl: mockPubkey,
       senderSol: lightProvider.wallet?.publicKey,
       action: Action.SHIELD,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
       encryptedUtxos: new Uint8Array(256).fill(2),
     });

--- a/light-zk.js/tests/transaction.test.ts
+++ b/light-zk.js/tests/transaction.test.ts
@@ -80,7 +80,6 @@ describe("Transaction Error Tests", () => {
       senderSpl: mockPubkey,
       senderSol: lightProvider.wallet?.publicKey,
       action: Action.SHIELD,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
   });
@@ -153,7 +152,6 @@ describe("Transaction Error Tests", () => {
       senderSpl: mockPubkey,
       senderSol: mockPubkey,
       action: Action.SHIELD,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
     expect(() => {
@@ -178,7 +176,6 @@ describe("Transaction Error Tests", () => {
       senderSpl: mockPubkey,
       senderSol: mockPubkey,
       action: Action.SHIELD,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
     expect(() => {
@@ -328,7 +325,6 @@ describe("Transaction Functional Tests", () => {
       senderSpl: mockPubkey,
       senderSol: lightProvider.wallet?.publicKey,
       action: Action.SHIELD,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
     lightProvider.solMerkleTree!.merkleTree = new MerkleTree(18, poseidon, [
@@ -349,7 +345,6 @@ describe("Transaction Functional Tests", () => {
       recipientSol: lightProvider.wallet?.publicKey,
       action: Action.UNSHIELD,
       relayer,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
   });
@@ -372,7 +367,6 @@ describe("Transaction Functional Tests", () => {
       recipientSpl: mockPubkey,
       recipientSol: lightProvider.wallet?.publicKey,
       action: Action.UNSHIELD,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_STORAGE,
       messageMerkleTreePubkey: MESSAGE_MERKLE_TREE_KEY,
       relayer,
@@ -438,7 +432,6 @@ describe("Transaction Functional Tests", () => {
       poseidon,
       action: Action.UNSHIELD,
       relayer,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
 
@@ -562,7 +555,6 @@ describe("Transaction Functional Tests", () => {
       action: Action.UNSHIELD,
       relayer: relayerConst,
       encryptedUtxos: new Uint8Array(256).fill(1),
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
 
@@ -658,7 +650,6 @@ describe("Transaction Functional Tests", () => {
       action: Action.UNSHIELD,
       relayer: relayerConst,
       encryptedUtxos: new Uint8Array(256).fill(1),
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
     let tx = new Transaction({
@@ -707,7 +698,6 @@ describe("Transaction Functional Tests", () => {
       lookUpTable: lightProvider.lookUpTable,
       poseidon,
       action: Action.SHIELD,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_TWO,
     });
     expect(() => {
@@ -732,7 +722,6 @@ describe("Transaction Functional Tests", () => {
       lookUpTable: lightProvider.lookUpTable,
       poseidon,
       action: Action.SHIELD,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
     expect(() => {

--- a/light-zk.js/tests/transactionParameters.test.ts
+++ b/light-zk.js/tests/transactionParameters.test.ts
@@ -95,7 +95,6 @@ describe("Transaction Parameters Functional", () => {
       poseidon,
       action: Action.TRANSFER,
       relayer,
-      transactionNonce: 0,
       verifierIdl: VERIFIER_IDLS[j],
     });
 
@@ -227,7 +226,7 @@ describe("Transaction Parameters Functional", () => {
         poseidon,
         action: Action.TRANSFER,
         relayer,
-        transactionNonce: 0,
+
         verifierIdl: VERIFIER_IDLS[j],
       });
 
@@ -337,7 +336,7 @@ describe("Transaction Parameters Functional", () => {
         lookUpTable: lightProvider.lookUpTable,
         poseidon,
         action: Action.SHIELD,
-        transactionNonce: 0,
+
         verifierIdl: VERIFIER_IDLS[j],
       });
 
@@ -437,7 +436,7 @@ describe("Transaction Parameters Functional", () => {
         poseidon,
         action: Action.UNSHIELD,
         relayer,
-        transactionNonce: 0,
+
         verifierIdl: VERIFIER_IDLS[j],
       });
       assert.equal(params.action.toString(), Action.UNSHIELD.toString());
@@ -714,7 +713,7 @@ describe("Test General TransactionParameters Errors", () => {
           lookUpTable: lightProvider.lookUpTable,
           poseidon,
           action: Action.SHIELD,
-          transactionNonce: 0,
+
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -840,7 +839,6 @@ describe("Test TransactionParameters Transfer Errors", () => {
       poseidon,
       action: Action.TRANSFER,
       relayer,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
   });
@@ -854,7 +852,7 @@ describe("Test TransactionParameters Transfer Errors", () => {
           transactionMerkleTreePubkey: mockPubkey,
           poseidon,
           action: Action.TRANSFER,
-          transactionNonce: 0,
+
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -888,7 +886,6 @@ describe("Test TransactionParameters Transfer Errors", () => {
           poseidon,
           action: Action.TRANSFER,
           relayer,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -919,7 +916,6 @@ describe("Test TransactionParameters Transfer Errors", () => {
           poseidon,
           action: Action.TRANSFER,
           relayer,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -942,7 +938,6 @@ describe("Test TransactionParameters Transfer Errors", () => {
           action: Action.TRANSFER,
           recipientSpl: mockPubkey,
           relayer,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -965,7 +960,6 @@ describe("Test TransactionParameters Transfer Errors", () => {
           action: Action.TRANSFER,
           recipientSol: mockPubkey,
           relayer,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -988,7 +982,6 @@ describe("Test TransactionParameters Transfer Errors", () => {
           action: Action.TRANSFER,
           senderSol: mockPubkey,
           relayer,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1011,7 +1004,6 @@ describe("Test TransactionParameters Transfer Errors", () => {
           action: Action.TRANSFER,
           senderSpl: mockPubkey,
           relayer,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1061,7 +1053,6 @@ describe("Test TransactionParameters Deposit Errors", () => {
       lookUpTable: mockPubkey,
       poseidon,
       action: Action.SHIELD,
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
   });
@@ -1076,7 +1067,6 @@ describe("Test TransactionParameters Deposit Errors", () => {
           lookUpTable: lightProvider.lookUpTable,
           poseidon,
           action: Action.SHIELD,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1098,7 +1088,6 @@ describe("Test TransactionParameters Deposit Errors", () => {
           lookUpTable: lightProvider.lookUpTable,
           poseidon,
           action: Action.SHIELD,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1120,7 +1109,6 @@ describe("Test TransactionParameters Deposit Errors", () => {
           senderSol: mockPubkey,
           poseidon,
           action: Action.SHIELD,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1144,7 +1132,6 @@ describe("Test TransactionParameters Deposit Errors", () => {
           poseidon,
           action: Action.SHIELD,
           relayer,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1188,7 +1175,6 @@ describe("Test TransactionParameters Deposit Errors", () => {
           lookUpTable: lightProvider.lookUpTable,
           poseidon,
           action: Action.SHIELD,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1231,7 +1217,6 @@ describe("Test TransactionParameters Deposit Errors", () => {
           lookUpTable: lightProvider.lookUpTable,
           poseidon,
           action: Action.SHIELD,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1255,7 +1240,6 @@ describe("Test TransactionParameters Deposit Errors", () => {
           lookUpTable: lightProvider.lookUpTable,
           poseidon,
           action: Action.SHIELD,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1279,7 +1263,6 @@ describe("Test TransactionParameters Deposit Errors", () => {
           lookUpTable: lightProvider.lookUpTable,
           poseidon,
           action: Action.SHIELD,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1301,7 +1284,6 @@ describe("Test TransactionParameters Deposit Errors", () => {
           lookUpTable: lightProvider.lookUpTable,
           poseidon,
           action: Action.SHIELD,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1323,7 +1305,6 @@ describe("Test TransactionParameters Deposit Errors", () => {
           lookUpTable: lightProvider.lookUpTable,
           poseidon,
           action: Action.SHIELD,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1355,7 +1336,6 @@ describe("Test TransactionParameters Deposit Errors", () => {
         lookUpTable: lightProvider.lookUpTable,
         poseidon,
         action: Action.SHIELD,
-        transactionNonce: 0,
         verifierIdl: VERIFIER_IDLS[verifier],
       });
     }
@@ -1373,7 +1353,6 @@ describe("Test TransactionParameters Deposit Errors", () => {
           lookUpTable: lightProvider.lookUpTable,
           poseidon,
           action: Action.SHIELD,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1397,7 +1376,6 @@ describe("Test TransactionParameters Deposit Errors", () => {
           lookUpTable: lightProvider.lookUpTable,
           poseidon,
           action: Action.SHIELD,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1466,7 +1444,6 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
           poseidon,
           action: Action.UNSHIELD,
           relayer,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1488,7 +1465,6 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
           recipientSol: mockPubkey,
           poseidon,
           action: Action.UNSHIELD,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1534,7 +1510,6 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
           poseidon,
           action: Action.UNSHIELD,
           relayer,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1577,7 +1552,6 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
           poseidon,
           action: Action.UNSHIELD,
           relayer,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1602,7 +1576,6 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
           poseidon,
           action: Action.UNSHIELD,
           relayer,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1627,7 +1600,6 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
           poseidon,
           action: Action.UNSHIELD,
           relayer,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1660,7 +1632,6 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
         poseidon,
         action: Action.UNSHIELD,
         relayer,
-        transactionNonce: 0,
         verifierIdl: VERIFIER_IDLS[verifier],
       });
     }
@@ -1687,7 +1658,6 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
         poseidon,
         action: Action.UNSHIELD,
         relayer,
-        transactionNonce: 0,
         verifierIdl: VERIFIER_IDLS[verifier],
       });
     }
@@ -1706,7 +1676,6 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
           poseidon,
           action: Action.UNSHIELD,
           relayer,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })
@@ -1731,7 +1700,6 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
           poseidon,
           action: Action.UNSHIELD,
           relayer,
-          transactionNonce: 0,
           verifierIdl: VERIFIER_IDLS[verifier],
         });
       })

--- a/light-zk.js/tests/utxo.test.ts
+++ b/light-zk.js/tests/utxo.test.ts
@@ -121,12 +121,10 @@ describe("Utxo Functional", () => {
       const encBytes4 = await utxo4.encrypt(
         poseidon,
         TRANSACTION_MERKLE_TREE_KEY,
-        0,
       );
       const encBytes41 = await utxo4.encrypt(
         poseidon,
         TRANSACTION_MERKLE_TREE_KEY,
-        0,
       );
       assert.equal(encBytes4.toString(), encBytes41.toString());
       const utxo41 = await Utxo.decrypt({
@@ -139,7 +137,6 @@ describe("Utxo Functional", () => {
           "le",
           32,
         ),
-        transactionNonce: 0,
         assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
         verifierProgramLookupTable:
           lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -305,11 +302,7 @@ describe("Utxo Functional", () => {
     Utxo.equal(poseidon, utxo0, utxo1);
 
     // encrypt
-    const encBytes = await utxo1.encrypt(
-      poseidon,
-      TRANSACTION_MERKLE_TREE_KEY,
-      0,
-    );
+    const encBytes = await utxo1.encrypt(poseidon, TRANSACTION_MERKLE_TREE_KEY);
 
     // decrypt
     const utxo3 = await Utxo.decrypt({
@@ -318,7 +311,6 @@ describe("Utxo Functional", () => {
       account: inputs.keypair,
       index: inputs.index,
       merkleTreePdaPublicKey: TRANSACTION_MERKLE_TREE_KEY,
-      transactionNonce: 0,
       commitment: new anchor.BN(utxo1.getCommitment(poseidon)).toBuffer(
         "le",
         32,
@@ -349,7 +341,6 @@ describe("Utxo Functional", () => {
     const encBytesNacl = await receivingUtxo.encrypt(
       poseidon,
       TRANSACTION_MERKLE_TREE_KEY,
-      0,
     );
 
     // decrypt
@@ -359,7 +350,6 @@ describe("Utxo Functional", () => {
       account: inputs.keypair,
       index: inputs.index,
       merkleTreePdaPublicKey: TRANSACTION_MERKLE_TREE_KEY,
-      transactionNonce: 0,
       aes: false,
       commitment: new anchor.BN(receivingUtxo.getCommitment(poseidon)).toBuffer(
         "le",

--- a/mock-app-verifier/tests/functional_test.ts
+++ b/mock-app-verifier/tests/functional_test.ts
@@ -289,7 +289,6 @@ describe("Mock verifier functional", () => {
         ...new Uint8Array(240).fill(1),
         ...new Uint8Array(16).fill(0),
       ]), // manual padding required
-      transactionNonce: 0,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
 
@@ -346,7 +345,6 @@ describe("Mock verifier functional", () => {
       action: Action.UNSHIELD,
       poseidon,
       relayer: RELAYER,
-      transactionNonce: 1,
       verifierIdl: IDL_VERIFIER_PROGRAM_TWO,
     });
 

--- a/mock-app-verifier/tests/verifier_tests.ts
+++ b/mock-app-verifier/tests/verifier_tests.ts
@@ -39,7 +39,6 @@ import {
   useWallet,
   TestRelayer,
   IDL_VERIFIER_PROGRAM_TWO,
-  LOOK_UP_TABLE,
 } from "@lightprotocol/zk.js";
 
 import { IDL } from "../target/types/mock_verifier";
@@ -137,7 +136,6 @@ describe("Verifier Two test", () => {
         poseidon: POSEIDON,
         action: Action.SHIELD,
         lookUpTable: LOOK_UP_TABLE,
-        transactionNonce: 0,
         verifierIdl: VERIFIER_IDLS[verifier],
       });
 
@@ -181,7 +179,6 @@ describe("Verifier Two test", () => {
         poseidon: POSEIDON,
         action: Action.SHIELD,
         lookUpTable: LOOK_UP_TABLE,
-        transactionNonce: 1,
         verifierIdl: VERIFIER_IDLS[verifier],
       });
       const appParams = {
@@ -217,7 +214,6 @@ describe("Verifier Two test", () => {
         relayer: lightProviderWithdrawal.relayer,
         poseidon: POSEIDON,
         action: Action.UNSHIELD,
-        transactionNonce: 2,
         verifierIdl: VERIFIER_IDLS[verifier],
       });
       var tx = new Transaction({


### PR DESCRIPTION
Problem:
- transaction nonce as domain separator is unreliable because it is easy to produce situations in which the transaction nonce is not up to date

Solution:
- changed domain separator from transaction nonce to commitment hash
- removed transaction nonces completely

Note:
- this will be revisited when benchmarking performance of encryption
- we should also evaluate whether we want to switch from blake2b to a hdkf