### PR TITLE
build: Define alias for `light` command in devenv

### DIFF
--- a/scripts/devenv.sh
+++ b/scripts/devenv.sh
@@ -6,6 +6,7 @@ deactivate () {
     NPM_CONFIG_PREFIX="${LIGHT_PROTOCOL_OLD_NPM_CONFIG_PREFIX}"
     PATH="${LIGHT_PROTOCOL_OLD_PATH}"
     unset LIGHT_PROTOCOL_DEVENV
+    unset LIGHT_PROTOCOL_TOPLEVEL
 }
 
 # Stop early if already in devenv.
@@ -15,22 +16,28 @@ else
     return
 fi
 
+# The root of the git repository.
+LIGHT_PROTOCOL_TOPLEVEL="`git rev-parse --show-toplevel`"
+
 # Shell prompt.
 LIGHT_PROTOCOL_OLD_PS1="${PS1:-}"
 PS1="[🧢 Light Protocol devenv] ${PS1:-}"
 
 # Ensure that our rustup environment is used.
 LIGHT_PROTOCOL_OLD_RUSTUP_HOME="${RUSTUP_HOME:-}"
-RUSTUP_HOME="`git rev-parse --show-toplevel`/.local/rustup"
+RUSTUP_HOME="${LIGHT_PROTOCOL_TOPLEVEL}/.local/rustup"
 LIGHT_PROTOCOL_OLD_CARGO_HOME="${CARGO_HOME:-}"
-CARGO_HOME="`git rev-parse --show-toplevel`/.local/cargo"
+CARGO_HOME="${LIGHT_PROTOCOL_TOPLEVEL}/.local/cargo"
 
 # Ensure that our npm prefix is used.
 LIGHT_PROTOCOL_OLD_NPM_CONFIG_PREFIX="${NPM_CONFIG_PREFIX:-}"
-NPM_CONFIG_PREFIX="`git rev-parse --show-toplevel`/.local/npm-global"
+NPM_CONFIG_PREFIX="${LIGHT_PROTOCOL_TOPLEVEL}/.local/npm-global"
 
 # Always use our binaries first.
 LIGHT_PROTOCOL_OLD_PATH="${PATH}"
-PATH="`git rev-parse --show-toplevel`/.local/bin:$PATH"
-PATH="`git rev-parse --show-toplevel`/.local/cargo/bin:$PATH"
-PATH="`git rev-parse --show-toplevel`/.local/npm-global/bin:$PATH"
+PATH="${LIGHT_PROTOCOL_TOPLEVEL}/.local/bin:${PATH}"
+PATH="${LIGHT_PROTOCOL_TOPLEVEL}/.local/cargo/bin:${PATH}"
+PATH="${LIGHT_PROTOCOL_TOPLEVEL}/.local/npm-global/bin:${PATH}"
+
+# Define alias of `light` to use the CLI built from source.
+alias light="${LIGHT_PROTOCOL_TOPLEVEL}/cli/test_bin/run"


### PR DESCRIPTION
To make sure that `light` command always points to the locally built CLI, instead of any globally installed command, and to get rid of necessity of typing `./cli/test_bin/run` manually, define an alias.