### PR TITLE
fix(cli): Correct the output of `merkle-tree:initialize` command

### DIFF
--- a/cli/src/commands/merkle-tree/initialize.ts
+++ b/cli/src/commands/merkle-tree/initialize.ts
@@ -12,7 +12,7 @@ class InitializeCommand extends Command {
   static examples = ["light merkle-tree:initialize"];
 
   async run() {
-    const loader = new CustomLoader("Initializing new Transaction Merkle Tree");
+    const loader = new CustomLoader("Initializing new Merkle Trees");
     loader.start();
 
     const { connection } = await setAnchorProvider();
@@ -30,25 +30,23 @@ class InitializeCommand extends Command {
 
     const newEventMerkleTreeIndex =
       merkleTreeAuthorityAccountInfo.eventMerkleTreeIndex;
-    const newEventMerkleTree = MerkleTreeConfig.getTransactionMerkleTreePda(
+    const newEventMerkleTree = MerkleTreeConfig.getEventMerkleTreePda(
       newEventMerkleTreeIndex
     );
 
     await merkleTreeConfig.initializeNewMerkleTrees();
-    this.log(
-      "Transaction Merkle Tree initialized successfully \x1b[32m✔\x1b[0m"
-    );
+    this.log("Merkle Trees initialized successfully \x1b[32m✔\x1b[0m");
     ux.table(
       [
         {
           type: "Transaction",
-          index: newTransactionMerkleTreeIndex,
-          publicKey: newTransactionMerkleTree,
+          index: newTransactionMerkleTreeIndex.toString(),
+          publicKey: newTransactionMerkleTree.toBase58(),
         },
         {
           type: "Event",
-          index: newEventMerkleTreeIndex,
-          publicKey: newEventMerkleTree,
+          index: newEventMerkleTreeIndex.toString(),
+          publicKey: newEventMerkleTree.toBase58(),
         },
       ],
       {

--- a/cli/test/commands/merkle-tree/index.test.ts
+++ b/cli/test/commands/merkle-tree/index.test.ts
@@ -20,8 +20,6 @@ describe("merkle-tree", () => {
     .stdout()
     .command(["merkle-tree:initialize"])
     .it("Initialize new Merkle Trees", ({ stdout }) => {
-      expect(stdout).to.contain(
-        "Transaction Merkle Tree initialized successfully"
-      );
+      expect(stdout).to.contain("Merkle Trees initialized successfully");
     });
 });


### PR DESCRIPTION
* Mention "Merkle Trees" instead of "Transaction Merkle Tree". This command initialized the pair of trees (transaction and event) at once.
* Make indexes and public keys human-readable.