### PR TITLE
feat: balance refactor

### DIFF
--- a/account.rs/src/main/wasm.ts
+++ b/account.rs/src/main/wasm.ts
@@ -1,148 +1,144 @@
 import type {
-    HashCreator,
-    AccountLoadOptions,
-    Hasher,
-    InitInput,
-    WasmInput,
+  HashCreator,
+  AccountLoadOptions,
+  Hasher,
+  InitInput,
+  WasmInput,
 } from "./model.js";
 
 import init, {
-    blake2 as blake2Wasm,
-    blake2str as blake2strWasm,
-    poseidon as poseidonWasm
+  blake2 as blake2Wasm,
+  blake2str as blake2strWasm,
+  poseidon as poseidonWasm,
 } from "./wasm/account_wasm";
 import simdInit, {
-    blake2 as blake2Simd,
-    blake2str as blake2strSimd,
-    poseidon as poseidonSimd
+  blake2 as blake2Simd,
+  blake2str as blake2strSimd,
+  poseidon as poseidonSimd,
 } from "./wasm-simd/account_wasm_simd";
-import {BN} from "@coral-xyz/anchor";
+import { BN } from "@coral-xyz/anchor";
 
 function stringify(input: string[] | BN[]): string[] {
-    if (input.length > 0 && input[0] instanceof BN) {
-        return (input as BN[]).map((item) => item.toString(10));
-    } else {
-        return input as string[];
-    }
+  if (input.length > 0 && input[0] instanceof BN) {
+    return (input as BN[]).map((item) => item.toString(10));
+  } else {
+    return input as string[];
+  }
 }
 
 let wasmInit: (() => InitInput) | undefined = undefined;
 export const setWasmInit = (arg: () => InitInput) => {
-    wasmInit = arg;
+  wasmInit = arg;
 };
 
 let wasmSimdInit: (() => InitInput) | undefined = undefined;
 export const setWasmSimdInit = (arg: () => InitInput) => {
-    wasmSimdInit = arg;
+  wasmSimdInit = arg;
 };
 
 const isWasmInput = (
-    x?: AccountLoadOptions["wasm"]
+  x?: AccountLoadOptions["wasm"]
 ): x is WasmInput | undefined =>
-    x === undefined || (typeof x === "object" && "simd" in x);
+  x === undefined || (typeof x === "object" && "simd" in x);
 
 /**
  * account.rs implemented in Web assembly.
  */
 export class WasmHasher {
-    static async loadModule(
-        options?: Partial<AccountLoadOptions>
-    ): Promise<HashCreator> {
-        if (isWasmInput(options?.wasm)) {
-            const useSimd = options?.simd ?? hasSimd();
-            if (!useSimd) {
-                return await loadWasm(options?.wasm?.sisd);
-            } else {
-                return await loadWasmSimd(options?.wasm?.simd);
-            }
-        } else {
-            return await loadWasm(options?.wasm);
-        }
+  static async loadModule(
+    options?: Partial<AccountLoadOptions>
+  ): Promise<HashCreator> {
+    if (isWasmInput(options?.wasm)) {
+      const useSimd = options?.simd ?? hasSimd();
+      if (!useSimd) {
+        return await loadWasm(options?.wasm?.sisd);
+      } else {
+        return await loadWasmSimd(options?.wasm?.simd);
+      }
+    } else {
+      return await loadWasm(options?.wasm);
     }
+  }
 
-    static async loadAccount(
-        options?: Partial<AccountLoadOptions>
-    ): Promise<Hasher> {
-        const module = await WasmHasher.loadModule(options);
-        return module.create();
-    }
+  static async loadAccount(
+    options?: Partial<AccountLoadOptions>
+  ): Promise<Hasher> {
+    const module = await WasmHasher.loadModule(options);
+    return module.create();
+  }
 
-    static resetModule() {
-        sisdMemory = undefined;
-        simdMemory = undefined;
-    }
+  static resetModule() {
+    sisdMemory = undefined;
+    simdMemory = undefined;
+  }
 
-
-    static async getInstance(): Promise<Hasher> {
-        return (await WasmHasher.loadModule()).create();
-    }
+  static async getInstance(): Promise<Hasher> {
+    return (await WasmHasher.loadModule()).create();
+  }
 }
-
 
 interface HashStrategy {
-    blake2str(input: string, hash_length: number): Uint8Array;
-    blake2(input: Uint8Array, hash_length: number): Uint8Array;
-    poseidon(inputs: Array<any>): Uint8Array;
+  blake2str(input: string, hash_length: number): Uint8Array;
+  blake2(input: Uint8Array, hash_length: number): Uint8Array;
+  poseidon(inputs: Array<any>): Uint8Array;
 }
 
+function wasmAccount(hasher: HashStrategy): HashCreator {
+  const WasmHasher = class implements Hasher {
+    blakeHash(input: string | Uint8Array, hashLength: number): Uint8Array {
+      if (typeof input === "string") {
+        return hasher.blake2str(input, hashLength);
+      } else {
+        return hasher.blake2(input, hashLength);
+      }
+    }
 
-function wasmAccount( hasher: HashStrategy): HashCreator {
-    const WasmHasher = class implements Hasher {
-        blakeHash(input: string | Uint8Array, hashLength: number): Uint8Array {
-            if (typeof input === 'string') {
-                return hasher.blake2str(input, hashLength);
-            }
-            else {
-                return hasher.blake2(input, hashLength);
-            }
-        }
+    poseidonHash(input: string[] | []): Uint8Array {
+      return hasher.poseidon(stringify(input));
+    }
 
-        poseidonHash(input: string[] | []): Uint8Array {
-            return hasher.poseidon(stringify(input));
-        }
+    poseidonHashBN(input: string[] | []): BN {
+      return new BN(this.poseidonHash(input));
+    }
 
-        poseidonHashBN(input: string[] | []): BN {
-            return new BN(this.poseidonHash(input));
-        }
+    poseidonHashString(input: string[] | []): string {
+      const bn = new BN(this.poseidonHash(input));
+      return bn.toString();
+    }
+  };
 
-        poseidonHashString(input: string[] | []): string {
-            const bn = new BN(this.poseidonHash(input));
-            return bn.toString();
-        }
-    };
-
-    return {
-        create: () => new WasmHasher(),
-    };
+  return {
+    create: () => new WasmHasher(),
+  };
 }
 
 let sisdMemory: Promise<HashCreator> | undefined;
 let simdMemory: Promise<HashCreator> | undefined;
 const loadWasmSimd = async (module?: InitInput) => {
-    if (simdMemory === undefined) {
-        simdMemory = simdInit(module ?? wasmSimdInit?.()).then((x) => {
-            return wasmAccount({
-                blake2str: blake2strSimd,
-                blake2: blake2Simd,
-                poseidon: poseidonSimd
-            });
-        });
-    }
-    return await simdMemory;
+  if (simdMemory === undefined) {
+    simdMemory = simdInit(module ?? wasmSimdInit?.()).then((x) => {
+      return wasmAccount({
+        blake2str: blake2strSimd,
+        blake2: blake2Simd,
+        poseidon: poseidonSimd,
+      });
+    });
+  }
+  return await simdMemory;
 };
 
 const loadWasm = async (module?: InitInput) => {
-    if (sisdMemory === undefined) {
-        sisdMemory = init(module ?? wasmInit?.()).then((x) => {
-            // grow by 1 page to hold key, results, and data hashing
-            return wasmAccount({
-                blake2str: blake2strWasm,
-                blake2: blake2Wasm,
-                poseidon: poseidonWasm
-            });
-        });
-    }
-    return await sisdMemory;
+  if (sisdMemory === undefined) {
+    sisdMemory = init(module ?? wasmInit?.()).then((x) => {
+      // grow by 1 page to hold key, results, and data hashing
+      return wasmAccount({
+        blake2str: blake2strWasm,
+        blake2: blake2Wasm,
+        poseidon: poseidonWasm,
+      });
+    });
+  }
+  return await sisdMemory;
 };
 
 // Extracted from the compiled file of:
@@ -153,10 +149,10 @@ const loadWasm = async (module?: InitInput) => {
 //  - There's no need to mark as async
 let simdEnabled: boolean | undefined;
 export const hasSimd = () =>
-    simdEnabled ??
-    (simdEnabled = WebAssembly.validate(
-        new Uint8Array([
-            0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 96, 0, 1, 123, 3, 2, 1, 0, 10, 10,
-            1, 8, 0, 65, 0, 253, 15, 253, 98, 11,
-        ])
-    ));
+  simdEnabled ??
+  (simdEnabled = WebAssembly.validate(
+    new Uint8Array([
+      0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 96, 0, 1, 123, 3, 2, 1, 0, 10, 10,
+      1, 8, 0, 65, 0, 253, 15, 253, 98, 11,
+    ])
+  ));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 1.3.2
       '@rollup/plugin-typescript':
         specifier: ^11.1.5
-        version: 11.1.5(rollup@4.6.1)(typescript@5.3.2)
+        version: 11.1.5(rollup@4.6.1)(typescript@4.9.5)
       '@rollup/plugin-wasm':
         specifier: ^6.2.2
         version: 6.2.2(rollup@4.6.1)
@@ -85,7 +85,7 @@ importers:
         version: 10.0.0(mocha@10.2.0)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@20.10.4)(typescript@5.3.2)
+        version: 10.9.1(@types/node@20.10.4)(typescript@4.9.5)
       tsx:
         specifier: ^4.1.2
         version: 4.1.2
@@ -850,6 +850,58 @@ importers:
         specifier: 5.3.2
         version: 5.3.2
 
+  psp-examples/tmp-test-circom:
+    dependencies:
+      '@coral-xyz/anchor':
+        specifier: ^0.28.0
+        version: 0.28.0
+      '@lightprotocol/account.rs':
+        specifier: workspace:*
+        version: link:../../account.rs
+      '@lightprotocol/circuit-lib.circom':
+        specifier: 0.1.0-alpha.1
+        version: link:../../circuit-lib/circuit-lib.circom
+      '@lightprotocol/prover.js':
+        specifier: 0.1.0-alpha.3
+        version: link:../../prover.js
+      '@lightprotocol/zk.js':
+        specifier: 0.3.2-alpha.16
+        version: link:../../zk.js
+      '@project-serum/anchor':
+        specifier: ^0.26.0
+        version: 0.26.0
+      circomlib:
+        specifier: ^2.0.5
+        version: 2.0.5
+      circomlibjs:
+        specifier: ^0.1.7
+        version: 0.1.7
+    devDependencies:
+      '@types/bn.js':
+        specifier: ^5.1.0
+        version: 5.1.2
+      '@types/chai':
+        specifier: ^4.3.0
+        version: 4.3.9
+      '@types/mocha':
+        specifier: ^9.0.0
+        version: 9.1.1
+      chai:
+        specifier: ^4.3.4
+        version: 4.3.10
+      mocha:
+        specifier: ^9.0.3
+        version: 9.2.2
+      prettier:
+        specifier: ^2.6.2
+        version: 2.8.8
+      ts-mocha:
+        specifier: ^10.0.0
+        version: 10.0.0(mocha@9.2.2)
+      typescript:
+        specifier: ^4.3.5
+        version: 4.9.5
+
   psp-examples/tmp-test-psp:
     dependencies:
       '@coral-xyz/anchor':
@@ -1257,6 +1309,9 @@ importers:
       seedrandom:
         specifier: ^3.0.5
         version: 3.0.5
+      sinon:
+        specifier: ^15.2.0
+        version: 15.2.0
       ts-mocha:
         specifier: ^10.0.0
         version: 10.0.0(mocha@10.2.0)
@@ -5232,6 +5287,25 @@ packages:
       estree-walker: 2.0.2
       magic-string: 0.30.5
       rollup: 4.6.1
+    dev: true
+
+  /@rollup/plugin-typescript@11.1.5(rollup@4.6.1)(typescript@4.9.5):
+    resolution: {integrity: sha512-rnMHrGBB0IUEv69Q8/JGRD/n4/n6b3nfpufUu26axhUcboUzv/twfZU8fIBbTOphRAe0v8EyxzeDpKXqGHfyDA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.14.0||^3.0.0||^4.0.0
+      tslib: '*'
+      typescript: '>=3.7.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      tslib:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.6.1)
+      resolve: 1.22.6
+      rollup: 4.6.1
+      typescript: 4.9.5
     dev: true
 
   /@rollup/plugin-typescript@11.1.5(rollup@4.6.1)(typescript@5.3.2):
@@ -16169,6 +16243,37 @@ packages:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.3.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
+  /ts-node@10.9.1(@types/node@20.10.4)(typescript@4.9.5):
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.10.4
+      acorn: 8.10.0
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.9.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true

--- a/zk.js/package.json
+++ b/zk.js/package.json
@@ -19,6 +19,7 @@
     "test-provider": "ts-mocha --resolveJsonModule ./tsconfig.json -t 100000000 tests/provider.test.ts --exit",
     "test-selectInUtxos": "ts-mocha --resolveJsonModule ./tsconfig.json -t 100000000 tests/selectInUtxos.test.ts --exit",
     "test-balance": "ts-mocha --resolveJsonModule ./tsconfig.json -t 100000000 tests/balance.test.ts --exit",
+    "test-balance-new": "ts-mocha --resolveJsonModule ./tsconfig.json -t 100000000 tests/balance.new.test.ts --exit",
     "test-convertDecimals": "ts-mocha --resolveJsonModule ./tsconfig.json -t 100000000 tests/convertDecimals.test.ts --exit",
     "test-system-programs": "pnpm run test-sp-functional && pnpm run test-sp-user && pnpm run test-sp-provider && pnpm test-sp-user-merge && pnpm run test-sp-verifiers && pnpm run test-sp-user-registry",
     "test-sp-functional": "pnpm run start-test-validator && ts-mocha -t 2000000 tests/system-programs/functional_tests.ts --exit",

--- a/zk.js/package.json
+++ b/zk.js/package.json
@@ -57,9 +57,9 @@
   "dependencies": {
     "@coral-xyz/anchor": "0.28.0",
     "@coral-xyz/borsh": "0.28.0",
+    "@lightprotocol/account.rs": "workspace:*",
     "@lightprotocol/circuit-lib.js": "workspace:*",
     "@lightprotocol/prover.js": "workspace:*",
-    "@lightprotocol/account.rs": "workspace:*",
     "@noble/hashes": "^1.3.2",
     "@solana/spl-account-compression": "^0.1.8",
     "@solana/spl-token": "^0.3.7",
@@ -95,6 +95,7 @@
     "prettier": "^3.0.3",
     "rimraf": "^5.0.5",
     "seedrandom": "^3.0.5",
+    "sinon": "^15.2.0",
     "ts-mocha": "^10.0.0",
     "ts-node": "^10.9.1",
     "typescript": "5.3.2",

--- a/zk.js/src/balance/balance.ts
+++ b/zk.js/src/balance/balance.ts
@@ -1,0 +1,199 @@
+import { BN } from "@coral-xyz/anchor";
+import { Utxo } from "../utxo";
+import { PublicKey } from "@solana/web3.js";
+import { BN_0, TOKEN_REGISTRY } from "../constants";
+import { getPoseidon } from "poseidon";
+/**
+ * the SOL asset is always the 0th index in the UTXO
+ * the SPL asset is an optional 1st index in the UTXO
+ */
+const UTXO_ASSET_SPL_INDEX = 1;
+const UTXO_ASSET_SOL_INDEX = 0;
+
+// TODO: add history (spentutxos)
+
+/**
+ * We keep spent UTXOs in a separate type,
+ * because we need to keep Balance up2date at
+ * any time, and syncing spent UTXOs is expensive.
+ */
+export type Balance = {
+  // key is token
+  // includes only unspent UTXOs
+  tokenBalances: Map<string, TokenBalance>;
+  // TODO: add programBalances
+};
+
+export type TokenBalance = {
+  amount: BN;
+  lamports: BN; // rent
+  data: TokenData;
+  utxos: Utxo[];
+};
+
+// from ctx
+export type TokenData = {
+  symbol: string;
+  decimals: BN;
+  isNft: boolean;
+  isNative: boolean;
+  mint: PublicKey;
+};
+export type SerializedTokenBalance = Omit<TokenBalance, "utxos"> & {
+  utxos: string[];
+};
+
+function getTokenDataByMint(
+  mintToFind: PublicKey,
+  tokenRegistry: Map<string, TokenData>,
+): TokenData {
+  for (let value of tokenRegistry.values()) {
+    if (value.mint.equals(mintToFind)) {
+      return value;
+    }
+  }
+  throw new Error(`Token with mint ${mintToFind} not found in token registry.`);
+}
+
+function initTokenBalance(tokenData: TokenData, utxos?: Utxo[]): TokenBalance {
+  return {
+    amount: BN_0,
+    lamports: BN_0,
+    data: tokenData,
+    utxos: utxos || [],
+  };
+}
+
+function updateTokenBalanceWithUtxo(
+  utxo: Utxo,
+  tokenBalance: TokenBalance,
+): boolean {
+  const utxoExists = tokenBalance.utxos.some(
+    (existingUtxo) => existingUtxo._commitment === utxo._commitment,
+  );
+  if (utxoExists) return false;
+
+  tokenBalance.utxos.push(utxo);
+  tokenBalance.lamports = tokenBalance.lamports.add(
+    utxo.amounts[UTXO_ASSET_SOL_INDEX],
+  );
+
+  tokenBalance.amount = tokenBalance.amount.add(
+    utxo.amounts[UTXO_ASSET_SPL_INDEX] ?? BN_0,
+  );
+
+  return true;
+}
+
+function isSPLUtxo(utxo: Utxo): boolean {
+  return !utxo.amounts[UTXO_ASSET_SPL_INDEX].eqn(0);
+}
+
+export function addUtxoToBalance(utxo: Utxo, balance: Balance): boolean {
+  const ASSET_INDEX = isSPLUtxo(utxo)
+    ? UTXO_ASSET_SPL_INDEX
+    : UTXO_ASSET_SOL_INDEX;
+
+  const assetKey = utxo.assets[ASSET_INDEX].toString();
+  let tokenBalance = balance.tokenBalances.get(assetKey);
+
+  if (!tokenBalance) {
+    const tokenData = getTokenDataByMint(
+      utxo.assets[ASSET_INDEX],
+      TOKEN_REGISTRY,
+    );
+
+    tokenBalance = initTokenBalance(tokenData, [utxo]);
+    balance.tokenBalances.set(assetKey, tokenBalance);
+    return true;
+  }
+
+  return updateTokenBalanceWithUtxo(utxo, tokenBalance);
+}
+
+export function spendUtxo(balance: Balance[], commitment: string): boolean {
+  for (let i = 0; i < balance.length; i++) {
+    for (const [_assetKey, tokenBalance] of balance[i].tokenBalances) {
+      // Find the utxo with the given commitment
+      const utxoIndex = tokenBalance.utxos.findIndex(
+        (utxo) => utxo._commitment === commitment,
+      );
+      // If found, remove it from the utxos array
+      if (utxoIndex !== -1) {
+        const [spentUtxo] = tokenBalance.utxos.splice(utxoIndex, 1);
+        tokenBalance.lamports = tokenBalance.lamports.sub(
+          spentUtxo.amounts[UTXO_ASSET_SOL_INDEX],
+        );
+        tokenBalance.amount = tokenBalance.amount.sub(
+          spentUtxo.amounts[UTXO_ASSET_SPL_INDEX] ?? BN_0,
+        );
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ *
+ * @param balance
+ * @returns
+ * TODO: we can consider using a more efficient serialization format.
+ * however, this won't be a bottleneck since the balance will consist of a
+ * few dozen UTXOs at most.
+ */
+export async function serializeBalance(balance: Balance): Promise<string> {
+  const clonedBalance: Balance = JSON.parse(JSON.stringify(balance));
+  const serializedBalance: {
+    tokenBalances: Map<string, SerializedTokenBalance>;
+  } = { tokenBalances: new Map() };
+
+  for (const [key, tokenBalance] of clonedBalance.tokenBalances.entries()) {
+    const utxosAsString: string[] = [];
+    for (let i = 0; i < tokenBalance.utxos.length; i++) {
+      utxosAsString[i] = await tokenBalance.utxos[i].toString();
+    }
+    const serializedTokenBalance: SerializedTokenBalance = {
+      ...tokenBalance,
+      utxos: utxosAsString,
+    };
+    serializedBalance.tokenBalances.set(key, serializedTokenBalance);
+  }
+  return JSON.stringify(serializedBalance);
+}
+
+export async function deserializeBalance(
+  serializedBalance: string,
+  assetLookupTable: string[], // provider.lookuptables.assetlookuptable
+): Promise<Balance> {
+  const poseidon = await getPoseidon();
+
+  const parsedBalance: {
+    tokenBalances: Map<string, SerializedTokenBalance>;
+  } = JSON.parse(serializedBalance);
+
+  const balance: Balance = { tokenBalances: new Map() };
+
+  for (const [key, serializedTokenBalance] of Object.entries(
+    parsedBalance.tokenBalances,
+  )) {
+    const utxos: Utxo[] = [];
+    for (let i = 0; i < serializedTokenBalance.utxos.length; i++) {
+      // Assuming Utxo has a static method fromString to convert a string back into a Utxo object
+      utxos[i] = Utxo.fromString(
+        serializedTokenBalance.utxos[i],
+        poseidon,
+        assetLookupTable,
+      );
+    }
+    const tokenBalance: TokenBalance = {
+      ...serializedTokenBalance,
+      utxos: utxos,
+    };
+    balance.tokenBalances.set(key, tokenBalance);
+  }
+
+  return balance;
+}
+
+// sync balance with chain/indexer

--- a/zk.js/src/balance/balance.ts
+++ b/zk.js/src/balance/balance.ts
@@ -8,8 +8,12 @@ import {
 } from "../constants";
 import { Provider } from "../wallet";
 import { Poseidon } from "../types/poseidon";
-import { TokenData, SerializedTokenBalance } from "../types";
-import { Balance, TokenBalance } from "../types/balance";
+import {
+  Balance,
+  TokenBalance,
+  TokenData,
+  SerializedTokenBalance,
+} from "../types/balance";
 
 export const isSPLUtxo = (utxo: Utxo): boolean => {
   return !utxo.amounts[UTXO_ASSET_SPL_INDEX].eqn(0);

--- a/zk.js/src/balance/balance.ts
+++ b/zk.js/src/balance/balance.ts
@@ -29,7 +29,7 @@ export function getTokenDataByMint(
   mintToFind: PublicKey,
   tokenRegistry: Map<string, TokenData>,
 ): TokenData {
-  for (let value of tokenRegistry.values()) {
+  for (const value of tokenRegistry.values()) {
     if (value.mint.equals(mintToFind)) {
       return value;
     }
@@ -272,31 +272,3 @@ export function deserializeBalance(
 
   return balance;
 }
-
-// export async function syncBalance(balance: Balance) {
-//   // identify spent utxos
-//   for (const [, tokenBalance] of balance.tokenBalances) {
-//     for (const [key, utxo] of tokenBalance.utxos) {
-//       const nullifierAccountInfo = await fetchNullifierAccountInfo(
-//         utxo.getNullifier({
-//           poseidon: this.provider.poseidon,
-//           account: this.account,
-//         })!,
-//         this.provider.provider.connection,
-//       );
-//       if (nullifierAccountInfo !== null) {
-//         // tokenBalance.utxos.delete(key)
-//         tokenBalance.moveToSpentUtxos(key);
-//       }
-//     }
-//   }
-// }
-
-// const lastSyncedBlock = 0;
-// const accountCreationBlock = 0;
-
-// export type SyncConfig = {
-//   lastSyncedBlock: number;
-//   accountCreationBlock: number;
-//   shouldLazyFetchInbox: boolean;
-// };

--- a/zk.js/src/balance/balance.ts
+++ b/zk.js/src/balance/balance.ts
@@ -15,6 +15,12 @@ export const isSPLUtxo = (utxo: Utxo): boolean => {
   return !utxo.amounts[UTXO_ASSET_SPL_INDEX].eqn(0);
 };
 
+/**
+ *
+ * @param mintToFind mint
+ * @param tokenRegistry TOKEN_REGISTRY
+ * @returns TokenData of the mint. Throws an error if mint not registered.
+ */
 export function getTokenDataByMint(
   mintToFind: PublicKey,
   tokenRegistry: Map<string, TokenData>,
@@ -27,6 +33,16 @@ export function getTokenDataByMint(
   throw new Error(`Token with mint ${mintToFind} not found in token registry.`);
 }
 
+/**
+ *
+ * initializes TokenBalance for mint of TokenData and Utxos
+ * Throws if Utxos do not match TokenData
+ * If Utxos are not provided, initializes empty TokenBalance for the mint specified in TokenData
+ * @param tokenData TokenData of the mint
+ * @param utxos Utxos to initialize TokenBalance with
+ * @returns TokenBalance
+ *
+ */
 export function initTokenBalance(
   tokenData: TokenData,
   utxos?: Utxo[],
@@ -52,6 +68,15 @@ export function initTokenBalance(
   };
 }
 
+/**
+ * Updates TokenBalance with Utxo
+ * Throws if Utxo does not match TokenBalance
+ * Returns false if Utxo already part of TokenBalance.
+ * @param utxo utxo to add to tokenBalance
+ * @param tokenBalance tokenBalance to add utxo to
+ * @param poseidon poseidon instance
+ * @returns boolean indicating if the utxo was added to the tokenBalance
+ */
 export function updateTokenBalanceWithUtxo(
   utxo: Utxo,
   tokenBalance: TokenBalance,
@@ -78,6 +103,16 @@ export function updateTokenBalanceWithUtxo(
   return true;
 }
 
+/**
+ *
+ * Given a balance and a utxo, adds the utxo to the balance.
+ * skips if utxo already exists in balance.
+ * initializes a new TokenBalance if the utxo is the first of its mint.
+ * @param utxo utxo to add to balance
+ * @param balance balance to add utxo to
+ * @param poseidon poseidon instance
+ * @returns
+ */
 export function addUtxoToBalance(
   utxo: Utxo,
   balance: Balance,
@@ -105,6 +140,12 @@ export function addUtxoToBalance(
 }
 
 /// TODO: after we implement history, extend this function to move the spentUtxo to history
+/**
+ * removes the specified utxo from balance
+ * @param balance balance to remove utxo from
+ * @param commitment commitment of the utxo to be removed
+ * @returns boolean indicating if the utxo was removed from the balance
+ */
 export function spendUtxo(balance: Balance[], commitment: string): boolean {
   for (let i = 0; i < balance.length; i++) {
     for (const [_assetKey, tokenBalance] of balance[i].tokenBalances) {
@@ -126,6 +167,12 @@ export function spendUtxo(balance: Balance[], commitment: string): boolean {
   return false;
 }
 
+/**
+ * serializes TokenBalance into a SerializedTokenBalance
+ * @param tokenBalance
+ * @returns serializedTokenBalance
+ */
+/// keeping track of index separately because it's not part of the UTXO IDL
 async function serializeTokenBalance(
   tokenBalance: TokenBalance,
 ): Promise<SerializedTokenBalance> {
@@ -144,6 +191,13 @@ async function serializeTokenBalance(
   return serializedTokenBalance;
 }
 
+/**
+ * deserializes SerializedTokenBalance into a TokenBalance
+ * @param serializedTokenBalance
+ * @param tokenRegistry
+ * @param provider lightProvider
+ * @returns tokenBalance
+ */
 function deserializeTokenBalance(
   serializedTokenBalance: SerializedTokenBalance,
   tokenRegistry: Map<string, TokenData>,
@@ -169,6 +223,11 @@ function deserializeTokenBalance(
   return initTokenBalance(tokenData, utxos);
 }
 
+/**
+ * serializes Balance into a stringified array of SerializedTokenBalances
+ * @param balance balance
+ * @returns serializedBalance
+ */
 export async function serializeBalance(balance: Balance): Promise<string> {
   const serializedBalance: SerializedTokenBalance[] = [];
 
@@ -179,6 +238,13 @@ export async function serializeBalance(balance: Balance): Promise<string> {
   return JSON.stringify(serializedBalance);
 }
 
+/**
+ * deserializes stringified array of SerializedTokenBalances and reconstructs into a Balance
+ * @param serializedBalance serializedBalance
+ * @param tokenRegistry
+ * @param provider lightProvider
+ * @returns balance
+ */
 export function deserializeBalance(
   serializedBalance: string,
   tokenRegistry: Map<string, TokenData>,

--- a/zk.js/src/balance/balance.ts
+++ b/zk.js/src/balance/balance.ts
@@ -1,15 +1,14 @@
 import { BN } from "@coral-xyz/anchor";
 import { Utxo } from "../utxo";
 import { PublicKey } from "@solana/web3.js";
-import { BN_0, TOKEN_REGISTRY } from "../constants";
+import {
+  BN_0,
+  TOKEN_REGISTRY,
+  UTXO_ASSET_SOL_INDEX,
+  UTXO_ASSET_SPL_INDEX,
+} from "../constants";
 import { Provider } from "../wallet";
 import { Poseidon } from "../types/poseidon";
-/**
- * the SOL asset is always the 0th index in the UTXO
- * the SPL asset is an optional 1st index in the UTXO
- */
-const UTXO_ASSET_SPL_INDEX = 1;
-const UTXO_ASSET_SOL_INDEX = 0;
 
 // TODO: add history (spentutxos)
 

--- a/zk.js/src/balance/balance.ts
+++ b/zk.js/src/balance/balance.ts
@@ -1,4 +1,3 @@
-import { BN } from "@coral-xyz/anchor";
 import { Utxo } from "../utxo";
 import { PublicKey } from "@solana/web3.js";
 import {
@@ -9,41 +8,8 @@ import {
 } from "../constants";
 import { Provider } from "../wallet";
 import { Poseidon } from "../types/poseidon";
-
-// TODO: add history (spentutxos)
-
-/**
- * We keep spent UTXOs in a separate type,
- * because we need to keep Balance up2date at
- * any time, and syncing spent UTXOs is expensive.
- */
-export type Balance = {
-  // key is token
-  // includes only unspent UTXOs
-  tokenBalances: Map<string, TokenBalance>;
-  // TODO: add programBalances
-};
-
-export type TokenBalance = {
-  amount: BN;
-  lamports: BN; // rent
-  data: TokenData;
-  utxos: Utxo[];
-};
-
-// from ctx
-export type TokenData = {
-  symbol: string;
-  decimals: BN;
-  isNft: boolean;
-  isNative: boolean;
-  mint: PublicKey;
-};
-
-export type SerializedTokenBalance = {
-  mint: string;
-  utxos: { utxo: string; index?: number }[];
-};
+import { TokenData, SerializedTokenBalance } from "../types";
+import { Balance, TokenBalance } from "../types/balance";
 
 export const isSPLUtxo = (utxo: Utxo): boolean => {
   return !utxo.amounts[UTXO_ASSET_SPL_INDEX].eqn(0);

--- a/zk.js/src/balance/index.ts
+++ b/zk.js/src/balance/index.ts
@@ -1,0 +1,14 @@
+export { type TokenBalance as TokenBalance_new } from "./balance";
+export { type Balance as Balance_new } from "./balance";
+export { type TokenData as TokenData_new } from "./balance";
+export { type SerializedTokenBalance } from "./balance";
+export {
+  getTokenDataByMint,
+  initTokenBalance,
+  isSPLUtxo,
+  addUtxoToBalance,
+  updateTokenBalanceWithUtxo,
+  serializeBalance,
+  deserializeBalance,
+  spendUtxo,
+} from "./balance";

--- a/zk.js/src/balance/index.ts
+++ b/zk.js/src/balance/index.ts
@@ -1,7 +1,3 @@
-export { type TokenBalance as TokenBalance_new } from "./balance";
-export { type Balance as Balance_new } from "./balance";
-export { type TokenData as TokenData_new } from "./balance";
-export { type SerializedTokenBalance } from "./balance";
 export {
   getTokenDataByMint,
   initTokenBalance,

--- a/zk.js/src/constants.ts
+++ b/zk.js/src/constants.ts
@@ -172,6 +172,13 @@ export const MAX_MESSAGE_SIZE = 800;
 
 export const SOL_DECIMALS = new anchor.BN(1e9);
 
+/**
+ * the SOL asset is always the 0th index in the UTXO
+ * the SPL asset is an optional 1st index in the UTXO
+ */
+export const UTXO_ASSET_SPL_INDEX = 1;
+export const UTXO_ASSET_SOL_INDEX = 0;
+
 export const TOKEN_REGISTRY: Map<string, TokenData> = new Map([
   [
     "SOL",

--- a/zk.js/src/errors.ts
+++ b/zk.js/src/errors.ts
@@ -208,6 +208,7 @@ export enum UtilsErrorCode {
 export enum ProgramUtxoBalanceErrorCode {
   INVALID_PROGRAM_ADDRESS = "INVALID_PROGRAM_ADDRESS",
   TOKEN_DATA_NOT_FOUND = "TOKEN_DATA_NOT_FOUND",
+  INVALID_UTXO_MINT = "INVALID_UTXO_MINT",
 }
 
 export enum SolanaTransactionErrorCode {

--- a/zk.js/src/index.ts
+++ b/zk.js/src/index.ts
@@ -13,5 +13,6 @@ export * from "./transaction";
 export * from "./convertCase";
 export * from "./closeVerifierState";
 export * from "./createRustVerifyingKey";
+export * from "./balance";
 
 export * as circuitlibjs from "@lightprotocol/circuit-lib.js";

--- a/zk.js/src/poseidon.ts
+++ b/zk.js/src/poseidon.ts
@@ -1,0 +1,8 @@
+/// load once globally.
+import circomlibjs from "circomlibjs";
+
+let poseidonPromise = circomlibjs.buildPoseidonOpt();
+
+export function getPoseidon() {
+  return poseidonPromise;
+}

--- a/zk.js/src/poseidon.ts
+++ b/zk.js/src/poseidon.ts
@@ -1,7 +1,7 @@
 /// load once globally.
 const circomlibjs = require("circomlibjs");
 
-let poseidonPromise = circomlibjs.buildPoseidonOpt();
+const poseidonPromise = circomlibjs.buildPoseidonOpt();
 
 export function getPoseidon() {
   return poseidonPromise;

--- a/zk.js/src/poseidon.ts
+++ b/zk.js/src/poseidon.ts
@@ -1,5 +1,5 @@
 /// load once globally.
-import circomlibjs from "circomlibjs";
+const circomlibjs = require("circomlibjs");
 
 let poseidonPromise = circomlibjs.buildPoseidonOpt();
 

--- a/zk.js/src/types/balance.ts
+++ b/zk.js/src/types/balance.ts
@@ -8,12 +8,12 @@ import { Utxo } from "../utxo";
  * because we need to keep Balance up2date at
  * any time, and syncing spent UTXOs is expensive.
  */
+// TODO: add programBalance to Balance
 export type Balance = {
   // key is token
   // includes only unspent UTXOs
   tokenBalances: Map<string, TokenBalance>;
   lastSyncedSlot: number;
-  // TODO: add programBalances
 };
 
 export type TokenBalance = {

--- a/zk.js/src/types/balance.ts
+++ b/zk.js/src/types/balance.ts
@@ -1,24 +1,25 @@
 import { BN } from "@coral-xyz/anchor";
 import { PublicKey } from "@solana/web3.js";
 import { Utxo } from "../utxo";
+// TODO: add history type (spentUtxos)
 
 /**
  * We keep spent UTXOs in a separate type,
  * because we need to keep Balance up2date at
  * any time, and syncing spent UTXOs is expensive.
  */
-// TODO: add history (spentutxos)
 export type Balance = {
   // key is token
   // includes only unspent UTXOs
   tokenBalances: Map<string, TokenBalance>;
+  lastSyncedSlot: number;
   // TODO: add programBalances
 };
 
 export type TokenBalance = {
-  amount: BN;
+  splAmount: BN;
   lamports: BN; // rent
-  data: TokenData;
+  tokenData: TokenData;
   utxos: Utxo[];
 };
 
@@ -34,4 +35,9 @@ export type TokenData = {
 export type SerializedTokenBalance = {
   mint: string;
   utxos: { utxo: string; index?: number }[];
+};
+
+export type SerializedBalance = {
+  tokenBalances: SerializedTokenBalance[];
+  lastSyncedSlot: number;
 };

--- a/zk.js/src/types/balance.ts
+++ b/zk.js/src/types/balance.ts
@@ -14,7 +14,10 @@ export type Balance = {
   // includes only unspent UTXOs
   tokenBalances: Map<string, TokenBalance>;
   lastSyncedSlot: number;
+  programBalances: Map<string, TokenBalance>; // unused for now
 };
+
+
 
 export type TokenBalance = {
   splAmount: BN;

--- a/zk.js/src/types/balance.ts
+++ b/zk.js/src/types/balance.ts
@@ -1,0 +1,37 @@
+import { BN } from "@coral-xyz/anchor";
+import { PublicKey } from "@solana/web3.js";
+import { Utxo } from "../utxo";
+
+/**
+ * We keep spent UTXOs in a separate type,
+ * because we need to keep Balance up2date at
+ * any time, and syncing spent UTXOs is expensive.
+ */
+// TODO: add history (spentutxos)
+export type Balance = {
+  // key is token
+  // includes only unspent UTXOs
+  tokenBalances: Map<string, TokenBalance>;
+  // TODO: add programBalances
+};
+
+export type TokenBalance = {
+  amount: BN;
+  lamports: BN; // rent
+  data: TokenData;
+  utxos: Utxo[];
+};
+
+// from ctx
+export type TokenData = {
+  symbol: string;
+  decimals: BN;
+  isNft: boolean;
+  isNative: boolean;
+  mint: PublicKey;
+};
+
+export type SerializedTokenBalance = {
+  mint: string;
+  utxos: { utxo: string; index?: number }[];
+};

--- a/zk.js/src/types/balance.ts
+++ b/zk.js/src/types/balance.ts
@@ -1,46 +1,106 @@
-import { BN } from "@coral-xyz/anchor";
+// TODO: add History type
+import { BN, Idl } from "@coral-xyz/anchor";
 import { PublicKey } from "@solana/web3.js";
-import { Utxo } from "../utxo";
-// TODO: add history type (spentUtxos)
 
-/**
- * We keep spent UTXOs in a separate type,
- * because we need to keep Balance up2date at
- * any time, and syncing spent UTXOs is expensive.
- */
-// TODO: add programBalance to Balance
-export type Balance = {
-  // key is token
-  // includes only unspent UTXOs
-  tokenBalances: Map<string, TokenBalance>;
-  lastSyncedSlot: number;
-  programBalances: Map<string, TokenBalance>; // unused for now
-};
+// top-level abstraction for TokenBalances
+export type Balance = Map<string, TokenBalance>; // key: mint
 
+export type SerializedBalance = SerializedTokenBalance[];
 
-
+/** Each mint can have public/private UTXOs */
 export type TokenBalance = {
   splAmount: BN;
-  lamports: BN; // rent
+  lamports: BN;
   tokenData: TokenData;
-  utxos: Utxo[];
+  utxos: DefaultUtxo[];
+  publicUtxos: PublicUtxo[];
+  /** The slot number at which the token balance was last updated, corresponding to the slot of the latest UTXO event. */
+  contextSlot: Slot;
 };
 
-// from ctx
+/** Serialized tokenBalance */
+export type SerializedTokenBalance = {
+  mint: string;
+  utxos: { utxo: string; index?: number }[];
+  publicUtxos: { utxo: string; index?: number }[];
+  contextSlot: Slot;
+};
+
+/** Context for Tokens. Synced with on-chain registry. */
 export type TokenData = {
+  mint: PublicKey;
   symbol: string;
   decimals: BN;
   isNft: boolean;
   isNative: boolean;
-  mint: PublicKey;
+  enforcePublic: boolean; // TODO: do we need this? default: false
+  // TODO: would want potentially other things such as authority / creator in here
+  // anything special for cNFTs required here?
 };
 
-export type SerializedTokenBalance = {
-  mint: string;
-  utxos: { utxo: string; index?: number }[];
+/** RPC context slot */
+export type Slot = number;
+
+export type SyncOptions = {
+  /** Mint or ProgramIds */
+  ids?: PublicKey[];
+  /** minimum slot to fetch from. This is useful for iterative scanning
+   * ignores all UTXOs inserted before specified slot.
+   */
+  minSlot?: Slot;
+  /** RPC can either return public or encrypted data. default = encrypted */
+  shouldSyncPublic?: boolean;
 };
 
-export type SerializedBalance = {
-  tokenBalances: SerializedTokenBalance[];
-  lastSyncedSlot: number;
+export type UtxoNewNew = {
+  publicKey: string;
+  amounts: BN[];
+  assets: PublicKey[];
+  assetsCircuit: string[];
+  blinding: string;
+  poolType: string;
+  utxoHash: string;
+  transactionVersion: string;
+  verifierAddress: PublicKey;
+  verifierAddressCircuit: string;
+  isFillingUtxo: boolean;
+  nullifier: string;
+  merkleTreeLeafIndex: number;
+  merkleProof: string[];
+  utxoDataHash: string;
+  isPublic?: boolean; // added
+};
+
+export type ProgramUtxo = {
+  utxo: UtxoNewNew;
+  pspId: PublicKey;
+  pspIdl: Idl;
+  includeUtxoData: boolean;
+  utxoData: any; // TODO: make depend on idl // could this be used as metadata field?
+  utxoName: string;
+};
+
+// default: !isPublic
+export type DefaultUtxo = UtxoNewNew & { isPublic: false };
+
+// Enforce isPublic
+export type PublicUtxo = UtxoNewNew & { isPublic: true };
+
+export type DefaultProgramUtxo = ProgramUtxo & {
+  utxo: DefaultUtxo;
+};
+
+export type PublicProgramUtxo = ProgramUtxo & {
+  utxo: PublicUtxo;
+};
+
+// Akin to all PDAs belonging to a Program
+// This is the top-level abstraction for Program state
+// Dapps want to control program-specific state
+// Wallets don't want to know about ProgramState at all.
+export type ProgramState = {
+  owner: PublicKey; // this can be public program or psp
+  ownerIdl: Idl;
+  utxos: DefaultProgramUtxo[]; /// these can be unique or not unique UTXOs (accounts)
+  publicUtxos: PublicProgramUtxo[];
 };

--- a/zk.js/src/types/index.ts
+++ b/zk.js/src/types/index.ts
@@ -4,8 +4,3 @@ export * from "./accounts";
 export * from "./data";
 export * from "./programParameters";
 export * from "./result";
-
-export { type TokenBalance as TokenBalance_new } from "./balance";
-export { type Balance as Balance_new } from "./balance";
-export { type TokenData as TokenData_new } from "./balance";
-export { type SerializedTokenBalance } from "./balance";

--- a/zk.js/src/types/index.ts
+++ b/zk.js/src/types/index.ts
@@ -4,3 +4,8 @@ export * from "./accounts";
 export * from "./data";
 export * from "./programParameters";
 export * from "./result";
+
+export { type TokenBalance as TokenBalance_new } from "./balance";
+export { type Balance as Balance_new } from "./balance";
+export { type TokenData as TokenData_new } from "./balance";
+export { type SerializedTokenBalance } from "./balance";

--- a/zk.js/src/types/poseidon.ts
+++ b/zk.js/src/types/poseidon.ts
@@ -1,0 +1,1 @@
+export type Poseidon = any;

--- a/zk.js/src/wallet/provider.ts
+++ b/zk.js/src/wallet/provider.ts
@@ -51,7 +51,8 @@ export type Wallet = {
   publicKey: PublicKey;
   isNodeWallet?: boolean;
   getProof?: (transaction: any) => Promise<any>;
-  getCompressedBalance?: () => Promise<SerializedBalance>;
+  getAssetBalances?: () => Promise<SerializedBalance>;
+  decryptState?: (encryptedState: Uint8Array) => Promise<Uint8Array>;
 };
 
 /**

--- a/zk.js/src/wallet/provider.ts
+++ b/zk.js/src/wallet/provider.ts
@@ -11,9 +11,11 @@ import {
 } from "@solana/web3.js";
 import { initLookUpTable } from "../utils";
 import {
+  Account,
   ADMIN_AUTH_KEYPAIR,
   BN_0,
   IDL_LIGHT_MERKLE_TREE_PROGRAM,
+  isSolanaKeypair,
   MerkleTreeConfig,
   merkleTreeProgramId,
   MINIMUM_LAMPORTS,
@@ -35,6 +37,7 @@ import {
   useWallet,
 } from "../index";
 import { WasmHasher, Hasher } from "@lightprotocol/account.rs";
+import { Balance, SerializedBalance } from "../types/balance";
 const axios = require("axios");
 
 /**
@@ -47,6 +50,8 @@ export type Wallet = {
   sendAndConfirmTransaction: (transaction: any) => Promise<any>;
   publicKey: PublicKey;
   isNodeWallet?: boolean;
+  getProof?: (transaction: any) => Promise<any>;
+  getCompressedBalance?: () => Promise<SerializedBalance>;
 };
 
 /**
@@ -375,7 +380,7 @@ export class Provider {
         "constructor",
         "No connection provided with browser wallet.",
       );
-    if ("secretKey" in wallet) {
+    if (isSolanaKeypair(wallet)) {
       wallet = useWallet(wallet as SolanaKeypair, url);
     } else {
       wallet = wallet as Wallet;
@@ -388,6 +393,7 @@ export class Provider {
     );
     if (!versionedTransactionLookupTable) {
       // initializing lookup table or fetching one from relayer in case of browser wallet
+      /// TODO: by default, this should be a pre-initialzed lookup table publicKey
       versionedTransactionLookupTable = await Provider.fetchLookupTable(
         wallet,
         anchorProvider,

--- a/zk.js/src/wallet/useWallet.ts
+++ b/zk.js/src/wallet/useWallet.ts
@@ -71,7 +71,9 @@ class Wallet {
   /** This mocks the interface, the wallet would implement this themselves inside their wallet */
   getProof = async (tx: Transaction): Promise<any> => {};
 
-  getCompressedBalance = async (): Promise<any> => {
+  /** Decrypt a batch of UTXOs (byte arrays) */
+  decryptState = async (encryptedState: Uint8Array): Promise<any> => {};
+  getAssetBalances = async (): Promise<any> => {
     /// wallets should cache/persist this
     const hasher = await WasmHasher.getInstance();
     /// wallets should cache/persist this
@@ -81,6 +83,10 @@ class Wallet {
 
     const assetLookupTable = [];
 
+    /**
+     * The wallet periodically sync it's balance with the latest merkletree state
+     * Ideally, RPC providers will expose getAssetsByOwner
+     */
     const balance = await syncBalance({
       connection: this._connection,
       relayer,
@@ -120,7 +126,8 @@ export const useWallet = (
     signAllTransactions: wallet.signAllTransactions,
     isNodeWallet,
     getProof: wallet.getProof,
-    getCompressedBalance: wallet.getCompressedBalance,
+    getAssetBalances: wallet.getAssetBalances,
+    decryptState: wallet.decryptState,
   };
 };
 

--- a/zk.js/tests/balance.new.test.ts
+++ b/zk.js/tests/balance.new.test.ts
@@ -3,8 +3,6 @@ import { PublicKey, SystemProgram } from "@solana/web3.js";
 import { BN } from "@coral-xyz/anchor";
 import { it } from "mocha";
 import { expect } from "chai";
-const lodash = require("lodash");
-
 const circomlibjs = require("circomlibjs");
 const { buildPoseidonOpt } = circomlibjs;
 const chai = require("chai");

--- a/zk.js/tests/balance.new.test.ts
+++ b/zk.js/tests/balance.new.test.ts
@@ -1,0 +1,312 @@
+import { assert } from "chai";
+import { PublicKey, SystemProgram } from "@solana/web3.js";
+import { BN } from "@coral-xyz/anchor";
+import { it } from "mocha";
+import { expect } from "chai";
+const circomlibjs = require("circomlibjs");
+const { buildPoseidonOpt } = circomlibjs;
+const chai = require("chai");
+
+const chaiAsPromised = require("chai-as-promised");
+// Load chai-as-promised support
+chai.use(chaiAsPromised);
+
+import {
+  FEE_ASSET,
+  Provider as LightProvider,
+  MINT,
+  Utxo,
+  Account,
+  TOKEN_REGISTRY,
+  BN_0,
+  getTokenDataByMint,
+  initTokenBalance,
+  isSPLUtxo,
+  addUtxoToBalance,
+  Balance_new,
+  updateTokenBalanceWithUtxo,
+  serializeBalance,
+  deserializeBalance,
+  spendUtxo,
+} from "../src";
+import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
+
+process.env.ANCHOR_PROVIDER_URL = "http://127.0.0.1:8899";
+process.env.ANCHOR_WALLET = process.env.HOME + "/.config/solana/id.json";
+
+describe("Balance", () => {
+  const seed32 = bs58.encode(new Uint8Array(32).fill(1));
+  const shieldAmount = 20_000;
+  const shieldFeeAmount = 10_000;
+
+  let poseidon: any,
+    lightProvider: LightProvider,
+    shieldUtxo1: Utxo,
+    solTestUtxo1: Utxo,
+    solTestUtxo2: Utxo,
+    keypair: Account;
+  before(async () => {
+    poseidon = await buildPoseidonOpt();
+    keypair = new Account({ poseidon: poseidon, seed: seed32 });
+    lightProvider = await LightProvider.loadMock();
+    shieldUtxo1 = new Utxo({
+      poseidon: poseidon,
+      assets: [FEE_ASSET, MINT],
+      amounts: [new BN(shieldFeeAmount), new BN(shieldAmount)],
+      publicKey: keypair.pubkey,
+      index: 1,
+      assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
+    });
+    solTestUtxo1 = new Utxo({
+      poseidon: poseidon,
+      assets: [FEE_ASSET, SystemProgram.programId],
+      amounts: [new BN(shieldAmount), new BN(0)],
+      publicKey: keypair.pubkey,
+      index: 3,
+      assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
+    });
+    solTestUtxo2 = new Utxo({
+      poseidon: poseidon,
+      assets: [FEE_ASSET, SystemProgram.programId],
+      amounts: [new BN(shieldAmount * 1.5), new BN(0)],
+      publicKey: keypair.pubkey,
+      index: 5,
+      assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
+    });
+  });
+
+  describe("getTokenDataByMint", () => {
+    it("should return the correct token data", () => {
+      const solTokenData = getTokenDataByMint(
+        SystemProgram.programId,
+        TOKEN_REGISTRY,
+      );
+      assert.equal(solTokenData.symbol, "SOL");
+    });
+
+    it("should throw an error if the token is not found", () => {
+      const NO_TOKEN = new PublicKey(
+        "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYC",
+      );
+      expect(() => getTokenDataByMint(NO_TOKEN, TOKEN_REGISTRY)).to.throw();
+    });
+    it("should throw an error if the registry is empty", () => {
+      expect(() =>
+        getTokenDataByMint(SystemProgram.programId, new Map()),
+      ).to.throw();
+    });
+  });
+
+  describe("initTokenBalance", () => {
+    it("should initialize a token balance correctly", () => {
+      const tokenData = getTokenDataByMint(
+        SystemProgram.programId,
+        TOKEN_REGISTRY,
+      );
+      const utxos: Utxo[] = [shieldUtxo1];
+
+      const tokenBalance = initTokenBalance(tokenData, utxos);
+
+      assert.equal(tokenBalance.amount, BN_0);
+      assert.equal(tokenBalance.lamports, BN_0);
+      assert.deepEqual(tokenBalance.data, tokenData);
+      assert.deepEqual(tokenBalance.utxos, utxos);
+    });
+    it("should throw an error if the mint does not match", () => {
+      const tokenData = getTokenDataByMint(
+        SystemProgram.programId,
+        TOKEN_REGISTRY,
+      );
+      const utxos: Utxo[] = [shieldUtxo1, solTestUtxo1]; // diff mints
+
+      expect(() => {
+        initTokenBalance(tokenData, utxos);
+      }).to.throw();
+    });
+
+    it("should initialize a token balance correctly without utxos", () => {
+      const tokenData = getTokenDataByMint(
+        SystemProgram.programId,
+        TOKEN_REGISTRY,
+      );
+      const tokenBalance = initTokenBalance(tokenData);
+
+      assert.equal(tokenBalance.amount, BN_0);
+      assert.equal(tokenBalance.lamports, BN_0);
+      assert.deepEqual(tokenBalance.data, tokenData);
+      assert.deepEqual(tokenBalance.utxos, []);
+    });
+  });
+  describe("isSPLUtxo", () => {
+    it("should return true if the utxo is an SPL utxo", () => {
+      const result = isSPLUtxo(shieldUtxo1);
+      assert.equal(result, true);
+    });
+
+    it("should return false if the utxo is not an SPL utxo", () => {
+      const result = isSPLUtxo(solTestUtxo1);
+      assert.equal(result, false);
+    });
+  });
+
+  describe("addUtxoToBalance", () => {
+    let balance: Balance_new;
+
+    before(() => {
+      // set up initial balance with 1 SOL tokenbalance
+      const tokenData = getTokenDataByMint(
+        SystemProgram.programId,
+        TOKEN_REGISTRY,
+      );
+      const tokenBalance = initTokenBalance(tokenData, [solTestUtxo1]);
+      balance = {
+        tokenBalances: new Map([
+          [tokenBalance.data.mint.toBase58(), tokenBalance],
+        ]),
+      };
+    });
+
+    it("should add a new mint UTXO to balance correctly", () => {
+      const utxo: Utxo = shieldUtxo1;
+
+      // fresh tokenbalance,
+      const result = addUtxoToBalance(utxo, balance);
+
+      assert.equal(result, true);
+      assert.deepEqual(
+        balance.tokenBalances.get(utxo.assets[1].toString())!.utxos[0],
+        utxo,
+      );
+      assert.deepEqual(
+        balance.tokenBalances.get(utxo.assets[1].toString())!.amount,
+        utxo.amounts[1],
+      );
+    });
+
+    it("should update the SOL token balance with another UTXO correctly", () => {
+      const utxo: Utxo = solTestUtxo2; // solTestUtxo2 = sol, but different
+
+      const result = addUtxoToBalance(utxo, balance);
+
+      assert.equal(result, true);
+      assert.deepEqual(
+        balance.tokenBalances.get(utxo.assets[0].toString())!.utxos[1], // 2nd
+        utxo,
+      );
+      assert.deepEqual(
+        balance.tokenBalances.get(utxo.assets[0].toString())!.lamports,
+        utxo.amounts[0].add(solTestUtxo1.amounts[0]), // 2 sol utxos
+      );
+    });
+  });
+
+  describe("updateTokenBalanceWithUtxo", () => {
+    let tokenBalance: TokenBalance;
+
+    before(() => {
+      const tokenData = getTokenDataByMint(
+        SystemProgram.programId,
+        TOKEN_REGISTRY,
+      );
+      tokenBalance = initTokenBalance(tokenData, [solTestUtxo1]);
+    });
+
+    it("should update the token balance with a new UTXO correctly", () => {
+      const utxo: Utxo = solTestUtxo2;
+
+      const result = updateTokenBalanceWithUtxo(utxo, tokenBalance);
+
+      assert.equal(result, true);
+      assert.deepEqual(tokenBalance.utxos[1], utxo);
+      assert.deepEqual(
+        tokenBalance.lamports,
+        utxo.amounts[0].add(solTestUtxo1.amounts[0]),
+      );
+      assert.deepEqual(tokenBalance.amount, utxo.amounts[1] ?? BN_0);
+    });
+
+    it("should not update the token balance with the same UTXO", () => {
+      const utxo: Utxo = solTestUtxo2;
+
+      const result = updateTokenBalanceWithUtxo(utxo, tokenBalance);
+
+      assert.equal(result, false);
+    });
+  });
+
+  describe("serializeBalance and deserializeBalance", () => {
+    it("should serialize and deserialize a balance correctly", async () => {
+      // Initialize a balance
+      const tokenData = getTokenDataByMint(
+        SystemProgram.programId,
+        TOKEN_REGISTRY,
+      );
+      const tokenBalance = initTokenBalance(tokenData, [solTestUtxo1]);
+      const balance: Balance_new = {
+        tokenBalances: new Map([
+          [tokenBalance.data.mint.toBase58(), tokenBalance],
+        ]),
+      };
+
+      // Serialize
+      const serializedBalance = await serializeBalance(balance);
+      assert.typeOf(serializedBalance, "string");
+
+      // Deserialize
+      const deserializedBalance: Balance_new = await deserializeBalance(
+        serializedBalance,
+        lightProvider,
+      );
+
+      // Check that the deserialized balance matches the original balance
+      const deserializedTokenBalance = deserializedBalance.tokenBalances.get(
+        tokenBalance.data.mint.toBase58(),
+      );
+      assert.deepEqual(deserializedTokenBalance, tokenBalance);
+    });
+  });
+
+  describe("spendUtxo", () => {
+    it("should spend a UTXO correctly and return true", () => {
+      const tokenData = getTokenDataByMint(
+        SystemProgram.programId,
+        TOKEN_REGISTRY,
+      );
+      const tokenBalance = initTokenBalance(tokenData, [shieldUtxo1]);
+      const balance: Balance_new = {
+        tokenBalances: new Map([
+          [tokenBalance.data.mint.toBase58(), tokenBalance],
+        ]),
+      };
+
+      const commitment = shieldUtxo1.getCommitment(poseidon);
+      const result = spendUtxo([balance], commitment);
+      assert.equal(result, true);
+
+      const updatedTokenBalance = balance.tokenBalances.get(
+        tokenBalance.data.mint.toBase58(),
+      )!;
+      assert.equal(updatedTokenBalance.utxos.length, 0);
+      assert.equal(updatedTokenBalance.lamports.toString(), "0");
+      assert.equal(updatedTokenBalance.amount.toString(), "0");
+    });
+
+    it("should return false when trying to spend a UTXO that has already been spent", () => {
+      const tokenData = getTokenDataByMint(
+        SystemProgram.programId,
+        TOKEN_REGISTRY,
+      );
+      const tokenBalance = initTokenBalance(tokenData, [shieldUtxo1]);
+      const balance: Balance_new = {
+        tokenBalances: new Map([
+          [tokenBalance.data.mint.toBase58(), tokenBalance],
+        ]),
+      };
+
+      const commitment = shieldUtxo1.getCommitment(poseidon);
+      spendUtxo([balance], commitment);
+      const result = spendUtxo([balance], commitment);
+      assert.equal(result, false);
+    });
+  });
+});

--- a/zk.js/tests/balance.new.test.ts
+++ b/zk.js/tests/balance.new.test.ts
@@ -33,7 +33,6 @@ import {
   TokenBalance_new,
 } from "../src";
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
-import { serializeTokenBalance } from "../src/balance/balance";
 
 process.env.ANCHOR_PROVIDER_URL = "http://127.0.0.1:8899";
 process.env.ANCHOR_WALLET = process.env.HOME + "/.config/solana/id.json";

--- a/zk.js/tests/balance.new.test.ts
+++ b/zk.js/tests/balance.new.test.ts
@@ -23,13 +23,14 @@ import {
   initTokenBalance,
   isSPLUtxo,
   addUtxoToBalance,
-  Balance_new,
   updateTokenBalanceWithUtxo,
   serializeBalance,
   deserializeBalance,
   spendUtxo,
-  TokenBalance_new,
 } from "../src";
+
+import { Balance, TokenBalance } from "../src/types/balance";
+
 import { bs58 } from "@coral-xyz/anchor/dist/cjs/utils/bytes";
 
 process.env.ANCHOR_PROVIDER_URL = "http://127.0.0.1:8899";
@@ -164,7 +165,7 @@ describe("Balance", () => {
   });
 
   describe("addUtxoToBalance", () => {
-    let balance: Balance_new;
+    let balance: Balance;
 
     before(() => {
       // set up initial balance with 1 SOL tokenbalance
@@ -214,7 +215,7 @@ describe("Balance", () => {
   });
 
   describe("updateTokenBalanceWithUtxo", () => {
-    let tokenBalance: TokenBalance_new;
+    let tokenBalance: TokenBalance;
 
     before(() => {
       const tokenData = getTokenDataByMint(
@@ -257,7 +258,7 @@ describe("Balance", () => {
         TOKEN_REGISTRY,
       );
       const tokenBalance = initTokenBalance(tokenData, [solTestUtxo1]);
-      const balance: Balance_new = {
+      const balance: Balance = {
         tokenBalances: new Map([
           [tokenBalance.data.mint.toBase58(), tokenBalance],
         ]),
@@ -267,7 +268,7 @@ describe("Balance", () => {
       const serializedBalance = await serializeBalance(balance);
 
       // Deserialize
-      const deserializedBalance: Balance_new = deserializeBalance(
+      const deserializedBalance: Balance = deserializeBalance(
         serializedBalance,
         TOKEN_REGISTRY,
         lightProvider,
@@ -293,7 +294,7 @@ describe("Balance", () => {
       );
       const utxo = solTestUtxo1;
       const tokenBalance = initTokenBalance(tokenData, [utxo]);
-      const balance: Balance_new = {
+      const balance: Balance = {
         tokenBalances: new Map([
           [tokenBalance.data.mint.toBase58(), tokenBalance],
         ]),
@@ -317,7 +318,7 @@ describe("Balance", () => {
         TOKEN_REGISTRY,
       );
       const tokenBalance = initTokenBalance(tokenData, [solTestUtxo1]);
-      const balance: Balance_new = {
+      const balance: Balance = {
         tokenBalances: new Map([
           [tokenBalance.data.mint.toBase58(), tokenBalance],
         ]),


### PR DESCRIPTION
adds
- getTokenDataByMint
- initTokenBalance
- updateTokenBalanceWithUtxo
- addUtxoToBalance
- spendUtxo

as well as high-level wrappers for 
- serializeTokenBalance
- deserializeTokenBalance
- serializeBalance
- deserializeBalance

and unit tests for all functions
- balance.new.tests.ts

what's missing is a proper syncBalance set of functions 
that
- don't need to re-fetch all txs
- utilizes a set of e.g. (lastSyncedBlock, userAccountCreationBlock) functions that can be manually cached and help pre-filter the txs to parse. 
- there should be a "lazyInboxCheck" which can be a long-running process and complement the actual syncBalance call

- [ ] move errors 