### PR TITLE
chore: ci - switch runner to ubuntu-latest, remove zk.js

### DIFF
--- a/.github/workflows/light-sdk-tests.yml
+++ b/.github/workflows/light-sdk-tests.yml
@@ -25,16 +25,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: sdk-tests-light-zk-relayer-cli
+          - name: sdk-tests-light-relayer-cli
             sub-tests: '[
-            "@lightprotocol/zk.js", 
-            "@lightprotocol/relayer", 
             "@lightprotocol/cli", 
             "@lightprotocol/prover.js"]'
           - name: circuit-tests
             sub-tests: '[
             "@lightprotocol/circuit-lib.js",
-            "@lightprotocol/circuit-lib.circom"
+            "@lightprotocol/circuit-lib.circom",
+            "@lightprotocol/relayer"
           ]'
     services:
       redis:

--- a/.github/workflows/light-system-programs-tests.yml
+++ b/.github/workflows/light-system-programs-tests.yml
@@ -37,9 +37,9 @@ jobs:
       matrix:
         include:
           - test: system-programs-tests-transaction-user-verifiers-merkle-tree-provider
-            sub-tests: '["functional", "user", "verifiers", "merkle-tree", "provider"]'
+            sub-tests: '["sp-functional", "sp-user", "sp-verifiers", "sp-merkle-tree", "sp-provider"]'
           - test: system-programs-tests-user-merge
-            sub-tests: '["user-merge"]'
+            sub-tests: '["sp-user-merge", "zk.js"]'
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -53,5 +53,5 @@ jobs:
           IFS=', ' read -r -a sub_tests <<< "${{ join(fromJSON(matrix['sub-tests']), ', ') }}"
           for subtest in "${sub_tests[@]}"
           do
-            npx nx test-sp-$subtest "@lightprotocol/zk.js"
+            npx nx test-$subtest "@lightprotocol/zk.js"
           done

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache .local directory
-        uses: buildjet/cache@v3
+        uses: actions/cache@v3
         with:
           path: .local
           key: ${{ runner.os }}-local-${{ hashFiles('**/install.sh') }}


### PR DESCRIPTION
- switched ci runner to ubuntu-latest
- removed zk.js from sdk ci tests, it was slowing ci down by a lot because it also executes system program tests since those were moved to zk.js
- moved zk.js to system program merge tests
- moved relayer tests to circuit tests to rebalance