### PR TITLE
chore: extract copy-circuits.sh into prebuild step

### DIFF
--- a/web/webapp/copy-circuits.sh
+++ b/web/webapp/copy-circuits.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+set -eux
+
+# copy build-circuits from zkjs into webapp/public
+SOURCE="./node_modules/@lightprotocol/zk.js/build-circuits/"
+DESTINATION="./public/"
+
+# mkdir -p "$DESTINATION"
+cp -LR "$SOURCE" "$DESTINATION"
+
+echo "Copied circuit files to $DESTINATION"
+
+sleep 5
+
+echo "Listing all folders/files in ./public:"
+ls -la ./public
+ls -la ./public/build-circuits || true # debug purpose

--- a/web/webapp/package.json
+++ b/web/webapp/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "prebuild": "chmod +x ./copy-circuits.sh && sh ./copy-circuits.sh",
+    "build": "pnpm prebuild && next build",
     "start": "next start",
     "lint": "next lint",
     "serve": "pnpm run build && npx serve@latest dist",

--- a/web/webapp/testSetup.sh
+++ b/web/webapp/testSetup.sh
@@ -53,21 +53,6 @@ trap 'if ps -p ${PID_redis} > /dev/null; then kill ${PID_redis}; fi; if ps -p ${
 
 
 
-# copy build-circuits from zkjs into webapp/public
-SOURCE="./node_modules/@lightprotocol/zk.js/build-circuits/"
-DESTINATION="./public/"
-
-# mkdir -p "$DESTINATION"
-cp -LR "$SOURCE" "$DESTINATION"
-
-echo "Copied circuit files to $DESTINATION"
-
-sleep 5
-
-echo "Listing all folders/files in ./public:"
-ls -la ./public
-ls -la ./public/build-circuits || true # debug purpose
-
 
 
 # Start your web application on port 3000


### PR DESCRIPTION
- running pnpm serve / build manually fails if the build-circuits folder isn't placed in the public folder prior. 
fix:
- extract it from the` testsetup.sh` script into its own` copy-circuits.sh` script and add it as its own prebuild step 