### PR TITLE
Add new clean.sh script for managing leftover files

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+find . -type d \( -name "test-ledger" \) -exec rm -rf {} +
+
+npx nx reset


### PR DESCRIPTION
Introduced a new shell script, clean.sh, that locates leftover 'test-ledger' directories and removes them. 
Additionally, it implements the 'npx nx reset' command to reset any changes and dependencies in the workspace.