### PR TITLE
ci: Add action-semantic-pull-request for linting pull requests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,31 @@
+name: "Lint PR"
+
+on:
+  pull_request:
+    branch:
+      - main
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          scopes: |
+            programs
+            verifier-sdk
+            circuits
+            light-zk.js
+            cli
+            relayer
+            scripts


### PR DESCRIPTION
This action makes sure that all pull requests are following the Conventional Commits specification[0], which can be summarized as:

```
<type>([optional scope]): <description>
```

Where types are: `fix`, `feat`, `build`, `chore`, `ci`, `docs`, `style`, `refactor`, `perf` and `test`.

For this repository, configure it with following scopes:

* `programs` - on-chain programs (verifiers, Merkle tree programs).
* `verifier-sdk` - SDK for on-chain verifier programs.
* `circuits` - arithmetic circuits.
* `light-zk.js` - client SDK.
* `cli`
* `relayer`
* `scripts`

For example, these PR titles are valid:

* feat: Add support of multiple Merkle trees
* feat(cli): Add `shield` command
* fix: Ensure consinstency of integrity hash inputs
* chore: Update Anchor version to 0.29.0
* refactor(program): Avoid unnecessary memory allcoations
* style: Apply Prettier conventions

These are not valid:

* Alice feature branch
* Bob pull request
* Fixing bug
* General changes and cleanup
* Refactor
* Fixing fix of fix with fix

(Take the bad examples to your heart and don't try to smuggle them by adding `feat:` or other valid prefix before. :P Being imprecise, saying that your changes are "general", mentioning names etc. is still discouraged even if you technically follow the convention.)

[0] https://www.conventionalcommits.org/