### PR TITLE
zk.js TestRelayer: make payer mandatory

### DIFF
--- a/light-system-programs/tests/functional_tests.ts
+++ b/light-system-programs/tests/functional_tests.ts
@@ -74,14 +74,13 @@ describe("verifier_program", () => {
       2_000_000_000,
     );
 
-    RELAYER = await new TestRelayer(
-      ADMIN_AUTH_KEYPAIR.publicKey,
-      LOOK_UP_TABLE,
+    RELAYER = await new TestRelayer({
+      relayerPubkey: ADMIN_AUTH_KEYPAIR.publicKey,
+      lookUpTable: LOOK_UP_TABLE,
       relayerRecipientSol,
-      new BN(100_000),
-      new BN(10_100_000),
-      ADMIN_AUTH_KEYPAIR,
-    );
+      relayerFee: new BN(100_000),
+      payer: ADMIN_AUTH_KEYPAIR,
+    });
   });
 
   const performDeposit = async ({

--- a/light-system-programs/tests/merkle_tree_tests.ts
+++ b/light-system-programs/tests/merkle_tree_tests.ts
@@ -91,12 +91,13 @@ describe("Merkle Tree Tests", () => {
       2_000_000_000,
     );
 
-    RELAYER = await new TestRelayer(
-      ADMIN_AUTH_KEYPAIR.publicKey,
-      LOOK_UP_TABLE,
+    RELAYER = new TestRelayer({
+      relayerPubkey: ADMIN_AUTH_KEYPAIR.publicKey,
+      lookUpTable: LOOK_UP_TABLE,
       relayerRecipientSol,
-      new anchor.BN(100000),
-    );
+      relayerFee: new anchor.BN(100_000),
+      payer: ADMIN_AUTH_KEYPAIR,
+    });
   });
 
   it("Initialize Merkle Tree Test", async () => {
@@ -731,7 +732,7 @@ describe("Merkle Tree Tests", () => {
             rent: DEFAULT_PROGRAMS.rent,
             transactionMerkleTree: TRANSACTION_MERKLE_TREE_KEY,
           })
-          .remainingAccounts(leavesPdas[1])
+          .remainingAccounts([leavesPdas[1]])
           .preInstructions([
             solana.ComputeBudgetProgram.setComputeUnitLimit({
               units: 1_400_000,

--- a/light-system-programs/tests/provider.test.ts
+++ b/light-system-programs/tests/provider.test.ts
@@ -76,14 +76,13 @@ describe("verifier_program", () => {
       2_000_000_000,
     );
 
-    RELAYER = await new TestRelayer(
-      userKeypair.publicKey,
-      LOOK_UP_TABLE,
+    RELAYER = new TestRelayer({
+      relayerPubkey: ADMIN_AUTH_KEYPAIR.publicKey,
+      lookUpTable: LOOK_UP_TABLE,
       relayerRecipientSol,
-      new BN(100000),
-      new BN(10_100_000),
-      userKeypair,
-    );
+      relayerFee: new anchor.BN(100_000),
+      payer: ADMIN_AUTH_KEYPAIR,
+    });
   });
 
   it("Provider", async () => {

--- a/light-system-programs/tests/user-merge-sol-specific.tests.ts
+++ b/light-system-programs/tests/user-merge-sol-specific.tests.ts
@@ -15,6 +15,7 @@ import {
   airdropShieldedSol,
   ADMIN_AUTH_KEY,
   airdropSol,
+  LOOK_UP_TABLE,
 } from "@lightprotocol/zk.js";
 
 import { BN } from "@coral-xyz/anchor";
@@ -57,14 +58,13 @@ describe("Test User", () => {
       recipientPublicKey: relayerRecipientSol,
     });
 
-    environmentConfig.relayer = new TestRelayer(
-      userKeypair.publicKey,
-      environmentConfig.lookUpTable,
+    environmentConfig.relayer = new TestRelayer({
+      relayerPubkey: ADMIN_AUTH_KEYPAIR.publicKey,
+      lookUpTable: LOOK_UP_TABLE,
       relayerRecipientSol,
-      new BN(100000),
-      new BN(10_100_000),
-      userKeypair,
-    );
+      relayerFee: new anchor.BN(100_000),
+      payer: ADMIN_AUTH_KEYPAIR,
+    });
 
     await airdropShieldedSol({
       seed: recipientSeed,

--- a/light-system-programs/tests/user-merge-sol.tests.ts
+++ b/light-system-programs/tests/user-merge-sol.tests.ts
@@ -63,14 +63,13 @@ describe("Test User", () => {
       recipientPublicKey: relayerRecipientSol,
     });
 
-    environmentConfig.relayer = new TestRelayer(
-      userKeypair.publicKey,
-      environmentConfig.lookUpTable,
+    environmentConfig.relayer = new TestRelayer({
+      relayerPubkey: ADMIN_AUTH_KEYPAIR.publicKey,
+      lookUpTable: LOOK_UP_TABLE,
       relayerRecipientSol,
-      new BN(100000),
-      new BN(10_100_000),
-      userKeypair,
-    );
+      relayerFee: new anchor.BN(100_000),
+      payer: ADMIN_AUTH_KEYPAIR,
+    });
 
     await airdropShieldedSol({
       seed: recipientSeed,

--- a/light-system-programs/tests/user-merge-spl-specific.tests.ts
+++ b/light-system-programs/tests/user-merge-spl-specific.tests.ts
@@ -15,6 +15,7 @@ import {
   MINT,
   airdropShieldedSol,
   airdropSol,
+  LOOK_UP_TABLE,
 } from "@lightprotocol/zk.js";
 
 import { BN } from "@coral-xyz/anchor";
@@ -58,14 +59,13 @@ describe("Test User", () => {
       recipientPublicKey: relayerRecipientSol,
     });
 
-    environmentConfig.relayer = new TestRelayer(
-      userKeypair.publicKey,
-      environmentConfig.lookUpTable,
+    environmentConfig.relayer = new TestRelayer({
+      relayerPubkey: ADMIN_AUTH_KEYPAIR.publicKey,
+      lookUpTable: LOOK_UP_TABLE,
       relayerRecipientSol,
-      new BN(100000),
-      new BN(10_100_000),
-      userKeypair,
-    );
+      relayerFee: new anchor.BN(100_000),
+      payer: ADMIN_AUTH_KEYPAIR,
+    });
 
     await airdropShieldedSol({
       seed: recipientSeed,

--- a/light-system-programs/tests/user-merge-spl.tests.ts
+++ b/light-system-programs/tests/user-merge-spl.tests.ts
@@ -12,6 +12,7 @@ import {
   Action,
   airdropSol,
   airdropShieldedMINTSpl,
+  LOOK_UP_TABLE,
 } from "@lightprotocol/zk.js";
 
 import { BN } from "@coral-xyz/anchor";
@@ -56,14 +57,13 @@ describe("Test User", () => {
       recipientPublicKey: relayerRecipientSol,
     });
 
-    environmentConfig.relayer = new TestRelayer(
-      userKeypair.publicKey,
-      environmentConfig.lookUpTable,
+    environmentConfig.relayer = new TestRelayer({
+      relayerPubkey: ADMIN_AUTH_KEYPAIR.publicKey,
+      lookUpTable: LOOK_UP_TABLE,
       relayerRecipientSol,
-      new BN(100000),
-      new BN(10_100_000),
-      userKeypair,
-    );
+      relayerFee: new anchor.BN(100_000),
+      payer: ADMIN_AUTH_KEYPAIR,
+    });
 
     await airdropShieldedMINTSpl({
       seed: recipientSeed,

--- a/light-system-programs/tests/user-merge.tests.ts
+++ b/light-system-programs/tests/user-merge.tests.ts
@@ -10,6 +10,7 @@ import {
   confirmConfig,
   TestRelayer,
   Action,
+  LOOK_UP_TABLE,
 } from "@lightprotocol/zk.js";
 
 import {
@@ -53,14 +54,13 @@ describe("Test User merge 1 sol utxo and one spl utxo in sequence ", () => {
       2_000_000_000,
     );
 
-    environmentConfig.relayer = new TestRelayer(
-      userKeypair.publicKey,
-      environmentConfig.lookUpTable,
+    environmentConfig.relayer = new TestRelayer({
+      relayerPubkey: ADMIN_AUTH_KEYPAIR.publicKey,
+      lookUpTable: LOOK_UP_TABLE,
       relayerRecipientSol,
-      new BN(100000),
-      new BN(10_100_000),
-      userKeypair,
-    );
+      relayerFee: new anchor.BN(100_000),
+      payer: ADMIN_AUTH_KEYPAIR,
+    });
   });
 
   it("(user class) shield SOL to recipient", async () => {

--- a/light-system-programs/tests/user-random.tests.ts
+++ b/light-system-programs/tests/user-random.tests.ts
@@ -18,6 +18,7 @@ import {
   airdropSplToAssociatedTokenAccount,
   convertAndComputeDecimals,
   TOKEN_REGISTRY,
+  ADMIN_AUTH_KEYPAIR,
 } from "@lightprotocol/zk.js";
 
 import { BN } from "@coral-xyz/anchor";
@@ -444,14 +445,13 @@ describe("Test User", () => {
       recipientPublicKey: relayerRecipientSol.publicKey,
     });
 
-    let relayer = new TestRelayer(
-      relayerKeypair.publicKey,
-      LOOK_UP_TABLE,
-      relayerRecipientSol.publicKey,
-      new BN(100000),
-      new BN(10_100_000),
-      relayerKeypair,
-    );
+    let relayer = new TestRelayer({
+      relayerPubkey: ADMIN_AUTH_KEYPAIR.publicKey,
+      lookUpTable: LOOK_UP_TABLE,
+      relayerRecipientSol: relayerRecipientSol.publicKey,
+      relayerFee: new anchor.BN(100_000),
+      payer: ADMIN_AUTH_KEYPAIR,
+    });
 
     let testUsers: { user: User; wallet: Keypair }[] = [];
     for (let user = 0; user < noUsers; user++) {

--- a/light-system-programs/tests/user_tests.ts
+++ b/light-system-programs/tests/user_tests.ts
@@ -57,14 +57,13 @@ describe("Test User", () => {
       2_000_000_000,
     );
 
-    RELAYER = new TestRelayer(
-      userKeypair.publicKey,
-      LOOK_UP_TABLE,
+    RELAYER = new TestRelayer({
+      relayerPubkey: ADMIN_AUTH_KEYPAIR.publicKey,
+      lookUpTable: LOOK_UP_TABLE,
       relayerRecipientSol,
-      new BN(100000),
-      new BN(10_100_000),
-      userKeypair,
-    );
+      relayerFee: new anchor.BN(100_000),
+      payer: ADMIN_AUTH_KEYPAIR,
+    });
     provider = await Provider.init({
       wallet: userKeypair,
       relayer: RELAYER,

--- a/light-system-programs/tests/verifier_tests.ts
+++ b/light-system-programs/tests/verifier_tests.ts
@@ -75,14 +75,13 @@ describe("Verifier Zero and One Tests", () => {
       2_000_000_000,
     );
 
-    RELAYER = await new TestRelayer(
-      ADMIN_AUTH_KEYPAIR.publicKey,
-      LOOK_UP_TABLE,
+    RELAYER = await new TestRelayer({
+      relayerPubkey: ADMIN_AUTH_KEYPAIR.publicKey,
+      lookUpTable: LOOK_UP_TABLE,
       relayerRecipientSol,
-      new BN(100000),
-      new BN(10_100_000),
-      ADMIN_AUTH_KEYPAIR,
-    );
+      relayerFee: new BN(100_000),
+      payer: ADMIN_AUTH_KEYPAIR,
+    });
 
     depositAmount =
       10_000 + (Math.floor(Math.random() * 1_000_000_000) % 1_100_000_000);

--- a/light-system-programs/tests/verifier_tests.ts
+++ b/light-system-programs/tests/verifier_tests.ts
@@ -75,7 +75,7 @@ describe("Verifier Zero and One Tests", () => {
       2_000_000_000,
     );
 
-    RELAYER = await new TestRelayer({
+    RELAYER = new TestRelayer({
       relayerPubkey: ADMIN_AUTH_KEYPAIR.publicKey,
       lookUpTable: LOOK_UP_TABLE,
       relayerRecipientSol,

--- a/light-verifier-sdk/Cargo.lock
+++ b/light-verifier-sdk/Cargo.lock
@@ -1489,13 +1489,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "light-account-compression"
-version = "0.1.0"
-dependencies = [
- "anchor-lang",
-]
-
-[[package]]
 name = "light-macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,7 +1598,6 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "getrandom 0.2.8",
- "light-account-compression",
  "light-macros",
  "light-merkle-tree",
  "solana-security-txt",

--- a/light-zk.js/src/test-utils/airdrop.ts
+++ b/light-zk.js/src/test-utils/airdrop.ts
@@ -37,16 +37,17 @@ export async function airdropShieldedSol({
     throw new Error(
       "Sol Airdrop seed and recipientPublicKey undefined define a seed to airdrop shielded sol aes encrypted, define a recipientPublicKey to airdrop shielded sol to the recipient nacl box encrypted",
     );
-  const RELAYER = await new TestRelayer(
-    ADMIN_AUTH_KEYPAIR.publicKey,
-    Keypair.generate().publicKey,
-    Keypair.generate().publicKey,
-    new BN(100000),
-  );
+  const relayer = await new TestRelayer({
+    relayerPubkey: ADMIN_AUTH_KEYPAIR.publicKey,
+    relayerRecipientSol: Keypair.generate().publicKey,
+    lookUpTable: Keypair.generate().publicKey,
+    relayerFee: new BN(100000),
+    payer: ADMIN_AUTH_KEYPAIR,
+  });
   if (!provider) {
     provider = await Provider.init({
       wallet: ADMIN_AUTH_KEYPAIR,
-      relayer: RELAYER,
+      relayer: relayer,
     });
   }
   const userKeypair = Keypair.generate();
@@ -102,16 +103,17 @@ export async function airdropShieldedMINTSpl({
     throw new Error(
       "Sol Airdrop seed and recipientPublicKey undefined define a seed to airdrop shielded sol aes encrypted, define a recipientPublicKey to airdrop shielded sol to the recipient nacl box encrypted",
     );
-  const RELAYER = await new TestRelayer(
-    ADMIN_AUTH_KEYPAIR.publicKey,
-    Keypair.generate().publicKey,
-    Keypair.generate().publicKey,
-    new BN(100000),
-  );
+  const relayer = await new TestRelayer({
+    relayerPubkey: ADMIN_AUTH_KEYPAIR.publicKey,
+    relayerRecipientSol: Keypair.generate().publicKey,
+    lookUpTable: Keypair.generate().publicKey,
+    relayerFee: new BN(100000),
+    payer: ADMIN_AUTH_KEYPAIR,
+  });
   if (!provider) {
     provider = await Provider.init({
       wallet: ADMIN_AUTH_KEYPAIR,
-      relayer: RELAYER,
+      relayer: relayer,
     });
   }
 

--- a/light-zk.js/src/transaction/sendVersionedTransaction.ts
+++ b/light-zk.js/src/transaction/sendVersionedTransaction.ts
@@ -115,6 +115,6 @@ export async function sendVersionedTransactions(
     }
     return { signatures };
   } catch (error) {
-    return { error: signature };
+    return { error };
   }
 }

--- a/mock-app-verifier/tests/functional_test.ts
+++ b/mock-app-verifier/tests/functional_test.ts
@@ -146,14 +146,13 @@ describe("Mock verifier functional", () => {
       2_000_000_000,
     );
 
-    RELAYER = new TestRelayer(
-      ADMIN_AUTH_KEYPAIR.publicKey,
-      LOOK_UP_TABLE,
+    RELAYER = new TestRelayer({
+      relayerPubkey: ADMIN_AUTH_KEYPAIR.publicKey,
+      lookUpTable: LOOK_UP_TABLE,
       relayerRecipientSol,
-      new BN(100000),
-      new BN(10_000_000),
-      ADMIN_AUTH_KEYPAIR
-    );
+      relayerFee: new BN(100_000),
+      payer: ADMIN_AUTH_KEYPAIR,
+    });
     lightProvider = await LightProvider.init({
       wallet: ADMIN_AUTH_KEYPAIR,
       relayer: RELAYER,


### PR DESCRIPTION
Problem:
- if payer was not provided a payer was generated and relayer pubkey and payer did not match
- error propagation in sendVersionedTransaction was broken
