### PR TITLE
chore: Remove `enable_nfts` configuration and instruction

### DIFF
--- a/DOCUMENTATION_v3.md
+++ b/DOCUMENTATION_v3.md
@@ -111,7 +111,6 @@ The second flow consists out of the following functions in the merkle_tree_progr
   - pubkey // is the current merkle tree authority
   - merkle_tree_index // is the counter how many merkle tree exist
   - registered_asset_index //
-  - enable_nfts
   - enable_permissionless_spl_tokens
   - enable_permissionless_merkle_tree_registration
 

--- a/cli/src/commands/merkle-tree-authority/get.ts
+++ b/cli/src/commands/merkle-tree-authority/get.ts
@@ -26,7 +26,6 @@ class GetCommand extends Command {
             merkleTreeAuthorityAccountInfo.eventMerkleTreeIndex.toString(),
           registeredAssetIndex:
             merkleTreeAuthorityAccountInfo.registeredAssetIndex.toString(),
-          enableNfts: merkleTreeAuthorityAccountInfo.enableNfts,
           enablePermissionlessSplTokens:
             merkleTreeAuthorityAccountInfo.enablePermissionlessSplTokens,
           enablePermissionlessMerkleTreeRegistration:
@@ -42,9 +41,6 @@ class GetCommand extends Command {
         },
         registeredAssetIndex: {
           header: "Registered asset index",
-        },
-        enableNfts: {
-          header: "Enable NFTs",
         },
         enablePermissionlessSplTokens: {
           header: "Enable permissionless SPL tokens",

--- a/system-programs/programs/merkle_tree_program/src/config_accounts/merkle_tree_authority.rs
+++ b/system-programs/programs/merkle_tree_program/src/config_accounts/merkle_tree_authority.rs
@@ -19,7 +19,6 @@ pub struct MerkleTreeAuthority {
     pub transaction_merkle_tree_index: u64,
     pub event_merkle_tree_index: u64,
     pub registered_asset_index: u64,
-    pub enable_nfts: bool,
     pub enable_permissionless_spl_tokens: bool,
     pub enable_permissionless_merkle_tree_registration: bool,
 }

--- a/system-programs/programs/merkle_tree_program/src/lib.rs
+++ b/system-programs/programs/merkle_tree_program/src/lib.rs
@@ -134,15 +134,6 @@ pub mod merkle_tree_program {
         Ok(())
     }
 
-    /// Enables permissionless deposits of any spl token with supply of one and zero decimals.
-    pub fn enable_nfts(
-        _ctx: Context<UpdateMerkleTreeAuthorityConfig>,
-        _enable_permissionless: bool,
-    ) -> Result<()> {
-        // ctx.accounts.merkle_tree_authority_pda.enable_nfts = enable_permissionless;
-        unimplemented!();
-    }
-
     /// Enables anyone to create token pools.
     pub fn enable_permissionless_spl_tokens(
         ctx: Context<UpdateMerkleTreeAuthorityConfig>,
@@ -194,20 +185,6 @@ pub mod merkle_tree_program {
 
     /// Creates a new spl token pool which can be used by any registered verifier.
     pub fn register_spl_pool(ctx: Context<RegisterSplPool>) -> Result<()> {
-        // let is_nft = false;
-        // ctx.accounts.mint.decimals == 0
-        // && ctx.accounts.mint.supply == 1
-        // should add check that authority is metaplex nft
-        // && metaplex_token_metadata::state::get_master_edition(&ctx.accounts.metaplex_token.to_account_info()).is_ok();
-        // msg!("is_nft {}", is_nft);
-        // nfts enabled
-        // if is_nft
-        //     && !ctx.accounts.merkle_tree_authority_pda.enable_nfts
-        //     && ctx.accounts.authority.key() != ctx.accounts.merkle_tree_authority_pda.pubkey
-        // {
-        //     return err!(ErrorCode::InvalidAuthority);
-        // }
-
         // any token enabled
         if !ctx
             .accounts

--- a/system-programs/tests/merkle_tree_tests.ts
+++ b/system-programs/tests/merkle_tree_tests.ts
@@ -265,44 +265,10 @@ describe("Merkle Tree Tests", () => {
     merkleTreeConfig.registeredVerifierPdas[0].registeredVerifierPda = tmp;
     error = undefined;
 
-    // update merkle tree with invalid signer
-    // merkleTreeConfig.payer = INVALID_SIGNER;
-    // try {
-    //   await merkleTreeConfig.enableNfts(true);
-    // } catch (e) {
-    //   error = e;
-    // }
-    // assert.equal(error.error.errorMessage, "InvalidAuthority");
-    // error = undefined;
-    // merkleTreeConfig.payer = ADMIN_AUTH_KEYPAIR;
-
-    // // update merkle tree with INVALID_MERKLE_TREE_AUTHORITY_PDA
-    // merkleTreeConfig.merkleTreeAuthorityPda = INVALID_MERKLE_TREE_AUTHORITY_PDA;
-    // try {
-    //   await merkleTreeConfig.enableNfts(true);
-    // } catch (e) {
-    //   error = e;
-    // }
-    // await merkleTreeConfig.getMerkleTreeAuthorityPda();
-    // assert.equal(
-    //   error.error.errorMessage,
-    //   "The program expected this account to be already initialized"
-    // );
-    // error = undefined;
-
-    // await merkleTreeConfig.enableNfts(true);
-
     let merkleTreeAuthority =
       await merkleTreeProgram.account.merkleTreeAuthority.fetch(
         merkleTreeConfig.merkleTreeAuthorityPda,
       );
-    // assert.equal(merkleTreeAuthority.enableNfts, true);
-    // await merkleTreeConfig.enableNfts(false);
-    // merkleTreeAuthority =
-    //   await merkleTreeProgram.account.merkleTreeAuthority.fetch(
-    //     merkleTreeConfig.merkleTreeAuthorityPda
-    //   );
-    // assert.equal(merkleTreeAuthority.enableNfts, false);
 
     // update lock duration with invalid signer
 

--- a/zk.js/src/idls/merkle_tree_program.ts
+++ b/zk.js/src/idls/merkle_tree_program.ts
@@ -299,30 +299,6 @@ export type MerkleTreeProgram = {
       ]
     },
     {
-      "name": "enableNfts",
-      "docs": [
-        "Enables permissionless deposits of any spl token with supply of one and zero decimals."
-      ],
-      "accounts": [
-        {
-          "name": "merkleTreeAuthorityPda",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "enablePermissionless",
-          "type": "bool"
-        }
-      ]
-    },
-    {
       "name": "enablePermissionlessSplTokens",
       "docs": [
         "Enables anyone to create token pools."
@@ -1019,10 +995,6 @@ export type MerkleTreeProgram = {
           {
             "name": "registeredAssetIndex",
             "type": "u64"
-          },
-          {
-            "name": "enableNfts",
-            "type": "bool"
           },
           {
             "name": "enablePermissionlessSplTokens",
@@ -1832,30 +1804,6 @@ export const IDL: MerkleTreeProgram = {
       ]
     },
     {
-      "name": "enableNfts",
-      "docs": [
-        "Enables permissionless deposits of any spl token with supply of one and zero decimals."
-      ],
-      "accounts": [
-        {
-          "name": "merkleTreeAuthorityPda",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "enablePermissionless",
-          "type": "bool"
-        }
-      ]
-    },
-    {
       "name": "enablePermissionlessSplTokens",
       "docs": [
         "Enables anyone to create token pools."
@@ -2552,10 +2500,6 @@ export const IDL: MerkleTreeProgram = {
           {
             "name": "registeredAssetIndex",
             "type": "u64"
-          },
-          {
-            "name": "enableNfts",
-            "type": "bool"
           },
           {
             "name": "enablePermissionlessSplTokens",

--- a/zk.js/src/merkleTree/merkleTreeConfig.ts
+++ b/zk.js/src/merkleTree/merkleTreeConfig.ts
@@ -283,7 +283,6 @@ export class MerkleTreeConfig {
     //     this.merkleTreeAuthorityPda!,
     //   );
     // assert(merkleTreeAuthority.enablePermissionlessSplTokens == false);
-    // assert(merkleTreeAuthority.enableNfts == false);
     // assert(
     //   merkleTreeAuthority.pubkey.toBase58() == authority!.publicKey.toBase58(),
     // );
@@ -346,39 +345,12 @@ export class MerkleTreeConfig {
         merkleTreeAuthorityPrior!.enablePermissionlessSplTokens,
       );
       assert.equal(
-        merkleTreeAuthority.enableNfts,
-        merkleTreeAuthorityPrior!.enableNfts,
-      );
-      assert.equal(
         merkleTreeAuthority.pubkey.toBase58(),
         newAuthority.toBase58(),
       );
     }
     return txHash;
   }
-
-  // commented in program
-  // async enableNfts(configValue: Boolean) {
-  //   if (this.merkleTreeAuthorityPda == undefined) {
-  //     await this.getMerkleTreeAuthorityPda();
-  //   }
-  //   const tx = await this.merkleTreeProgram.methods
-  //     .enableNfts(configValue)
-  //     .accounts({
-  //       authority: this.payer.publicKey,
-  //       merkleTreeAuthorityPda: this.merkleTreeAuthorityPda,
-  //       ...DEFAULT_PROGRAMS,
-  //     })
-  //     .signers([this.payer])
-  //     .rpc(confirmConfig);
-  //   let merkleTreeAuthority =
-  //     await this.merkleTreeProgram.account.merkleTreeAuthority.fetch(
-  //       this.merkleTreeAuthorityPda,
-  //     );
-  //   assert(merkleTreeAuthority.enableNfts == configValue);
-
-  //   return tx;
-  // }
 
   async enablePermissionlessSplTokens(configValue: boolean) {
     if (!this.payer) throw new Error("Payer undefined");


### PR DESCRIPTION
It wasn't used anywhere. We can treat uncompressed NFTs as regular SPL tokens. Supporting compressed NTFs is going to require an another approach.