### PR TITLE
feat(relayer): added getRelayerInfo

### DIFF
--- a/cli/config.json
+++ b/cli/config.json
@@ -4,5 +4,7 @@
   "rpcUrl": "http://127.0.0.1:8899",
   "relayerPublicKey": "EkXDLi1APzu6oxJbg5Hnjb24kfKauJp1xCb5FAUMxf9D",
   "lookupTable": "8SezKuv7wMNPd574Sq4rQ1wvVrxa22xPYtkeruJRjrhG",
+  "relayerFee": "0186a0",
+  "highRelayerFee": "1660e8",
   "secretKey": "LsYPAULcTDhjnECes7qhwAdeEUVYgbpX5ri5zijUceTQXCwkxP94zKdG4pmDQmicF7Zbj1AqB44t8qfGE8RuUk8"
 }

--- a/cli/src/psp-utils/constants.ts
+++ b/cli/src/psp-utils/constants.ts
@@ -1,3 +1,5 @@
+import { RELAYER_FEE, TOKEN_ACCOUNT_FEE } from "@lightprotocol/zk.js";
+
 export const PSP_TEMPLATE_TAG = "v0.1.2";
 export const PROGRAM_TAG = "v0.3.2";
 export const MACRO_CIRCOM_TAG = "v0.1.6";
@@ -22,4 +24,6 @@ export const DEFAULT_CONFIG = {
   rpcUrl: "http://127.0.0.1:8899",
   relayerPublicKey: "EkXDLi1APzu6oxJbg5Hnjb24kfKauJp1xCb5FAUMxf9D",
   lookupTable: "8SezKuv7wMNPd574Sq4rQ1wvVrxa22xPYtkeruJRjrhG",
+  relayerFee: RELAYER_FEE,
+  highRelayerFee: TOKEN_ACCOUNT_FEE,
 };

--- a/cli/src/utils/utils.ts
+++ b/cli/src/utils/utils.ts
@@ -120,12 +120,13 @@ export const getRelayer = async (localTestRelayer?: boolean) => {
       });
       return relayer;
     } else {
+      const config = getConfig();
       relayer = new Relayer(
-        getRelayerPublicKey(),
-        getRelayerRecipient(),
-        RELAYER_FEE,
-        TOKEN_ACCOUNT_FEE,
-        getRelayerUrl()
+        new solana.PublicKey(config.relayerPublicKey),
+        new solana.PublicKey(config.relayerRecipient),
+        new BN(config.relayerFee),
+        new BN(config.highRelayerFee),
+        config.relayerUrl
       );
     }
   }
@@ -138,6 +139,8 @@ type Config = {
   secretKey: string;
   relayerRecipient: string;
   relayerPublicKey: string;
+  relayerFee: string;
+  highRelayerFee: string;
   payer: string;
   lookUpTable: string;
 };
@@ -214,7 +217,6 @@ export const setPayer = (key: string) => {
   setConfig({ payer: key });
 };
 import { existsSync } from "fs";
-import { config } from "dotenv";
 
 function getConfigPath(): string {
   // Check for the environment variable

--- a/relayer/src/index.ts
+++ b/relayer/src/index.ts
@@ -9,6 +9,7 @@ import {
   handleRelayRequest,
   runIndexer,
   getLookUpTable,
+  getRelayerInfo,
 } from "./services";
 import { getTransactions } from "./db/redis";
 import { createTestAccounts } from "@lightprotocol/zk.js";
@@ -40,6 +41,8 @@ app.get("/lookuptable", getLookUpTable);
 app.post("/relayTransaction", handleRelayRequest);
 
 app.get("/indexedTransactions", getIndexedTransactions);
+
+app.get("/getRelayerInfo", getRelayerInfo);
 
 app.listen(port, async () => {
   const anchorProvider = await getAnchorProvider();

--- a/relayer/src/services/index.ts
+++ b/relayer/src/services/index.ts
@@ -2,3 +2,4 @@ export * from "./relayService/index";
 export * from "./indexerService/index";
 export * from "./lookupTableService";
 export * from "./merkleTreeService";
+export * from "./infoService";

--- a/relayer/src/services/infoService.ts
+++ b/relayer/src/services/infoService.ts
@@ -1,0 +1,18 @@
+import { getRelayer } from "../utils/provider";
+
+export async function getRelayerInfo(_req: any, res: any): Promise<string> {
+  try {
+    let relayer = await getRelayer();
+    return res.status(200).json({
+      data: {
+        relayerPubkey: relayer.accounts.relayerPubkey.toBase58(),
+        relayerRecipientSol: relayer.accounts.relayerRecipientSol.toBase58(),
+        relayerFee: relayer.relayerFee.toString(),
+        highRelayerFee: relayer.highRelayerFee.toString(),
+      },
+    });
+  } catch (e) {
+    console.log("@getRelayerInfo error: ", e);
+    return res.status(500).json({ status: "error", message: e.message });
+  }
+}

--- a/relayer/tests/runTestCli.sh
+++ b/relayer/tests/runTestCli.sh
@@ -32,6 +32,10 @@ sleep 15
 echo "executing cli tests"
 cd ../cli
 # export LIGHT_PROTOCOL_CONFIG=$PWD/config.json
+# set invalid relayerRecipient
+./test_bin/run config --relayerRecipient=AV3LnV78ezsEBZebNeMPtEcH1hmvSfUBC5Xbyrz66666
+# sync valid relayer stats again
+./test_bin/run config --syncRelayer
 ./test_bin/run config --secretKey=LsYPAULcTDhjnECes7qhwAdeEUVYgbpX5ri5zijUceTQXCwkxP94zKdG4pmDQmicF7Zbj1AqB44t8qfGE8RuUk8
 ./test_bin/run config --relayerRecipient=AV3LnV78ezsEBZebNeMPtEcH1hmvSfUBC5Xbyrzqbt44
 ./test_bin/run airdrop 50 ALA2cnz41Wa2v2EYUdkYHsg7VnKsbH1j7secM5aiP8k

--- a/zk.js/src/relayer.ts
+++ b/zk.js/src/relayer.ts
@@ -144,4 +144,25 @@ export class Relayer {
       throw err;
     }
   }
+
+  async syncRelayerInfo(): Promise<void> {
+    const response = await axios.get(this.url + "/getRelayerInfo");
+    const data = response.data.data;
+    this.accounts.relayerPubkey = new PublicKey(data.relayerPubkey);
+    this.accounts.relayerRecipientSol = new PublicKey(data.relayerRecipientSol);
+    this.relayerFee = new BN(data.relayerFee);
+    this.highRelayerFee = new BN(data.highRelayerFee);
+  }
+
+  static async initFromUrl(url: string): Promise<Relayer> {
+    const response = await axios.get(url + "/getRelayerInfo");
+    const data = response.data.data;
+    return new Relayer(
+      new PublicKey(data.relayerPubkey),
+      new PublicKey(data.relayerRecipientSol),
+      new BN(data.relayerFee),
+      new BN(data.highRelayerFee),
+      url,
+    );
+  }
 }


### PR DESCRIPTION
Problem:
- relayerPubkey and relayerRecipientSol need to be configured manually
- inconsistencies cause transactions to fail

Changes:
- relayer server:
  - add getRelayerInfo path to relayer server (returns current relayerPubkey, relayerRecipientSol, relayerFee, relayerFeeHigh)
- Relayer class zk.js
  - added Relayer.initFromUrl and relayer.syncRelayerInfo(url: string) which does a request to getRelayerInfo()
- CLI:
    - added config fields for relayerFee and highRelayerFee
    - added syncRelayer flag to config command which syncs the relayer info