### PR TITLE
feat(programs): Add User Registry mapping Solana to Light Protocol accounts

### DIFF
--- a/cli/scripts/copyLocalProgramBinaries.sh
+++ b/cli/scripts/copyLocalProgramBinaries.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-keys="merkle_tree_program verifier_program_zero verifier_program_one verifier_program_two verifier_program_storage"
+keys="merkle_tree_program verifier_program_zero verifier_program_one verifier_program_two verifier_program_storage user_registry"
 
 mkdir -p bin/programs
 cd ..

--- a/cli/src/utils/initTestEnv.ts
+++ b/cli/src/utils/initTestEnv.ts
@@ -115,6 +115,10 @@ export async function start_test_validator({
       id: "2cxC8e8uNYLcymH6RTGuJs3N8fXGkwmMpw45pY65Ay86",
       name: "verifier_program_two.so",
     },
+    {
+      id: "6UqiSPd2mRCTTwkzhcs1M6DGYsqHWd5jiPueX3LwDMXQ",
+      name: "user_registry.so",
+    },
   ];
   if (additonalPrograms)
     additonalPrograms.forEach((program) => {

--- a/light-system-programs/Cargo.lock
+++ b/light-system-programs/Cargo.lock
@@ -1076,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -5568,6 +5568,14 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "user_registry"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "bytemuck",
 ]
 
 [[package]]

--- a/light-system-programs/package.json
+++ b/light-system-programs/package.json
@@ -12,7 +12,8 @@
     "test-verifiers": "yarn start-test-validator && ts-mocha -t 2000000 tests/verifier_tests.ts --exit",
     "test-merkle-tree": "./../cli/test_bin/run test-validator -b -s && ts-mocha -t 2000000 tests/merkle_tree_tests.ts --exit",
     "test-provider": "yarn start-test-validator && ts-mocha -t 2000000 tests/provider.test.ts --exit",
-    "test": "yarn test-functional && yarn run test-merkle-tree && yarn run test-user && yarn run test-provider && yarn test-user-merge && yarn run test-verifiers",
+    "test-user-registry": "yarn start-test-validator && ts-mocha -t 2000000 tests/user-registry.tests.ts --exit",
+    "test": "yarn test-functional && yarn run test-merkle-tree && yarn run test-user && yarn run test-provider && yarn test-user-merge && yarn run test-verifiers && yarn run test-user-registry",
     "airdrop-testnet": "yarn ts-node ./scripts/airdropTestnet.ts",
     "createLookupTable-testnet": "yarn ts-node ./scripts/createLookUpTable.ts",
     "format": "yarn prettier --write \"tests/**/*.{ts,js}\""

--- a/light-system-programs/programs/user_registry/Cargo.toml
+++ b/light-system-programs/programs/user_registry/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "user_registry"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "user_registry"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = "0.28.0"
+bytemuck = "1.14"

--- a/light-system-programs/programs/user_registry/Xargo.toml
+++ b/light-system-programs/programs/user_registry/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/light-system-programs/programs/user_registry/src/lib.rs
+++ b/light-system-programs/programs/user_registry/src/lib.rs
@@ -1,0 +1,45 @@
+use anchor_lang::prelude::*;
+
+declare_id!("6UqiSPd2mRCTTwkzhcs1M6DGYsqHWd5jiPueX3LwDMXQ");
+
+const USER_ENTRY_SEED: &[u8] = b"user-entry";
+
+#[program]
+pub mod user_registry {
+    use super::*;
+
+    pub fn initialize_user_entry(
+        ctx: Context<InitializeUserEntry>,
+        light_pubkey: [u8; 32],
+        light_encryption_pubkey: [u8; 32],
+    ) -> Result<()> {
+        let user_entry = &mut ctx.accounts.user_entry;
+        user_entry.solana_pubkey = ctx.accounts.signer.key().to_bytes();
+        user_entry.light_pubkey = light_pubkey;
+        user_entry.light_encryption_pubkey = light_encryption_pubkey;
+
+        Ok(())
+    }
+}
+
+#[account]
+pub struct UserEntry {
+    pub solana_pubkey: [u8; 32],
+    pub light_pubkey: [u8; 32],
+    pub light_encryption_pubkey: [u8; 32],
+}
+
+#[derive(Accounts)]
+pub struct InitializeUserEntry<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+    #[account(
+        init,
+        space = 8 + 32 + 32 + 32,
+        seeds = [USER_ENTRY_SEED, signer.key().to_bytes().as_ref()],
+        bump,
+        payer = signer,
+    )]
+    pub user_entry: Account<'info, UserEntry>,
+}

--- a/light-system-programs/tests/user-registry.tests.ts
+++ b/light-system-programs/tests/user-registry.tests.ts
@@ -1,0 +1,109 @@
+import * as anchor from "@coral-xyz/anchor";
+import { AnchorProvider, Program } from "@coral-xyz/anchor";
+import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
+import {
+  IDL_USER_REGISTRY,
+  userRegistryProgramId,
+  confirmConfig,
+  UserRegistry,
+  ADMIN_AUTH_KEYPAIR,
+  ADMIN_AUTH_KEY,
+  createTestAccounts,
+  userTokenAccount,
+  Account,
+  Provider,
+  TestRelayer,
+  RELAYER_FEE,
+} from "@lightprotocol/zk.js";
+import {
+  Keypair as SolanaKeypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+} from "@solana/web3.js";
+import { assert } from "chai";
+const circomlibjs = require("circomlibjs");
+
+let KEYPAIR: Account, RELAYER: TestRelayer;
+
+describe("User registry", () => {
+  // Configure the client to use the local cluster.
+  process.env.ANCHOR_WALLET = process.env.HOME + "/.config/solana/id.json";
+  process.env.ANCHOR_PROVIDER_URL = "http://127.0.0.1:8899";
+
+  const provider = AnchorProvider.local("http://127.0.0.1:8899", confirmConfig);
+  anchor.setProvider(provider);
+
+  const userRegistryProgram: Program<UserRegistry> = new Program(
+    IDL_USER_REGISTRY,
+    userRegistryProgramId,
+    provider,
+  );
+
+  before("Create user", async () => {
+    await createTestAccounts(provider.connection, userTokenAccount);
+
+    let poseidon = await circomlibjs.buildPoseidonOpt();
+    const seed = bs58.encode(new Uint8Array(32).fill(1));
+    KEYPAIR = new Account({
+      poseidon: poseidon,
+      seed,
+    });
+
+    const relayerRecipientSol = SolanaKeypair.generate().publicKey;
+
+    await provider.connection.requestAirdrop(
+      relayerRecipientSol,
+      2_000_000_000,
+    );
+
+    RELAYER = new TestRelayer({
+      relayerPubkey: ADMIN_AUTH_KEYPAIR.publicKey,
+      relayerRecipientSol,
+      relayerFee: RELAYER_FEE,
+      payer: ADMIN_AUTH_KEYPAIR,
+    });
+
+    await Provider.init({
+      wallet: ADMIN_AUTH_KEYPAIR,
+      relayer: RELAYER,
+      confirmConfig,
+    });
+  });
+
+  it("Register user", async () => {
+    const userEntryPubkey = PublicKey.findProgramAddressSync(
+      [anchor.utils.bytes.utf8.encode("user-entry"), ADMIN_AUTH_KEY.toBuffer()],
+      userRegistryProgramId,
+    )[0];
+    const tx = await userRegistryProgram.methods
+      .initializeUserEntry(KEYPAIR.pubkey.toArray(), [
+        ...KEYPAIR.encryptionKeypair.publicKey,
+      ])
+      .accounts({
+        signer: ADMIN_AUTH_KEYPAIR.publicKey,
+        systemProgram: SystemProgram.programId,
+        userEntry: userEntryPubkey,
+      })
+      .signers([ADMIN_AUTH_KEYPAIR])
+      .transaction();
+    await sendAndConfirmTransaction(
+      provider.connection,
+      tx,
+      [ADMIN_AUTH_KEYPAIR],
+      confirmConfig,
+    );
+
+    let accountInfo = await userRegistryProgram.account.userEntry.fetch(
+      userEntryPubkey,
+    );
+    assert.deepEqual(accountInfo.lightPubkey, KEYPAIR.pubkey.toArray());
+    assert.deepEqual(accountInfo.lightEncryptionPubkey, [
+      ...KEYPAIR.encryptionKeypair.publicKey,
+    ]);
+    assert.deepEqual(
+      new Uint8Array(accountInfo.solanaPubkey),
+      ADMIN_AUTH_KEY.toBytes(),
+    );
+  });
+});

--- a/light-zk.js/src/constants.ts
+++ b/light-zk.js/src/constants.ts
@@ -11,7 +11,7 @@ import {
   VerifierProgramOne,
   VerifierProgramZero,
   MerkleTreeProgram,
-} from "./idls";
+} from "./idls/index";
 
 import {
   ConfirmOptions,
@@ -58,6 +58,9 @@ export const verifierProgramOneProgramId = new PublicKey(
 );
 export const verifierProgramTwoProgramId = new PublicKey(
   "2cxC8e8uNYLcymH6RTGuJs3N8fXGkwmMpw45pY65Ay86",
+);
+export const userRegistryProgramId = new PublicKey(
+  "6UqiSPd2mRCTTwkzhcs1M6DGYsqHWd5jiPueX3LwDMXQ",
 );
 
 export const LOOK_UP_TABLE = new PublicKey(

--- a/light-zk.js/src/idls/index.ts
+++ b/light-zk.js/src/idls/index.ts
@@ -18,3 +18,7 @@ export {
   VerifierProgramZero,
   IDL as IDL_VERIFIER_PROGRAM_ZERO,
 } from "./verifier_program_zero";
+export {
+  UserRegistry,
+  IDL as IDL_USER_REGISTRY,
+} from "./user_registry";

--- a/light-zk.js/src/idls/user_registry.ts
+++ b/light-zk.js/src/idls/user_registry.ts
@@ -1,0 +1,167 @@
+export type UserRegistry = {
+  "version": "0.1.0",
+  "name": "user_registry",
+  "instructions": [
+    {
+      "name": "initializeUserEntry",
+      "accounts": [
+        {
+          "name": "signer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "userEntry",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "lightPubkey",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "lightEncryptionPubkey",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "userEntry",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "solanaPubkey",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "lightPubkey",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "lightEncryptionPubkey",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+};
+
+export const IDL: UserRegistry = {
+  "version": "0.1.0",
+  "name": "user_registry",
+  "instructions": [
+    {
+      "name": "initializeUserEntry",
+      "accounts": [
+        {
+          "name": "signer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "userEntry",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "lightPubkey",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "lightEncryptionPubkey",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "userEntry",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "solanaPubkey",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "lightPubkey",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "lightEncryptionPubkey",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+};


### PR DESCRIPTION
This registry is the on-chain program where Solana users are supposed to store their Light Protocol public keys. Then this program and its accounts should be used by the SDK for resolution.