### PR TITLE
chore: Do not cache node modules

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -21,12 +21,6 @@ runs:
           **/target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-    - name: Cache Node modules
-      uses: buildjet/cache@v3
-      with:
-        path: "**/node_modules"
-        key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock', '**/package.json') }}
-
     - name: Cache .local directory
       uses: buildjet/cache@v3
       with:


### PR DESCRIPTION
Node builds are not a bottleneck and caching them makes builds flaky. Let's disable caching of node modules and keep caching only Rust and third-party dependencies from install.sh.