### PR TITLE
feat(cli): Add `config:pubkey` command

### DIFF
--- a/cli/src/commands/config/pubkey.ts
+++ b/cli/src/commands/config/pubkey.ts
@@ -1,0 +1,20 @@
+import { Command } from "@oclif/core";
+import { CustomLoader, getPayer } from "../../utils";
+
+class PubkeyCommand extends Command {
+  static description =
+    "Get the Solana public key from the secret key specified in configuration.";
+
+  static examples = ["light config:pubkey"];
+
+  async run() {
+    const loader = new CustomLoader("Retrieving the public key");
+    loader.start();
+
+    const payer = getPayer();
+    loader.stop(false);
+    this.log(payer.publicKey.toBase58());
+  }
+}
+
+export default PubkeyCommand;

--- a/cli/test/commands/config/index.test.ts
+++ b/cli/test/commands/config/index.test.ts
@@ -62,3 +62,15 @@ describe("config with env variable", () => {
       );
     });
 });
+
+describe("pubkey", () => {
+  before(async () => {
+    await initTestEnvIfNeeded();
+  });
+  test
+    .stdout({ print: true })
+    .command("config:pubkey")
+    .it("Get public key", ({ stdout }) => {
+      expect(stdout).to.contain("ALA2cnz41Wa2v2EYUdkYHsg7VnKsbH1j7secM5aiP8k");
+    });
+});


### PR DESCRIPTION
A new command which retrieves the Solana public key from the secret key specified in the config. Might be useful when dealing with default config or when simply forgetting what the public key was.