### PR TITLE
chore: add aarch64 to install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -146,7 +146,7 @@ case "${OS}" in
                 ARCH_SUFFIX_LP="linux-amd64"
                 ARCH_SUFFIX_NODE="linux-x64"
                 ;;
-            "arch64"|"arm64")
+            "aarch64"|"arch64"|"arm64")
                 ARCH_SUFFIX_SOLANA="aarch64-unknown-linux-gnu"
                 ARCH_SUFFIX_LP="linux-arm64"
                 ARCH_SUFFIX_NODE="linux-arm64"


### PR DESCRIPTION
… ensure compatibility with 'aarch64' systems alongside 'arch64' and 'arm64'.