### PR TITLE
zk.js - user - unshield: fixed associated token account creation

### DIFF
--- a/light-zk.js/src/wallet/user.ts
+++ b/light-zk.js/src/wallet/user.ts
@@ -724,14 +724,9 @@ export class User {
         tokenCtx!.mint,
         recipient,
       );
-
-      let tokenBalance =
-        await this.provider.provider!.connection?.getTokenAccountBalance(
-          recipientSpl,
-        );
-
-      if (!tokenBalance?.value.uiAmount) {
-        /** Signal relayer to create the ATA and charge an extra fee for it */
+      const tokenAccountInfo =
+        await this.provider.provider!.connection?.getAccountInfo(recipientSpl);
+      if (!tokenAccountInfo) {
         ataCreationFee = true;
       }
     }

--- a/light-zk.js/src/wallet/user.ts
+++ b/light-zk.js/src/wallet/user.ts
@@ -720,17 +720,20 @@ export class User {
     let ataCreationFee = false;
     let recipientSpl = undefined;
     if (publicAmountSpl) {
-      let tokenBalance = await this.provider.connection?.getTokenAccountBalance(
-        recipient,
-      );
-      if (!tokenBalance?.value.uiAmount) {
-        /** Signal relayer to create the ATA and charge an extra fee for it */
-        ataCreationFee = true;
-      }
       recipientSpl = splToken.getAssociatedTokenAddressSync(
         tokenCtx!.mint,
         recipient,
       );
+
+      let tokenBalance =
+        await this.provider.provider!.connection?.getTokenAccountBalance(
+          recipientSpl,
+        );
+
+      if (!tokenBalance?.value.uiAmount) {
+        /** Signal relayer to create the ATA and charge an extra fee for it */
+        ataCreationFee = true;
+      }
     }
 
     var _publicSplAmount: BN | undefined = undefined;


### PR DESCRIPTION
Problem:
- unshielding to a sol address which already has an initialized associated token account fails because it always tries to create a new token account

Solution:
- fix detection whether an associated token account already exists, thus don't try to create one when it already exists