### PR TITLE
feat: add storage functionality to 4in 4out system psp

### DIFF
--- a/psp-examples/streaming-payments/package.json
+++ b/psp-examples/streaming-payments/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "format": "prettier --write \"tests/**/*.{ts,js}\" -w",
     "lint": "prettier \"tests/**/*{ts,js}\" --check",
-    "test": "../../cli/test_bin/run psp:test streaming-payments Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
+    "test": "../../cli/test_bin/run psp:test streaming-payments",
     "build": "../../cli/test_bin/run psp:build streaming-payments --ptau=15"
   },
   "dependencies": {

--- a/psp-examples/streaming-payments/programs/streaming-payments/src/lib.rs
+++ b/psp-examples/streaming-payments/programs/streaming-payments/src/lib.rs
@@ -98,7 +98,7 @@ pub mod streaming_payments {
     // under the hood we could just generate a constant with the name including the suffix and use that in the sdk for ordering
     // it should work independently from light
     // maybe it would be more the anchor way to add it to the anchor object
-    pub fn shielded_transfer_storage_third<'a, 'b, 'c, 'info>(
+    pub fn light_instruction_third<'a, 'b, 'c, 'info>(
         ctx: Context<
             'a,
             'b,
@@ -106,42 +106,17 @@ pub mod streaming_payments {
             'info,
             LightInstructionThird<'info, { VERIFYINGKEY_STREAMING_PAYMENTS.nr_pubinputs }>,
         >,
-        message: [u8; 1024],
+        // 999 is the max value anchor ts sdk supports
+        message: [u8; 800],
     ) -> Result<()> {
         let mut state = ctx.accounts.verifier_state.load_mut()?;
 
-        // if state.message_len.len() > MSG_SIZE {
-        //     return Err(VerifierError::MessageTooLarge.into());
-        // }
-        // // Reallocate space.
-        // let cur_acc_size = state.to_account_info().data_len();
-        // let new_needed_size = cur_acc_size + message.len();
-        // if new_needed_size > cur_acc_size {
-        //     let new_acc_size = cur_acc_size + MESSAGE_PER_CALL_SIZE;
-        //     if new_acc_size > VERIFIER_STATE_MAX_SIZE {
-        //         return Err(VerifierError::VerifierStateNoSpace.into());
-        //     }
-        //     state.to_account_info().realloc(new_acc_size, false)?;
-        //     state.reload()?;
-        // }
-
-        // state.msg.extend_from_slice(&message);
         let off_set = state.message_write_offset as usize;
         if off_set + message.len() > MSG_SIZE {
             return Err(VerifierError::MessageTooLarge.into());
         }
         state.message[off_set..message.len()].copy_from_slice(&message);
         state.message_write_offset += message.len() as u64;
-
-        // let inputs: InstructionDataShieldedTransferFirst =
-        //     InstructionDataShieldedTransferFirst::try_deserialize_unchecked(
-        //         &mut [vec![0u8; 8], inputs].concat().as_slice(),
-        //     )?;
-        // let message = inputs.message;
-        // if message.len() > MESSAGE_PER_CALL_SIZE {
-        //     return Err(VerifierError::MessageTooLarge.into());
-        // }
-
         Ok(())
     }
 

--- a/psp-examples/streaming-payments/programs/streaming-payments/src/processor.rs
+++ b/psp-examples/streaming-payments/programs/streaming-payments/src/processor.rs
@@ -63,6 +63,7 @@ pub fn cpi_verifier_two<'a, 'b, 'c, 'info, const NR_CHECKED_INPUTS: usize>(
         &final_seed[..],
     );
     cpi_ctx = cpi_ctx.with_remaining_accounts(ctx.remaining_accounts.to_vec());
+    let message_offset = memoffset::offset_of!(crate::psp_accounts::VerifierState, message);
     light_psp4in4out_app_storage::cpi::shielded_transfer_inputs(
         cpi_ctx,
         proof_verifier.a,
@@ -71,6 +72,8 @@ pub fn cpi_verifier_two<'a, 'b, 'c, 'info, const NR_CHECKED_INPUTS: usize>(
         <Vec<u8> as TryInto<[u8; 32]>>::try_into(verifier_state.checked_public_inputs[1].to_vec())
             .unwrap(),
         memoffset::offset_of!(crate::psp_accounts::VerifierState, verifier_state_data),
+        message_offset,
+        message_offset + 800,
     )
 }
 

--- a/psp-examples/streaming-payments/programs/streaming-payments/src/processor.rs
+++ b/psp-examples/streaming-payments/programs/streaming-payments/src/processor.rs
@@ -1,5 +1,5 @@
 use crate::verifying_key_streaming_payments::VERIFYINGKEY_STREAMING_PAYMENTS;
-use crate::LightInstructionThird;
+use crate::LightInstructionFourth;
 use anchor_lang::prelude::*;
 use light_macros::pubkey;
 use light_verifier_sdk::light_transaction::Proof;
@@ -13,7 +13,7 @@ impl Config for TransactionsConfig {
 }
 
 pub fn cpi_verifier_two<'a, 'b, 'c, 'info, const NR_CHECKED_INPUTS: usize>(
-    ctx: &'a Context<'a, 'b, 'c, 'info, LightInstructionThird<'info, NR_CHECKED_INPUTS>>,
+    ctx: &'a Context<'a, 'b, 'c, 'info, LightInstructionFourth<'info, NR_CHECKED_INPUTS>>,
     inputs: &'a Vec<u8>,
 ) -> Result<()> {
     let proof_verifier = Proof {
@@ -75,7 +75,7 @@ pub fn cpi_verifier_two<'a, 'b, 'c, 'info, const NR_CHECKED_INPUTS: usize>(
 }
 
 pub fn verify_program_proof<'a, 'b, 'c, 'info, const NR_CHECKED_INPUTS: usize>(
-    ctx: &'a Context<'a, 'b, 'c, 'info, LightInstructionThird<'info, NR_CHECKED_INPUTS>>,
+    ctx: &'a Context<'a, 'b, 'c, 'info, LightInstructionFourth<'info, NR_CHECKED_INPUTS>>,
     inputs: &'a Vec<u8>,
 ) -> Result<()> {
     let verifier_state = ctx.accounts.verifier_state.load()?;

--- a/psp-examples/streaming-payments/programs/streaming-payments/src/psp_accounts.rs
+++ b/psp-examples/streaming-payments/programs/streaming-payments/src/psp_accounts.rs
@@ -125,7 +125,7 @@ pub const MSG_SIZE: usize = 1024;
 pub struct VerifierState {
     pub signer: Pubkey,
     pub verifier_state_data: [u8; 1024],
-    pub checked_public_inputs: [[u8; 32]; 3],
     pub message: [u8; MSG_SIZE],
     pub message_write_offset: u64,
+    pub checked_public_inputs: [[u8; 32]; 3],
 }

--- a/psp-examples/streaming-payments/tests/streaming-payments.ts
+++ b/psp-examples/streaming-payments/tests/streaming-payments.ts
@@ -138,8 +138,6 @@ describe("Streaming Payments tests", () => {
       appDataIdl: IDL,
       verifierAddress: verifierProgramId,
       assetLookupTable: lightProvider.lookUpTables.assetLookupTable,
-      verifierProgramLookupTable:
-        lightProvider.lookUpTables.verifierProgramLookupTable,
       includeAppData: true,
     });
     const testInputsShield = {
@@ -195,6 +193,7 @@ describe("Streaming Payments tests", () => {
         verifierProgramId,
         relayer.accounts.relayerPubkey,
       ),
+      message: Buffer.alloc(800).fill(2),
     });
 
     await txParams.getTxIntegrityHash(POSEIDON);
@@ -225,11 +224,13 @@ describe("Streaming Payments tests", () => {
       completePspProofInputs,
       false,
     );
+    console.log("systemProof ", systemProof);
     const solanaTransactionInputs: SolanaTransactionInputs = {
       systemProof,
       pspProof,
       transaction: txParams,
       pspTransactionInput,
+      prefix: "lightInstruction"
     };
 
     const res = await sendAndConfirmShieldedTransaction({
@@ -237,6 +238,8 @@ describe("Streaming Payments tests", () => {
       provider: lightProvider,
     });
     console.log("tx Hash : ", res.txHash);
+
+    console.log("get events ", await lightUser.provider.relayer.getIndexedTransactions(lightProvider.provider.connection))
   }
 
   async function paymentStreaming(
@@ -401,8 +404,6 @@ class PaymentStreamClient {
       appDataIdl: this.idl,
       verifierAddress: TransactionParameters.getVerifierProgramId(this.idl),
       assetLookupTable: this.lightProvider.lookUpTables.assetLookupTable,
-      verifierProgramLookupTable:
-        this.lightProvider.lookUpTables.verifierProgramLookupTable,
     });
 
     this.streamInitUtxo = streamInitUtxo;
@@ -444,8 +445,6 @@ class PaymentStreamClient {
           publicKey: inUtxo.publicKey,
           poseidon: this.poseidon,
           assetLookupTable: this.lightProvider.lookUpTables.assetLookupTable,
-          verifierProgramLookupTable:
-            this.lightProvider.lookUpTables.verifierProgramLookupTable,
         });
         return { programParameters, inUtxo, outUtxo, action };
       }
@@ -478,8 +477,6 @@ class PaymentStreamClient {
         appDataIdl: this.idl,
         verifierAddress: TransactionParameters.getVerifierProgramId(this.idl),
         assetLookupTable: this.lightProvider.lookUpTables.assetLookupTable,
-        verifierProgramLookupTable:
-          this.lightProvider.lookUpTables.verifierProgramLookupTable,
       });
       return { programParameters, outUtxo, inUtxo };
     }

--- a/verifier-sdk/src/cpi_instructions.rs
+++ b/verifier-sdk/src/cpi_instructions.rs
@@ -168,8 +168,12 @@ pub fn get_seeds<'a>(
     Ok((seed, bump))
 }
 
-pub fn invoke_indexer_transaction_event<'info>(
-    event: &TransactionIndexerEvent,
+pub fn invoke_indexer_transaction_event<
+    'info,
+    const NR_NULLIFIERS: usize,
+    const NR_LEAVES: usize,
+>(
+    event: &TransactionIndexerEvent<NR_NULLIFIERS, NR_LEAVES>,
     noop_program: &AccountInfo<'info>,
     signer: &AccountInfo<'info>,
 ) -> Result<()> {

--- a/verifier-sdk/src/light_transaction.rs
+++ b/verifier-sdk/src/light_transaction.rs
@@ -197,18 +197,23 @@ impl<
             Some(message) => message.content.clone(),
             None => Vec::<u8>::new(),
         };
-        let transaction_data_event = TransactionIndexerEvent {
-            leaves: leaves_vec.clone(),
+        // msg!("nR_leave: {}", NR_LEAVES);
+        // msg!("leaves_vec: {}", leaves_vec.len());
+        // let nr_leaves: usize = NR_LEAVES * 2;
+        let transaction_data_event = TransactionIndexerEvent::<NR_NULLIFIERS, NR_LEAVES> {
+            nr_leaves: NR_LEAVES as u64 * 2,
+            nr_nullifiers: NR_NULLIFIERS as u64,
+            leaves: leaves_vec,
             public_amount_sol: self.input.public_amount.sol,
             public_amount_spl: self.input.public_amount.spl,
             relayer_fee: self.input.relayer_fee,
-            encrypted_utxos: self.input.encrypted_utxos.clone(),
-            nullifiers: self.input.nullifiers.to_vec(),
+            encrypted_utxos: &self.input.encrypted_utxos,
+            nullifiers: &self.input.nullifiers,
             first_leaf_index,
-            message,
+            message: &message,
         };
 
-        invoke_indexer_transaction_event(
+        invoke_indexer_transaction_event::<NR_NULLIFIERS, NR_LEAVES>(
             &transaction_data_event,
             &self.input.ctx.accounts.get_log_wrapper().to_account_info(),
             &self

--- a/verifier-sdk/src/state.rs
+++ b/verifier-sdk/src/state.rs
@@ -90,13 +90,15 @@ impl<
 }
 
 #[derive(AnchorDeserialize, AnchorSerialize, Clone, Debug)]
-pub struct TransactionIndexerEvent {
+pub struct TransactionIndexerEvent<'a, const NR_NULLIFIERS: usize, const NR_LEAVES: usize> {
+    pub nr_leaves: u64,
+    pub nr_nullifiers: u64,
     pub leaves: Vec<[u8; 32]>,
     pub public_amount_spl: [u8; 32],
     pub public_amount_sol: [u8; 32],
     pub relayer_fee: u64,
-    pub encrypted_utxos: Vec<u8>,
-    pub nullifiers: Vec<[u8; 32]>,
+    pub encrypted_utxos: &'a Vec<u8>,
+    pub nullifiers: &'a [[u8; 32]; NR_NULLIFIERS],
     pub first_leaf_index: u64,
-    pub message: Vec<u8>,
+    pub message: &'a Vec<u8>,
 }

--- a/zk.js/src/idls/light_psp4in4out_app_storage.ts
+++ b/zk.js/src/idls/light_psp4in4out_app_storage.ts
@@ -148,6 +148,18 @@ export type LightPsp4in4outAppStorage = {
           "type": {
             "defined": "usize"
           }
+        },
+        {
+          "name": "messageStartOffset",
+          "type": {
+            "defined": "usize"
+          }
+        },
+        {
+          "name": "messageEndOffset",
+          "type": {
+            "defined": "usize"
+          }
         }
       ]
     }
@@ -220,6 +232,18 @@ export type LightPsp4in4outAppStorage = {
           {
             "name": "merkleRootIndex",
             "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "instructionDataShieldedTransferFirst",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "message",
+            "type": "bytes"
           }
         ]
       }
@@ -787,6 +811,18 @@ export const IDL: LightPsp4in4outAppStorage = {
           "type": {
             "defined": "usize"
           }
+        },
+        {
+          "name": "messageStartOffset",
+          "type": {
+            "defined": "usize"
+          }
+        },
+        {
+          "name": "messageEndOffset",
+          "type": {
+            "defined": "usize"
+          }
         }
       ]
     }
@@ -859,6 +895,18 @@ export const IDL: LightPsp4in4outAppStorage = {
           {
             "name": "merkleRootIndex",
             "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "instructionDataShieldedTransferFirst",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "message",
+            "type": "bytes"
           }
         ]
       }

--- a/zk.js/src/transaction/sendVersionedTransaction.ts
+++ b/zk.js/src/transaction/sendVersionedTransaction.ts
@@ -34,7 +34,8 @@ export const sendVersionedTransaction = async (
   const txMsg = new TransactionMessage({
     payerKey: payer.publicKey,
     instructions: [
-      ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 }),
+      ComputeBudgetProgram.setComputeUnitLimit({ units: 600_000 }),
+      ComputeBudgetProgram.requestHeapFrame({bytes: 128_000}),
       ix,
     ],
     recentBlockhash: recentBlockhash,

--- a/zk.js/src/transaction/solanaTransaction.ts
+++ b/zk.js/src/transaction/solanaTransaction.ts
@@ -197,7 +197,7 @@ export async function createSolanaInstructions(
     );
   }
   let inputObject = {
-    message: instructionInputs.message,
+    message: txParams.message,
     ...instructionInputs.proofBytes,
     ...instructionInputs.publicInputs,
     rootIndex: instructionInputs.rootIndex,

--- a/zk.js/tests/system-programs/functional_tests.ts
+++ b/zk.js/tests/system-programs/functional_tests.ts
@@ -82,7 +82,7 @@ describe("verifier_program", () => {
     });
   });
 
-  it("Shield (verifier one)", async () => {
+  it.only("Shield (verifier one)", async () => {
     await performShield({
       delegate: AUTHORITY_ONE,
       spl: true,
@@ -91,7 +91,7 @@ describe("verifier_program", () => {
     });
   });
 
-  it("Shield (verifier storage)", async () => {
+  it.only("Shield (verifier storage)", async () => {
     await performShield({
       delegate: AUTHORITY,
       spl: false,
@@ -242,6 +242,9 @@ describe("verifier_program", () => {
       verifierIdl: verifierIdl,
       account: KEYPAIR,
     });
+    for (let i = 0; i < 2; i++) {
+      console.log("nullifier : ", new anchor.BN(txParams.inputUtxos[i].getNullifier({poseidon: POSEIDON, account: KEYPAIR})).toArray("be", 32));
+    }
     const transactionTester = new TestTransaction({
       txParams,
       provider: lightProvider,


### PR DESCRIPTION
## Problem:
- PSPs need to be able to store program output utxos in a message.

## Changes:
- add message storage to psp-template and verifier 4in 4out