### PR TITLE
refactor: circuit-lib.circom - execute test-build-light-circuits only in ci

### DIFF
--- a/.github/workflows/light-sdk-tests.yml
+++ b/.github/workflows/light-sdk-tests.yml
@@ -43,5 +43,8 @@ jobs:
           do
             cd $subtest
             yarn test
+            if [[ "$subtest" == "circuit-lib/circuit-lib.circom" ]]; then
+              yarn test-build-light-circuits
+            fi
             cd -
           done

--- a/circuit-lib/circuit-lib.circom/package.json
+++ b/circuit-lib/circuit-lib.circom/package.json
@@ -8,7 +8,7 @@
     "build-app": "sh scripts/buildCircuit.sh App",
     "test-light-circuits": "ts-mocha --resolveJsonModule ./tsconfig.json -t 100000000 tests/**.ts --exit",
     "test-build-light-circuits": "yarn build-all && ./scripts/checkBuildCircuit.sh",
-    "test": "yarn test-light-circuits && yarn test-build-light-circuits",
+    "test": "yarn test-light-circuits",
     "format": "prettier --write \"tests/**/*.{ts,js,circom}\"",
     "build-all": "yarn build-app 4 && yarn build-masp 2 && yarn build-masp 10",
     "lint": "yarn prettier \"tests/**/*.{ts,js}\" --check",


### PR DESCRIPTION
Problem:
- scripts/test.sh is rebuilding circuits but we do not want to commit new proving keys with every pr

Solution:
- just execute yarn test-build-light-circuits (in circuit-lib.circom) in ci