### PR TITLE
ci: cache node rust

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -10,6 +10,29 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Checkout sources
+      uses: actions/checkout@v3
+
+    - name: Cache Rust dependencies
+      uses: buildjet/cache@v3
+      with:
+        path: |
+          ~/.cargo
+          **/target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Cache Node modules
+      uses: buildjet/cache@v3
+      with:
+        path: "**/node_modules"
+        key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock', '**/package.json') }}
+
+    - name: Cache .local directory
+      uses: buildjet/cache@v3
+      with:
+        path: .local
+        key: ${{ runner.os }}-local-${{ hashFiles('**/install.sh') }}
+
     - name: Install dependencies
       shell: bash
       run: |

--- a/.github/workflows/light-sdk-tests.yml
+++ b/.github/workflows/light-sdk-tests.yml
@@ -8,8 +8,8 @@ on:
     types:
       - opened
       - synchronize
-      - reopened
       - ready_for_review
+      - reopened
 
 name: light-sdk-tests
 
@@ -30,7 +30,7 @@ jobs:
       - name: Setup and build
         uses: ./.github/actions/setup-and-build
         with:
-          enable_redis: 'true'
+          enable_redis: "true"
 
       - name: ${{ matrix.test.name }}
         run: |


### PR DESCRIPTION
adds  cache for rust and node dependencies
rust: (cargo/registry cargo/git, target) 
node: (node_modules)
and generates hashkeys to check for deps changes as per https://buildjet.com/for-github-actions/docs/guides/migrating-to-buildjet-cache

