### PR TITLE
fix: Use the old workflow for building macro-circom

### DIFF
--- a/.github/workflows/release-macro-circom.yml
+++ b/.github/workflows/release-macro-circom.yml
@@ -1,0 +1,98 @@
+name: Publish a release
+
+on:
+  push:
+    tags:
+      - "macro-circom-*"
+
+permissions:
+  contents: write
+
+env:
+  CROSS_VERSION: 0.2.5
+
+jobs:
+  release-linux:
+    name: Release (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Install cross
+        uses: supplypike/setup-bin@v3
+        with:
+          uri: "https://github.com/cross-rs/cross/releases/download/v${{ env.CROSS_VERSION }}/cross-x86_64-unknown-linux-musl.tar.gz"
+          name: "cross"
+          version: "${{ env.CROSS_VERSION }}"
+
+      - name: Build (Linux amd64)
+        run: |
+          cargo clean
+          cross build --release --target x86_64-unknown-linux-musl
+          cp target/x86_64-unknown-linux-musl/release/macro-circom \
+            macro-circom-linux-amd64
+
+      - name: Build (Linux arm64)
+        run: |
+          cargo clean
+          cross build --release --target aarch64-unknown-linux-musl
+          cp target/aarch64-unknown-linux-musl/release/macro-circom \
+            macro-circom-linux-arm64
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          files: |
+            macro-circom-linux-amd64
+            macro-circom-linux-arm64
+
+  release-macos:
+    name: Release (macOS)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Install Rust aarch64-apple-darwin target
+        run: |
+          rustup target add aarch64-apple-darwin
+
+      - name: Build (macOS amd64)
+        run: |
+          cargo build --release --target x86_64-apple-darwin
+          cp target/x86_64-apple-darwin/release/macro-circom \
+            macro-circom-macos-amd64
+
+      - name: Build (macOS arm64)
+        run: |
+          cargo build --release --target aarch64-apple-darwin
+          cp target/aarch64-apple-darwin/release/macro-circom \
+            macro-circom-macos-arm64
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          files: |
+            macro-circom-macos-amd64
+            macro-circom-macos-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,12 +41,6 @@ jobs:
           echo "crate=$CRATE_NAME" >> $GITHUB_OUTPUT
           echo "artifact=$ARTIFACT" >> $GITHUB_OUTPUT
 
-      - name: Build macro-circom
-        if: steps.extract-crate.outputs.crate == 'macro-circom'
-        run: |
-          cargo build --release -p macro-circom
-          cp target/release/macro-circom .
-
       - name: Prepare artifacts
         run: |
           if [ "$CRATE_NAME" == *"light-merkle-tree-program"* ]; then


### PR DESCRIPTION
The one which we used in the Lightprotocol/macro-circom repo.