### PR TITLE
refactor(light-zk.js): Avoid allocations and string operations when using `BN`

### DIFF
--- a/light-system-programs/tests/functional_tests.ts
+++ b/light-system-programs/tests/functional_tests.ts
@@ -37,6 +37,7 @@ import {
   airdropSol,
   MerkleTreeConfig,
   RELAYER_FEE,
+  BN_0,
 } from "@lightprotocol/zk.js";
 
 import { BN } from "@coral-xyz/anchor";
@@ -331,7 +332,7 @@ describe("verifier_program", () => {
         new Utxo({
           poseidon: POSEIDON,
           assets: inputUtxos[0].assets,
-          amounts: [new BN(0), inputUtxos[0].amounts[1]],
+          amounts: [BN_0, inputUtxos[0].amounts[1]],
           assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
           verifierProgramLookupTable:
             lightProvider.lookUpTables.verifierProgramLookupTable,

--- a/light-system-programs/tests/user-random.tests.ts
+++ b/light-system-programs/tests/user-random.tests.ts
@@ -19,6 +19,7 @@ import {
   TOKEN_REGISTRY,
   ADMIN_AUTH_KEYPAIR,
   RELAYER_FEE,
+  BN_0,
 } from "@lightprotocol/zk.js";
 
 import { BN } from "@coral-xyz/anchor";
@@ -377,7 +378,7 @@ const checkSolBalanceGtRelayerFee = async (
   )?.totalBalanceSpl;
   if (
     tokenMint.toBase58() !== PublicKey.default.toBase58() &&
-    (!splBalance || splBalance.eq(new BN(0)))
+    (!splBalance || splBalance.eq(BN_0))
   )
     return false;
   return (

--- a/light-system-programs/tests/user.tests.ts
+++ b/light-system-programs/tests/user.tests.ts
@@ -29,6 +29,7 @@ import {
   TOKEN_ACCOUNT_FEE,
   useWallet,
   RELAYER_FEE,
+  BN_1,
 } from "@lightprotocol/zk.js";
 
 import { BN, AnchorProvider, setProvider } from "@coral-xyz/anchor";
@@ -526,7 +527,7 @@ describe("Test User Errors", () => {
   it("SOL_RECIPIENT_UNDEFINED unshield", async () => {
     await chai.assert.isRejected(
       // @ts-ignore
-      user.unshield({ token: "SOL", publicAmountSol: new BN(1) }),
+      user.unshield({ token: "SOL", publicAmountSol: BN_1 }),
       TransactionErrorCode.SOL_RECIPIENT_UNDEFINED,
     );
 
@@ -534,8 +535,8 @@ describe("Test User Errors", () => {
       // @ts-ignore
       user.unshield({
         token,
-        publicAmountSol: new BN(1),
-        publicAmountSpl: new BN(1),
+        publicAmountSol: BN_1,
+        publicAmountSpl: BN_1,
         recipientSpl: SolanaKeypair.generate().publicKey,
       }),
       TransactionErrorCode.SOL_RECIPIENT_UNDEFINED,
@@ -545,7 +546,7 @@ describe("Test User Errors", () => {
   it("SPL_RECIPIENT_UNDEFINED unshield", async () => {
     await chai.assert.isRejected(
       // @ts-ignore
-      user.unshield({ token, publicAmountSpl: new BN(1) }),
+      user.unshield({ token, publicAmountSpl: BN_1 }),
       TransactionErrorCode.SPL_RECIPIENT_UNDEFINED,
     );
   });
@@ -563,7 +564,7 @@ describe("Test User Errors", () => {
       // @ts-ignore
       user.transfer({
         recipient: new Account({ poseidon: POSEIDON }).getPublicKey(),
-        amountSol: new BN(1),
+        amountSol: BN_1,
         token: "SPL",
       }),
       UserErrorCode.TOKEN_NOT_FOUND,

--- a/light-system-programs/tests/verifier_tests.ts
+++ b/light-system-programs/tests/verifier_tests.ts
@@ -36,6 +36,7 @@ import {
   getSystem,
   System,
   RELAYER_FEE,
+  BN_0,
 } from "@lightprotocol/zk.js";
 
 import { BN } from "@coral-xyz/anchor";
@@ -315,7 +316,7 @@ describe("Verifier Zero and One Tests", () => {
         MINT: newMintKeypair.publicKey,
         ADMIN_AUTH_KEYPAIR,
         userAccount: relayer,
-        amount: new BN(0),
+        amount: BN_0,
       });
       await sendTestTx(tmp_tx, "ProofVerificationFails");
     }

--- a/light-zk.js/src/account.ts
+++ b/light-zk.js/src/account.ts
@@ -8,6 +8,7 @@ import {
   AccountErrorCode,
   TransactionParametersErrorCode,
   UtxoErrorCode,
+  BN_0,
 } from "./index";
 const { blake2b } = require("@noble/hashes/blake2b");
 const b2params = { dkLen: 32 };
@@ -78,8 +79,8 @@ export class Account {
     this.burnerSeed = new Uint8Array();
     if (aesSecret && !privateKey) {
       this.aesSecret = aesSecret;
-      this.privkey = new BN(0);
-      this.pubkey = new BN(0);
+      this.privkey = BN_0;
+      this.pubkey = BN_0;
       this.encryptionKeypair = {
         publicKey: new Uint8Array(32),
         secretKey: new Uint8Array(32),
@@ -138,7 +139,7 @@ export class Account {
         nacl.box.keyPair.fromSecretKey(encryptionPrivateKey);
     } else if (publicKey) {
       this.pubkey = publicKey;
-      this.privkey = new BN("0");
+      this.privkey = BN_0;
       this.encryptionKeypair = {
         publicKey: encryptionPublicKey ? encryptionPublicKey : new Uint8Array(),
         secretKey: new Uint8Array(),

--- a/light-zk.js/src/constants.ts
+++ b/light-zk.js/src/constants.ts
@@ -23,6 +23,10 @@ import {
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
 import { TokenData } from "./index";
 
+export const BN_0 = new anchor.BN(0);
+export const BN_1 = new anchor.BN(1);
+export const BN_2 = new anchor.BN(2);
+
 export const CONSTANT_SECRET_AUTHKEY: Uint8Array = Uint8Array.from([
   155, 249, 234, 55, 8, 49, 0, 14, 84, 72, 10, 224, 21, 139, 87, 102, 115, 88,
   217, 72, 137, 38, 0, 179, 93, 202, 220, 31, 143, 79, 247, 200,

--- a/light-zk.js/src/relayer.ts
+++ b/light-zk.js/src/relayer.ts
@@ -14,6 +14,7 @@ import {
   TOKEN_ACCOUNT_FEE,
   SendVersionedTransactionsResult,
   ParsedIndexedTransaction,
+  BN_0,
 } from "./index";
 
 export type RelayerSendTransactionsResponse =
@@ -41,7 +42,7 @@ export class Relayer {
   constructor(
     relayerPubkey: PublicKey,
     relayerRecipientSol?: PublicKey,
-    relayerFee: BN = new BN(0),
+    relayerFee: BN = BN_0,
     highRelayerFee: BN = new BN(TOKEN_ACCOUNT_FEE),
     url: string = "http://localhost:3331",
   ) {
@@ -51,7 +52,7 @@ export class Relayer {
         "constructor",
       );
     }
-    if (relayerRecipientSol && relayerFee.toString() === "0") {
+    if (relayerRecipientSol && relayerFee.eq(BN_0)) {
       throw new RelayerError(
         RelayerErrorCode.RELAYER_FEE_UNDEFINED,
         "constructor",

--- a/light-zk.js/src/test-utils/createAccounts.ts
+++ b/light-zk.js/src/test-utils/createAccounts.ts
@@ -37,6 +37,7 @@ import {
   TOKEN_REGISTRY,
   sleep,
   confirmTransaction,
+  BN_0,
 } from "../index";
 import { assert } from "chai";
 import { Program } from "@coral-xyz/anchor";
@@ -330,7 +331,7 @@ export async function createTestAccounts(
         MINT,
         ADMIN_AUTH_KEYPAIR,
         userAccount: RECIPIENT_TOKEN_ACCOUNT,
-        amount: new BN(0),
+        amount: BN_0,
       });
     }
   } catch (error) {}

--- a/light-zk.js/src/test-utils/testChecks.ts
+++ b/light-zk.js/src/test-utils/testChecks.ts
@@ -91,9 +91,10 @@ export async function checkMerkleTreeUpdateStateCreated({
     leavesPdas.length,
     "The incorrect number of leaves was saved",
   );
-  assert.equal(
-    merkleTreeUpdateStateData.currentInstructionIndex.toString(),
-    current_instruction_index.toString(),
+  assert(
+    merkleTreeUpdateStateData.currentInstructionIndex.eq(
+      new anchor.BN(current_instruction_index),
+    ),
     "The instruction index is wrong",
   );
   assert.equal(
@@ -153,18 +154,17 @@ export async function checkMerkleTreeBatchUpdateSuccess({
     merkleTreeAccountPrior.currentRootIndex;
   let current_root_index = merkleTreeAccount.currentRootIndex;
 
-  assert.equal(
+  assert(
     merkle_tree_prior_current_root_index
       .add(new anchor.BN("1"))
       .mod(new anchor.BN(256))
-      .toString(),
-    current_root_index.toString(),
+      .eq(current_root_index),
   );
 
   assert(
     merkle_tree_prior_leaves_index
-      .add(new anchor.BN(numberOfLeaves.toString()))
-      .toString() == merkleTreeAccount.nextIndex.toString(),
+      .add(new anchor.BN(numberOfLeaves))
+      .eq(merkleTreeAccount.nextIndex),
   );
 }
 

--- a/light-zk.js/src/test-utils/testRelayer.ts
+++ b/light-zk.js/src/test-utils/testRelayer.ts
@@ -9,7 +9,7 @@ import {
 } from "../transaction";
 import { ParsedIndexedTransaction } from "../types";
 import { airdropSol } from "./airdrop";
-import { IDL_MERKLE_TREE_PROGRAM, MerkleTreeConfig } from "../index";
+import { IDL_MERKLE_TREE_PROGRAM, MerkleTreeConfig, BN_0 } from "../index";
 
 export class TestRelayer extends Relayer {
   indexedTransactions: ParsedIndexedTransaction[] = [];
@@ -18,7 +18,7 @@ export class TestRelayer extends Relayer {
   constructor({
     relayerPubkey,
     relayerRecipientSol,
-    relayerFee = new BN(0),
+    relayerFee = BN_0,
     highRelayerFee,
     payer,
   }: {

--- a/light-zk.js/src/test-utils/userTestAssertHelper.ts
+++ b/light-zk.js/src/test-utils/userTestAssertHelper.ts
@@ -27,6 +27,7 @@ import {
   merkleTreeProgramId,
   verifierProgramOneProgramId,
   verifierProgramZeroProgramId,
+  BN_0,
 } from "../constants";
 import { Utxo } from "../utxo";
 import { MerkleTreeConfig } from "../index";
@@ -190,14 +191,12 @@ export class UserTestAssertHelper {
         reference.signer.toBase58(),
         "Signer mismatch",
       );
-      assert.equal(
-        transaction.publicAmountSol.toString(),
-        reference.publicAmountSol.toString(),
+      assert(
+        transaction.publicAmountSol.eq(reference.publicAmountSol),
         "Public SOL amount mismatch",
       );
-      assert.equal(
-        transaction.publicAmountSpl.toString(),
-        reference.publicAmountSpl.toString(),
+      assert(
+        transaction.publicAmountSpl.eq(reference.publicAmountSpl),
         "Public SPL amount mismatch",
       );
       assert.equal(
@@ -220,9 +219,8 @@ export class UserTestAssertHelper {
         reference.relayerRecipientSol.toBase58(),
         "Relayer recipient SOL mismatch",
       );
-      assert.equal(
-        transaction.relayerFee.toString(),
-        reference.relayerFee.toString(),
+      assert(
+        transaction.relayerFee.eq(reference.relayerFee),
         "Relayer fee mismatch",
       );
 
@@ -285,8 +283,8 @@ export class UserTestAssertHelper {
           assertTransactionProperties(
             {
               signer: this.provider.relayer.accounts.relayerPubkey,
-              publicAmountSpl: new BN(0),
-              publicAmountSol: new BN(0),
+              publicAmountSpl: BN_0,
+              publicAmountSol: BN_0,
               relayerFee: this.sender.user.provider.relayer.getRelayerFee(),
               to: AUTHORITY,
               from: MerkleTreeConfig.getSolPoolPda(merkleTreeProgramId).pda,
@@ -312,11 +310,11 @@ export class UserTestAssertHelper {
               ),
               publicAmountSpl: amountSpl
                 ? convertAndComputeDecimals(amountSpl, this.tokenCtx!.decimals)
-                : new BN(0),
+                : BN_0,
               publicAmountSol: amountSol
                 ? convertAndComputeDecimals(amountSol, new BN(1e9))
-                : new BN(0),
-              relayerFee: new BN(0),
+                : BN_0,
+              relayerFee: BN_0,
               relayerRecipientSol: AUTHORITY,
               type: Action.SHIELD,
               verifier: verifierProgramZeroProgramId,
@@ -336,10 +334,10 @@ export class UserTestAssertHelper {
               signer: this.provider.relayer.accounts.relayerPubkey,
               publicAmountSpl: amountSpl
                 ? convertAndComputeDecimals(amountSpl, this.tokenCtx!.decimals)
-                : new BN(0),
+                : BN_0,
               publicAmountSol: amountSol
                 ? convertAndComputeDecimals(amountSol, new BN(1e9))
-                : new BN(0),
+                : BN_0,
               relayerFee:
                 this.tokenCtx!.symbol != "SOL" &&
                 !this.recipient.preTokenBalance
@@ -484,8 +482,8 @@ export class UserTestAssertHelper {
    * - check that utxos with an aggregate amount greater or equal than the spl and sol transfer amounts were spent
    */
   async assertUserUtxoSpent() {
-    let amountSol = new BN(0);
-    let amountSpl = new BN(0);
+    let amountSol = BN_0;
+    let amountSpl = BN_0;
     for (var [
       asset,
       tokenBalance,
@@ -537,7 +535,7 @@ export class UserTestAssertHelper {
       : userBalances.preShieldedInboxBalance!.tokenBalances.get(
           this.tokenCtx?.mint.toBase58(),
         )?.totalBalanceSpl;
-    let tokenBalancePre = _tokenBalancePre ? _tokenBalancePre : new BN(0);
+    let tokenBalancePre = _tokenBalancePre ? _tokenBalancePre : BN_0;
 
     assert.equal(
       tokenBalanceAfter!
@@ -1032,7 +1030,7 @@ export class UserTestAssertHelper {
      * post Balance:
      * - has increased by sum
      */
-    let sum = new BN(0);
+    let sum = BN_0;
     for (var commitment of this.testInputs.utxoCommitments!) {
       const existedInPreInbox = this.sender
         .preShieldedInboxBalance!.tokenBalances.get(
@@ -1072,7 +1070,7 @@ export class UserTestAssertHelper {
       : this.recipient.preShieldedBalance?.tokenBalances.get(
           this.tokenCtx.mint.toBase58(),
         )?.totalBalanceSpl;
-    preBalance = preBalance ? preBalance : new BN(0);
+    preBalance = preBalance ? preBalance : BN_0;
 
     assert.equal(postBalance?.toString(), preBalance!.add(sum).toString());
   }

--- a/light-zk.js/src/transaction/fetchRecentTransactions.ts
+++ b/light-zk.js/src/transaction/fetchRecentTransactions.ts
@@ -16,6 +16,7 @@ import {
   MAX_U64,
   FIELD_SIZE,
   merkleTreeProgramId,
+  BN_0,
 } from "../constants";
 
 import { Action } from "./transaction";
@@ -204,7 +205,7 @@ async function enrichParsedTransactionEvents(
         .abs()
         .sub(relayerFee);
       type =
-        amountSpl.eq(new BN(0)) && amountSol.eq(new BN(0))
+        amountSpl.eq(BN_0) && amountSol.eq(BN_0)
           ? Action.TRANSFER
           : Action.UNSHIELD;
     }
@@ -246,7 +247,7 @@ async function enrichParsedTransactionEvents(
     tx.meta.postBalances[solTokenPoolIndex] -
       tx.meta.preBalances[solTokenPoolIndex],
   );
-  changeSolAmount = changeSolAmount.lt(new BN(0))
+  changeSolAmount = changeSolAmount.lt(BN_0)
     ? changeSolAmount.abs().sub(relayerFee)
     : changeSolAmount;
 

--- a/light-zk.js/src/transaction/transaction.ts
+++ b/light-zk.js/src/transaction/transaction.ts
@@ -25,6 +25,7 @@ import {
   AUTHORITY,
   MerkleTreeConfig,
   TRANSACTION_MERKLE_TREE_SWITCH_TRESHOLD,
+  BN_0,
 } from "../index";
 import { IDL_MERKLE_TREE_PROGRAM } from "../idls/index";
 import { remainingAccount } from "../types/accounts";
@@ -306,8 +307,8 @@ export class Transaction {
   }
 
   getMint() {
-    if (this.params.publicAmountSpl.toString() == "0") {
-      return new BN(0);
+    if (this.params.publicAmountSpl.eq(BN_0)) {
+      return BN_0;
     } else if (this.params.assetPubkeysCircuit) {
       return this.params.assetPubkeysCircuit[1];
     } else {
@@ -497,7 +498,7 @@ export class Transaction {
       console.log(
         "provider not defined did not fetch rootIndex set root index to 0",
       );
-      this.transactionInputs.rootIndex = new BN(0);
+      this.transactionInputs.rootIndex = BN_0;
     }
   }
 
@@ -578,10 +579,7 @@ export class Transaction {
     var inputMerklePathElements = new Array<Array<string>>();
     // getting merkle proofs
     for (const inputUtxo of inputUtxos) {
-      if (
-        inputUtxo.amounts[0] > new BN(0) ||
-        inputUtxo.amounts[1] > new BN(0)
-      ) {
+      if (inputUtxo.amounts[0].gt(BN_0) || inputUtxo.amounts[1].gt(BN_0)) {
         inputUtxo.index = provider.solMerkleTree.merkleTree.indexOf(
           inputUtxo.getCommitment(provider.poseidon),
         );

--- a/light-zk.js/src/transaction/transactionParameters.ts
+++ b/light-zk.js/src/transaction/transactionParameters.ts
@@ -28,6 +28,7 @@ import {
   IDL_VERIFIER_PROGRAM_ZERO,
   AppUtxoConfig,
   createOutUtxos,
+  BN_0,
 } from "../index";
 import { sha256 } from "@noble/hashes/sha256";
 import { SPL_NOOP_PROGRAM_ID } from "@solana/spl-account-compression";
@@ -177,13 +178,13 @@ export class TransactionParameters implements transactionParameters {
       this.assetPubkeysCircuit,
     );
     // safeguard should not be possible
-    if (!this.publicAmountSol.gte(new BN(0)))
+    if (!this.publicAmountSol.gte(BN_0))
       throw new TransactionParametersError(
         TransactionParametersErrorCode.PUBLIC_AMOUNT_NEGATIVE,
         "constructor",
         "Public sol amount cannot be negative.",
       );
-    if (!this.publicAmountSpl.gte(new BN(0)))
+    if (!this.publicAmountSpl.gte(BN_0))
       throw new TransactionParametersError(
         TransactionParametersErrorCode.PUBLIC_AMOUNT_NEGATIVE,
         "constructor",
@@ -223,14 +224,14 @@ export class TransactionParameters implements transactionParameters {
           `Public amount spl ${this.publicAmountSpl} needs to be a u64 at deposit. Check whether you defined input and output utxos correctly, for a deposit the amounts of output utxos need to be bigger than the amounts of input utxos`,
         );
       }
-      if (!this.publicAmountSol.eq(new BN(0)) && recipientSol) {
+      if (!this.publicAmountSol.eq(BN_0) && recipientSol) {
         throw new TransactionParametersError(
           TransactionParametersErrorCode.SOL_RECIPIENT_DEFINED,
           "constructor",
           "",
         );
       }
-      if (!this.publicAmountSpl.eq(new BN(0)) && recipientSpl) {
+      if (!this.publicAmountSpl.eq(BN_0) && recipientSpl) {
         throw new TransactionParametersError(
           TransactionParametersErrorCode.SPL_RECIPIENT_DEFINED,
           "constructor",
@@ -238,14 +239,14 @@ export class TransactionParameters implements transactionParameters {
         );
       }
 
-      if (!this.publicAmountSol.eq(new BN(0)) && !senderSol) {
+      if (!this.publicAmountSol.eq(BN_0) && !senderSol) {
         throw new TransactionParametersError(
           TransactionErrorCode.SOL_SENDER_UNDEFINED,
           "constructor",
           "",
         );
       }
-      if (!this.publicAmountSpl.eq(new BN(0)) && !senderSpl) {
+      if (!this.publicAmountSpl.eq(BN_0) && !senderSpl) {
         throw new TransactionParametersError(
           TransactionErrorCode.SPL_SENDER_UNDEFINED,
           "constructor",
@@ -270,21 +271,21 @@ export class TransactionParameters implements transactionParameters {
       // public amount is either 0 or negative
       // this.publicAmountSol.add(FIELD_SIZE).mod(FIELD_SIZE) this changes the value
       const tmpSol = this.publicAmountSol;
-      if (!tmpSol.sub(FIELD_SIZE).lte(new BN(0)))
+      if (!tmpSol.sub(FIELD_SIZE).lte(BN_0))
         throw new TransactionParametersError(
           TransactionParametersErrorCode.INVALID_PUBLIC_AMOUNT,
           "constructor",
           "",
         );
       const tmpSpl = this.publicAmountSpl;
-      if (!tmpSpl.sub(FIELD_SIZE).lte(new BN(0)))
+      if (!tmpSpl.sub(FIELD_SIZE).lte(BN_0))
         throw new TransactionParametersError(
           TransactionParametersErrorCode.INVALID_PUBLIC_AMOUNT,
           "constructor",
           "",
         );
       try {
-        if (!tmpSol.eq(new BN(0))) {
+        if (!tmpSol.eq(BN_0)) {
           tmpSol.sub(FIELD_SIZE).toArray("be", 8);
         }
       } catch (error) {
@@ -296,7 +297,7 @@ export class TransactionParameters implements transactionParameters {
       }
 
       try {
-        if (!tmpSpl.eq(new BN(0))) {
+        if (!tmpSpl.eq(BN_0)) {
           tmpSpl.sub(FIELD_SIZE).toArray("be", 8);
         }
       } catch (error) {
@@ -307,7 +308,7 @@ export class TransactionParameters implements transactionParameters {
         );
       }
 
-      if (!this.publicAmountSol.eq(new BN(0)) && !recipientSol) {
+      if (!this.publicAmountSol.eq(BN_0) && !recipientSol) {
         throw new TransactionParametersError(
           TransactionErrorCode.SOL_RECIPIENT_UNDEFINED,
           "constructor",
@@ -315,7 +316,7 @@ export class TransactionParameters implements transactionParameters {
         );
       }
 
-      if (!this.publicAmountSpl.eq(new BN(0)) && !recipientSpl) {
+      if (!this.publicAmountSpl.eq(BN_0) && !recipientSpl) {
         throw new TransactionParametersError(
           TransactionErrorCode.SPL_RECIPIENT_UNDEFINED,
           "constructor",
@@ -323,14 +324,14 @@ export class TransactionParameters implements transactionParameters {
         );
       }
       // && senderSol.toBase58() != merkle tree token pda
-      if (!this.publicAmountSol.eq(new BN(0)) && senderSol) {
+      if (!this.publicAmountSol.eq(BN_0) && senderSol) {
         throw new TransactionParametersError(
           TransactionParametersErrorCode.SOL_SENDER_DEFINED,
           "constructor",
           "",
         );
       }
-      if (!this.publicAmountSpl.eq(new BN(0)) && senderSpl) {
+      if (!this.publicAmountSpl.eq(BN_0) && senderSpl) {
         throw new TransactionParametersError(
           TransactionParametersErrorCode.SPL_SENDER_DEFINED,
           "constructor",
@@ -351,7 +352,7 @@ export class TransactionParameters implements transactionParameters {
           "constructor",
           "For a transfer a relayer needs to be provided.",
         );
-      if (!this.publicAmountSpl.eq(new BN(0)))
+      if (!this.publicAmountSpl.eq(BN_0))
         throw new TransactionParametersError(
           TransactionParametersErrorCode.PUBLIC_AMOUNT_SPL_NOT_ZERO,
           "constructor",
@@ -653,8 +654,8 @@ export class TransactionParameters implements transactionParameters {
 
   static async getTxParams({
     tokenCtx,
-    publicAmountSpl = new BN(0),
-    publicAmountSol = new BN(0),
+    publicAmountSpl = BN_0,
+    publicAmountSol = BN_0,
     action,
     userSplAccount = AUTHORITY,
     account,
@@ -833,7 +834,7 @@ export class TransactionParameters implements transactionParameters {
       if (!this.accounts.recipientSpl) {
         // AUTHORITY is used as place holder
         this.accounts.recipientSpl = AUTHORITY;
-        if (!this.publicAmountSpl?.eq(new BN(0))) {
+        if (!this.publicAmountSpl?.eq(BN_0)) {
           throw new TransactionError(
             TransactionErrorCode.SPL_RECIPIENT_UNDEFINED,
             "assignAccounts",
@@ -846,12 +847,12 @@ export class TransactionParameters implements transactionParameters {
         // AUTHORITY is used as place holder
         this.accounts.recipientSol = AUTHORITY;
         if (
-          !this.publicAmountSol.eq(new BN(0)) &&
+          !this.publicAmountSol.eq(BN_0) &&
           !this.publicAmountSol
             ?.sub(FIELD_SIZE)
             .mul(new BN(-1))
             .sub(new BN(this.relayer.getRelayerFee(this.ataCreationFee)))
-            .eq(new BN(0))
+            .eq(BN_0)
         ) {
           throw new TransactionParametersError(
             TransactionErrorCode.SOL_RECIPIENT_UNDEFINED,
@@ -879,7 +880,7 @@ export class TransactionParameters implements transactionParameters {
       if (!this.accounts.senderSpl) {
         /// assigning a placeholder account
         this.accounts.senderSpl = AUTHORITY;
-        if (!this.publicAmountSpl?.eq(new BN(0))) {
+        if (!this.publicAmountSpl?.eq(BN_0)) {
           throw new TransactionParametersError(
             TransactionErrorCode.SPL_SENDER_UNDEFINED,
             "assignAccounts",
@@ -972,7 +973,7 @@ export class TransactionParameters implements transactionParameters {
     }
 
     while (assetPubkeysCircuit.length < N_ASSET_PUBKEYS) {
-      assetPubkeysCircuit.push(new BN(0).toString());
+      assetPubkeysCircuit.push(BN_0.toString());
       assetPubkeys.push(SystemProgram.programId);
     }
 

--- a/light-zk.js/src/utils.ts
+++ b/light-zk.js/src/utils.ts
@@ -13,6 +13,8 @@ import {
   TOKEN_AUTHORITY,
   verifierProgramTwoProgramId,
   verifierProgramZeroProgramId,
+  BN_0,
+  BN_1,
 } from "./constants";
 import {
   AddressLookupTableProgram,
@@ -117,14 +119,10 @@ export function decimalConversion({
       ? convertAndComputeDecimals(publicAmountSol, new BN(1e9))
       : minimumLamports
       ? minimumLamportsAmount
-      : new BN(0);
+      : BN_0;
   } else {
-    publicAmountSpl = publicAmountSpl
-      ? new BN(publicAmountSpl.toString())
-      : undefined;
-    publicAmountSol = publicAmountSol
-      ? new BN(publicAmountSol?.toString())
-      : new BN(0);
+    publicAmountSpl = publicAmountSpl ? new BN(publicAmountSpl) : undefined;
+    publicAmountSol = publicAmountSol ? new BN(publicAmountSol) : BN_0;
   }
   return { publicAmountSpl, publicAmountSol };
 }
@@ -139,7 +137,7 @@ export const convertAndComputeDecimals = (
   if (typeof amount === "string" && amount.startsWith("-")) {
     throw new Error("Negative amounts are not allowed.");
   }
-  if (decimals.lt(new BN(1))) {
+  if (decimals.lt(BN_1)) {
     throw new Error(
       "Decimal numbers have to be at least 1 since we precompute 10**decimalValue.",
     );

--- a/light-zk.js/src/utxo.ts
+++ b/light-zk.js/src/utxo.ts
@@ -34,6 +34,7 @@ import {
   fetchVerifierByIdLookUp,
   setEnvironment,
   FIELD_SIZE,
+  BN_0,
 } from "./index";
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
 
@@ -42,9 +43,6 @@ export const newNonce = () => nacl.randomBytes(nacl.box.nonceLength);
 // TODO: move to constants
 export const N_ASSETS = 2;
 export const N_ASSET_PUBKEYS = 3;
-
-// Constant in order to avoid multiple "new BN(0);" instantiations.
-const BN_0 = new BN(0);
 
 // TODO: Idl support for U256
 // TODO: add static createSolUtxo()

--- a/light-zk.js/src/wallet/buildBalance.ts
+++ b/light-zk.js/src/wallet/buildBalance.ts
@@ -17,6 +17,7 @@ import {
   ProgramUtxoBalanceErrorCode,
   TOKEN_PUBKEY_SYMBOL,
   UserErrorCode,
+  BN_0,
 } from "../index";
 
 // mint | programAdress for programUtxos
@@ -43,8 +44,8 @@ export class TokenUtxoBalance {
   spentUtxos: Map<string, Utxo>; // ordered for slot spent - maybe this should just be an UserIndexedTransaction
   constructor(tokenData: TokenData) {
     this.tokenData = tokenData;
-    this.totalBalanceSol = new BN(0);
-    this.totalBalanceSpl = new BN(0);
+    this.totalBalanceSol = BN_0;
+    this.totalBalanceSpl = BN_0;
     this.utxos = new Map();
     this.committedUtxos = new Map();
     this.spentUtxos = new Map();

--- a/light-zk.js/src/wallet/createOutUtxos.ts
+++ b/light-zk.js/src/wallet/createOutUtxos.ts
@@ -11,6 +11,9 @@ import {
   TransactionParameters,
   AppUtxoConfig,
   MINIMUM_LAMPORTS,
+  BN_0,
+  BN_1,
+  BN_2,
 } from "../index";
 
 type Asset = { sumIn: BN; sumOut: BN; asset: PublicKey };
@@ -24,7 +27,7 @@ export type Recipient = {
 };
 // mint: PublicKey, expectedAmount: BN,
 export const getUtxoArrayAmount = (mint: PublicKey, inUtxos: Utxo[]) => {
-  let inAmount = new BN(0);
+  let inAmount = BN_0;
   inUtxos.forEach((inUtxo) => {
     inUtxo.assets.forEach((asset, i) => {
       if (asset.toBase58() === mint.toBase58()) {
@@ -42,15 +45,15 @@ export const getRecipientsAmount = (
   if (mint.toBase58() === SystemProgram.programId.toBase58()) {
     return recipients.reduce(
       (sum, recipient) => sum.add(recipient.solAmount),
-      new BN(0),
+      BN_0,
     );
   } else {
     return recipients.reduce(
       (sum, recipient) =>
         recipient.mint.toBase58() === mint.toBase58()
           ? sum.add(recipient.splAmount)
-          : sum.add(new BN(0)),
-      new BN(0),
+          : sum.add(BN_0),
+      BN_0,
     );
   }
 };
@@ -192,7 +195,7 @@ export function createOutUtxos({
         "createOutUtxos",
         "publicAmountSol not initialized for unshield",
       );
-    if (!publicAmountSpl) publicAmountSpl = new BN(0);
+    if (!publicAmountSpl) publicAmountSpl = BN_0;
     if (!publicAmountSol)
       throw new CreateUtxoError(
         CreateUtxoErrorCode.PUBLIC_SOL_AMOUNT_UNDEFINED,
@@ -222,8 +225,8 @@ export function createOutUtxos({
         "createOutUtxos",
         "Shield and relayer fee defined",
       );
-    if (!publicAmountSpl) publicAmountSpl = new BN(0);
-    if (!publicAmountSol) publicAmountSol = new BN(0);
+    if (!publicAmountSpl) publicAmountSpl = BN_0;
+    if (!publicAmountSol) publicAmountSol = BN_0;
     let publicSplAssetIndex = assets.findIndex(
       (x) => x.asset.toBase58() === publicMint?.toBase58(),
     );
@@ -260,8 +263,8 @@ export function createOutUtxos({
       );
     }
 
-    let solAmount = outUtxos[j].amounts[0] ? outUtxos[j].amounts[0] : new BN(0);
-    let splAmount = outUtxos[j].amounts[1] ? outUtxos[j].amounts[1] : new BN(0);
+    let solAmount = outUtxos[j].amounts[0] ? outUtxos[j].amounts[0] : BN_0;
+    let splAmount = outUtxos[j].amounts[1] ? outUtxos[j].amounts[1] : BN_0;
     let splMint = outUtxos[j].assets[1]
       ? outUtxos[j].assets[1]
       : SystemProgram.programId;
@@ -298,7 +301,7 @@ export function createOutUtxos({
      * - sol amount should leave a minimum amount in spl utxos if possible
      */
     const preliminarySolAmount = assets[publicSolAssetIndex].sumIn.sub(
-      MINIMUM_LAMPORTS.mul(new BN(2)),
+      MINIMUM_LAMPORTS.mul(BN_2),
     );
     const solAmount = preliminarySolAmount.isNeg()
       ? assets[publicSolAssetIndex].sumIn
@@ -321,14 +324,12 @@ export function createOutUtxos({
   }
 
   for (var x = 0; x < nrOutUtxos; x++) {
-    let solAmount = new BN(0);
+    let solAmount = BN_0;
     if (x == 0) {
       solAmount = assets[publicSolAssetIndex].sumIn;
     }
     // catch case of sol deposit with undefined spl assets
-    let splAmount = publicSplAssets[x]?.sumIn
-      ? publicSplAssets[x].sumIn
-      : new BN(0);
+    let splAmount = publicSplAssets[x]?.sumIn ? publicSplAssets[x].sumIn : BN_0;
     let splAsset = publicSplAssets[x]?.asset
       ? publicSplAssets[x].asset
       : SystemProgram.programId;
@@ -393,12 +394,8 @@ export function createRecipientUtxos({
       );
     }
 
-    let solAmount = recipients[j].solAmount
-      ? recipients[j].solAmount
-      : new BN(0);
-    let splAmount = recipients[j].splAmount
-      ? recipients[j].splAmount
-      : new BN(0);
+    let solAmount = recipients[j].solAmount ? recipients[j].solAmount : BN_0;
+    let splAmount = recipients[j].splAmount ? recipients[j].splAmount : BN_0;
     let splMint = recipients[j].mint
       ? recipients[j].mint
       : SystemProgram.programId;
@@ -445,18 +442,17 @@ export function validateUtxoAmounts({
   publicAmountSpl?: BN;
   action?: Action;
 }): Asset[] {
-  const publicAmountMultiplier =
-    action === Action.SHIELD ? new BN(1) : new BN(-1);
+  const publicAmountMultiplier = action === Action.SHIELD ? BN_1 : new BN(-1);
   const _publicAmountSol = publicAmountSol
     ? publicAmountSol.mul(publicAmountMultiplier)
-    : new BN(0);
+    : BN_0;
   const _publicAmountSpl = publicAmountSpl
     ? publicAmountSpl.mul(publicAmountMultiplier)
-    : new BN(0);
+    : BN_0;
 
   let assets: Asset[] = [];
   for (const [index, assetPubkey] of assetPubkeys.entries()) {
-    var sumIn = inUtxos ? getUtxoArrayAmount(assetPubkey, inUtxos) : new BN(0);
+    var sumIn = inUtxos ? getUtxoArrayAmount(assetPubkey, inUtxos) : BN_0;
     var sumOut =
       action === Action.TRANSFER && outUtxos.length === 0
         ? sumIn
@@ -481,7 +477,7 @@ export function validateUtxoAmounts({
       sumIn,
       sumOut,
     });
-    if (sumInAdd.lt(new BN(0)))
+    if (sumInAdd.lt(BN_0))
       throw new CreateUtxoError(
         CreateUtxoErrorCode.RECIPIENTS_SUM_AMOUNT_MISSMATCH,
         "validateUtxoAmounts",

--- a/light-zk.js/src/wallet/selectInUtxos.ts
+++ b/light-zk.js/src/wallet/selectInUtxos.ts
@@ -10,10 +10,8 @@ import {
   getUtxoArrayAmount,
   Utxo,
   TOKEN_REGISTRY,
+  BN_0,
 } from "../index";
-
-// Constant in order to avoid multiple "new BN(0);" instantiations.
-const BN_0 = new BN(0);
 
 // TODO: turn these into static user.class methods
 export const getAmount = (u: Utxo, asset: PublicKey) => {

--- a/light-zk.js/src/wallet/user.ts
+++ b/light-zk.js/src/wallet/user.ts
@@ -50,6 +50,8 @@ import {
   decimalConversion,
   ParsedIndexedTransaction,
   MerkleTreeConfig,
+  BN_0,
+  BN_1,
 } from "../index";
 import { Idl } from "@coral-xyz/anchor";
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
@@ -126,7 +128,7 @@ export class User {
       ]),
       programBalances: new Map(),
       nftBalances: new Map(),
-      totalSolBalance: new BN(0),
+      totalSolBalance: BN_0,
     };
     this.inboxBalance = {
       tokenBalances: new Map([
@@ -135,7 +137,7 @@ export class User {
       programBalances: new Map(),
       nftBalances: new Map(),
       numberInboxUtxos: 0,
-      totalSolBalance: new BN(0),
+      totalSolBalance: BN_0,
     };
   }
 
@@ -237,7 +239,7 @@ export class User {
 
     // caclulate total sol balance
     const calaculateTotalSolBalance = (balance: Balance) => {
-      let totalSolBalance = new BN(0);
+      let totalSolBalance = BN_0;
       for (var tokenBalance of balance.tokenBalances.values()) {
         totalSolBalance = totalSolBalance.add(tokenBalance.totalBalanceSol);
       }
@@ -397,7 +399,7 @@ export class User {
     });
     publicAmountSol = convertedPublicAmounts.publicAmountSol
       ? convertedPublicAmounts.publicAmountSol
-      : new BN(0);
+      : BN_0;
     publicAmountSpl = convertedPublicAmounts.publicAmountSpl;
 
     if (!tokenCtx.isNative && publicAmountSpl) {
@@ -497,7 +499,7 @@ export class User {
         "createShieldTransactionParameters need to be executed to approve spl funds prior a shield transaction",
       );
     if (
-      this.recentTransactionParameters?.publicAmountSpl.gt(new BN(0)) &&
+      this.recentTransactionParameters?.publicAmountSpl.gt(BN_0) &&
       this.recentTransactionParameters?.action === Action.SHIELD
     ) {
       let tokenAccountInfo =
@@ -749,7 +751,7 @@ export class User {
       ? convertAndComputeDecimals(publicAmountSol, new BN(1e9))
       : minimumLamports
       ? this.provider.minimumLamports
-      : new BN(0);
+      : BN_0;
     let utxosEntries = this.balance.tokenBalances
       .get(tokenCtx.mint.toBase58())
       ?.utxos.values();
@@ -893,10 +895,10 @@ export class User {
     });
     var parsedSolAmount = convertedPublicAmounts.publicAmountSol
       ? convertedPublicAmounts.publicAmountSol
-      : new BN(0);
+      : BN_0;
     var parsedSplAmount = convertedPublicAmounts.publicAmountSpl
       ? convertedPublicAmounts.publicAmountSpl
-      : new BN(0);
+      : BN_0;
 
     if (recipient && !tokenCtx)
       throw new UserError(
@@ -1635,7 +1637,7 @@ export class User {
     if (shield) {
       const txParams = await this.createShieldTransactionParameters({
         token: "SOL",
-        publicAmountSol: new BN(0),
+        publicAmountSol: BN_0,
         minimumLamports: false,
         message,
         verifierIdl: IDL_VERIFIER_PROGRAM_STORAGE,
@@ -1722,8 +1724,8 @@ export class User {
       );
     let isAppInUtxo = [];
     for (var i in appUtxos) {
-      let array = new Array(4).fill(new BN(0));
-      array[i] = new BN(1);
+      let array = new Array(4).fill(BN_0);
+      array[i] = BN_1;
       isAppInUtxo.push(array);
     }
     programParameters.inputs.isAppInUtxo = isAppInUtxo;

--- a/light-zk.js/tests/balance.test.ts
+++ b/light-zk.js/tests/balance.test.ts
@@ -28,6 +28,7 @@ import {
   User,
   NACL_ENCRYPTED_COMPRESSED_UTXO_BYTES_LENGTH,
   MerkleTreeConfig,
+  BN_0,
 } from "../src";
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
 
@@ -65,7 +66,7 @@ describe("Utxo Functional", () => {
       tokenBalances: new Map([
         [SystemProgram.programId.toBase58(), TokenUtxoBalance.initSol()],
       ]),
-      totalSolBalance: new BN(0),
+      totalSolBalance: BN_0,
       programBalances: new Map(),
       nftBalances: new Map(),
     };

--- a/light-zk.js/tests/circuits.test.ts
+++ b/light-zk.js/tests/circuits.test.ts
@@ -24,6 +24,8 @@ import {
   Action,
   IDL_VERIFIER_PROGRAM_ZERO,
   IDL_VERIFIER_PROGRAM_TWO,
+  BN_0,
+  BN_1,
 } from "../src";
 import { IDL } from "./testData/tmp_test_psp";
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
@@ -70,7 +72,7 @@ describe("Masp circuit tests", () => {
       index: 0,
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
-      amounts: [new BN(depositFeeAmount), new BN(0)],
+      amounts: [new BN(depositFeeAmount), BN_0],
       account: account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
@@ -125,7 +127,7 @@ describe("Masp circuit tests", () => {
       relayer,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
     });
-    appData = { releaseSlot: new BN(1) };
+    appData = { releaseSlot: BN_1 };
     txParamsApp = new TransactionParameters({
       inputUtxos: [
         new Utxo({

--- a/light-zk.js/tests/convertDecimals.test.ts
+++ b/light-zk.js/tests/convertDecimals.test.ts
@@ -1,7 +1,12 @@
 import { expect } from "chai";
 import { BN } from "@coral-xyz/anchor";
 import { it } from "mocha";
-import { convertAndComputeDecimals, generateRandomTestAmount } from "../src";
+import {
+  BN_0,
+  BN_1,
+  convertAndComputeDecimals,
+  generateRandomTestAmount,
+} from "../src";
 
 const chai = require("chai");
 const chaiAsPromised = require("chai-as-promised");
@@ -72,7 +77,7 @@ describe("convertAndComputeDecimals", () => {
   });
 
   it("should correctly handle zero amount", () => {
-    const amount = new BN(0);
+    const amount = BN_0;
     const decimals = new BN(100);
     const result = convertAndComputeDecimals(amount, decimals);
     expect(result.toString()).to.equal("0");
@@ -80,7 +85,7 @@ describe("convertAndComputeDecimals", () => {
 
   it("should handle zero decimals correctly", () => {
     const amount = "5";
-    const decimals = new BN(1);
+    const decimals = BN_1;
     const result = convertAndComputeDecimals(amount, decimals);
     expect(result.toString()).to.equal("5");
   });
@@ -100,7 +105,7 @@ describe("convertAndComputeDecimals", () => {
 
   it("should correctly handle max u64 amount", () => {
     const amount = new BN("18446744073709551615"); // max u64
-    const decimals = new BN(1);
+    const decimals = BN_1;
     const result = convertAndComputeDecimals(amount, decimals);
     expect(result.toString()).to.equal("18446744073709551615");
   });

--- a/light-zk.js/tests/createOutUtxos.test.ts
+++ b/light-zk.js/tests/createOutUtxos.test.ts
@@ -31,6 +31,9 @@ import {
   Provider,
   TokenData,
   RELAYER_FEE,
+  BN_0,
+  BN_1,
+  BN_2,
 } from "../src";
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
 const numberMaxOutUtxos = 2;
@@ -105,7 +108,7 @@ describe("Test createOutUtxos Functional", () => {
   it("shield sol", async () => {
     let outUtxos = createOutUtxos({
       publicMint: tokenCtx.mint,
-      publicAmountSpl: new BN(0),
+      publicAmountSpl: BN_0,
       publicAmountSol: solAmount,
       poseidon,
       changeUtxoAccount: k0,
@@ -135,7 +138,7 @@ describe("Test createOutUtxos Functional", () => {
     let outUtxos = createOutUtxos({
       publicMint: tokenCtx.mint,
       publicAmountSpl: new BN(10),
-      publicAmountSol: new BN(0),
+      publicAmountSol: BN_0,
       poseidon,
       changeUtxoAccount: k0,
       action: Action.SHIELD,
@@ -164,7 +167,7 @@ describe("Test createOutUtxos Functional", () => {
     let outUtxos = createOutUtxos({
       inUtxos: [utxo1],
       publicMint: tokenCtx.mint,
-      publicAmountSpl: new BN(0),
+      publicAmountSpl: BN_0,
       publicAmountSol: solAmount,
       poseidon,
       changeUtxoAccount: k0,
@@ -254,9 +257,9 @@ describe("Test createOutUtxos Functional", () => {
       inUtxos: [utxo1],
       publicMint: tokenCtx.mint,
       publicAmountSpl: splAmount,
-      publicAmountSol: new BN(0),
+      publicAmountSol: BN_0,
       poseidon,
-      relayerFee: new BN(0),
+      relayerFee: BN_0,
       changeUtxoAccount: k0,
       action: Action.UNSHIELD,
       numberMaxOutUtxos,
@@ -285,7 +288,7 @@ describe("Test createOutUtxos Functional", () => {
       inUtxos: [utxo1],
       publicMint: tokenCtx.mint,
       publicAmountSpl: splAmount,
-      publicAmountSol: new BN(0),
+      publicAmountSol: BN_0,
       poseidon,
       relayerFee,
       changeUtxoAccount: k0,
@@ -315,10 +318,10 @@ describe("Test createOutUtxos Functional", () => {
     let outUtxos = createOutUtxos({
       inUtxos: [utxo1],
       publicMint: tokenCtx.mint,
-      publicAmountSpl: new BN(0),
+      publicAmountSpl: BN_0,
       publicAmountSol: solAmount,
       poseidon,
-      relayerFee: new BN(0),
+      relayerFee: BN_0,
       changeUtxoAccount: k0,
       action: Action.UNSHIELD,
       numberMaxOutUtxos,
@@ -346,7 +349,7 @@ describe("Test createOutUtxos Functional", () => {
     let outUtxos = createOutUtxos({
       inUtxos: [utxo1],
       publicMint: tokenCtx.mint,
-      publicAmountSpl: new BN(0),
+      publicAmountSpl: BN_0,
       publicAmountSol: solAmount,
       poseidon,
       relayerFee,
@@ -380,7 +383,7 @@ describe("Test createOutUtxos Functional", () => {
       publicAmountSpl: splAmount,
       publicAmountSol: solAmount,
       poseidon,
-      relayerFee: new BN(0),
+      relayerFee: BN_0,
       changeUtxoAccount: k0,
       action: Action.UNSHIELD,
       numberMaxOutUtxos,
@@ -440,7 +443,7 @@ describe("Test createOutUtxos Functional", () => {
       publicMint: tokenCtx.mint,
       publicAmountSpl: splAmount,
       inUtxos: [utxo1, utxoSol],
-      publicAmountSol: new BN(0),
+      publicAmountSol: BN_0,
       poseidon,
       changeUtxoAccount: k0,
       action: Action.UNSHIELD,
@@ -471,7 +474,7 @@ describe("Test createOutUtxos Functional", () => {
       publicMint: tokenCtx.mint,
       publicAmountSpl: splAmount,
       inUtxos: [utxo1, utxo1],
-      publicAmountSol: new BN(0),
+      publicAmountSol: BN_0,
       poseidon,
       changeUtxoAccount: k0,
       action: Action.UNSHIELD,
@@ -482,14 +485,14 @@ describe("Test createOutUtxos Functional", () => {
     });
     assert.equal(
       outUtxos[0].amounts[0].toNumber(),
-      utxo1.amounts[0].mul(new BN(2)).toNumber(),
+      utxo1.amounts[0].mul(BN_2).toNumber(),
       `${outUtxos[0].amounts[0]} fee != ${
         utxo1.amounts[0].toNumber() + utxo1.amounts[0].toNumber()
       }`,
     );
     assert.equal(
       outUtxos[0].amounts[1].toString(),
-      utxo1.amounts[1].mul(new BN(2)).sub(splAmount).toString(),
+      utxo1.amounts[1].mul(BN_2).sub(splAmount).toString(),
       `${outUtxos[0].amounts[1].toNumber()}  spl !=  ${
         utxo1.amounts[1].toNumber() - splAmount.toNumber()
       }`,
@@ -501,8 +504,8 @@ describe("Test createOutUtxos Functional", () => {
       {
         account: recipientAccount,
         mint: utxo1.assets[1],
-        solAmount: new BN(0),
-        splAmount: new BN(1),
+        solAmount: BN_0,
+        splAmount: BN_1,
       },
     ];
     let outUtxos = createRecipientUtxos({
@@ -515,11 +518,11 @@ describe("Test createOutUtxos Functional", () => {
 
     outUtxos = createOutUtxos({
       publicMint: tokenCtx.mint,
-      publicAmountSpl: new BN(0),
+      publicAmountSpl: BN_0,
       inUtxos: [utxo1],
       outUtxos,
       relayerFee,
-      publicAmountSol: new BN(0),
+      publicAmountSol: BN_0,
       poseidon,
       changeUtxoAccount: k0,
       action: Action.TRANSFER,
@@ -624,7 +627,7 @@ describe("validateUtxoAmounts", () => {
       poseidon,
       amounts,
       assets,
-      blinding: new BN(0),
+      blinding: BN_0,
       account: new Account({ poseidon }),
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
@@ -722,7 +725,7 @@ describe("Test createOutUtxos Errors", () => {
       publicMint: tokenCtx.mint,
       publicAmountSpl: splAmount,
       inUtxos: [utxo1, utxoSol],
-      publicAmountSol: new BN(0),
+      publicAmountSol: BN_0,
       changeUtxoAccount: k0,
       action: Action.UNSHIELD,
       poseidon,
@@ -740,7 +743,7 @@ describe("Test createOutUtxos Errors", () => {
         publicMint: tokenCtx.mint,
         publicAmountSpl: splAmount,
         inUtxos: [utxo1, utxoSol],
-        publicAmountSol: new BN(0),
+        publicAmountSol: BN_0,
         // poseidon,
         changeUtxoAccount: k0,
         action: Action.UNSHIELD,
@@ -759,7 +762,7 @@ describe("Test createOutUtxos Errors", () => {
         publicMint: tokenCtx.mint,
         publicAmountSpl: splAmount,
         inUtxos: [utxo1, utxoSol],
-        publicAmountSol: new BN(0),
+        publicAmountSol: BN_0,
         poseidon,
         changeUtxoAccount: k0,
         action: Action.UNSHIELD,
@@ -798,7 +801,7 @@ describe("Test createOutUtxos Errors", () => {
         publicMint: tokenCtx.mint,
         publicAmountSpl: splAmount,
         inUtxos: [utxo1, utxoSol],
-        publicAmountSol: new BN(0),
+        publicAmountSol: BN_0,
         poseidon,
         changeUtxoAccount: k0,
         action: Action.UNSHIELD,
@@ -806,7 +809,7 @@ describe("Test createOutUtxos Errors", () => {
           new Utxo({
             poseidon,
             assets: [SystemProgram.programId, invalidMint],
-            amounts: [new BN(0), new BN(1)],
+            amounts: [BN_0, BN_1],
             assetLookupTable: [
               ...lightProvider.lookUpTables.assetLookupTable,
               ...[invalidMint.toBase58()],
@@ -831,7 +834,7 @@ describe("Test createOutUtxos Errors", () => {
         publicMint: tokenCtx.mint,
         publicAmountSpl: splAmount,
         inUtxos: [utxo1, utxoSol],
-        publicAmountSol: new BN(0),
+        publicAmountSol: BN_0,
         poseidon,
         changeUtxoAccount: k0,
         action: Action.UNSHIELD,
@@ -839,7 +842,7 @@ describe("Test createOutUtxos Errors", () => {
           new Utxo({
             poseidon,
             assets: [SystemProgram.programId, utxo1.assets[1]],
-            amounts: [new BN(0), new BN(1e12)],
+            amounts: [BN_0, new BN(1e12)],
             assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
             verifierProgramLookupTable:
               lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -861,7 +864,7 @@ describe("Test createOutUtxos Errors", () => {
         publicMint: tokenCtx.mint,
         // publicAmountSpl: splAmount,
         inUtxos: [utxo1, utxoSol],
-        // publicAmountSol: new BN(0),
+        // publicAmountSol: BN_0,
         poseidon,
         changeUtxoAccount: k0,
         action: Action.UNSHIELD,
@@ -881,11 +884,11 @@ describe("Test createOutUtxos Errors", () => {
         // publicMint: tokenCtx.mint,
         publicAmountSpl: splAmount,
         inUtxos: [utxo1, utxoSol],
-        // publicAmountSol: new BN(0),
+        // publicAmountSol: BN_0,
         poseidon,
         changeUtxoAccount: k0,
         action: Action.UNSHIELD,
-        relayerFee: new BN(1),
+        relayerFee: BN_1,
       });
     })
       .to.throw(CreateUtxoError)
@@ -902,12 +905,12 @@ describe("Test createOutUtxos Errors", () => {
   //             publicMint: tokenCtx.mint,
   //             publicAmountSpl: splAmount,
   //             inUtxos: [utxo1, utxoSol],
-  //             publicAmountSol: new BN(0),
+  //             publicAmountSol: BN_0,
   //             poseidon,
   //             changeUtxoAccount: k0,
   //             action: Action.UNSHIELD,
   //             // @ts-ignore
-  //             recipients: [{account: recipientAccount, mint: utxo1.assets[1], solAmount: new BN(0)}],
+  //             recipients: [{account: recipientAccount, mint: utxo1.assets[1], solAmount: BN_0}],
   //         });
   //     }).to.throw(CreateUtxoError).includes({
   //         code: CreateUtxoErrorCode.SPL_AMOUNT_UNDEFINED,
@@ -935,7 +938,7 @@ describe("Test createOutUtxos Errors", () => {
         publicMint: tokenCtx.mint,
         publicAmountSpl: splAmount,
         inUtxos: [utxo1, utxoSol0],
-        publicAmountSol: new BN(0),
+        publicAmountSol: BN_0,
         poseidon,
         changeUtxoAccount: k0,
         action: Action.UNSHIELD,
@@ -943,7 +946,7 @@ describe("Test createOutUtxos Errors", () => {
           new Utxo({
             poseidon,
             assets: [SystemProgram.programId, utxo1.assets[1]],
-            amounts: [new BN(0), new BN(1)],
+            amounts: [BN_0, BN_1],
             assetLookupTable: [
               ...lightProvider.lookUpTables.assetLookupTable,
               ...[invalidMint.toBase58()],

--- a/light-zk.js/tests/relayer.test.ts
+++ b/light-zk.js/tests/relayer.test.ts
@@ -5,6 +5,8 @@ import { BN } from "@coral-xyz/anchor";
 import { it } from "mocha";
 
 import {
+  BN_0,
+  BN_1,
   Relayer,
   RelayerError,
   RelayerErrorCode,
@@ -23,7 +25,7 @@ describe("Test Relayer Functional", () => {
     let relayer = new Relayer(
       mockKeypair.publicKey,
       mockKeypair1.publicKey,
-      new BN(1),
+      BN_1,
     );
     assert.equal(
       relayer.accounts.relayerRecipientSol.toBase58(),
@@ -60,7 +62,7 @@ describe("Test Relayer Functional", () => {
       TOKEN_ACCOUNT_FEE.toNumber(),
       relayer.getRelayerFee(true).toNumber(),
     );
-    assert.equal(new BN(0).toNumber(), relayer.getRelayerFee(false).toNumber());
+    assert.equal(BN_0.toNumber(), relayer.getRelayerFee(false).toNumber());
   });
 });
 

--- a/light-zk.js/tests/selectInUtxos.test.ts
+++ b/light-zk.js/tests/selectInUtxos.test.ts
@@ -26,6 +26,8 @@ import {
   createRecipientUtxos,
   Provider,
   RELAYER_FEE,
+  BN_0,
+  BN_1,
 } from "../src";
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
 
@@ -117,7 +119,7 @@ describe("Test selectInUtxos Functional", () => {
     let selectedUtxo = selectInUtxos({
       publicMint: utxo1.assets[1],
       relayerFee: RELAYER_FEE,
-      publicAmountSpl: new BN(1),
+      publicAmountSpl: BN_1,
       poseidon,
       utxos: inUtxos,
       action: Action.UNSHIELD,
@@ -154,7 +156,7 @@ describe("Test selectInUtxos Functional", () => {
       poseidon,
       publicMint: utxo1.assets[1],
       publicAmountSol: new BN(1e7),
-      publicAmountSpl: new BN(1),
+      publicAmountSpl: BN_1,
       numberMaxInUtxos,
       numberMaxOutUtxos,
     });
@@ -170,7 +172,7 @@ describe("Test selectInUtxos Functional", () => {
         {
           mint: utxo1.assets[1],
           solAmount: new BN(1e7),
-          splAmount: new BN(1),
+          splAmount: BN_1,
           account: new Account({ poseidon }),
         },
       ],
@@ -201,7 +203,7 @@ describe("Test selectInUtxos Functional", () => {
         {
           mint: utxo1.assets[1],
           solAmount: new BN(1e7),
-          splAmount: new BN(0),
+          splAmount: BN_0,
           account: new Account({ poseidon }),
         },
       ],
@@ -230,8 +232,8 @@ describe("Test selectInUtxos Functional", () => {
       recipients: [
         {
           mint: utxo1.assets[1],
-          solAmount: new BN(0),
-          splAmount: new BN(1),
+          solAmount: BN_0,
+          splAmount: BN_1,
           account: new Account({ poseidon }),
         },
       ],
@@ -263,7 +265,7 @@ describe("Test selectInUtxos Functional", () => {
       publicMint: utxo1.assets[1],
       publicAmountSol: new BN(1e7),
       poseidon,
-      publicAmountSpl: new BN(1),
+      publicAmountSpl: BN_1,
       numberMaxInUtxos,
       numberMaxOutUtxos,
     });
@@ -295,7 +297,7 @@ describe("Test selectInUtxos Functional", () => {
       action: Action.SHIELD,
       publicMint: utxo1.assets[1],
       poseidon,
-      publicAmountSpl: new BN(1),
+      publicAmountSpl: BN_1,
       numberMaxInUtxos,
       numberMaxOutUtxos,
     });
@@ -417,7 +419,7 @@ describe("Test selectInUtxos Errors", () => {
         {
           mint: utxo1.assets[1],
           solAmount: new BN(1e7),
-          splAmount: new BN(1),
+          splAmount: BN_1,
           account: new Account({ poseidon }),
         },
       ],
@@ -454,7 +456,7 @@ describe("Test selectInUtxos Errors", () => {
         poseidon,
         // publicMint: utxo1.assets[1],
         publicAmountSol: new BN(1e7),
-        publicAmountSpl: new BN(1),
+        publicAmountSpl: BN_1,
         numberMaxInUtxos,
         numberMaxOutUtxos,
       });
@@ -499,7 +501,7 @@ describe("Test selectInUtxos Errors", () => {
         poseidon,
         publicMint: utxo1.assets[1],
         publicAmountSol: new BN(1e7),
-        publicAmountSpl: new BN(1),
+        publicAmountSpl: BN_1,
         numberMaxInUtxos,
         numberMaxOutUtxos,
       });
@@ -522,7 +524,7 @@ describe("Test selectInUtxos Errors", () => {
         poseidon,
         publicMint: utxo1.assets[1],
         publicAmountSol: new BN(1e7),
-        publicAmountSpl: new BN(1),
+        publicAmountSpl: BN_1,
         numberMaxInUtxos,
         numberMaxOutUtxos,
       });
@@ -545,7 +547,7 @@ describe("Test selectInUtxos Errors", () => {
         poseidon,
         publicMint: utxo1.assets[1],
         publicAmountSol: new BN(1e7),
-        publicAmountSpl: new BN(1),
+        publicAmountSpl: BN_1,
         numberMaxInUtxos,
         numberMaxOutUtxos,
       });
@@ -568,7 +570,7 @@ describe("Test selectInUtxos Errors", () => {
         poseidon,
         publicMint: utxo1.assets[1],
         publicAmountSol: new BN(1e7),
-        publicAmountSpl: new BN(1),
+        publicAmountSpl: BN_1,
         numberMaxInUtxos,
         numberMaxOutUtxos,
       });
@@ -588,13 +590,13 @@ describe("Test selectInUtxos Errors", () => {
         {
           mint: utxo1.assets[1],
           solAmount: new BN(1e7),
-          splAmount: new BN(1),
+          splAmount: BN_1,
           account: new Account({ poseidon }),
         },
         {
           mint,
           solAmount: new BN(1e7),
-          splAmount: new BN(1),
+          splAmount: BN_1,
           account: new Account({ poseidon }),
         },
       ],
@@ -631,7 +633,7 @@ describe("Test selectInUtxos Errors", () => {
         {
           mint: utxo1.assets[1],
           solAmount: new BN(2e10),
-          splAmount: new BN(1),
+          splAmount: BN_1,
           account: new Account({ poseidon }),
         },
       ],
@@ -664,7 +666,7 @@ describe("Test selectInUtxos Errors", () => {
       recipients: [
         {
           mint: utxo1.assets[1],
-          solAmount: new BN(0),
+          solAmount: BN_0,
           splAmount: new BN(1e10),
           account: new Account({ poseidon }),
         },

--- a/light-zk.js/tests/transaction.test.ts
+++ b/light-zk.js/tests/transaction.test.ts
@@ -28,6 +28,9 @@ import {
   IDL_VERIFIER_PROGRAM_ZERO,
   IDL_VERIFIER_PROGRAM_TWO,
   IDL_VERIFIER_PROGRAM_STORAGE,
+  BN_0,
+  BN_1,
+  BN_2,
 } from "../src";
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
 
@@ -385,7 +388,7 @@ describe("Transaction Functional Tests", () => {
     let deposit_utxo1 = new Utxo({
       poseidon,
       assets: [FEE_ASSET, MINT],
-      amounts: [new BN(1), new BN(2)],
+      amounts: [BN_1, BN_2],
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -429,7 +432,7 @@ describe("Transaction Functional Tests", () => {
     let deposit_utxo2 = new Utxo({
       poseidon,
       assets: [FEE_ASSET],
-      amounts: [new BN(1)],
+      amounts: [BN_1],
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -461,7 +464,7 @@ describe("Transaction Functional Tests", () => {
     let deposit_utxo4 = new Utxo({
       poseidon,
       assets: [FEE_ASSET, MINT],
-      amounts: [new BN(0), new BN(2)],
+      amounts: [BN_0, BN_2],
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -493,7 +496,7 @@ describe("Transaction Functional Tests", () => {
     let deposit_utxo5 = new Utxo({
       poseidon,
       assets: [FEE_ASSET, MINT],
-      amounts: [new BN(2), new BN(0)],
+      amounts: [BN_2, BN_0],
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,

--- a/light-zk.js/tests/transactionParameters.test.ts
+++ b/light-zk.js/tests/transactionParameters.test.ts
@@ -28,6 +28,8 @@ import {
   IDL_VERIFIER_PROGRAM_ONE,
   IDL_VERIFIER_PROGRAM_TWO,
   MerkleTreeConfig,
+  BN_0,
+  BN_2,
 } from "../src";
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
@@ -539,7 +541,7 @@ describe("Test TransactionParameters Methods", () => {
     let outputUtxos = [
       new Utxo({
         poseidon,
-        amounts: [new BN(2), new BN(4)],
+        amounts: [BN_2, new BN(4)],
         assets: [SystemProgram.programId, MINT],
         assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
         verifierProgramLookupTable:
@@ -595,7 +597,7 @@ describe("Test TransactionParameters Methods", () => {
     let outputUtxos = [
       new Utxo({
         poseidon,
-        amounts: [new BN(2), new BN(4)],
+        amounts: [BN_2, new BN(4)],
         assets: [SystemProgram.programId, MINT],
         assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
         verifierProgramLookupTable:
@@ -836,10 +838,7 @@ describe("Test TransactionParameters Transfer Errors", () => {
     const localOutputUtxo = new Utxo({
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
-      amounts: [
-        new BN(depositFeeAmount).sub(relayer.getRelayerFee()),
-        new BN(0),
-      ],
+      amounts: [new BN(depositFeeAmount).sub(relayer.getRelayerFee()), BN_0],
       account: keypair,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
@@ -870,7 +869,7 @@ describe("Test TransactionParameters Transfer Errors", () => {
     const localOutputUtxo = new Utxo({
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
-      amounts: [new BN(0), new BN(depositAmount)],
+      amounts: [BN_0, new BN(depositAmount)],
       account: keypair,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
@@ -1096,7 +1095,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
     let utxo_sol_amount_no_u642 = new Utxo({
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
-      amounts: [new BN("18446744073709551615"), new BN(0)],
+      amounts: [new BN("18446744073709551615"), BN_0],
       account: keypair,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
@@ -1127,7 +1126,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
     let utxo_spl_amount_no_u641 = new Utxo({
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
-      amounts: [new BN(0), new BN("18446744073709551615")],
+      amounts: [BN_0, new BN("18446744073709551615")],
       account: keypair,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
@@ -1137,7 +1136,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
     let utxo_spl_amount_no_u642 = new Utxo({
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
-      amounts: [new BN(0), new BN("1")],
+      amounts: [BN_0, new BN("1")],
       account: keypair,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
@@ -1215,7 +1214,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
     let utxo_sol_amount_no_u642 = new Utxo({
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
-      amounts: [new BN("18446744073709551615"), new BN(0)],
+      amounts: [new BN("18446744073709551615"), BN_0],
       account: keypair,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
@@ -1385,7 +1384,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
     let utxo_sol_amount_no_u642 = new Utxo({
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
-      amounts: [new BN("18446744073709551615"), new BN(0)],
+      amounts: [new BN("18446744073709551615"), BN_0],
       account: keypair,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
@@ -1418,7 +1417,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
     let utxo_spl_amount_no_u641 = new Utxo({
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
-      amounts: [new BN(0), new BN("18446744073709551615")],
+      amounts: [BN_0, new BN("18446744073709551615")],
       account: keypair,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
@@ -1428,7 +1427,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
     let utxo_spl_amount_no_u642 = new Utxo({
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
-      amounts: [new BN(0), new BN("1")],
+      amounts: [BN_0, new BN("1")],
       account: keypair,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
@@ -1508,7 +1507,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
     let utxo_sol_amount_no_u642 = new Utxo({
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
-      amounts: [new BN("18446744073709551615"), new BN(0)],
+      amounts: [new BN("18446744073709551615"), BN_0],
       account: keypair,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
@@ -1534,7 +1533,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
     let utxo_sol_amount_no_u642 = new Utxo({
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
-      amounts: [new BN(0), new BN("18446744073709551615")],
+      amounts: [BN_0, new BN("18446744073709551615")],
       account: keypair,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:

--- a/light-zk.js/tests/utxo.test.ts
+++ b/light-zk.js/tests/utxo.test.ts
@@ -28,6 +28,8 @@ import {
   MerkleTreeConfig,
   createAccountObject,
   FIELD_SIZE,
+  BN_1,
+  BN_2,
 } from "../src";
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
 process.env.ANCHOR_PROVIDER_URL = "http://127.0.0.1:8899";
@@ -379,7 +381,7 @@ describe("Utxo Functional", () => {
       assets: [SystemProgram.programId],
       account,
       amounts: [new BN(1_000_000)],
-      appData: { releaseSlot: new BN(1) },
+      appData: { releaseSlot: BN_1 },
       appDataIdl: TEST_PSP_IDL,
       verifierAddress: verifierProgramId,
       index: 0,
@@ -406,7 +408,7 @@ describe("Utxo Functional", () => {
       {
         releaseSlot: 1,
         rndOtherStuff: { s: 2342 },
-        o: [2, 2, new BN(2)],
+        o: [2, 2, BN_2],
       },
       TEST_PSP_IDL.accounts,
       "utxoAppData",
@@ -418,7 +420,7 @@ describe("Utxo Functional", () => {
 
     expect(() => {
       createAccountObject(
-        { rndOtherStuff: { s: 2342 }, o: [2, 2, new BN(2)] },
+        { rndOtherStuff: { s: 2342 }, o: [2, 2, BN_2] },
         TEST_PSP_IDL.accounts,
         "utxoAppData",
       );
@@ -455,7 +457,7 @@ describe("Utxo Errors", () => {
     let account = Account.fromPubkey(publicKey, poseidon);
     let pubkeyUtxo = new Utxo({
       poseidon,
-      amounts: [new BN(1)],
+      amounts: [BN_1],
       account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
@@ -478,7 +480,7 @@ describe("Utxo Errors", () => {
     let account = Account.fromPubkey(publicKey, poseidon);
     let pubkeyUtxo = new Utxo({
       poseidon,
-      amounts: [new BN(1)],
+      amounts: [BN_1],
       account,
       index: 1,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
@@ -521,7 +523,7 @@ describe("Utxo Errors", () => {
       new Utxo({
         poseidon,
         assets: [MINT, MINT, MINT],
-        amounts: [new BN(1), new BN(1), new BN(1)],
+        amounts: [BN_1, BN_1, BN_1],
         account: inputs.keypair,
         blinding: inputs.blinding,
         assetLookupTable: lightProvider.lookUpTables.assetLookupTable,


### PR DESCRIPTION
* Define often used big numbers (0, 1, 2) as constants, exported in light-zk.js as a whole.
* Avoid conversion to strings when comparing big numbers, favor using `.eq()` instead. Sadly, `===` is not reliable in this case.