### PR TITLE
chore(cli): Switch to the main branch of Light Protocol

### DIFF
--- a/cli/src/psp-utils/constants.ts
+++ b/cli/src/psp-utils/constants.ts
@@ -6,8 +6,8 @@ export const PROVER_JS_VERSION = "file:../light-prover.js";
 export const PSP_DEFAULT_PROGRAM_ID =
   "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS";
 export const LIGHT_SYSTEM_PROGRAMS_VERSION =
-  '{ git = "https://github.com/lightprotocol/light-protocol", features = ["cpi"], branch = "vadorovsky/verifier-sdk-ctx-accounts-v2" }';
+  '{ git = "https://github.com/lightprotocol/light-protocol", features = ["cpi"], branch = "main" }';
 export const LIGHT_MACROS_VERSION =
-  '{ git = "https://github.com/lightprotocol/light-protocol", branch = "vadorovsky/verifier-sdk-ctx-accounts-v2" }';
+  '{ git = "https://github.com/lightprotocol/light-protocol", branch = "main" }';
 export const LIGHT_VERIFIER_SDK_VERSION =
-  '{ git = "https://github.com/lightprotocol/light-protocol", branch = "vadorovsky/verifier-sdk-ctx-accounts-v2" }';
+  '{ git = "https://github.com/lightprotocol/light-protocol", branch = "main" }';


### PR DESCRIPTION
The change with `#[light_verifier_accounts]` macro (#232) is already merged, so it's time to use the main branch of Light Protocol in the PSP template.