### PR TITLE
feat(cli): Add `pool-type:register` command

### DIFF
--- a/cli/src/commands/asset-pool/list.ts
+++ b/cli/src/commands/asset-pool/list.ts
@@ -1,5 +1,5 @@
 import { Command, ux } from "@oclif/core";
-import { Program } from "@coral-xyz/anchor";
+import { BN, Program } from "@coral-xyz/anchor";
 import { CustomLoader, setAnchorProvider } from "../../utils/utils";
 import {
   IDL_MERKLE_TREE_PROGRAM,
@@ -33,7 +33,7 @@ class AssetPoolListCommand extends Command {
       },
       type: {
         header: "Type",
-        get: (account) => account.account.poolType,
+        get: (account) => new BN(account.account.poolType).toString(),
       },
       publicKey: {
         header: "Public key",

--- a/cli/src/commands/asset-pool/register-spl.ts
+++ b/cli/src/commands/asset-pool/register-spl.ts
@@ -1,6 +1,6 @@
+import { BN } from "@coral-xyz/anchor";
 import { Args, Command } from "@oclif/core";
 import { CustomLoader, getWalletConfig, setAnchorProvider } from "../../utils";
-import { POOL_TYPE } from "@lightprotocol/zk.js";
 import { PublicKey } from "@solana/web3.js";
 
 class RegisterSplCommand extends Command {
@@ -9,6 +9,10 @@ class RegisterSplCommand extends Command {
   static examples = ["light asset-pool:register-spl"];
 
   static args = {
+    poolType: Args.string({
+      description: "Pool type to register the SPL pool in.",
+      required: true,
+    }),
     mint: Args.string({
       name: "mint",
       description: "Solana public key for the mint.",
@@ -21,14 +25,20 @@ class RegisterSplCommand extends Command {
     loader.start();
 
     const { args } = await this.parse(RegisterSplCommand);
-    const { mint } = args;
+    const poolType = new BN(args.poolType);
+    const mint = new PublicKey(args.mint);
 
     const { connection } = await setAnchorProvider();
     let merkleTreeConfig = await getWalletConfig(connection);
 
-    const mintKey = new PublicKey(mint);
-
-    await merkleTreeConfig.registerSplPool(POOL_TYPE, mintKey);
+    try {
+      await merkleTreeConfig.registerSplPool(
+        [...poolType.toArrayLike(Buffer, "be", 32)],
+        mint
+      );
+    } catch (e) {
+      console.log(e);
+    }
 
     loader.stop(false);
     this.log("SPL pool registered successfully \x1b[32m✔\x1b[0m");

--- a/cli/src/commands/pool-type/list.ts
+++ b/cli/src/commands/pool-type/list.ts
@@ -1,5 +1,5 @@
 import { Command, ux } from "@oclif/core";
-import { Program } from "@coral-xyz/anchor";
+import { BN, Program } from "@coral-xyz/anchor";
 import { CustomLoader, setAnchorProvider } from "../../utils";
 import {
   IDL_MERKLE_TREE_PROGRAM,
@@ -28,7 +28,7 @@ class PoolTypeListCommand extends Command {
     ux.table(poolTypes, {
       type: {
         header: "Type",
-        get: (account) => account.account.poolType,
+        get: (account) => new BN(account.account.poolType).toString(),
       },
     });
   }

--- a/cli/src/commands/pool-type/register.ts
+++ b/cli/src/commands/pool-type/register.ts
@@ -2,35 +2,34 @@ import { BN } from "@coral-xyz/anchor";
 import { Args, Command } from "@oclif/core";
 import { CustomLoader, getWalletConfig, setAnchorProvider } from "../../utils";
 
-class RegisterSolCommand extends Command {
-  static description = "Register SOL pool.";
+class PoolTypeRegister extends Command {
+  static description = "Register pool type.";
 
-  static examples = ["light asset-pool:register-sol"];
+  static examples = ["light pool-type:register 0"];
 
   static args = {
     poolType: Args.string({
-      description: "Pool type to register the SOL pool in.",
+      description: "Pool type to register.",
       required: true,
     }),
   };
 
   async run() {
-    const loader = new CustomLoader("Registering SOL pool");
+    const loader = new CustomLoader("Registering pool type");
     loader.start();
 
-    const { args } = await this.parse(RegisterSolCommand);
+    const { args } = await this.parse(PoolTypeRegister);
     const poolType = new BN(args.poolType);
 
     const { connection } = await setAnchorProvider();
     let merkleTreeConfig = await getWalletConfig(connection);
 
-    await merkleTreeConfig.registerSolPool([
+    await merkleTreeConfig.registerPoolType([
       ...poolType.toArrayLike(Buffer, "be", 32),
     ]);
-
+    this.log("Pool type registered successfully \x1b[32m✔\x1b[0m");
     loader.stop(false);
-    this.log("SOL pool registered successfully \x1b[32m✔\x1b[0m");
   }
 }
 
-export default RegisterSolCommand;
+export default PoolTypeRegister;

--- a/cli/test/commands/asset-pool/index.test.ts
+++ b/cli/test/commands/asset-pool/index.test.ts
@@ -1,5 +1,51 @@
 import test, { expect } from "@oclif/test";
-import { initTestEnv } from "../../../src/utils/initTestEnv";
+import { initTestEnv, killTestValidator } from "../../../src/utils/initTestEnv";
+
+describe("Without preloaded accounts", () => {
+  before(async () => {
+    await initTestEnv({ skip_system_accounts: true });
+  });
+  // Other tests require a validator with system accounts. Kill the current one
+  // which doesn't have them.
+  after(async () => {
+    await killTestValidator();
+  });
+
+  // TODO(vadorovsky): Teach `initTestEnv` to initialize only some accounts,
+  // then we will be able to not initialize the Merkle Tree Authority this
+  // way.
+  test
+    .stdout()
+    .command(["merkle-tree-authority:initialize"])
+    .it("Initialize Merkle Tree Authority", ({ stdout }) => {
+      expect(stdout).to.contain(
+        "Merkle Tree Authority initialized successfully"
+      );
+    });
+  test
+    .stdout()
+    .command(["pool-type:register", "0"])
+    .it("Register pool type", ({ stdout }) => {
+      expect(stdout).to.contain("Pool type registered successfully");
+    });
+
+  test
+    .stdout()
+    .command(["asset-pool:register-sol", "0"])
+    .it("Register SOL pool", ({ stdout }) => {
+      expect(stdout).to.contain("SOL pool registered successfully");
+    });
+  test
+    .stdout()
+    .command([
+      "asset-pool:register-spl",
+      "0",
+      "ycrF6Bw3doNPMSDmZM1rxNHimD2bwq1UFmifMCzbjAe",
+    ])
+    .it("Register SPL pool", ({ stdout }) => {
+      expect(stdout).to.contain("SPL pool registered successfully");
+    });
+});
 
 describe("With preloaded accounts", () => {
   before(async () => {

--- a/cli/test/commands/pool-type/index.test.ts
+++ b/cli/test/commands/pool-type/index.test.ts
@@ -1,14 +1,57 @@
 import test, { expect } from "@oclif/test";
-import { initTestEnv } from "../../../src/utils/initTestEnv";
+import { initTestEnv, killTestValidator } from "../../../src/utils/initTestEnv";
+
+describe("Without preloaded accounts", () => {
+  before(async () => {
+    await initTestEnv({ skip_system_accounts: true });
+  });
+  // Other tests require a validator with system accounts. Kill the current one
+  // which doesn't have them.
+  after(async () => {
+    await killTestValidator();
+  });
+
+  // TODO(vadorovsky): Teach `initTestEnv` to initialize only some accounts,
+  // then we will be able to not initialize the Merkle Tree Authority this
+  // way.
+  test
+    .stdout()
+    .command(["merkle-tree-authority:initialize"])
+    .it("Initialize Merkle Tree Authority", ({ stdout }) => {
+      expect(stdout).to.contain(
+        "Merkle Tree Authority initialized successfully"
+      );
+    });
+
+  test
+    .stdout()
+    .command(["pool-type:register", "0"])
+    .it("Register pool type", ({ stdout }) => {
+      expect(stdout).to.contain("Pool type registered successfully");
+    });
+  test
+    .stdout()
+    .command(["pool-type:register", "1"])
+    .it("Register pool type", ({ stdout }) => {
+      expect(stdout).to.contain("Pool type registered successfully");
+    });
+  test
+    .stdout()
+    .command(["pool-type:list"])
+    .it("List pool types", ({ stdout }) => {
+      expect(stdout).to.contain("0");
+      expect(stdout).to.contain("1");
+    });
+});
 
 describe("With preloaded accounts", () => {
   before(async () => {
     await initTestEnv({});
   });
   test
-    .stdout({ print: true })
+    .stdout()
     .command(["pool-type:list"])
     .it("List pool types", ({ stdout }) => {
-      expect(stdout).to.contain("0, 0");
+      expect(stdout).to.contain("0");
     });
 });


### PR DESCRIPTION
Previously we were able to only list pool types. This command allows to register them as well.

Also, fix the `asset-pool:register-sol` and `asset-pool:register-spl` subcommands to take pool type (as big number) as a required argument.