### PR TITLE
tests: Run without Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ and development environment.
 First, install the dependencies (they are going to be installed in `.local`
 directory inside your repository clone):
 
-```bash
+```shell
 ./scripts/install.sh
 ```
 
 Then, optionally, you can activate the development environment:
 
-```bash
-source ./scripts/devenv.sh
+```shell
+. ./scripts/devenv.sh
 ```
 
 (The scripts mentioned later, like `./scripts/build.sh` or `./scripts/test.sh`

--- a/cli/scripts/runTest.sh
+++ b/cli/scripts/runTest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 set -eux
 

--- a/light-circuits/buildCircuit.sh
+++ b/light-circuits/buildCircuit.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -e
+#!/usr/bin/env sh
+
+set -e
+
 POWERS_OF_TAU=17 # circuit will support max 2^POWERS_OF_TAU constraints
 if [ ! -f ./ptau$POWERS_OF_TAU ]; then
   echo "Downloading powers of tau file"

--- a/light-system-programs/scripts/runTest.sh
+++ b/light-system-programs/scripts/runTest.sh
@@ -12,59 +12,19 @@ VERIFIER_PROGRAM_ONE_ID="J85SuNBBsba7FQS66BiBCQjiQrQTif7v249zL2ffmRZc"
 
 solana config set --url http://localhost:8899
 
-if [ -f /.dockerenv ]; then
-    solana-test-validator \
-        --reset \
-        --limit-ledger-size=$LIMIT_LEDGER_SIZE \
-        --quiet \
-        --bpf-program $NOOP_PROGRAM_ID ~/.local/light-protocol/lib/solana-program-library/spl_noop.so \
-        --bpf-program $MERKLE_TREE_PROGRAM_ID ./target/deploy/merkle_tree_program.so \
-        --bpf-program $VERIFIER_PROGRAM_ZERO_ID ./target/deploy/verifier_program_zero.so \
-        --bpf-program $VERIFIER_PROGRAM_STORAGE_ID ./target/deploy/verifier_program_storage.so \
-        --bpf-program $VERIFIER_PROGRAM_ONE_ID ./target/deploy/verifier_program_one.so \
-        --account-dir ../../test-env/accounts \
-        &
-    PID=$!
-    trap "kill $PID" EXIT
-
-    sleep 7
-    $1
-else
-    docker rm -f solana-validator || true
-    docker run -d \
-        --name solana-validator \
-        --pull=always \
-        -p 8899:8899 \
-        -p 8900:8900 \
-        -p 8901:8901 \
-        -p 8902:8902 \
-        -p 9900:9900 \
-        -p 8000:8000 \
-        -p 8001:8001 \
-        -p 8002:8002 \
-        -p 8003:8003 \
-        -p 8004:8004 \
-        -p 8005:8005 \
-        -p 8006:8006 \
-        -p 8007:8007 \
-        -p 8008:8008 \
-        -p 8009:8009 \
-        -v $HOME/.config/solana/id.json:/home/node/.config/solana/id.json \
-        -v $(pwd)/target/deploy:/home/node/.local/light-protocol/lib/light-protocol \
-        -v $(pwd)/../test-env/accounts:/home/node/.local/light-protocol/lib/accounts \
-        ghcr.io/lightprotocol/solana-test-validator:main \
-        --reset \
-        --limit-ledger-size=$LIMIT_LEDGER_SIZE \
-        --quiet \
-        --bpf-program $NOOP_PROGRAM_ID /home/node/.local/light-protocol/lib/solana-program-library/spl_noop.so \
-        --bpf-program $MERKLE_TREE_PROGRAM_ID /home/node/.local/light-protocol/lib/light-protocol/merkle_tree_program.so \
-        --bpf-program $VERIFIER_PROGRAM_ZERO_ID /home/node/.local/light-protocol/lib/light-protocol/verifier_program_zero.so \
-        --bpf-program $VERIFIER_PROGRAM_STORAGE_ID /home/node/.local/light-protocol/lib/light-protocol/verifier_program_storage.so \
-        --bpf-program $VERIFIER_PROGRAM_ONE_ID /home/node/.local/light-protocol/lib/light-protocol/verifier_program_one.so \
-        --account-dir /home/node/.local/light-protocol/lib/accounts
-    trap "docker rm -f solana-validator" EXIT
-
-    sleep 15
-    docker logs solana-validator
-    $1
-fi
+pkill solana-test-validator || true
+solana-test-validator \
+    --reset \
+    --limit-ledger-size=$LIMIT_LEDGER_SIZE \
+    --quiet \
+    --bpf-program $NOOP_PROGRAM_ID ~/.local/light-protocol/lib/solana-program-library/spl_noop.so \
+    --bpf-program $MERKLE_TREE_PROGRAM_ID ./target/deploy/merkle_tree_program.so \
+    --bpf-program $VERIFIER_PROGRAM_ZERO_ID ./target/deploy/verifier_program_zero.so \
+    --bpf-program $VERIFIER_PROGRAM_STORAGE_ID ./target/deploy/verifier_program_storage.so \
+    --bpf-program $VERIFIER_PROGRAM_ONE_ID ./target/deploy/verifier_program_one.so \
+    --account-dir ../test-env/accounts \
+    &
+PID=$!
+trap "kill $PID" EXIT
+sleep 7
+$1

--- a/light-system-programs/scripts/runTest.sh
+++ b/light-system-programs/scripts/runTest.sh
@@ -17,7 +17,7 @@ solana-test-validator \
     --reset \
     --limit-ledger-size=$LIMIT_LEDGER_SIZE \
     --quiet \
-    --bpf-program $NOOP_PROGRAM_ID ~/.local/light-protocol/lib/solana-program-library/spl_noop.so \
+    --bpf-program $NOOP_PROGRAM_ID ../test-env/programs/spl_noop.so \
     --bpf-program $MERKLE_TREE_PROGRAM_ID ./target/deploy/merkle_tree_program.so \
     --bpf-program $VERIFIER_PROGRAM_ZERO_ID ./target/deploy/verifier_program_zero.so \
     --bpf-program $VERIFIER_PROGRAM_STORAGE_ID ./target/deploy/verifier_program_storage.so \

--- a/light-system-programs/scripts/runTest.sh
+++ b/light-system-programs/scripts/runTest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 set -eux
 

--- a/light-system-programs/scripts/runTestNoAccounts.sh
+++ b/light-system-programs/scripts/runTestNoAccounts.sh
@@ -12,55 +12,18 @@ VERIFIER_PROGRAM_ONE_ID="J85SuNBBsba7FQS66BiBCQjiQrQTif7v249zL2ffmRZc"
 
 solana config set --url http://localhost:8899
 
-if [ -f /.dockerenv ]; then
-    solana-test-validator \
-        --reset \
-        --limit-ledger-size=$LIMIT_LEDGER_SIZE \
-        --quiet \
-        --bpf-program $NOOP_PROGRAM_ID ~/.local/light-protocol/lib/solana-program-library/spl_noop.so \
-        --bpf-program $MERKLE_TREE_PROGRAM_ID ./target/deploy/merkle_tree_program.so \
-        --bpf-program $VERIFIER_PROGRAM_ZERO_ID ./target/deploy/verifier_program_zero.so \
-        --bpf-program $VERIFIER_PROGRAM_STORAGE_ID ./target/deploy/verifier_program_storage.so \
-        --bpf-program $VERIFIER_PROGRAM_ONE_ID ./target/deploy/verifier_program_one.so \
-        &
-    PID=$!
-    trap "kill $PID" EXIT
-
-    sleep 7
-    $1
-else
-    docker rm -f solana-validator || true
-    docker run -d \
-        --name solana-validator \
-        --pull=always \
-        -p 8899:8899 \
-        -p 8900:8900 \
-        -p 8901:8901 \
-        -p 8902:8902 \
-        -p 9900:9900 \
-        -p 8000:8000 \
-        -p 8001:8001 \
-        -p 8002:8002 \
-        -p 8003:8003 \
-        -p 8004:8004 \
-        -p 8005:8005 \
-        -p 8006:8006 \
-        -p 8007:8007 \
-        -p 8008:8008 \
-        -p 8009:8009 \
-        -v $HOME/.config/solana/id.json:/home/node/.config/solana/id.json \
-        -v $(pwd)/target/deploy:/home/node/.local/light-protocol/lib/light-protocol \
-        ghcr.io/lightprotocol/solana-test-validator:main \
-        --reset \
-        --limit-ledger-size=$LIMIT_LEDGER_SIZE \
-        --quiet \
-        --bpf-program $NOOP_PROGRAM_ID /home/node/.local/light-protocol/lib/solana-program-library/spl_noop.so \
-        --bpf-program $MERKLE_TREE_PROGRAM_ID /home/node/.local/light-protocol/lib/light-protocol/merkle_tree_program.so \
-        --bpf-program $VERIFIER_PROGRAM_ZERO_ID /home/node/.local/light-protocol/lib/light-protocol/verifier_program_zero.so \
-        --bpf-program $VERIFIER_PROGRAM_STORAGE_ID /home/node/.local/light-protocol/lib/light-protocol/verifier_program_storage.so \
-        --bpf-program $VERIFIER_PROGRAM_ONE_ID /home/node/.local/light-protocol/lib/light-protocol/verifier_program_one.so
-    trap "docker rm -f solana-validator" EXIT
-
-    sleep 15
-    $1
-fi
+pkill solana-test-validator || true
+solana-test-validator \
+    --reset \
+    --limit-ledger-size=$LIMIT_LEDGER_SIZE \
+    --quiet \
+    --bpf-program $NOOP_PROGRAM_ID ~/.local/light-protocol/lib/solana-program-library/spl_noop.so \
+    --bpf-program $MERKLE_TREE_PROGRAM_ID ./target/deploy/merkle_tree_program.so \
+    --bpf-program $VERIFIER_PROGRAM_ZERO_ID ./target/deploy/verifier_program_zero.so \
+    --bpf-program $VERIFIER_PROGRAM_STORAGE_ID ./target/deploy/verifier_program_storage.so \
+    --bpf-program $VERIFIER_PROGRAM_ONE_ID ./target/deploy/verifier_program_one.so \
+    &
+PID=$!
+trap "kill $PID" EXIT
+sleep 7
+$1

--- a/light-system-programs/scripts/runTestNoAccounts.sh
+++ b/light-system-programs/scripts/runTestNoAccounts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 set -eux
 
@@ -15,15 +15,15 @@ solana config set --url http://localhost:8899
 pkill solana-test-validator || true
 solana-test-validator \
     --reset \
-    --limit-ledger-size=$LIMIT_LEDGER_SIZE \
+    --limit-ledger-size="${LIMIT_LEDGER_SIZE}" \
     --quiet \
-    --bpf-program $NOOP_PROGRAM_ID ../test-env/programs/spl_noop.so \
-    --bpf-program $MERKLE_TREE_PROGRAM_ID ./target/deploy/merkle_tree_program.so \
-    --bpf-program $VERIFIER_PROGRAM_ZERO_ID ./target/deploy/verifier_program_zero.so \
-    --bpf-program $VERIFIER_PROGRAM_STORAGE_ID ./target/deploy/verifier_program_storage.so \
-    --bpf-program $VERIFIER_PROGRAM_ONE_ID ./target/deploy/verifier_program_one.so \
+    --bpf-program "${NOOP_PROGRAM_ID}" ../test-env/programs/spl_noop.so \
+    --bpf-program "${MERKLE_TREE_PROGRAM_ID}" ./target/deploy/merkle_tree_program.so \
+    --bpf-program "${VERIFIER_PROGRAM_ZERO_ID}" ./target/deploy/verifier_program_zero.so \
+    --bpf-program "${VERIFIER_PROGRAM_STORAGE_ID}" ./target/deploy/verifier_program_storage.so \
+    --bpf-program "${VERIFIER_PROGRAM_ONE_ID}" ./target/deploy/verifier_program_one.so \
     &
-PID=$!
-trap "kill $PID" EXIT
+PID="${!}"
+trap "kill ${PID}" EXIT
 sleep 7
 $1

--- a/light-system-programs/scripts/runTestNoAccounts.sh
+++ b/light-system-programs/scripts/runTestNoAccounts.sh
@@ -17,7 +17,7 @@ solana-test-validator \
     --reset \
     --limit-ledger-size=$LIMIT_LEDGER_SIZE \
     --quiet \
-    --bpf-program $NOOP_PROGRAM_ID ~/.local/light-protocol/lib/solana-program-library/spl_noop.so \
+    --bpf-program $NOOP_PROGRAM_ID ../test-env/programs/spl_noop.so \
     --bpf-program $MERKLE_TREE_PROGRAM_ID ./target/deploy/merkle_tree_program.so \
     --bpf-program $VERIFIER_PROGRAM_ZERO_ID ./target/deploy/verifier_program_zero.so \
     --bpf-program $VERIFIER_PROGRAM_STORAGE_ID ./target/deploy/verifier_program_storage.so \

--- a/mock-app-verifier/runTest.sh
+++ b/mock-app-verifier/runTest.sh
@@ -14,6 +14,7 @@ MOCK_VERIFIER_PROGRAM_ID="Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
 solana config set --url http://localhost:8899
 
+pkill solana-test-validator || true
 solana-test-validator \
     --reset \
     --limit-ledger-size=$LIMIT_LEDGER_SIZE \

--- a/mock-app-verifier/runTest.sh
+++ b/mock-app-verifier/runTest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 set -eux
 

--- a/mock-app-verifier/scripts/buildCircuit.sh
+++ b/mock-app-verifier/scripts/buildCircuit.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env sh
+
+set -e
 
 POWERS_OF_TAU=17 # circuit will support max 2^POWERS_OF_TAU constraints
 mkdir -p build
@@ -17,4 +19,3 @@ ts-node ./scripts/createRustVerifyingKey.ts app verifier CIRCUIT_NAME # TODO: ne
 rm ./sdk/build-circuit/verifyingkey.json
 rm ./sdk/build-circuit/CIRCUIT_NAME.r1cs
 rm ./sdk/build-circuit/CIRCUIT_NAME.sym
-

--- a/relayer/runScript.sh
+++ b/relayer/runScript.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 set -eux
 

--- a/relayer/runTest.sh
+++ b/relayer/runTest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 set -eux
 
@@ -17,23 +17,23 @@ solana config set --url http://localhost:8899
 pkill solana-test-validator || true
 solana-test-validator \
     --reset \
-    --limit-ledger-size=$LIMIT_LEDGER_SIZE \
+    --limit-ledger-size="${LIMIT_LEDGER_SIZE}" \
     --quiet \
-    --bpf-program $NOOP_PROGRAM_ID ../test-env/programs/spl_noop.so \
-    --bpf-program $MERKLE_TREE_PROGRAM_ID ../light-system-programs/target/deploy/merkle_tree_program.so \
-    --bpf-program $VERIFIER_PROGRAM_ZERO_ID ../light-system-programs/target/deploy/verifier_program_zero.so \
-    --bpf-program $VERIFIER_PROGRAM_STORAGE_ID ../light-system-programs/target/deploy/verifier_program_storage.so \
-    --bpf-program $VERIFIER_PROGRAM_ONE_ID ../light-system-programs/target/deploy/verifier_program_one.so \
-    --bpf-program $VERIFIER_PROGRAM_TWO_ID ../light-system-programs/target/deploy/verifier_program_two.so \
+    --bpf-program "${NOOP_PROGRAM_ID}" ../test-env/programs/spl_noop.so \
+    --bpf-program "${MERKLE_TREE_PROGRAM_ID}" ../light-system-programs/target/deploy/merkle_tree_program.so \
+    --bpf-program "${VERIFIER_PROGRAM_ZERO_ID}" ../light-system-programs/target/deploy/verifier_program_zero.so \
+    --bpf-program "${VERIFIER_PROGRAM_STORAGE_ID}" ../light-system-programs/target/deploy/verifier_program_storage.so \
+    --bpf-program "${VERIFIER_PROGRAM_ONE_ID}" ../light-system-programs/target/deploy/verifier_program_one.so \
+    --bpf-program "${VERIFIER_PROGRAM_TWO_ID}" ../light-system-programs/target/deploy/verifier_program_two.so \
     --account-dir ../test-env/accounts \
     &
-PID=$!
-trap "kill $PID" EXIT
+PID="${!}"
+trap "kill ${PID}" EXIT
 sleep 7
 
 node lib/index.js &
 relayer_pid=$!
-trap "kill $relayer_pid" EXIT
+trap "kill ${relayer_pid}" EXIT
 
 sleep 20
 

--- a/relayer/runTest.sh
+++ b/relayer/runTest.sh
@@ -14,7 +14,7 @@ MOCK_VERIFIER_PROGRAM_ID="Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
 solana config set --url http://localhost:8899
 
-
+pkill solana-test-validator || true
 solana-test-validator \
     --reset \
     --limit-ledger-size=$LIMIT_LEDGER_SIZE \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,52 +1,52 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -eux
 
 cleanup_and_install() {
-  if [ $# -ne 6 ]; then
+  if [ "${#}" -ne 6 ]; then
     echo "Usage: cleanup_and_install --dir <dir> --yarn <yarn_build> --anchor <anchor_build>"
     exit 1
   fi
-  while [ "$#" -gt 0 ]; do
-    case "$1" in
+  while [ "${#}" -gt 0 ]; do
+    case "${1}" in
       -d|--dir) 
-        dir="$2"
+        dir="${2}"
         shift 2
         ;;
       -y|--yarn) 
-        yarn="$2"
+        yarn="${2}"
         shift 2
         ;;
       -a|--anchor) 
-        anchor="$2"
+        anchor="${2}"
         shift 2
         ;;
       *)
-        echo "Unknown option: $1"
+        echo "Unknown option: ${1}"
         return 1
         ;;
     esac
   done
 
-  pushd $dir
+  cd "${dir}"
 
   for sub_dir in node_modules lib bin; do
-    if [ -d ./$sub_dir ]; then
-      rm -rf $sub_dir
+    if [ -d "./${sub_dir}" ]; then
+      rm -rf "${sub_dir}"
     fi
   done
 
   yarn install
 
-  if [ "$yarn" = true ] ; then
+  if [ "${yarn}" = true ] ; then
     yarn run build
   fi
 
-  if [ "$anchor" = true ] ; then
+  if [ "${anchor}" = true ] ; then
     light-anchor build
   fi
 
-  popd
+  cd ..
 }
 
 cleanup_and_install --dir "light-zk.js" --yarn true --anchor false

--- a/scripts/devenv.sh
+++ b/scripts/devenv.sh
@@ -21,16 +21,16 @@ PS1="[🧢 Light Protocol devenv] ${PS1:-}"
 
 # Ensure that our rustup environment is used.
 LIGHT_PROTOCOL_OLD_RUSTUP_HOME="${RUSTUP_HOME:-}"
-RUSTUP_HOME="$(git rev-parse --show-toplevel)/.local/rustup"
+RUSTUP_HOME="`git rev-parse --show-toplevel`/.local/rustup"
 LIGHT_PROTOCOL_OLD_CARGO_HOME="${CARGO_HOME:-}"
-CARGO_HOME="$(git rev-parse --show-toplevel)/.local/cargo"
+CARGO_HOME="`git rev-parse --show-toplevel`/.local/cargo"
 
 # Ensure that our npm prefix is used.
 LIGHT_PROTOCOL_OLD_NPM_CONFIG_PREFIX="${NPM_CONFIG_PREFIX:-}"
-NPM_CONFIG_PREFIX="$(git rev-parse --show-toplevel)/.local/npm-global"
+NPM_CONFIG_PREFIX="`git rev-parse --show-toplevel`/.local/npm-global"
 
 # Always use our binaries first.
 LIGHT_PROTOCOL_OLD_PATH="${PATH}"
-PATH="$(git rev-parse --show-toplevel)/.local/bin:$PATH"
-PATH="$(git rev-parse --show-toplevel)/.local/cargo/bin:$PATH"
-PATH="$(git rev-parse --show-toplevel)/.local/npm-global/bin:$PATH"
+PATH="`git rev-parse --show-toplevel`/.local/bin:$PATH"
+PATH="`git rev-parse --show-toplevel`/.local/cargo/bin:$PATH"
+PATH="`git rev-parse --show-toplevel`/.local/npm-global/bin:$PATH"

--- a/scripts/getAccountState.sh
+++ b/scripts/getAccountState.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-#!/bin/bash
+#!/usr/bin/env sh
 
 declare -A keys=(
     ["LOOK_UP_TABLE"]="DyZnme4h32E66deCvsAV6pVceVw8s6ucRhNcwoofVCem"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,7 @@
 set -eu
 
 PREFIX="${PWD}/.local"
+OS=`uname`
 ARCH=`uname -m`
 
 # Checks the latest release of the given GitHub repository.
@@ -91,24 +92,45 @@ if ! rustup toolchain list 2>/dev/null | grep -q "nightly"; then
     echo "    rustup toolchain install nightly" 
 fi
 
-case "${ARCH}" in
-    "x86_64")
-        ARCH_SUFFIX_SOLANA="x86_64-unknown-linux-gnu"
-        ARCH_SUFFIX_LP="linux-amd64"
-        ARCH_SUFFIX_NODE="linux-x64"
+case "${OS}" in
+    "Darwin")
+        case "${ARCH}" in
+            "x86_64")
+                ARCH_SUFFIX_SOLANA="x86_64-apple-darwin"
+                ARCH_SUFFIX_LP="macos-amd64"
+                ARCH_SUFFIX_NODE="darwin-x64"
+                ;;
+            "aarch64"|"arm64")
+                ARCH_SUFFIX_SOLANA="aarch64-apple-darwin"
+                ARCH_SUFFIX_LP="macos-arm64"
+                ARCH_SUFFIX_NODE="darwin-arm64"
+                ;;
+            "*")
+                echo "Architecture ${ARCH} on operating system ${OS} is not supported."
+                exit 1
+                ;;
+        esac
         ;;
-    "aarch64")
-        ARCH_SUFFIX_SOLANA="aarch64-unknown-linux-gnu"
-        ARCH_SUFFIX_LP="linux-arm64"
-        ARCH_SUFFIX_NODE="linux-arm64"
+    "Linux")
+        case "${ARCH}" in
+            "x86_64")
+                ARCH_SUFFIX_SOLANA="x86_64-unknown-linux-gnu"
+                ARCH_SUFFIX_LP="linux-amd64"
+                ARCH_SUFFIX_NODE="linux-x64"
+                ;;
+            "arch64"|"arm64")
+                ARCH_SUFFIX_SOLANA="aarch64-unknown-linux-gnu"
+                ARCH_SUFFIX_LP="linux-arm64"
+                ARCH_SUFFIX_NODE="linux-arm64"
+                ;;
+            "*")
+                echo "Architecture ${ARCH} on operating system ${OS} is not supported."
+                exit 1
+                ;;
+        esac
         ;;
-    "arm64")
-        ARCH_SUFFIX_SOLANA="aarch64-apple-darwin"
-        ARCH_SUFFIX_LP="macos-arm64"
-        ARCH_SUFFIX_NODE="darwin-arm64"
-        ;;
-    *)
-        echo "Architecture ${ARCH} is not supported."
+    "*")
+        echo "Operating system ${OS} is not supported."
         exit 1
         ;;
 esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,89 +1,89 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 set -eu
 
-PREFIX=$(pwd)/.local
-ARCH=$(uname -m)
+PREFIX="${PWD}/.local"
+ARCH=`uname -m`
 
 # Checks the latest release of the given GitHub repository.
-function latest_release() {
-    local OWNER="$1"
-    local REPO="$2"
+latest_release() {
+    local OWNER="${1}"
+    local REPO="${2}"
     local GITHUB="https://api.github.com"
 
-    local LATEST_RELEASE=$(curl -s $GITHUB/repos/$OWNER/$REPO/releases/latest)
+    local LATEST_RELEASE=`curl -s "${GITHUB}/repos/${OWNER}/${REPO}/releases/latest"`
 
     # Extract the tag name
-    local TAG_NAME=$(echo "$LATEST_RELEASE" | perl -ne 'print "$1\n" if /"tag_name":\s*"([^"]*)"/' | head -1)
+    local TAG_NAME=`echo "${LATEST_RELEASE}" | perl -ne 'print "${1}\n" if /"tag_name":\s*"([^"]*)"/' | head -1`
 
     echo "$TAG_NAME"
 }
 
 # Downloads a file from the given URL and places it in the given destination.
-function download_file() {
-    local url=$1
-    local dest_name=$2
-    local dest=$3
+download_file() {
+    local url="${1}"
+    local dest_name="${2}"
+    local dest="${3}"
 
     echo "📥 Downloading ${dest_name}"
-    curl -L -o ${dest}/${dest_name} ${url}
-    chmod +x ${dest}/${dest_name}
+    curl -L -o "${dest}/${dest_name}" "${url}"
+    chmod +x "${dest}/${dest_name}"
 }
 
 # Downloads a tarball from the given URL and extracts it to the given
 # destination.
-function download_and_extract() {
-    local archive_name=$1
-    local url=$2
-    local archive_type=$3
-    local dest=$4
-    local strip_components=${5:-0}
+download_and_extract() {
+    local archive_name="${1}"
+    local url="${2}"
+    local archive_type="${3}"
+    local dest="${4}"
+    local strip_components="${5:-0}"
 
     echo "📥 Downloading ${archive_name}"
-    curl -L ${url} | tar -x${archive_type}f - --strip-components ${strip_components} -C ${dest}
+    curl -L "${url}" | tar "-x${archive_type}f" - --strip-components "${strip_components}" -C "${dest}"
 }
 
 # Downloads a file from the given GitHub repository and places it in the given
 # destination.
-function download_file_github () {
-    local git_org=$1
-    local git_repo=$2
-    local git_release=$3
-    local src_name=$4
-    local dest_name=$5
-    local dest=$6
+download_file_github () {
+    local git_org="${1}"
+    local git_repo="${2}"
+    local git_release="${3}"
+    local src_name="${4}"
+    local dest_name="${5}"
+    local dest="${6}"
 
     download_file \
-        https://github.com/${git_org}/${git_repo}/releases/download/${git_release}/${src_name} \
-        ${dest_name} \
-        ${dest}
+        "https://github.com/${git_org}/${git_repo}/releases/download/${git_release}/${src_name}" \
+        "${dest_name}" \
+        "${dest}"
 }
 
 # Downloads a tarball from the given GitHub repository and extracts it to the
 # given destination.
-function download_and_extract_github () {
-    local git_org=$1
-    local git_repo=$2
-    local git_release=$3
-    local archive_name=$4
-    local archive_type=$5
-    local dest=$6
-    local strip_components=${7:-0}
+download_and_extract_github () {
+    local git_org="${1}"
+    local git_repo="${2}"
+    local git_release="${3}"
+    local archive_name="${4}"
+    local archive_type="${5}"
+    local dest="${6}"
+    local strip_components="${7:-0}"
 
     download_and_extract \
-        ${archive_name} \
-        https://github.com/${git_org}/${git_repo}/releases/download/${git_release}/${archive_name} \
-        ${archive_type} \
-        ${dest} \
-        ${strip_components}
+        "${archive_name}" \
+        "https://github.com/${git_org}/${git_repo}/releases/download/${git_release}/${archive_name}" \
+        "${archive_type}" \
+        "${dest}" \
+        "${strip_components}"
 }
 
 NODE_VERSION="16.20.1"
 SOLANA_VERSION="1.16.1"
-ANCHOR_VERSION=$(latest_release Lightprotocol anchor)
-CIRCOM_VERSION=$(latest_release Lightprotocol circom)
-MACRO_CIRCOM_VERSION=$(latest_release Lightprotocol macro-circom)
-LIGHT_PROTOCOL_VERSION=$(latest_release Lightprotocol light-protocol)
+ANCHOR_VERSION=`latest_release Lightprotocol anchor`
+CIRCOM_VERSION=`latest_release Lightprotocol circom`
+MACRO_CIRCOM_VERSION=`latest_release Lightprotocol macro-circom`
+LIGHT_PROTOCOL_VERSION=`latest_release Lightprotocol light-protocol`
 
 if ! rustup toolchain list 2>/dev/null | grep -q "nightly"; then
     echo "Rust nightly is not installed!"
@@ -91,7 +91,7 @@ if ! rustup toolchain list 2>/dev/null | grep -q "nightly"; then
     echo "    rustup toolchain install nightly" 
 fi
 
-case $ARCH in
+case "${ARCH}" in
     "x86_64")
         ARCH_SUFFIX_SOLANA="x86_64-unknown-linux-gnu"
         ARCH_SUFFIX_LP="linux-amd64"
@@ -108,36 +108,36 @@ case $ARCH in
         ARCH_SUFFIX_NODE="darwin-arm64"
         ;;
     *)
-        echo "Architecture $ARCH is not supported."
+        echo "Architecture ${ARCH} is not supported."
         exit 1
         ;;
 esac
 
-echo "🔍 Detected system $ARCH_SUFFIX_LP"
+echo "🔍 Detected system ${ARCH_SUFFIX_LP}"
 
-echo "📁 Creating directory $PREFIX"
+echo "📁 Creating directory ${PREFIX}"
 mkdir -p $PREFIX/bin/deps
 
 echo "🦀 Installing Rust"
-export RUSTUP_HOME=$PREFIX/rustup
-export CARGO_HOME=$PREFIX/cargo
+export RUSTUP_HOME="${PREFIX}/rustup"
+export CARGO_HOME="${PREFIX}/cargo"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     --no-modify-path # We want to control the PATH ourselves.
-source $CARGO_HOME/env
+. "${CARGO_HOME}/env"
 cargo install cargo-expand
 
 echo "📥 Downloading Node.js"
 download_and_extract \
-    node-v${NODE_VERSION}-${ARCH_SUFFIX_NODE}.tar.gz \
-    https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${ARCH_SUFFIX_NODE}.tar.gz \
+    "node-v${NODE_VERSION}-${ARCH_SUFFIX_NODE}.tar.gz" \
+    "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${ARCH_SUFFIX_NODE}.tar.gz" \
     z \
-    ${PREFIX} \
+    "${PREFIX}" \
     1
 
-NPM_DIR=$PREFIX/npm-global
-mkdir -p $NPM_DIR
-export PATH=$PREFIX/bin:$NPM_DIR/bin:$PATH
-export NPM_CONFIG_PREFIX=$NPM_DIR
+NPM_DIR="${PREFIX}/npm-global"
+mkdir -p "${NPM_DIR}"
+export PATH="${PREFIX}/bin:${NPM_DIR}/bin:${PATH}"
+export NPM_CONFIG_PREFIX="${NPM_DIR}"
 
 echo "📦 Installing yarn"
 npm install -g yarn
@@ -149,37 +149,37 @@ echo "📥 Downloading Solana toolchain"
 download_and_extract_github \
     solana-labs \
     solana \
-    v${SOLANA_VERSION} \
-    solana-release-${ARCH_SUFFIX_SOLANA}.tar.bz2 \
+    "v${SOLANA_VERSION}" \
+    "solana-release-${ARCH_SUFFIX_SOLANA}.tar.bz2" \
     j \
-    ${PREFIX}/bin \
+    "${PREFIX}/bin" \
     2
 
 echo "📥 Downloading Light Anchor"
 download_file_github \
     Lightprotocol \
     anchor \
-    ${ANCHOR_VERSION} \
-    light-anchor-${ARCH_SUFFIX_LP} \
+    "${ANCHOR_VERSION}" \
+    "light-anchor-${ARCH_SUFFIX_LP}" \
     light-anchor \
-    ${PREFIX}/bin
+    "${PREFIX}/bin"
 
 echo "📥 Downloading Circom"
 download_file_github \
     Lightprotocol \
     circom \
-    ${CIRCOM_VERSION} \
-    circom-${ARCH_SUFFIX_LP} \
+    "${CIRCOM_VERSION}" \
+    "circom-${ARCH_SUFFIX_LP}" \
     circom \
-    ${PREFIX}/bin
+    "${PREFIX}/bin"
 
 echo "📥 Downloading macro-circom"
 download_file_github \
     Lightprotocol \
     macro-circom \
-    ${MACRO_CIRCOM_VERSION} \
-    macro-circom-${ARCH_SUFFIX_LP} \
+    "${MACRO_CIRCOM_VERSION}" \
+    "macro-circom-${ARCH_SUFFIX_LP}" \
     macro-circom \
-    ${PREFIX}/bin
+    "${PREFIX}/bin"
 
 echo "✨ Light Protocol development dependencies installed"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,15 +1,15 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -e
 
-pushd light-system-programs
+cd light-system-programs
 yarn install
 yarn run lint
 cargo fmt --all -- --check
 cargo clippy --all -- -A clippy::result_large_err -D warnings
-popd
+cd ..
 
-pushd light-zk.js
+cd light-zk.js
 yarn install
 yarn run lint
-popd
+cd ..

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,28 +1,28 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -e
 
-$(dirname "${BASH_SOURCE[0]}")/build.sh
+`dirname "${0}"`/build.sh
 
-pushd light-system-programs
+cd light-system-programs
 yarn test
-popd
+cd ..
 
-pushd light-zk.js
+cd light-zk.js
 yarn test
 sleep 1
-popd
+cd ..
 
-pushd mock-app-verifier
+cd mock-app-verifier
 yarn test
-popd
+cd ..
 
-pushd relayer
+cd relayer
 yarn test
-popd
+cd ..
 
-pushd light-circuits
+cd light-circuits
 yarn run test
-popd
+cd ..
 
 # && cd programs/merkle_tree_program && cargo test


### PR DESCRIPTION
Since we have a reliable devenv which doesn't require containerization, stop using docker in `yarn *test*` commands.

This change doesn't impact devcontainer. It's affects only running tests on host systems, where Docker is not required anymore.