### PR TITLE
fix(zk.js): Don't override selected UTXOs, but merge it with new results 

### DIFF
--- a/zk.js/src/wallet/selectInUtxos.ts
+++ b/zk.js/src/wallet/selectInUtxos.ts
@@ -320,7 +320,7 @@ export function selectInUtxos({
       sumOutSol,
       numberMaxInUtxos - selectedUtxosR.length,
     );
-    selectedUtxosR = selectedUtxos;
+    selectedUtxosR = [...selectedUtxosR, ...selectedUtxos];
   }
 
   if (mint && !getUtxoArrayAmount(mint, selectedUtxosR).gte(sumOutSpl))

--- a/zk.js/src/wallet/selectInUtxos.ts
+++ b/zk.js/src/wallet/selectInUtxos.ts
@@ -92,7 +92,9 @@ const selectBiggestSmallest = (
           filteredUtxos[utxo].amounts[0],
         );
 
-        if (selectedUtxos.length == threshold) {
+        // If we select more than 1 UTXO and we reached the treshold, set the
+        // current UTXO as the 2nd one.
+        if (selectedUtxos.length > 1 && selectedUtxos.length == threshold) {
           // overwrite existing utxo
           selectedUtxosAmount = selectedUtxosAmount.sub(
             selectedUtxos[1].amounts[assetIndex],

--- a/zk.js/tests/selectInUtxos.test.ts
+++ b/zk.js/tests/selectInUtxos.test.ts
@@ -27,6 +27,7 @@ import {
   RELAYER_FEE,
   BN_0,
   BN_1,
+  BN_2,
 } from "../src";
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
 
@@ -53,9 +54,9 @@ describe("Test selectInUtxos Functional", () => {
   before(async () => {
     lightProvider = await Provider.loadMock();
     poseidon = await circomlibjs.buildPoseidonOpt();
-    utxo1Burner = new Account({ poseidon, seed: seed32 });
-    utxo2Burner = Account.createBurner(poseidon, seed32, new anchor.BN("0"));
-    utxoSolBurner = Account.createBurner(poseidon, seed32, new anchor.BN("1"));
+    utxo1Burner = Account.createBurner(poseidon, seed32, BN_0);
+    utxo2Burner = Account.createBurner(poseidon, seed32, BN_1);
+    utxoSolBurner = Account.createBurner(poseidon, seed32, BN_2);
 
     splAmount = new BN(3);
     token = "USDC";
@@ -76,7 +77,7 @@ describe("Test selectInUtxos Functional", () => {
       poseidon,
       assets: [SystemProgram.programId, tokenCtx.mint],
       amounts: [new BN(1e6), new BN(5 * tokenCtx.decimals.toNumber())],
-      index: 0,
+      index: 1,
       account: utxo2Burner,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:
@@ -86,7 +87,7 @@ describe("Test selectInUtxos Functional", () => {
       poseidon,
       assets: [SystemProgram.programId],
       amounts: [new BN(1e8)],
-      index: 1,
+      index: 2,
       account: utxoSolBurner,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
       verifierProgramLookupTable:

--- a/zk.js/tests/selectInUtxos.test.ts
+++ b/zk.js/tests/selectInUtxos.test.ts
@@ -164,7 +164,7 @@ describe("Test selectInUtxos Functional", () => {
         lightProvider.lookUpTables.verifierProgramLookupTable,
     });
 
-    let selectedUtxo = selectInUtxos({
+    let selectedUtxos = selectInUtxos({
       utxos,
       action: Action.TRANSFER,
       relayerFee: RELAYER_FEE,
@@ -174,8 +174,8 @@ describe("Test selectInUtxos Functional", () => {
       numberMaxOutUtxos,
     });
 
-    Utxo.equal(poseidon, selectedUtxo[1], utxoSol);
-    Utxo.equal(poseidon, selectedUtxo[0], utxo1);
+    Utxo.equal(poseidon, selectedUtxos[1], utxoSol);
+    Utxo.equal(poseidon, selectedUtxos[0], utxo1);
   });
 
   it("Transfer select sol", async () => {
@@ -194,7 +194,7 @@ describe("Test selectInUtxos Functional", () => {
       verifierProgramLookupTable:
         lightProvider.lookUpTables.verifierProgramLookupTable,
     });
-    let selectedUtxo = selectInUtxos({
+    let selectedUtxos = selectInUtxos({
       utxos,
       action: Action.TRANSFER,
       relayerFee: RELAYER_FEE,
@@ -204,8 +204,8 @@ describe("Test selectInUtxos Functional", () => {
       numberMaxOutUtxos,
     });
 
-    Utxo.equal(poseidon, selectedUtxo[0], utxoSol);
-    Utxo.equal(poseidon, selectedUtxo[1], utxo1);
+    Utxo.equal(poseidon, selectedUtxos[0], utxoSol);
+    Utxo.equal(poseidon, selectedUtxos[1], utxo1);
   });
 
   it("Transfer select spl", async () => {
@@ -225,7 +225,7 @@ describe("Test selectInUtxos Functional", () => {
         lightProvider.lookUpTables.verifierProgramLookupTable,
     });
 
-    let selectedUtxo = selectInUtxos({
+    let selectedUtxos = selectInUtxos({
       utxos,
       action: Action.TRANSFER,
       relayerFee: RELAYER_FEE,
@@ -235,13 +235,13 @@ describe("Test selectInUtxos Functional", () => {
       numberMaxOutUtxos,
     });
 
-    Utxo.equal(poseidon, selectedUtxo[0], utxo1);
+    Utxo.equal(poseidon, selectedUtxos[0], utxo1);
   });
 
   it("Shield select sol & spl", async () => {
     const utxos = [utxoSol, utxo1];
 
-    let selectedUtxo = selectInUtxos({
+    let selectedUtxos = selectInUtxos({
       utxos,
       action: Action.SHIELD,
       publicMint: utxo1.assets[1],
@@ -252,13 +252,13 @@ describe("Test selectInUtxos Functional", () => {
       numberMaxOutUtxos,
     });
 
-    Utxo.equal(poseidon, selectedUtxo[0], utxo1);
+    Utxo.equal(poseidon, selectedUtxos[0], utxo1);
   });
 
   it("Shield select sol", async () => {
     const utxos = [utxoSol, utxo1];
 
-    let selectedUtxo = selectInUtxos({
+    let selectedUtxos = selectInUtxos({
       utxos,
       action: Action.SHIELD,
       poseidon,
@@ -267,14 +267,14 @@ describe("Test selectInUtxos Functional", () => {
       numberMaxOutUtxos,
     });
 
-    Utxo.equal(poseidon, selectedUtxo[0], utxoSol);
-    Utxo.equal(poseidon, selectedUtxo[1], utxo1);
+    Utxo.equal(poseidon, selectedUtxos[0], utxoSol);
+    Utxo.equal(poseidon, selectedUtxos[1], utxo1);
   });
 
   it("Shield select spl", async () => {
     const utxos = [utxoSol, utxo1];
 
-    let selectedUtxo = selectInUtxos({
+    let selectedUtxos = selectInUtxos({
       utxos,
       action: Action.SHIELD,
       publicMint: utxo1.assets[1],
@@ -284,8 +284,8 @@ describe("Test selectInUtxos Functional", () => {
       numberMaxOutUtxos,
     });
 
-    Utxo.equal(poseidon, selectedUtxo[0], utxo1);
-    assert.equal(selectedUtxo.length, 1);
+    Utxo.equal(poseidon, selectedUtxos[0], utxo1);
+    assert.equal(selectedUtxos.length, 1);
   });
 
   it("3 utxos spl & sol", async () => {
@@ -305,7 +305,7 @@ describe("Test selectInUtxos Functional", () => {
         lightProvider.lookUpTables.verifierProgramLookupTable,
     });
 
-    let selectedUtxo = selectInUtxos({
+    let selectedUtxos = selectInUtxos({
       utxos,
       action: Action.TRANSFER,
       relayerFee: RELAYER_FEE,
@@ -315,8 +315,8 @@ describe("Test selectInUtxos Functional", () => {
       numberMaxOutUtxos,
     });
 
-    Utxo.equal(poseidon, selectedUtxo[0], utxo1);
-    Utxo.equal(poseidon, selectedUtxo[1], utxo2);
+    Utxo.equal(poseidon, selectedUtxos[0], utxo1);
+    Utxo.equal(poseidon, selectedUtxos[1], utxo2);
   });
 });
 

--- a/zk.js/tests/selectInUtxos.test.ts
+++ b/zk.js/tests/selectInUtxos.test.ts
@@ -96,26 +96,26 @@ describe("Test selectInUtxos Functional", () => {
   });
 
   it("Unshield select spl", async () => {
-    const inUtxos: Utxo[] = [utxo1, utxoSol];
+    const utxos: Utxo[] = [utxo1, utxoSol];
 
-    let selectedUtxo = selectInUtxos({
+    let selectedUtxos = selectInUtxos({
       publicMint: utxo1.assets[1],
       relayerFee: RELAYER_FEE,
       publicAmountSpl: BN_1,
       poseidon,
-      utxos: inUtxos,
+      utxos,
       action: Action.UNSHIELD,
       numberMaxInUtxos,
       numberMaxOutUtxos,
     });
-    Utxo.equal(poseidon, selectedUtxo[0], utxo1);
+    Utxo.equal(poseidon, selectedUtxos[0], utxo1);
   });
 
   it("Unshield select sol", async () => {
-    const inUtxos = [utxoSol, utxo1];
+    const utxos = [utxoSol, utxo1];
 
-    let selectedUtxo = selectInUtxos({
-      utxos: inUtxos,
+    let selectedUtxos = selectInUtxos({
+      utxos,
       relayerFee: RELAYER_FEE,
       publicAmountSol: new BN(1e7),
       poseidon,
@@ -124,15 +124,15 @@ describe("Test selectInUtxos Functional", () => {
       numberMaxOutUtxos,
     });
 
-    Utxo.equal(poseidon, selectedUtxo[0], utxoSol);
+    Utxo.equal(poseidon, selectedUtxos[0], utxoSol);
     assert.equal(selectInUtxos.length, 1);
   });
 
   it("UNSHIELD select sol & spl", async () => {
-    const inUtxos = [utxoSol, utxo1];
+    const utxos = [utxoSol, utxo1];
 
-    let selectedUtxo = selectInUtxos({
-      utxos: inUtxos,
+    let selectedUtxos = selectInUtxos({
+      utxos,
       action: Action.UNSHIELD,
       relayerFee: RELAYER_FEE,
       poseidon,
@@ -143,12 +143,12 @@ describe("Test selectInUtxos Functional", () => {
       numberMaxOutUtxos,
     });
 
-    Utxo.equal(poseidon, selectedUtxo[1], utxoSol);
-    Utxo.equal(poseidon, selectedUtxo[0], utxo1);
+    Utxo.equal(poseidon, selectedUtxos[1], utxoSol);
+    Utxo.equal(poseidon, selectedUtxos[0], utxo1);
   });
 
   it("Transfer select sol & spl", async () => {
-    const inUtxos = [utxoSol, utxo1];
+    const utxos = [utxoSol, utxo1];
     const outUtxos = createRecipientUtxos({
       recipients: [
         {
@@ -165,7 +165,7 @@ describe("Test selectInUtxos Functional", () => {
     });
 
     let selectedUtxo = selectInUtxos({
-      utxos: inUtxos,
+      utxos,
       action: Action.TRANSFER,
       relayerFee: RELAYER_FEE,
       poseidon,
@@ -179,7 +179,7 @@ describe("Test selectInUtxos Functional", () => {
   });
 
   it("Transfer select sol", async () => {
-    const inUtxos = [utxoSol, utxo1];
+    const utxos = [utxoSol, utxo1];
     const outUtxos = createRecipientUtxos({
       recipients: [
         {
@@ -195,7 +195,7 @@ describe("Test selectInUtxos Functional", () => {
         lightProvider.lookUpTables.verifierProgramLookupTable,
     });
     let selectedUtxo = selectInUtxos({
-      utxos: inUtxos,
+      utxos,
       action: Action.TRANSFER,
       relayerFee: RELAYER_FEE,
       poseidon,
@@ -209,7 +209,7 @@ describe("Test selectInUtxos Functional", () => {
   });
 
   it("Transfer select spl", async () => {
-    const inUtxos = [utxoSol, utxo1];
+    const utxos = [utxoSol, utxo1];
     const outUtxos = createRecipientUtxos({
       recipients: [
         {
@@ -226,7 +226,7 @@ describe("Test selectInUtxos Functional", () => {
     });
 
     let selectedUtxo = selectInUtxos({
-      utxos: inUtxos,
+      utxos,
       action: Action.TRANSFER,
       relayerFee: RELAYER_FEE,
       poseidon,
@@ -239,10 +239,10 @@ describe("Test selectInUtxos Functional", () => {
   });
 
   it("Shield select sol & spl", async () => {
-    const inUtxos = [utxoSol, utxo1];
+    const utxos = [utxoSol, utxo1];
 
     let selectedUtxo = selectInUtxos({
-      utxos: inUtxos,
+      utxos,
       action: Action.SHIELD,
       publicMint: utxo1.assets[1],
       publicAmountSol: new BN(1e7),
@@ -256,10 +256,10 @@ describe("Test selectInUtxos Functional", () => {
   });
 
   it("Shield select sol", async () => {
-    const inUtxos = [utxoSol, utxo1];
+    const utxos = [utxoSol, utxo1];
 
     let selectedUtxo = selectInUtxos({
-      utxos: inUtxos,
+      utxos,
       action: Action.SHIELD,
       poseidon,
       publicAmountSol: new BN(1e7),
@@ -272,10 +272,10 @@ describe("Test selectInUtxos Functional", () => {
   });
 
   it("Shield select spl", async () => {
-    const inUtxos = [utxoSol, utxo1];
+    const utxos = [utxoSol, utxo1];
 
     let selectedUtxo = selectInUtxos({
-      utxos: inUtxos,
+      utxos,
       action: Action.SHIELD,
       publicMint: utxo1.assets[1],
       poseidon,
@@ -289,7 +289,7 @@ describe("Test selectInUtxos Functional", () => {
   });
 
   it("3 utxos spl & sol", async () => {
-    const inUtxos = [utxoSol, utxo1, utxo2];
+    const utxos = [utxoSol, utxo1, utxo2];
     const outUtxos = createRecipientUtxos({
       recipients: [
         {
@@ -306,7 +306,7 @@ describe("Test selectInUtxos Functional", () => {
     });
 
     let selectedUtxo = selectInUtxos({
-      utxos: inUtxos,
+      utxos,
       action: Action.TRANSFER,
       relayerFee: RELAYER_FEE,
       poseidon,
@@ -368,7 +368,7 @@ describe("Test selectInUtxos Errors", () => {
   });
 
   it("NO_PUBLIC_AMOUNTS_PROVIDED", async () => {
-    const inUtxos = [utxoSol, utxo1];
+    const utxos = [utxoSol, utxo1];
     const outUtxos = createRecipientUtxos({
       recipients: [
         {
@@ -385,7 +385,7 @@ describe("Test selectInUtxos Errors", () => {
     });
     expect(() => {
       selectInUtxos({
-        utxos: inUtxos,
+        utxos,
         action: Action.UNSHIELD,
         poseidon,
         outUtxos,
@@ -401,11 +401,11 @@ describe("Test selectInUtxos Errors", () => {
   });
 
   it("NO_PUBLIC_MINT_PROVIDED", async () => {
-    const inUtxos = [utxoSol, utxo1];
+    const utxos = [utxoSol, utxo1];
 
     expect(() => {
       selectInUtxos({
-        utxos: inUtxos,
+        utxos,
         action: Action.UNSHIELD,
         relayerFee: RELAYER_FEE,
         poseidon,
@@ -423,11 +423,11 @@ describe("Test selectInUtxos Errors", () => {
   });
 
   it("PUBLIC_SPL_AMOUNT_UNDEFINED", async () => {
-    const inUtxos = [utxoSol, utxo1];
+    const utxos = [utxoSol, utxo1];
 
     expect(() => {
       selectInUtxos({
-        utxos: inUtxos,
+        utxos,
         action: Action.UNSHIELD,
         relayerFee: RELAYER_FEE,
         poseidon,
@@ -445,11 +445,11 @@ describe("Test selectInUtxos Errors", () => {
   });
 
   it("RELAYER_FEE_UNDEFINED", async () => {
-    const inUtxos = [utxoSol, utxo1];
+    const utxos = [utxoSol, utxo1];
 
     expect(() => {
       selectInUtxos({
-        utxos: inUtxos,
+        utxos,
         action: Action.UNSHIELD,
         poseidon,
         publicMint: utxo1.assets[1],
@@ -467,11 +467,11 @@ describe("Test selectInUtxos Errors", () => {
   });
 
   it("RELAYER_FEE_UNDEFINED", async () => {
-    const inUtxos = [utxoSol, utxo1];
+    const utxos = [utxoSol, utxo1];
 
     expect(() => {
       selectInUtxos({
-        utxos: inUtxos,
+        utxos,
         action: Action.TRANSFER,
         poseidon,
         publicMint: utxo1.assets[1],
@@ -489,11 +489,11 @@ describe("Test selectInUtxos Errors", () => {
   });
 
   it("RELAYER_FEE_DEFINED", async () => {
-    const inUtxos = [utxoSol, utxo1];
+    const utxos = [utxoSol, utxo1];
 
     expect(() => {
       selectInUtxos({
-        utxos: inUtxos,
+        utxos,
         action: Action.SHIELD,
         relayerFee: RELAYER_FEE,
         poseidon,
@@ -576,7 +576,7 @@ describe("Test selectInUtxos Errors", () => {
   });
 
   it("FAILED_TO_FIND_UTXO_COMBINATION sol", async () => {
-    const inUtxos = [utxoSol, utxo1];
+    const utxos = [utxoSol, utxo1];
     const outUtxos = createRecipientUtxos({
       recipients: [
         {
@@ -593,7 +593,7 @@ describe("Test selectInUtxos Errors", () => {
     });
     expect(() => {
       selectInUtxos({
-        utxos: inUtxos,
+        utxos,
         action: Action.TRANSFER,
         relayerFee: RELAYER_FEE,
         poseidon,
@@ -610,7 +610,7 @@ describe("Test selectInUtxos Errors", () => {
   });
 
   it("FAILED_TO_FIND_UTXO_COMBINATION spl", async () => {
-    const inUtxos = [utxoSol, utxo1];
+    const utxos = [utxoSol, utxo1];
     const outUtxos = createRecipientUtxos({
       recipients: [
         {
@@ -627,7 +627,7 @@ describe("Test selectInUtxos Errors", () => {
     });
     expect(() => {
       selectInUtxos({
-        utxos: inUtxos,
+        utxos,
         action: Action.TRANSFER,
         relayerFee: RELAYER_FEE,
         poseidon,
@@ -644,7 +644,7 @@ describe("Test selectInUtxos Errors", () => {
   });
 
   it("FAILED_TO_FIND_UTXO_COMBINATION spl & sol", async () => {
-    const inUtxos = [utxoSol, utxo1, utxo2];
+    const utxos = [utxoSol, utxo1, utxo2];
     const outUtxos = createRecipientUtxos({
       recipients: [
         {
@@ -661,7 +661,7 @@ describe("Test selectInUtxos Errors", () => {
     });
     expect(() => {
       selectInUtxos({
-        utxos: inUtxos,
+        utxos,
         action: Action.TRANSFER,
         relayerFee: RELAYER_FEE,
         poseidon,


### PR DESCRIPTION
* The purpose of `selectInUtxos` is to find more UTXOs in case the one
provided has insufficient funds.

* Override 2nd selected UTXO only if there are >= selected UTXOs.
Otherwise, it results in going out of bounds. This can happen either
when there is only one UTXO or when threshold is 1.