### PR TITLE
chore: Unify the `MERKLE_TREE_HEIGHT` constant

### DIFF
--- a/system-programs/programs/merkle_tree_program/src/event_merkle_tree/initialize.rs
+++ b/system-programs/programs/merkle_tree_program/src/event_merkle_tree/initialize.rs
@@ -9,9 +9,7 @@ use light_merkle_tree::{
     HashFunction, MerkleTree,
 };
 
-use crate::{
-    impl_indexed_merkle_tree, utils::constants::EVENT_MERKLE_TREE_HEIGHT, MerkleTreeAuthority,
-};
+use crate::{impl_indexed_merkle_tree, utils::config::MERKLE_TREE_HEIGHT, MerkleTreeAuthority};
 
 #[derive(Clone, Copy)]
 pub struct EventMerkleTreeConfig {}
@@ -37,7 +35,7 @@ pub fn process_initialize_new_event_merkle_tree(
 ) {
     merkle_tree
         .merkle_tree
-        .init(EVENT_MERKLE_TREE_HEIGHT, HashFunction::Sha256);
+        .init(MERKLE_TREE_HEIGHT, HashFunction::Sha256);
     merkle_tree.merkle_tree_nr = merkle_tree_authority.event_merkle_tree_index;
     merkle_tree.newest = 1;
 

--- a/system-programs/programs/merkle_tree_program/src/lib.rs
+++ b/system-programs/programs/merkle_tree_program/src/lib.rs
@@ -33,7 +33,7 @@ use crate::{
     transaction_merkle_tree::state::TransactionMerkleTree,
     utils::{
         accounts::deserialize_and_update_old_merkle_tree,
-        config::{self, ZERO_BYTES_MERKLE_TREE_18},
+        config::{self, MERKLE_TREE_HEIGHT, ZERO_BYTES_MERKLE_TREE_18},
         constants::{EVENT_MERKLE_TREE_SEED, TRANSACTION_MERKLE_TREE_SEED},
     },
 };
@@ -74,7 +74,7 @@ pub mod merkle_tree_program {
         process_initialize_new_merkle_tree_18(
             new_transaction_merkle_tree,
             merkle_tree_authority,
-            18,
+            MERKLE_TREE_HEIGHT,
             ZERO_BYTES_MERKLE_TREE_18.to_vec(),
         );
         new_transaction_merkle_tree.lock_duration = lock_duration;
@@ -103,7 +103,7 @@ pub mod merkle_tree_program {
         process_initialize_new_merkle_tree_18(
             merkle_tree,
             merkle_tree_authority,
-            18,
+            MERKLE_TREE_HEIGHT,
             ZERO_BYTES_MERKLE_TREE_18.to_vec(),
         );
 

--- a/system-programs/programs/merkle_tree_program/src/transaction_merkle_tree/initialize_new_merkle_tree_18.rs
+++ b/system-programs/programs/merkle_tree_program/src/transaction_merkle_tree/initialize_new_merkle_tree_18.rs
@@ -18,17 +18,16 @@ pub struct PreInsertedLeavesIndex {
 pub fn process_initialize_new_merkle_tree_18(
     merkle_tree: &mut RefMut<'_, TransactionMerkleTree>,
     merkle_tree_authority: &mut Account<'_, MerkleTreeAuthority>,
-    height: u64,
+    height: usize,
     zero_bytes: Vec<[u8; 32]>,
 ) {
     merkle_tree.newest = 1;
 
-    merkle_tree.filled_subtrees[..usize::try_from(height).unwrap()]
-        .copy_from_slice(&zero_bytes[..usize::try_from(height).unwrap()]);
+    merkle_tree.filled_subtrees[..height].copy_from_slice(&zero_bytes[..height]);
 
     merkle_tree.height = merkle_tree.filled_subtrees.len().try_into().unwrap();
     merkle_tree.merkle_tree_nr = merkle_tree_authority.transaction_merkle_tree_index;
-    merkle_tree.roots[0] = zero_bytes[height as usize];
+    merkle_tree.roots[0] = zero_bytes[height];
     msg!(
         "merkle_tree_state_data.roots[0]: {:?}",
         merkle_tree.roots[0]

--- a/system-programs/programs/merkle_tree_program/src/transaction_merkle_tree/state.rs
+++ b/system-programs/programs/merkle_tree_program/src/transaction_merkle_tree/state.rs
@@ -1,4 +1,7 @@
-use crate::{impl_indexed_merkle_tree, utils::config::MERKLE_TREE_HISTORY_SIZE};
+use crate::{
+    impl_indexed_merkle_tree,
+    utils::config::{MERKLE_TREE_HEIGHT, MERKLE_TREE_HISTORY_SIZE},
+};
 use anchor_lang::prelude::*;
 
 // NOTE(vadorovsky): This implementation of Merkle tree exists only for
@@ -8,7 +11,7 @@ use anchor_lang::prelude::*;
 #[account(zero_copy)]
 #[derive(Eq, PartialEq, Debug)]
 pub struct TransactionMerkleTree {
-    pub filled_subtrees: [[u8; 32]; 18],
+    pub filled_subtrees: [[u8; 32]; MERKLE_TREE_HEIGHT],
     pub current_root_index: u64,
     pub next_index: u64,
     pub roots: [[u8; 32]; MERKLE_TREE_HISTORY_SIZE as usize],

--- a/system-programs/programs/merkle_tree_program/src/transaction_merkle_tree/update_merkle_tree_lib/merkle_tree_update_state.rs
+++ b/system-programs/programs/merkle_tree_program/src/transaction_merkle_tree/update_merkle_tree_lib/merkle_tree_update_state.rs
@@ -20,7 +20,7 @@ pub struct MerkleTreeUpdateState {
     pub current_level: u64,
     pub current_level_hash: [u8; 32],
     pub tmp_leaves_index: u64,
-    pub filled_subtrees: [[u8; 32]; MERKLE_TREE_HEIGHT as usize],
+    pub filled_subtrees: [[u8; 32]; MERKLE_TREE_HEIGHT],
 
     pub leaves: [[[u8; 32]; 2]; 16],
     pub number_of_leaves: u8,

--- a/system-programs/programs/merkle_tree_program/src/transaction_merkle_tree/update_merkle_tree_lib/processor.rs
+++ b/system-programs/programs/merkle_tree_program/src/transaction_merkle_tree/update_merkle_tree_lib/processor.rs
@@ -24,7 +24,7 @@ pub fn compute_updated_merkle_tree(
     } else if id == HASH_2 {
         poseidon_2(merkle_tree_update_state_data)?;
         // Updating the current level hash after a new hash is completely computed.
-        if merkle_tree_update_state_data.current_level < MERKLE_TREE_HEIGHT {
+        if merkle_tree_update_state_data.current_level < MERKLE_TREE_HEIGHT as u64 {
             insert_1_inner_loop(merkle_tree_pda_data, merkle_tree_update_state_data)?;
         }
     } else if id == MERKLE_TREE_UPDATE_START {

--- a/system-programs/programs/merkle_tree_program/src/utils/config.rs
+++ b/system-programs/programs/merkle_tree_program/src/utils/config.rs
@@ -4,10 +4,12 @@ use anchor_lang::constant;
 pub const ENCRYPTED_UTXOS_LENGTH: usize = 174;
 #[constant]
 pub const MERKLE_TREE_TMP_PDA_SIZE: usize = 2048;
+
 #[constant]
 pub const MERKLE_TREE_HISTORY_SIZE: u64 = 256;
+
 #[constant]
-pub const MERKLE_TREE_HEIGHT: u64 = 18;
+pub const MERKLE_TREE_HEIGHT: usize = 18;
 
 #[constant]
 pub const INITIAL_MERKLE_TREE_AUTHORITY: [u8; 32] = [

--- a/system-programs/programs/merkle_tree_program/src/utils/constants.rs
+++ b/system-programs/programs/merkle_tree_program/src/utils/constants.rs
@@ -39,7 +39,3 @@ pub const TOKEN_AUTHORITY_SEED: &[u8] = b"spl";
 pub const EVENT_MERKLE_TREE_SEED: &[u8] = b"event_merkle_tree";
 #[constant]
 pub const TRANSACTION_MERKLE_TREE_SEED: &[u8] = b"transaction_merkle_tree";
-
-// Merkle tree parameters
-#[constant]
-pub const EVENT_MERKLE_TREE_HEIGHT: usize = 18;

--- a/zk.js/src/idls/merkle_tree_program.ts
+++ b/zk.js/src/idls/merkle_tree_program.ts
@@ -23,7 +23,9 @@ export type MerkleTreeProgram = {
     },
     {
       "name": "MERKLE_TREE_HEIGHT",
-      "type": "u64",
+      "type": {
+        "defined": "usize"
+      },
       "value": "18"
     },
     {
@@ -150,13 +152,6 @@ export type MerkleTreeProgram = {
       "name": "TRANSACTION_MERKLE_TREE_SEED",
       "type": "bytes",
       "value": "[116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 95, 109, 101, 114, 107, 108, 101, 95, 116, 114, 101, 101]"
-    },
-    {
-      "name": "EVENT_MERKLE_TREE_HEIGHT",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "18"
     }
   ],
   "instructions": [
@@ -1528,7 +1523,9 @@ export const IDL: MerkleTreeProgram = {
     },
     {
       "name": "MERKLE_TREE_HEIGHT",
-      "type": "u64",
+      "type": {
+        "defined": "usize"
+      },
       "value": "18"
     },
     {
@@ -1655,13 +1652,6 @@ export const IDL: MerkleTreeProgram = {
       "name": "TRANSACTION_MERKLE_TREE_SEED",
       "type": "bytes",
       "value": "[116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 95, 109, 101, 114, 107, 108, 101, 95, 116, 114, 101, 101]"
-    },
-    {
-      "name": "EVENT_MERKLE_TREE_HEIGHT",
-      "type": {
-        "defined": "usize"
-      },
-      "value": "18"
     }
   ],
   "instructions": [


### PR DESCRIPTION
Use it both for Transaction and Event Merkle Tree.