### PR TITLE
chore(cli): Point PSP template to the commit that it's compatible with

### DIFF
--- a/cli/src/psp-utils/constants.ts
+++ b/cli/src/psp-utils/constants.ts
@@ -10,11 +10,11 @@ export const CIRCUIT_LIB_CIRCOM_VERSION =
 export const PSP_DEFAULT_PROGRAM_ID =
   "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS";
 export const LIGHT_SYSTEM_PROGRAMS_VERSION =
-  '{ git = "https://github.com/lightprotocol/light-protocol", features = ["cpi"], branch = "main" }';
+  '{ git = "https://github.com/lightprotocol/light-protocol", features = ["cpi"], rev = "cf88fdedc3596a78f1e04a08695a29cb0f1b607f" }';
 export const LIGHT_MACROS_VERSION =
-  '{ git = "https://github.com/lightprotocol/light-protocol", branch = "main" }';
+  '{ git = "https://github.com/lightprotocol/light-protocol", rev = "cf88fdedc3596a78f1e04a08695a29cb0f1b607f" }';
 export const LIGHT_VERIFIER_SDK_VERSION =
-  '{ git = "https://github.com/lightprotocol/light-protocol", branch = "main" }';
+  '{ git = "https://github.com/lightprotocol/light-protocol", rev = "cf88fdedc3596a78f1e04a08695a29cb0f1b607f" }';
 export const CONFIG_PATH = "/.config/light/";
 export const CONFIG_FILE_NAME = "config.json";
 


### PR DESCRIPTION
Recently we renamed some crates, therefore breaking PSP template and building PSPs. Before we apply necessary changes in the template, let's pin the monorepo dependency to the commit before breaking changes.