### PR TITLE
chore: optimize Github workflow with integrated Redis service

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -16,14 +16,22 @@ jobs:
   docker-build-test:
     name: docker-build-test
     runs-on: buildjet-16vcpu-ubuntu-2204
+    services:
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
       - name: Setup and build
         uses: ./.github/actions/setup-and-build
-        with:
-          enable_redis: "true"
 
       - name: Set execute permissions
         run: |

--- a/.github/workflows/light-sdk-tests.yml
+++ b/.github/workflows/light-sdk-tests.yml
@@ -36,14 +36,22 @@ jobs:
             "@lightprotocol/circuit-lib.js",
             "@lightprotocol/circuit-lib.circom"
           ]'
+    services:
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
       - name: Setup and build
         uses: ./.github/actions/setup-and-build
-        with:
-          enable_redis: "true"
 
       - name: ${{ matrix.test.name }}
         run: |

--- a/.github/workflows/psp-examples-tests.yml
+++ b/.github/workflows/psp-examples-tests.yml
@@ -33,14 +33,22 @@ jobs:
               "@lightprotocol/streaming-payments",
               "@lightprotocol/swap"              
             ]'
+    services:
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
       - name: Setup and build
         uses: ./.github/actions/setup-and-build
-        with:
-          enable_redis: "true"
 
       - name: ${{ matrix.test.name }}
         run: |


### PR DESCRIPTION
Removed enable_redis flag in GitHub workflows and integrated Redis service directly within docker-build-test, light-sdk-tests, and psp-examples-tests workflows.