### PR TITLE
fix: prevent redundant indexer rounds (infinite loop bug)

### DIFF
--- a/relayer/src/services/indexerService/indexer.ts
+++ b/relayer/src/services/indexerService/indexer.ts
@@ -34,7 +34,7 @@ export async function indexTransactions({
   connection: Connection;
 }) {
   try {
-    const olderTransactions: IndexedTransaction[] = await searchBackward(
+    const { olderTransactions, oldestFetchedSignature } = await searchBackward(
       job,
       connection,
     );
@@ -60,6 +60,7 @@ export async function indexTransactions({
     await job.updateData({
       transactions: filteredByDeploymentVersion,
       lastFetched: Date.now(),
+      oldestFetchedSignature,
     });
   } catch (e) {
     console.log("restarting indexer -- crash reason:", e);

--- a/relayer/src/services/indexerService/runIndexer.ts
+++ b/relayer/src/services/indexerService/runIndexer.ts
@@ -12,7 +12,7 @@ export async function runIndexer(rounds: number = 0) {
   var initialSync = false;
   var laps = -1;
   while (laps < rounds) {
-    if (initialSync) await sleep(2 * SECONDS);
+    if (initialSync) await sleep(3 * SECONDS);
     else await sleep(5 * SECONDS);
     const { job } = await getTransactions(DB_VERSION);
     const url = process.env.RPC_URL;

--- a/relayer/src/services/indexerService/search.ts
+++ b/relayer/src/services/indexerService/search.ts
@@ -47,6 +47,9 @@ export async function searchBackward(job: Job, connection: Connection) {
           before: oldestTransaction.signature,
         },
       },
+      undefined,
+      job.data.transactions.ll,
+
     );
     return olderTransactions;
   }

--- a/relayer/src/services/transactionService.ts
+++ b/relayer/src/services/transactionService.ts
@@ -50,12 +50,14 @@ export async function indexedTransactions(_req: any, res: any) {
 
     if (!provider) throw new Error("no provider set");
 
-    const indexedTransactions = await fetchRecentTransactions({
-      connection: provider.connection,
-      batchOptions: {
-        limit: 5000,
+    const { transactions: indexedTransactions } = await fetchRecentTransactions(
+      {
+        connection: provider.connection,
+        batchOptions: {
+          limit: 5000,
+        },
       },
-    });
+    );
 
     const stringifiedIndexedTransactions = indexedTransactions.map(
       (trx: IndexedTransaction) => {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-# `dirname "${0}"`/build.sh
+`dirname "${0}"`/build.sh
 
 
 cd zk.js

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-`dirname "${0}"`/build.sh
+# `dirname "${0}"`/build.sh
 
 
 cd zk.js

--- a/zk.js/src/test-utils/testRelayer.ts
+++ b/zk.js/src/test-utils/testRelayer.ts
@@ -109,7 +109,7 @@ export class TestRelayer extends Relayer {
     // which is approximately the number of transactions sent to send one shielded transaction and update the merkle tree
     const limit = 1000 + 260 * merkleTreeAccount.nextIndex.toNumber();
     if (this.indexedTransactions.length === 0) {
-      let newTransactions = await fetchRecentTransactions({
+      let { transactions: newTransactions } = await fetchRecentTransactions({
         connection,
         batchOptions: {
           limit,
@@ -133,7 +133,7 @@ export class TestRelayer extends Relayer {
         a.blockTime > b.blockTime ? a : b,
       );
 
-      let newTransactions = await fetchRecentTransactions({
+      let { transactions: newTransactions } = await fetchRecentTransactions({
         connection,
         batchOptions: {
           limit,

--- a/zk.js/src/test-utils/testTransaction.ts
+++ b/zk.js/src/test-utils/testTransaction.ts
@@ -517,12 +517,13 @@ export class TestTransaction {
     }
 
     if (this.params.message) {
-      const indexedTransactions = await fetchRecentTransactions({
-        connection: this.provider!.provider!.connection,
-        batchOptions: {
-          limit: 5000,
-        },
-      });
+      const { transactions: indexedTransactions } =
+        await fetchRecentTransactions({
+          connection: this.provider!.provider!.connection,
+          batchOptions: {
+            limit: 5000,
+          },
+        });
       indexedTransactions.sort((a, b) => b.blockTime - a.blockTime);
       assert.equal(
         indexedTransactions[0].message.toString(),

--- a/zk.js/src/test-utils/userTestAssertHelper.ts
+++ b/zk.js/src/test-utils/userTestAssertHelper.ts
@@ -1076,12 +1076,14 @@ export class UserTestAssertHelper {
   async checkMessageStored() {
     if (!this.testInputs.message)
       throw new Error("Test inputs message undefined to assert message stored");
-    const indexedTransactions = await fetchRecentTransactions({
-      connection: this.provider!.provider!.connection,
-      batchOptions: {
-        limit: 5000,
+    const { transactions: indexedTransactions } = await fetchRecentTransactions(
+      {
+        connection: this.provider!.provider!.connection,
+        batchOptions: {
+          limit: 5000,
+        },
       },
-    });
+    );
     indexedTransactions.sort((a, b) => b.blockTime - a.blockTime);
     assert.equal(
       indexedTransactions[0].message.toString(),

--- a/zk.js/src/transaction/fetchRecentTransactions.ts
+++ b/zk.js/src/transaction/fetchRecentTransactions.ts
@@ -332,7 +332,7 @@ const parseTransactionEvents = (
  * @param {any[]} transactions - The array where the fetched transactions will be stored.
  * @returns {Promise<string>} - The signature of the last fetched transaction.
  */
-// TODO: consider explicitly returning a new txs array instead of mutating the passed in one
+// TODO: consider explicitly returning a new txs array instead of mutating the passed in oneDasync functio getn
 async function getTransactionsBatch({
   connection,
   merkleTreeProgramId,
@@ -344,6 +344,11 @@ async function getTransactionsBatch({
   batchOptions: ConfirmedSignaturesForAddress2Options;
   transactions: any;
 }) {
+  /// TODO: hash sigs. poll for hash in db. if matches, skip and keep hash. if not, add to db and process full batch there.
+  /// = if no activity, no/ish calls
+  /// = if heavy activity, lots of calls still. might have to make this slimmer. 
+  ///   e.g. filter by cutoff date before.
+  ///   
   const signatures = await connection.getConfirmedSignaturesForAddress2(
     new PublicKey(merkleTreeProgramId),
     batchOptions,

--- a/zk.js/src/transaction/fetchRecentTransactions.ts
+++ b/zk.js/src/transaction/fetchRecentTransactions.ts
@@ -333,7 +333,7 @@ const parseTransactionEvents = (
  * @param {any[]} transactions - The array where the fetched transactions will be stored.
  * @returns {Promise<string>} - The signature of the last fetched transaction.
  */
-// TODO: consider explicitly returning a new txs array instead of mutating the passed in oneDasync functio getn
+// TODO: consider explicitly returning a new txs array instead of mutating the passed in one.
 async function getTransactionsBatch({
   connection,
   merkleTreeProgramId,


### PR DESCRIPTION
problem
- fetchRecentTransactions applies several filters after its 'getConfirmedSignaturesForAddress2' call. if the oldest fetched signature gets filtered out i.e. is not a shielded tx, the last indexed shielded tx != lastfetched sig.
in that case the indexer would get stuck in an infinite loop where it would always find new sigs to fetch, resulting in tons of redundant calls (hundreds every couple of seconds)

fix:
- store the actual oldestFetchedSig  in the db. searchBackward now uses that sig instead of the sig of the oldest indexed tx.
results:
- each "index" round now only does 2 single rpc calls (1 forward, 1 backward) if no new transactions get added. 