### PR TITLE
fix(programs): Require signer and registered verifier in `insert_two_leaves_event` instruction

### DIFF
--- a/light-system-programs/programs/merkle_tree_program/src/verifier_invoked_instructions/insert_two_leaves_event.rs
+++ b/light-system-programs/programs/merkle_tree_program/src/verifier_invoked_instructions/insert_two_leaves_event.rs
@@ -1,6 +1,9 @@
 use anchor_lang::prelude::*;
 
-use crate::{event_merkle_tree::EventMerkleTree, utils::constants::EVENT_MERKLE_TREE_SEED};
+use crate::{
+    event_merkle_tree::EventMerkleTree, utils::constants::EVENT_MERKLE_TREE_SEED,
+    RegisteredVerifier,
+};
 
 #[derive(Accounts)]
 #[instruction(
@@ -8,12 +11,24 @@ use crate::{event_merkle_tree::EventMerkleTree, utils::constants::EVENT_MERKLE_T
     leaf_right: [u8; 32],
 )]
 pub struct InsertTwoLeavesEvent<'info> {
+    #[account(
+        mut,
+        seeds = [__program_id.to_bytes().as_ref()],
+        bump,
+        seeds::program = registered_verifier.pubkey,
+    )]
+    pub authority: Signer<'info>,
     #[account(mut, seeds = [
         EVENT_MERKLE_TREE_SEED,
         event_merkle_tree.load().unwrap().merkle_tree_nr.to_le_bytes().as_ref()
     ], bump)]
     pub event_merkle_tree: AccountLoader<'info, EventMerkleTree>,
     pub system_program: Program<'info, System>,
+    #[account(
+        seeds = [&registered_verifier.pubkey.to_bytes()],
+        bump,
+    )]
+    pub registered_verifier: Account<'info, RegisteredVerifier>,
 }
 
 pub fn process_insert_two_leaves_event(

--- a/light-verifier-sdk/src/cpi_instructions.rs
+++ b/light-verifier-sdk/src/cpi_instructions.rs
@@ -127,8 +127,10 @@ pub fn insert_two_leaves_cpi<'a, 'b>(
 pub fn insert_two_leaves_event_cpi<'a, 'b>(
     program_id: &Pubkey,
     merkle_tree_program_id: &'b AccountInfo<'a>,
+    authority: &'b AccountInfo<'a>,
     event_merkle_tree: &'b AccountInfo<'a>,
     system_program: &'b AccountInfo<'a>,
+    registered_verifier: &'b AccountInfo<'a>,
     leaf_left: &'b [u8; 32],
     leaf_right: &'b [u8; 32],
 ) -> Result<()> {
@@ -137,8 +139,10 @@ pub fn insert_two_leaves_event_cpi<'a, 'b>(
     let seeds = &[&[seed.as_slice(), bump][..]];
 
     let accounts = merkle_tree_program::cpi::accounts::InsertTwoLeavesEvent {
+        authority: authority.clone(),
         event_merkle_tree: event_merkle_tree.clone(),
         system_program: system_program.clone(),
+        registered_verifier: registered_verifier.clone(),
     };
 
     let cpi_ctx = CpiContext::new_with_signer(merkle_tree_program_id.clone(), accounts, seeds);

--- a/light-verifier-sdk/src/light_transaction.rs
+++ b/light-verifier-sdk/src/light_transaction.rs
@@ -366,12 +366,19 @@ impl<
                 .unwrap()
                 .program_merkle_tree
                 .to_account_info(),
+            &self.input.accounts.unwrap().authority.to_account_info(),
             &event_merkle_tree.to_account_info(),
             &self
                 .input
                 .accounts
                 .unwrap()
                 .system_program
+                .to_account_info(),
+            &self
+                .input
+                .accounts
+                .unwrap()
+                .registered_verifier_pda
                 .to_account_info(),
             &self.event_hash,
             &[0; 32],

--- a/light-zk.js/src/idls/merkle_tree_program.ts
+++ b/light-zk.js/src/idls/merkle_tree_program.ts
@@ -745,12 +745,22 @@ export type MerkleTreeProgram = {
       "name": "insertTwoLeavesEvent",
       "accounts": [
         {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
           "name": "eventMerkleTree",
           "isMut": true,
           "isSigner": false
         },
         {
           "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "registeredVerifier",
           "isMut": false,
           "isSigner": false
         }
@@ -2238,12 +2248,22 @@ export const IDL: MerkleTreeProgram = {
       "name": "insertTwoLeavesEvent",
       "accounts": [
         {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
           "name": "eventMerkleTree",
           "isMut": true,
           "isSigner": false
         },
         {
           "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "registeredVerifier",
           "isMut": false,
           "isSigner": false
         }


### PR DESCRIPTION
These fields are securing that instruction, making sure that it's called via CPI from a registered verifier program.