### PR TITLE
refactor: move proof gen to account

### DIFF
--- a/system-programs/tests/functional_tests.ts
+++ b/system-programs/tests/functional_tests.ts
@@ -235,6 +235,7 @@ describe("verifier_program", () => {
       action: Action.SHIELD,
       poseidon: POSEIDON,
       verifierIdl: verifierIdl,
+      account: KEYPAIR,
     });
     let transactionTester = new TestTransaction({
       txParams,
@@ -246,7 +247,7 @@ describe("verifier_program", () => {
       params: txParams,
       shuffleEnabled,
     });
-    await tx.compileAndProve();
+    await tx.compileAndProve(KEYPAIR);
 
     try {
       let res = await tx.sendAndConfirmTransaction();
@@ -316,6 +317,7 @@ describe("verifier_program", () => {
       action: Action.UNSHIELD,
       poseidon: POSEIDON,
       verifierIdl: verifierIdl,
+      account: KEYPAIR,
     });
 
     let transactionTester = new TestTransaction({
@@ -330,7 +332,7 @@ describe("verifier_program", () => {
       params: txParams,
     });
 
-    await tx.compileAndProve();
+    await tx.compileAndProve(KEYPAIR);
 
     await tx.sendAndConfirmTransaction();
 

--- a/system-programs/tests/merkle_tree_tests.ts
+++ b/system-programs/tests/merkle_tree_tests.ts
@@ -632,12 +632,13 @@ describe("Merkle Tree Tests", () => {
       action: Action.SHIELD,
       poseidon: POSEIDON,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
+      account: KEYPAIR,
     });
     var transaction = new Transaction({
       provider: lightProvider,
       params: txParams,
     });
-    await transaction.compileAndProve();
+    await transaction.compileAndProve(KEYPAIR);
     console.log(transaction.params.accounts);
 
     // does one successful transaction
@@ -1105,6 +1106,7 @@ describe("Merkle Tree Tests", () => {
       action: Action.SHIELD,
       poseidon: POSEIDON,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
+      account: KEYPAIR,
     });
     let transaction = new Transaction({
       provider: lightProvider,
@@ -1121,7 +1123,7 @@ describe("Merkle Tree Tests", () => {
       pubkey: newEventMerkleTreePubkey,
     };
 
-    await transaction.compileAndProve();
+    await transaction.compileAndProve(KEYPAIR);
     await transaction.sendAndConfirmTransaction();
 
     let leavesPdas = await SolMerkleTree.getUninsertedLeavesRelayer(

--- a/system-programs/tests/provider.test.ts
+++ b/system-programs/tests/provider.test.ts
@@ -151,12 +151,13 @@ describe("verifier_program", () => {
       poseidon: POSEIDON,
       action: Action.SHIELD,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
+      account: KEYPAIR,
     });
     let tx = new Transaction({
       provider: lightProvider,
       params: txParams,
     });
-    await tx.compileAndProve();
+    await tx.compileAndProve(KEYPAIR);
 
     try {
       let res = await tx.sendAndConfirmTransaction();

--- a/system-programs/tests/verifier_tests.ts
+++ b/system-programs/tests/verifier_tests.ts
@@ -39,8 +39,6 @@ import {
   BN_0,
 } from "@lightprotocol/zk.js";
 
-import { BN } from "@coral-xyz/anchor";
-
 var POSEIDON, ACCOUNT, RELAYER, deposit_utxo1;
 var SLEEP_BUFFER = 0;
 const system = getSystem();
@@ -138,6 +136,7 @@ describe("Verifier Zero and One Tests", () => {
         poseidon: POSEIDON,
         action: Action.SHIELD,
         verifierIdl: VERIFIER_IDLS[verifier],
+        account: ACCOUNT,
       });
 
       var transaction = new Transaction({
@@ -145,7 +144,7 @@ describe("Verifier Zero and One Tests", () => {
         params: txParams,
       });
 
-      await transaction.compileAndProve();
+      await transaction.compileAndProve(ACCOUNT);
       await transaction.provider.provider.connection.confirmTransaction(
         await transaction.provider.provider.connection.requestAirdrop(
           transaction.params.accounts.authority,
@@ -181,13 +180,14 @@ describe("Verifier Zero and One Tests", () => {
         poseidon: POSEIDON,
         action: Action.SHIELD,
         verifierIdl: VERIFIER_IDLS[verifier],
+        account: ACCOUNT,
       });
 
       var transaction1 = new Transaction({
         provider: lightProvider,
         params: txParams1,
       });
-      await transaction1.compileAndProve();
+      await transaction1.compileAndProve(ACCOUNT);
       transactions.push(transaction1);
 
       // Withdrawal
@@ -224,13 +224,14 @@ describe("Verifier Zero and One Tests", () => {
         poseidon: POSEIDON,
         action: Action.UNSHIELD,
         verifierIdl: VERIFIER_IDLS[verifier],
+        account: ACCOUNT,
       });
       var tx = new Transaction({
         provider: lightProviderWithdrawal,
         params: txParams2,
       });
 
-      await tx.compileAndProve();
+      await tx.compileAndProve(ACCOUNT);
       transactions.push(tx);
     }
   });

--- a/zk.js/src/test-utils/functionalCircuit.ts
+++ b/zk.js/src/test-utils/functionalCircuit.ts
@@ -23,14 +23,14 @@ export async function functionalCircuitTest(
 
   const poseidon = await circomlibjs.buildPoseidonOpt();
   let seed32 = bs58.encode(new Uint8Array(32).fill(1));
-  let keypair = new Account({ poseidon: poseidon, seed: seed32 });
+  let account = new Account({ poseidon: poseidon, seed: seed32 });
   let depositAmount = 20_000;
   let depositFeeAmount = 10_000;
   let deposit_utxo1 = new Utxo({
     poseidon: poseidon,
     assets: [FEE_ASSET, MINT],
     amounts: [new anchor.BN(depositFeeAmount), new anchor.BN(depositAmount)],
-    account: keypair,
+    account,
     assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
     verifierProgramLookupTable:
       lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -46,6 +46,7 @@ export async function functionalCircuitTest(
     action: Action.SHIELD,
     poseidon,
     verifierIdl: verifierIdl,
+    account,
   });
 
   let tx;
@@ -70,7 +71,7 @@ export async function functionalCircuitTest(
   }
   await tx.compile();
 
-  await tx.getProof();
+  await tx.getProof(account);
   // unsuccessful proof generation
   let x = true;
 
@@ -78,7 +79,7 @@ export async function functionalCircuitTest(
     tx.proofInput.inIndices[0][1][1] = "1";
     // TODO: investigate why this does not kill the proof
     tx.proofInput.inIndices[0][1][0] = "1";
-    await tx.getProof();
+    await tx.getProof(account);
     x = false;
   } catch (error) {
     // assert.isTrue(error.toString().includes("CheckIndices_3 line:"));

--- a/zk.js/src/transaction/transactionParameters.ts
+++ b/zk.js/src/transaction/transactionParameters.ts
@@ -61,6 +61,7 @@ export class TransactionParameters implements transactionParameters {
   verifierIdl: Idl;
   verifierProgramId: PublicKey;
   verifierConfig: VerifierConfig;
+  account: Account;
 
   constructor({
     message,
@@ -78,6 +79,7 @@ export class TransactionParameters implements transactionParameters {
     action,
     ataCreationFee,
     verifierIdl,
+    account,
   }: {
     message?: Buffer;
     eventMerkleTreePubkey: PublicKey;
@@ -95,6 +97,7 @@ export class TransactionParameters implements transactionParameters {
     provider?: Provider;
     ataCreationFee?: boolean;
     verifierIdl: Idl;
+    account: Account;
   }) {
     if (!outputUtxos && !inputUtxos) {
       throw new TransactionParametersError(
@@ -127,7 +130,7 @@ export class TransactionParameters implements transactionParameters {
         "Define an action either Action.TRANSFER, Action.SHIELD,Action.UNSHIELD",
       );
     }
-
+    this.account = account;
     this.verifierProgramId =
       TransactionParameters.getVerifierProgramId(verifierIdl);
     this.verifierConfig = TransactionParameters.getVerifierConfig(verifierIdl);
@@ -786,6 +789,7 @@ export class TransactionParameters implements transactionParameters {
       verifierIdl,
       message,
       eventMerkleTreePubkey: MerkleTreeConfig.getEventMerkleTreePda(),
+      account,
     });
 
     return txParams;
@@ -804,8 +808,10 @@ export class TransactionParameters implements transactionParameters {
       utxos.push(
         new Utxo({
           poseidon: this.poseidon,
+          account: this.account,
           assetLookupTable: [SystemProgram.programId.toBase58()],
           verifierProgramLookupTable: [SystemProgram.programId.toBase58()],
+          isFillingUtxo: true,
         }),
       );
     }

--- a/zk.js/src/wallet/user.ts
+++ b/zk.js/src/wallet/user.ts
@@ -496,7 +496,7 @@ export class User {
       shuffleEnabled,
     });
 
-    await tx.compileAndProve();
+    await tx.compileAndProve(this.account);
     this.recentTransaction = tx;
     return tx;
   }

--- a/zk.js/tests/circuits.test.ts
+++ b/zk.js/tests/circuits.test.ts
@@ -91,6 +91,7 @@ describe("Masp circuit tests", () => {
       action: Action.SHIELD,
       poseidon,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
+      account,
     });
 
     txParamsSol = new TransactionParameters({
@@ -102,6 +103,7 @@ describe("Masp circuit tests", () => {
       action: Action.SHIELD,
       poseidon,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
+      account,
     });
     lightProvider.solMerkleTree!.merkleTree = new MerkleTree(18, poseidon, [
       deposit_utxo1.getCommitment(poseidon),
@@ -126,6 +128,7 @@ describe("Masp circuit tests", () => {
       action: Action.UNSHIELD,
       relayer,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
+      account,
     });
     appData = { releaseSlot: BN_1 };
     txParamsApp = new TransactionParameters({
@@ -148,6 +151,7 @@ describe("Masp circuit tests", () => {
       poseidon,
       relayer,
       verifierIdl: IDL_VERIFIER_PROGRAM_TWO,
+      account,
     });
     txParamsPoolType = new TransactionParameters({
       inputUtxos: [
@@ -168,6 +172,7 @@ describe("Masp circuit tests", () => {
       poseidon,
       relayer,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
+      account,
     });
     txParamsPoolTypeOut = new TransactionParameters({
       outputUtxos: [
@@ -187,6 +192,7 @@ describe("Masp circuit tests", () => {
       poseidon,
       relayer,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
+      account,
     });
     txParamsOutApp = new TransactionParameters({
       outputUtxos: [
@@ -208,6 +214,7 @@ describe("Masp circuit tests", () => {
       // automatic encryption for app utxos is not implemented
       encryptedUtxos: new Uint8Array(256).fill(1),
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
+      account,
     });
   });
 
@@ -220,7 +227,7 @@ describe("Masp circuit tests", () => {
     await tx.compile();
     tx.proofInput.root = new BN("123").toString();
 
-    await tx.getProof();
+    await tx.getProof(account);
   });
 
   it("With in utxo test invalid root", async () => {
@@ -231,7 +238,7 @@ describe("Masp circuit tests", () => {
     await tx.compile();
     tx.proofInput.root = new BN("123").toString();
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -246,7 +253,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.txIntegrityHash = new BN("123").toString();
 
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -261,7 +268,7 @@ describe("Masp circuit tests", () => {
       SolanaKeypair.generate().publicKey.toBytes(),
     );
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -276,7 +283,7 @@ describe("Masp circuit tests", () => {
       SolanaKeypair.generate().publicKey.toBytes(),
     );
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -291,7 +298,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.publicMintPubkey = hashAndTruncateToCircuit(
       SolanaKeypair.generate().publicKey.toBytes(),
     );
-    await tx.getProof();
+    await tx.getProof(account);
   });
 
   it("With in utxo test invalid merkle proof path elements", async () => {
@@ -304,7 +311,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.inPathElements[0] =
       tx.provider.solMerkleTree?.merkleTree.path(1).pathElements;
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -318,7 +325,7 @@ describe("Masp circuit tests", () => {
 
     tx.proofInput.inPathIndices[0] = 1;
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -330,10 +337,9 @@ describe("Masp circuit tests", () => {
     });
 
     await tx.compile();
-    tx.proofInput.inPrivateKey[0] = new BN("123").toString();
-
+    // tx.proofInput.inPrivateKey[0] = new BN("123").toString();
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(new Account({ poseidon })),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -348,7 +354,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.publicAmountSpl = new BN("123").toString();
 
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -363,7 +369,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.publicAmountSol = new BN("123").toString();
 
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -378,7 +384,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.publicAmountSpl = new BN("123").toString();
 
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -395,7 +401,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.outputCommitment[0] = new BN("123").toString();
 
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -410,7 +416,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.inAmount[0] = new BN("123").toString();
 
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -425,7 +431,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.outAmount[0] = new BN("123").toString();
 
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -440,7 +446,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.inBlinding[0] = new BN("123").toString();
 
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -455,7 +461,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.outBlinding[0] = new BN("123").toString();
 
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -470,7 +476,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.outPubkey[0] = new BN("123").toString();
 
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -488,7 +494,7 @@ describe("Masp circuit tests", () => {
       );
 
       await chai.assert.isRejected(
-        tx.getProof(),
+        tx.getProof(account),
         TransactionErrorCode.PROOF_GENERATION_FAILED,
       );
     }
@@ -504,7 +510,7 @@ describe("Masp circuit tests", () => {
 
     await tx.compile();
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -517,7 +523,7 @@ describe("Masp circuit tests", () => {
     });
 
     await tx.compile();
-    await tx.getProof();
+    await tx.getProof(account);
   });
 
   // this fails because it's inconsistent with the utxo
@@ -531,7 +537,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.outAppDataHash[0] = new BN("123").toString();
 
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -544,7 +550,7 @@ describe("Masp circuit tests", () => {
 
     await tx.compile();
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -557,7 +563,7 @@ describe("Masp circuit tests", () => {
 
     await tx.compile();
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -572,7 +578,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.inPoolType[0] = new BN("123").toString();
 
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -587,7 +593,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.outPoolType[0] = new BN("123").toString();
 
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -603,7 +609,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.inIndices[0][0][0] = new BN("123").toString();
 
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -619,7 +625,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.inIndices[1][1][1] = "1";
 
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -635,7 +641,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.outIndices[0][0][0] = new BN("123").toString();
 
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -651,7 +657,7 @@ describe("Masp circuit tests", () => {
     tx.proofInput.outIndices[1][1][1] = "1";
 
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -689,6 +695,7 @@ describe("App system circuit tests", () => {
       action: Action.SHIELD,
       poseidon,
       verifierIdl: IDL_VERIFIER_PROGRAM_TWO,
+      account,
     });
 
     relayer = new Relayer(relayerPubkey, mockPubkey, new BN(5000));
@@ -711,6 +718,7 @@ describe("App system circuit tests", () => {
       poseidon,
       relayer,
       verifierIdl: IDL_VERIFIER_PROGRAM_TWO,
+      account,
     });
   });
 
@@ -724,7 +732,7 @@ describe("App system circuit tests", () => {
 
     tx.proofInput.transactionHash = new BN("123").toString();
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });
@@ -738,7 +746,7 @@ describe("App system circuit tests", () => {
     await tx.compile();
     tx.proofInput.publicAppVerifier = new BN("123").toString();
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_GENERATION_FAILED,
     );
   });

--- a/zk.js/tests/transaction.test.ts
+++ b/zk.js/tests/transaction.test.ts
@@ -47,18 +47,18 @@ describe("Transaction Error Tests", () => {
   let poseidon: any,
     lightProvider: LightProvider,
     deposit_utxo1: Utxo,
-    keypair,
+    account: Account,
     params: TransactionParameters;
   before(async () => {
     poseidon = await circomlibjs.buildPoseidonOpt();
     // TODO: make fee mandatory
-    keypair = new Account({ poseidon: poseidon, seed: seed32 });
+    account = new Account({ poseidon: poseidon, seed: seed32 });
     lightProvider = await LightProvider.loadMock();
     deposit_utxo1 = new Utxo({
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [new BN(depositFeeAmount), new BN(depositAmount)],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -72,6 +72,7 @@ describe("Transaction Error Tests", () => {
       senderSol: lightProvider.wallet?.publicKey,
       action: Action.SHIELD,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
+      account,
     });
   });
 
@@ -144,6 +145,7 @@ describe("Transaction Error Tests", () => {
       senderSol: mockPubkey,
       action: Action.SHIELD,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
+      account,
     });
     expect(() => {
       new Transaction({
@@ -193,7 +195,7 @@ describe("Transaction Error Tests", () => {
       params,
     });
     await chai.assert.isRejected(
-      tx.getProof(),
+      tx.getProof(account),
       TransactionErrorCode.PROOF_INPUT_UNDEFINED,
     );
   });
@@ -204,7 +206,7 @@ describe("Transaction Error Tests", () => {
       params,
     });
     await chai.assert.isRejected(
-      tx.getAppProof(),
+      tx.getAppProof(account),
       TransactionErrorCode.APP_PARAMETERS_UNDEFINED,
     );
   });
@@ -272,21 +274,21 @@ describe("Transaction Functional Tests", () => {
     lightProvider: LightProvider,
     deposit_utxo1: Utxo,
     relayer: Relayer,
-    keypair,
+    account: Account,
     paramsDeposit: TransactionParameters,
     paramsWithdrawal: TransactionParameters;
   before(async () => {
     poseidon = await circomlibjs.buildPoseidonOpt();
     // TODO: make fee mandatory
     relayer = new Relayer(mockPubkey3, mockPubkey, new BN(5000));
-    keypair = new Account({ poseidon: poseidon, seed: seed32 });
+    account = new Account({ poseidon: poseidon, seed: seed32 });
     lightProvider = await LightProvider.loadMock();
     deposit_utxo1 = new Utxo({
       index: 0,
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [new BN(depositFeeAmount), new BN(depositAmount)],
-      account: keypair,
+      account: account,
       blinding: new BN(new Array(31).fill(1)),
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
@@ -301,6 +303,7 @@ describe("Transaction Functional Tests", () => {
       senderSol: lightProvider.wallet?.publicKey,
       action: Action.SHIELD,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
+      account,
     });
     lightProvider.solMerkleTree!.merkleTree = new MerkleTree(18, poseidon, [
       deposit_utxo1.getCommitment(poseidon),
@@ -322,6 +325,7 @@ describe("Transaction Functional Tests", () => {
       action: Action.UNSHIELD,
       relayer,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
+      account,
     });
   });
 
@@ -330,7 +334,7 @@ describe("Transaction Functional Tests", () => {
       provider: lightProvider,
       params: paramsDeposit,
     });
-    await tx.compileAndProve();
+    await tx.compileAndProve(account);
   });
 
   it("Functional storage ", async () => {
@@ -345,12 +349,13 @@ describe("Transaction Functional Tests", () => {
       action: Action.UNSHIELD,
       verifierIdl: IDL_VERIFIER_PROGRAM_STORAGE,
       relayer,
+      account,
     });
     let tx = new Transaction({
       provider: lightProvider,
       params: paramsDepositStorage,
     });
-    await tx.compileAndProve();
+    await tx.compileAndProve(account);
     await tx.getInstructions(tx.params);
   });
 
@@ -403,6 +408,7 @@ describe("Transaction Functional Tests", () => {
       action: Action.UNSHIELD,
       relayer,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
+      account,
     });
 
     let tx = new Transaction({
@@ -522,6 +528,7 @@ describe("Transaction Functional Tests", () => {
       relayer: relayerConst,
       encryptedUtxos: new Uint8Array(256).fill(1),
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
+      account,
     });
 
     let txIntegrityHash = await paramsStaticEncryptedUtxos.getTxIntegrityHash(
@@ -613,6 +620,7 @@ describe("Transaction Functional Tests", () => {
       relayer: relayerConst,
       encryptedUtxos: new Uint8Array(256).fill(1),
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
+      account,
     });
     let tx = new Transaction({
       provider: lightProvider,
@@ -661,6 +669,7 @@ describe("Transaction Functional Tests", () => {
       poseidon,
       action: Action.SHIELD,
       verifierIdl: IDL_VERIFIER_PROGRAM_TWO,
+      account,
     });
     expect(() => {
       new Transaction({
@@ -685,6 +694,7 @@ describe("Transaction Functional Tests", () => {
       poseidon,
       action: Action.SHIELD,
       verifierIdl: IDL_VERIFIER_PROGRAM_ZERO,
+      account,
     });
     expect(() => {
       new Transaction({

--- a/zk.js/tests/transactionParameters.test.ts
+++ b/zk.js/tests/transactionParameters.test.ts
@@ -55,19 +55,19 @@ describe("Transaction Parameters Functional", () => {
     lightProvider: LightProvider,
     deposit_utxo1: Utxo,
     relayer: Relayer,
-    keypair: Account;
+    account: Account;
   before(async () => {
     poseidon = await circomlibjs.buildPoseidonOpt();
     lightProvider = await LightProvider.loadMock();
 
     // TODO: make fee mandatory
     relayer = new Relayer(mockPubkey3, mockPubkey, new BN(5000));
-    keypair = new Account({ poseidon: poseidon, seed: seed32 });
+    account = new Account({ poseidon: poseidon, seed: seed32 });
     deposit_utxo1 = new Utxo({
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [new BN(depositFeeAmount), new BN(depositAmount)],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -85,7 +85,7 @@ describe("Transaction Parameters Functional", () => {
         new BN(depositFeeAmount).sub(relayer.getRelayerFee()),
         new BN(depositAmount),
       ],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -105,6 +105,7 @@ describe("Transaction Parameters Functional", () => {
       action: Action.TRANSFER,
       relayer,
       verifierIdl: VERIFIER_IDLS[j],
+      account,
     });
 
     let bytes = await paramsOriginal.toBytes();
@@ -213,7 +214,7 @@ describe("Transaction Parameters Functional", () => {
         new BN(depositFeeAmount).sub(relayer.getRelayerFee()),
         new BN(depositAmount),
       ],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -231,8 +232,8 @@ describe("Transaction Parameters Functional", () => {
         poseidon,
         action: Action.TRANSFER,
         relayer,
-
         verifierIdl: VERIFIER_IDLS[j],
+        account,
       });
 
       assert.equal(params.action.toString(), Action.TRANSFER.toString());
@@ -336,6 +337,7 @@ describe("Transaction Parameters Functional", () => {
         action: Action.SHIELD,
 
         verifierIdl: VERIFIER_IDLS[j],
+        account,
       });
 
       assert.equal(params.publicAmountSpl.toString(), depositAmount.toString());
@@ -433,6 +435,7 @@ describe("Transaction Parameters Functional", () => {
         relayer,
 
         verifierIdl: VERIFIER_IDLS[j],
+        account,
       });
       assert.equal(params.action.toString(), Action.UNSHIELD.toString());
       assert.equal(
@@ -666,18 +669,18 @@ describe("Test General TransactionParameters Errors", () => {
   let poseidon: any,
     lightProvider: LightProvider,
     deposit_utxo1: Utxo,
-    keypair: Account;
+    account: Account;
 
   before(async () => {
     poseidon = await circomlibjs.buildPoseidonOpt();
     // TODO: make fee mandatory
-    keypair = new Account({ poseidon: poseidon, seed: seed32 });
+    account = new Account({ poseidon: poseidon, seed: seed32 });
     lightProvider = await LightProvider.loadMock();
     deposit_utxo1 = new Utxo({
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [new BN(depositFeeAmount), new BN(depositAmount)],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -694,8 +697,8 @@ describe("Test General TransactionParameters Errors", () => {
           senderSol: mockPubkey,
           poseidon,
           action: Action.SHIELD,
-
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -717,6 +720,7 @@ describe("Test General TransactionParameters Errors", () => {
           senderSol: mockPubkey,
           action: Action.SHIELD,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -738,6 +742,7 @@ describe("Test General TransactionParameters Errors", () => {
           senderSol: mockPubkey,
           poseidon,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -773,7 +778,7 @@ describe("Test TransactionParameters Transfer Errors", () => {
   let depositAmount = 20_000;
   let depositFeeAmount = 10_000;
   let mockPubkey = SolanaKeypair.generate().publicKey;
-  let keypair: Account;
+  let account: Account;
   let poseidon: any,
     lightProvider: LightProvider,
     deposit_utxo1: Utxo,
@@ -783,13 +788,13 @@ describe("Test TransactionParameters Transfer Errors", () => {
     poseidon = await circomlibjs.buildPoseidonOpt();
     // TODO: make fee mandatory
     relayer = new Relayer(mockPubkey, mockPubkey, new BN(5000));
-    keypair = new Account({ poseidon: poseidon, seed: seed32 });
+    account = new Account({ poseidon: poseidon, seed: seed32 });
     lightProvider = await LightProvider.loadMock();
     deposit_utxo1 = new Utxo({
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [new BN(depositFeeAmount), new BN(depositAmount)],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -802,7 +807,7 @@ describe("Test TransactionParameters Transfer Errors", () => {
         new BN(depositFeeAmount).sub(relayer.getRelayerFee()),
         new BN(depositAmount),
       ],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -819,8 +824,8 @@ describe("Test TransactionParameters Transfer Errors", () => {
           transactionMerkleTreePubkey: mockPubkey,
           poseidon,
           action: Action.TRANSFER,
-
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -836,7 +841,7 @@ describe("Test TransactionParameters Transfer Errors", () => {
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [new BN(depositFeeAmount).sub(relayer.getRelayerFee()), BN_0],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -852,6 +857,7 @@ describe("Test TransactionParameters Transfer Errors", () => {
           action: Action.TRANSFER,
           relayer,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -867,7 +873,7 @@ describe("Test TransactionParameters Transfer Errors", () => {
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [BN_0, new BN(depositAmount)],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -883,6 +889,7 @@ describe("Test TransactionParameters Transfer Errors", () => {
           action: Action.TRANSFER,
           relayer,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -906,6 +913,7 @@ describe("Test TransactionParameters Transfer Errors", () => {
           recipientSpl: mockPubkey,
           relayer,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -929,6 +937,7 @@ describe("Test TransactionParameters Transfer Errors", () => {
           recipientSol: mockPubkey,
           relayer,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -952,6 +961,7 @@ describe("Test TransactionParameters Transfer Errors", () => {
           senderSol: mockPubkey,
           relayer,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -975,6 +985,7 @@ describe("Test TransactionParameters Transfer Errors", () => {
           senderSpl: mockPubkey,
           relayer,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -991,7 +1002,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
   let depositAmount = 20_000;
   let depositFeeAmount = 10_000;
   let mockPubkey = SolanaKeypair.generate().publicKey;
-  let keypair: Account;
+  let account: Account;
 
   let poseidon: any,
     lightProvider: LightProvider,
@@ -1001,13 +1012,13 @@ describe("Test TransactionParameters Deposit Errors", () => {
     poseidon = await circomlibjs.buildPoseidonOpt();
     // TODO: make fee mandatory
     relayer = new Relayer(mockPubkey, mockPubkey, new BN(5000));
-    keypair = new Account({ poseidon: poseidon, seed: seed32 });
+    account = new Account({ poseidon: poseidon, seed: seed32 });
     lightProvider = await LightProvider.loadMock();
     deposit_utxo1 = new Utxo({
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [new BN(depositFeeAmount), new BN(depositAmount)],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -1025,6 +1036,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
           poseidon,
           action: Action.SHIELD,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -1046,6 +1058,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
           poseidon,
           action: Action.SHIELD,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -1069,6 +1082,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
           action: Action.SHIELD,
           relayer,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -1084,7 +1098,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [new BN("18446744073709551615"), new BN(depositAmount)],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -1093,7 +1107,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [new BN("18446744073709551615"), BN_0],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -1109,6 +1123,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
           poseidon,
           action: Action.SHIELD,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -1124,7 +1139,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [BN_0, new BN("18446744073709551615")],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -1134,7 +1149,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [BN_0, new BN("1")],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -1151,6 +1166,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
           poseidon,
           action: Action.SHIELD,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -1174,6 +1190,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
           poseidon,
           action: Action.SHIELD,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -1197,6 +1214,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
           poseidon,
           action: Action.SHIELD,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -1212,7 +1230,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [new BN("18446744073709551615"), BN_0],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -1228,6 +1246,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
         poseidon,
         action: Action.SHIELD,
         verifierIdl: VERIFIER_IDLS[verifier],
+        account,
       });
     }
   });
@@ -1245,6 +1264,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
           poseidon,
           action: Action.SHIELD,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -1268,6 +1288,7 @@ describe("Test TransactionParameters Deposit Errors", () => {
           poseidon,
           action: Action.SHIELD,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -1284,7 +1305,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
   let depositAmount = 20_000;
   let depositFeeAmount = 10_000;
   let mockPubkey = SolanaKeypair.generate().publicKey;
-  let keypair: Account;
+  let account: Account;
 
   let poseidon: any,
     lightProvider: LightProvider,
@@ -1295,13 +1316,13 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
     poseidon = await circomlibjs.buildPoseidonOpt();
     // TODO: make fee mandatory
     relayer = new Relayer(mockPubkey, mockPubkey, new BN(5000));
-    keypair = new Account({ poseidon: poseidon, seed: seed32 });
+    account = new Account({ poseidon: poseidon, seed: seed32 });
     lightProvider = await LightProvider.loadMock();
     deposit_utxo1 = new Utxo({
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [new BN(depositFeeAmount), new BN(depositAmount)],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -1321,6 +1342,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
           action: Action.UNSHIELD,
           relayer,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -1343,6 +1365,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
           poseidon,
           action: Action.UNSHIELD,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -1358,7 +1381,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [new BN("18446744073709551615"), new BN(depositAmount)],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -1368,7 +1391,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [new BN("18446744073709551615"), BN_0],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -1386,6 +1409,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
           action: Action.UNSHIELD,
           relayer,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -1401,7 +1425,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [BN_0, new BN("18446744073709551615")],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -1411,7 +1435,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [BN_0, new BN("1")],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -1428,6 +1452,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
           action: Action.UNSHIELD,
           relayer,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -1452,6 +1477,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
           action: Action.UNSHIELD,
           relayer,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -1476,6 +1502,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
           action: Action.UNSHIELD,
           relayer,
           verifierIdl: VERIFIER_IDLS[verifier],
+          account,
         });
       })
         .to.throw(TransactionParametersError)
@@ -1491,7 +1518,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [new BN("18446744073709551615"), BN_0],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -1508,6 +1535,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
         action: Action.UNSHIELD,
         relayer,
         verifierIdl: VERIFIER_IDLS[verifier],
+        account,
       });
     }
   });
@@ -1517,7 +1545,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
       poseidon: poseidon,
       assets: [FEE_ASSET, MINT],
       amounts: [BN_0, new BN("18446744073709551615")],
-      account: keypair,
+      account,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
@@ -1534,6 +1562,7 @@ describe("Test TransactionParameters Withdrawal Errors", () => {
         action: Action.UNSHIELD,
         relayer,
         verifierIdl: VERIFIER_IDLS[verifier],
+        account,
       });
     }
   });


### PR DESCRIPTION
This pr is based on https://github.com/Lightprotocol/light-protocol/pull/275 please merge in sequence.

### Problem:
 - secrets are necessary to generate light system proofs

### Solution:
- move proof gen into account class and add private key class internally so that secrets are not exposed

### Changes:
- move proof gen from transaction to account
- add addPrivateKey method to account.ts -> it can only add the private key of the account. This clashes with the way we so far added empty/filling utxos.
- add account as input to TransactionParameters so that filling utxos are all owned by the same account not random accounts
- add isFillingUtxo marker to Utxo
  We don't want to decrypt a lot of random utxos therefore  if utxo is filling utxo make the prefix random, so that we don't decrypt  these utxos by default.