### PR TITLE
perf: add merkleProof circuit benchmarks

### DIFF
--- a/circuit-lib/circuit-lib.circom/benchmarks/merkle-tree/README.md
+++ b/circuit-lib/circuit-lib.circom/benchmarks/merkle-tree/README.md
@@ -1,0 +1,37 @@
+## Benchmark Results
+***iterations** = 2000*
+
+| Height | Capacity  | Average Proving Time |
+|--------|---------- |------------------------|
+| 18     | 262,144   | 35ms/op                |
+| 20     | 1,048,576 | 40ms/op                |
+| 22     | 4,194,304 | 44ms/op                |
+| 24     | 16,777,216| 48ms/op                |
+| 26     | 67,108,864| 57ms/op                |
+
+
+## Interpretation of Benchmark Results
+
+- **Height vs. Average Proving Time**: 
+  - The average proving time per operation increases with higher circuit heights. 
+  - There is a **63% increase** in proving time from height 18 to height 26.
+
+- **Regression Speed Analysis**:
+  - **Minimum to Maximum Regression**: The benchmarks show a **37% regression** in operations per second at height 26 compared height 18.
+
+  - **Step Regression Speed**: The performance regresses by approximately **10%** when moving from height 18 to height 20, and this trend continues with similar regressions for each subsequent height increment.
+
+
+## Benchmark Script
+```shell
+$ yarn bench-merkle-tree
+```
+## NOTE
+If you get this error:
+> `AssertionError: Wrong compiler version. Must be at least 2.0.0`
+
+Then always delete the `circom` directory inside `node_modules` when using [circom_tester](https://www.npmjs.com/package/circom_tester) to fix the bug.
+
+```shell
+$ rm -rf node_modules/circom
+```

--- a/circuit-lib/circuit-lib.circom/benchmarks/merkle-tree/merkleProof-height.ts
+++ b/circuit-lib/circuit-lib.circom/benchmarks/merkle-tree/merkleProof-height.ts
@@ -1,0 +1,92 @@
+const bench = require("micro-bmark");
+const buildPoseidonOpt = require("circomlibjs").buildPoseidonOpt;
+const wasm_tester = require("circom_tester").wasm;
+const assert = require("assert");
+
+import { genRandomSalt as generateRandomFieldElement } from "maci-crypto";
+import { Provider as LightProvider } from "@lightprotocol/zk.js";
+import { MerkleTree } from "../../../circuit-lib.js/src";
+
+function getSignalByName(
+  circuit: any,
+  witness: any,
+  signalName: string,
+): string {
+  const signal = `main.${signalName}`;
+  return witness[circuit.symbols[signal].varIdx].toString();
+}
+
+function generateCircuitInputs(merkleTree: MerkleTree): {
+  leaf: string;
+  pathElements: string[];
+  pathIndices: string;
+} {
+  const leaf = merkleTree.elements()[2];
+  const pathElements = merkleTree.path(merkleTree.indexOf(leaf)).pathElements;
+  const pathIndices = merkleTree.indexOf(leaf).toString();
+  const circuitInputs = {
+    leaf,
+    pathElements,
+    pathIndices,
+  };
+
+  return circuitInputs;
+}
+
+async function loadMerkleTree(
+  height: number,
+  hash: any,
+  elements: string[],
+): Promise<MerkleTree> {
+  const lightProvider = await LightProvider.loadMock();
+  lightProvider.solMerkleTree!.merkleTree = new MerkleTree(
+    height,
+    hash,
+    elements,
+  );
+  return lightProvider.solMerkleTree?.merkleTree!;
+}
+
+async function markMerkleTree(merkleTree: MerkleTree, circuit: any) {
+  const circuitInputs = generateCircuitInputs(merkleTree);
+  const witness = await circuit.calculateWitness(circuitInputs);
+  await circuit.checkConstraints(witness);
+  await circuit.loadSymbols();
+
+  const root = getSignalByName(circuit, witness, "root");
+  assert(root, merkleTree.root());
+
+  return root;
+}
+
+const { compare, run } = bench;
+run(async () => {
+  let poseidon = await buildPoseidonOpt();
+  let elements = new Array<string>();
+  for (let i = 0; i < 2 ** 16; i++) {
+    elements.push(generateRandomFieldElement().toString());
+  }
+
+  let circuitPromises = new Array<Promise<any>>();
+  let merkleTreePromises = new Array<Promise<MerkleTree>>();
+
+  [18, 20, 22, 24, 26].map(async (height) => {
+    circuitPromises.push(
+      wasm_tester(`./tests/merkle-tree/merkleProof_test${height}.circom`, {
+        include: "node_modules/circomlib/circuits",
+      }),
+    );
+    merkleTreePromises.push(loadMerkleTree(Number(height), poseidon, elements));
+  });
+  const circuits = await Promise.all(circuitPromises);
+  const merkleTrees = await Promise.all(merkleTreePromises);
+
+  await compare("\x1b[35mBenchmarking MerkleProof Circuit\x1b[0m", 2000, {
+    height_18: async () => markMerkleTree(merkleTrees[0], circuits[0]),
+    height_20: async () => markMerkleTree(merkleTrees[1], circuits[1]),
+    height_22: async () => markMerkleTree(merkleTrees[2], circuits[2]),
+    height_24: async () => markMerkleTree(merkleTrees[3], circuits[3]),
+    height_26: async () => markMerkleTree(merkleTrees[4], circuits[4]),
+  });
+  bench.utils.logMem(); // Log current RAM
+});

--- a/circuit-lib/circuit-lib.circom/package.json
+++ b/circuit-lib/circuit-lib.circom/package.json
@@ -7,30 +7,37 @@
     "build-masp": "sh scripts/buildCircuit.sh Masp",
     "build-app": "sh scripts/buildCircuit.sh App",
     "test-light-circuits": "ts-mocha --resolveJsonModule ./tsconfig.json -t 100000000 tests/**.ts --exit",
+    "bench-merkle-tree": "pnpm ts-node ./benchmarks/merkle-tree/merkleProof-height.ts",
     "test-build-light-circuits": "pnpm build-all && ./scripts/checkBuildCircuit.sh",
     "test": "pnpm test-light-circuits",
-    "format": "prettier --write \"tests/**/*.{ts,js,circom}\"",
+    "format": "prettier --write \"tests/**/*.{ts,js}\" \"benchmarks/**/*.{ts,js}\"",
     "build-all": "pnpm build-app 4 && pnpm build-masp 2 && pnpm build-masp 10",
-    "lint": "pnpm prettier \"tests/**/*.{ts,js}\" --check",
+    "lint": "pnpm prettier \"tests/**/*.{ts,js}\" \"benchmarks/**/*.{ts,js}\" --check",
     "build": "pnpm tsc",
     "preinstall": "npx only-allow pnpm"
   },
   "author": "",
+  "dependencies": {
+    "@lightprotocol/zk.js": "0.3.2-alpha.15",
+    "circomlib": "^2.0.5",
+    "maci-crypto": "^1.1.2"
+  },
   "devDependencies": {
     "@coral-xyz/anchor": "0.28",
     "@lightprotocol/zk.js": "workspace:*",
     "@types/chai": "^4.3.0",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^20.8.0",
     "@types/node-fetch": "^2.6.2",
     "chai": "^4.3.7",
-    "circomlib": "^2.0.5",
     "mocha": "^10.2.0",
     "prettier": "^2.6.2",
     "ts-mocha": "^10.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.3.5",
-    "typescript-collections": "^1.3.3"
+    "typescript-collections": "^1.3.3",
+    "@types/node": "^20.8.1",
+    "circom_tester": "^0.0.19",
+    "micro-bmark": "^0.3.1"
   },
   "main": "lib/index.js",
   "files": [

--- a/circuit-lib/circuit-lib.circom/tests/merkle-tree/merkleProof_test18.circom
+++ b/circuit-lib/circuit-lib.circom/tests/merkle-tree/merkleProof_test18.circom
@@ -1,0 +1,5 @@
+pragma circom 2.0.0;
+
+include "../../src/merkle-tree/merkleProof.circom";
+
+component main = MerkleProof(18);

--- a/circuit-lib/circuit-lib.circom/tests/merkle-tree/merkleProof_test20.circom
+++ b/circuit-lib/circuit-lib.circom/tests/merkle-tree/merkleProof_test20.circom
@@ -1,0 +1,5 @@
+pragma circom 2.0.0;
+
+include "../../src/merkle-tree/merkleProof.circom";
+
+component main = MerkleProof(20);

--- a/circuit-lib/circuit-lib.circom/tests/merkle-tree/merkleProof_test22.circom
+++ b/circuit-lib/circuit-lib.circom/tests/merkle-tree/merkleProof_test22.circom
@@ -1,0 +1,5 @@
+pragma circom 2.0.0;
+
+include "../../src/merkle-tree/merkleProof.circom";
+
+component main = MerkleProof(22);

--- a/circuit-lib/circuit-lib.circom/tests/merkle-tree/merkleProof_test24.circom
+++ b/circuit-lib/circuit-lib.circom/tests/merkle-tree/merkleProof_test24.circom
@@ -1,0 +1,5 @@
+pragma circom 2.0.0;
+
+include "../../src/merkle-tree/merkleProof.circom";
+
+component main = MerkleProof(24);

--- a/circuit-lib/circuit-lib.circom/tests/merkle-tree/merkleProof_test26.circom
+++ b/circuit-lib/circuit-lib.circom/tests/merkle-tree/merkleProof_test26.circom
@@ -1,0 +1,5 @@
+pragma circom 2.0.0;
+
+include "../../src/merkle-tree/merkleProof.circom";
+
+component main = MerkleProof(26);


### PR DESCRIPTION
Changes:
- Add a new `benchmarks` dir inside `circuit-lib/ciruit-lib.circom`
- Use [micro-bmark](https://github.com/paulmillr/micro-bmark) package for micro benchmarks
- Benchmark `merkleProof` circuit directly comparing heights in [18, 20, 22, 24, 26]
- Add benchmarks README.md summary for the `merkleProof` circuit.
- The Merkle Tree is initialized with 2^16 elements generated from a Field Element PRNG(imported from `maci-crypto`)
- The leaf input for benchmarks is constant and taken as `elements[2]` (agnostic to performance) because using a random sample adds noise to benchmarks
