### PR TITLE
github action - release: fix cp paths, include spl_noop.so

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ jobs:
           cp test-env/programs/spl_noop.so ./spl_noop.so
 
 
-
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,14 @@ jobs:
 
       - name: Prepare artifacts
         run: |
-          cp light-system-programs/target/deploy/merkle_tree_program.so ../merkle_tree_program.so
-          cp light-system-programs/target/deploy/verifier_program_zero.so ../verifier_program_zero.so
-          cp light-system-programs/target/deploy/verifier_program_storage.so ../verifier_program_storage.so
-          cp light-system-programs/target/deploy/verifier_program_one.so ../verifier_program_one.so
-          cp light-system-programs/target/deploy/verifier_program_two.so ../verifier_program_two.so
+          cp light-system-programs/target/deploy/merkle_tree_program.so ./merkle_tree_program.so
+          cp light-system-programs/target/deploy/verifier_program_zero.so ./verifier_program_zero.so
+          cp light-system-programs/target/deploy/verifier_program_storage.so ./verifier_program_storage.so
+          cp light-system-programs/target/deploy/verifier_program_one.so ./verifier_program_one.so
+          cp light-system-programs/target/deploy/verifier_program_two.so ./verifier_program_two.so
+          cp test-env/programs/spl_noop.so ./spl_noop.so
+
+
 
       - name: Release
         uses: softprops/action-gh-release@v1
@@ -38,3 +41,4 @@ jobs:
             verifier_program_storage.so
             verifier_program_one.so
             verifier_program_two.so
+            spl_noop.so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
           cp light-system-programs/target/deploy/verifier_program_two.so ./verifier_program_two.so
           cp test-env/programs/spl_noop.so ./spl_noop.so
 
-
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Problem:
Release with prior fix pr did not public release binaries [see release](https://github.com/Lightprotocol/light-protocol/releases/tag/v0.3.1) 

Changes:
- adjust path to which binaries are copied so that the release action finds them
- added spl_noop.so binary