### PR TITLE
chore: Specify versions of local crates which are published on crates.io

### DIFF
--- a/programs/merkle-tree/Cargo.toml
+++ b/programs/merkle-tree/Cargo.toml
@@ -45,7 +45,7 @@ arkworks-gadgets = "0.3.14"
 #spl-noop = { version = "0.1.3", features = ["no-entrypoint"] }
 
 # Light dependencies
-light-macros = "0.1.0"
+light-macros = { version = "0.3.0", path = "../../macros" }
 light-merkle-tree = { version = "0.1.1", features = ["solana"] }
 
 [dev-dependencies]

--- a/programs/psp10in2out/Cargo.toml
+++ b/programs/psp10in2out/Cargo.toml
@@ -24,5 +24,5 @@ solana-security-txt = "1.1.0"
 
 # Light Deps
 groth16-solana = "0.0.2"
-light-macros = { path = "../../macros" }
-light-verifier-sdk = {path = "../../verifier-sdk"}
+light-macros = { version = "0.3.0", path = "../../macros" }
+light-verifier-sdk = { version = "0.3.0", path = "../../verifier-sdk" }

--- a/programs/psp2in2out-storage/Cargo.toml
+++ b/programs/psp2in2out-storage/Cargo.toml
@@ -22,6 +22,6 @@ anchor-spl = "0.28.0"
 
 # Light deps
 groth16-solana = "0.0.2"
-light-macros = { path = "../../macros" }
-light-merkle-tree-program = { path = "../merkle-tree", features = ["cpi"] }
-light-verifier-sdk = { path = "../../verifier-sdk" }
+light-macros = { version = "0.3.0", path = "../../macros" }
+light-merkle-tree-program = { version = "0.3.0", path = "../merkle-tree", features = ["cpi"] }
+light-verifier-sdk = { version = "0.3.0", path = "../../verifier-sdk" }

--- a/programs/psp2in2out/Cargo.toml
+++ b/programs/psp2in2out/Cargo.toml
@@ -24,5 +24,5 @@ solana-security-txt = "1.1.0"
 
 # Light Deps
 groth16-solana = "0.0.2"
-light-macros = { path = "../../macros" }
-light-verifier-sdk = {path = "../../verifier-sdk"}
+light-macros = { version = "0.3.0", path = "../../macros" }
+light-verifier-sdk = { version = "0.3.0", path = "../../verifier-sdk" }

--- a/programs/psp4in4out-app-storage/Cargo.toml
+++ b/programs/psp4in4out-app-storage/Cargo.toml
@@ -24,5 +24,5 @@ solana-security-txt = "1.1.0"
 
 # Light Deps
 groth16-solana = "0.0.2"
-light-macros = { path = "../../macros" }
-light-verifier-sdk = {path = "../../verifier-sdk"}
+light-macros = { version = "0.3.0", path = "../../macros" }
+light-verifier-sdk = { version = "0.3.0", path = "../../verifier-sdk" }


### PR DESCRIPTION
That's required in order to avoid errors like this one:

https://github.com/Lightprotocol/light-protocol/actions/runs/6532753325/job/17736550803