### PR TITLE
refactor: move encryption to account

### DIFF
--- a/zk.js/src/account.ts
+++ b/zk.js/src/account.ts
@@ -471,16 +471,16 @@ export class Account {
 
   /**
    * Encrypts bytes with aes secret key.
-   * @param encryptedBytes - The bytes to be encrypted.
+   * @param messageBytes - The bytes to be encrypted.
    * @param iv16 - Optional Initialization Vector (iv), 16 random bytes by default.
    * @returns A Uint8Array of encrypted bytes with the iv as the first 16 bytes of the cipher text.
    */
   async encryptAes(
-    encryptedBytes: Uint8Array,
+    messageBytes: Uint8Array,
     iv16: Uint8Array = nacl.randomBytes(16),
   ) {
     const ciphertext = await encrypt(
-      encryptedBytes,
+      messageBytes,
       this.aesSecret,
       iv16,
       "aes-256-cbc",

--- a/zk.js/src/utxo.ts
+++ b/zk.js/src/utxo.ts
@@ -1,11 +1,10 @@
-import nacl, { box } from "tweetnacl";
+import nacl from "tweetnacl";
 import { PublicKey, SystemProgram } from "@solana/web3.js";
 import { BN, BorshAccountsCoder, Idl } from "@coral-xyz/anchor";
 import {
   Account,
   BN_0,
   COMPRESSED_UTXO_BYTES_LENGTH,
-  CONSTANT_SECRET_AUTHKEY,
   createAccountObject,
   CreateUtxoErrorCode,
   ENCRYPTED_COMPRESSED_UTXO_BYTES_LENGTH,

--- a/zk.js/src/wallet/user.ts
+++ b/zk.js/src/wallet/user.ts
@@ -1517,8 +1517,7 @@ export class User {
     /**
      * - aes: boolean = true
      * - decrypt storage verifier
-     */
-
+    */
     const decryptIndexStorage = async (
       indexedTransactions: ParsedIndexedTransaction[],
       assetLookupTable: string[],

--- a/zk.js/src/wallet/user.ts
+++ b/zk.js/src/wallet/user.ts
@@ -1517,7 +1517,7 @@ export class User {
     /**
      * - aes: boolean = true
      * - decrypt storage verifier
-    */
+     */
     const decryptIndexStorage = async (
       indexedTransactions: ParsedIndexedTransaction[],
       assetLookupTable: string[],

--- a/zk.js/tests/account.test.ts
+++ b/zk.js/tests/account.test.ts
@@ -266,10 +266,7 @@ describe("Test Account Functional", () => {
     // added try catch because in some cases it doesn't decrypt but doesn't throw an error either
     //TODO: revisit this and possibly switch aes library
     try {
-      await chai.assert.isRejected(
-        kBurner.decryptAes(cipherText1),
-        Error,
-      );
+      await chai.assert.isRejected(kBurner.decryptAes(cipherText1), Error);
     } catch (error) {
       const msg = k0.decryptAes(cipherText1);
       assert.notEqual(msg.toString(), message.toString());

--- a/zk.js/tests/account.test.ts
+++ b/zk.js/tests/account.test.ts
@@ -24,6 +24,7 @@ const b2params = { dkLen: 32 };
 process.env.ANCHOR_PROVIDER_URL = "http://127.0.0.1:8899";
 process.env.ANCHOR_WALLET = process.env.HOME + "/.config/solana/id.json";
 let seed32 = bs58.encode(new Uint8Array(32).fill(1));
+let seed32_2 = bs58.encode(new Uint8Array(32).fill(2));
 
 describe("Test Account Functional", () => {
   let poseidon: any,
@@ -252,25 +253,25 @@ describe("Test Account Functional", () => {
     let nonce = newNonce().subarray(0, 16);
     if (!k0.aesSecret) throw new Error("aes secret undefined");
 
-    let cipherText1 = await Account.encryptAes(k0.aesSecret, message, nonce);
-    let cleartext1 = await Account.decryptAes(k0.aesSecret, cipherText1);
+    let cipherText1 = await k0.encryptAes(message, nonce);
+    let cleartext1 = await k0.decryptAes(cipherText1);
 
-    assert.equal(cleartext1.toString(), message.toString());
+    assert.equal(cleartext1.value!.toString(), message.toString());
     assert.notEqual(
       new Uint8Array(32).fill(1).toString(),
       k0.aesSecret.toString(),
     );
 
-    // try to decrypt with invalid secret key
+    // try to decrypt with invalid secretkey
     // added try catch because in some cases it doesn't decrypt but doesn't throw an error either
     //TODO: revisit this and possibly switch aes library
     try {
       await chai.assert.isRejected(
-        Account.decryptAes(new Uint8Array(32).fill(1), cipherText1),
+        kBurner.decryptAes(cipherText1),
         Error,
       );
     } catch (error) {
-      const msg = Account.decryptAes(new Uint8Array(32).fill(1), cipherText1);
+      const msg = k0.decryptAes(cipherText1);
       assert.notEqual(msg.toString(), message.toString());
     }
   });

--- a/zk.js/tests/utxo.test.ts
+++ b/zk.js/tests/utxo.test.ts
@@ -123,7 +123,7 @@ describe("Utxo Functional", () => {
       if (utxo41.value) {
         Utxo.equal(poseidon, utxo4, utxo41.value);
       } else {
-        throw new Error(`decrypt failed: ${utxo41.error.toString()}`);
+        throw new Error(`decrypt failed: ${utxo41.error?.toString()}`);
       }
 
       // decrypt unchecked


### PR DESCRIPTION
- refactor encryption so that secrets do not leave the account class
- move nacl and aes encryption to account class

Account Aes Api:
- encryptAesUtxo (encrypts utxo bytes with utxo viewing key and iv from commitment)
- encryptAes (encrypts bytes with aes secret key, iv16 is optional and 16 random bytes by default, the iv is the first 16 bytes of the cipher text)
- _encryptAes (private aes encryption method which is used in encryptAes and encryptAesUtxo)
- decryptAesUtxo (decrypts encrypted utxo bytes with utxo viewing key and iv from commitment)
- decryptAes (decrypts aes encrypted bytes, the iv is expected to be the first 16 bytes)
- _decryptAes (private aes decryption method which is used in decryptAes and decryptAesUtxo)

Account Nacl Api:
(Encrypt operations do use a secret thus do not need a private method and are static.)
- encryptNaclUtxo (encrypts utxo bytes to public key with nonce= commitment.slice(0,24), and uses standardized secret for hmac)
- encryptNacl (encrypts bytes to public key, if nonce is undefined generates random nonce, if signing secret is undefined generates random signing secret)
- decryptNaclUtxo (decrypts encrypted utxo bytes, )
- decryptNacl (decrypts encrypted bytes, if nonce is not provided it expects the first 24 bytes to be the nonce, if signer publickey is not provided expects the subsequent 32 bytes (after the nonce) to be the singner public key)
- _decryptNacl (private nacl decryption method which is used in decryptNacl and decryptNaclUtxo)