### PR TITLE
fix(verifier-sdk): Remove redundant comparison of mint public key

### DIFF
--- a/light-verifier-sdk/src/light_transaction.rs
+++ b/light-verifier-sdk/src/light_transaction.rs
@@ -725,14 +725,6 @@ impl<
                 );
                 return err!(VerifierSdkError::InconsistentMintProofSenderOrRecipient);
             }
-            if self.mint_pubkey[1..] != hash(&sender_mint.mint.to_bytes()).try_to_vec()?[1..] {
-                msg!(
-                    "*self.mint_pubkey[..31] {:?}, {:?}, sender_spl mint",
-                    self.mint_pubkey[1..].to_vec(),
-                    hash(&sender_mint.mint.to_bytes()).try_to_vec()?[1..].to_vec()
-                );
-                return err!(VerifierSdkError::InconsistentMintProofSenderOrRecipient);
-            }
 
             // is a token deposit or withdrawal
             if self.is_deposit() {


### PR DESCRIPTION
`self.mint_pubkey` is set as follows:

```rust
self.mint_pubkey = [
   vec![0u8],
   hash(&sender_mint.mint.to_bytes()).try_to_vec()?[1..].to_vec(),
];
```

So the removed condition check (whether `self.mint_pubkey[1..]` is not equal to `hash(&sender_mint.mint.to_bytes())[1..]` can be never true. It's redundant.

Fixes: #238