### PR TITLE
ci: Distinguish between caches with and without atomic transactions

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -22,13 +22,13 @@ runs:
         path: |
           ~/.cargo
           **/target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-${{ inputs.atomic-transactions }}-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Cache .local directory
       uses: buildjet/cache@v3
       with:
         path: .local
-        key: ${{ runner.os }}-local-${{ hashFiles('**/install.sh') }}
+        key: ${{ runner.os }}-local-${{ inputs.atomic-transactions }}-${{ hashFiles('**/install.sh') }}
 
     - name: Install dependencies
       shell: bash
@@ -55,9 +55,9 @@ runs:
       name: Setup pnpm cache
       with:
         path: ${{ env.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-store-${{ inputs.atomic-transactions }}-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-pnpm-store-
+          ${{ runner.os }}-pnpm-store-${{ inputs.atomic-transactions }}-
 
     - name: Install pnpm dependencies
       shell: bash

--- a/psp-examples/private-compressed-account/Cargo.lock
+++ b/psp-examples/private-compressed-account/Cargo.lock
@@ -1559,6 +1559,7 @@ dependencies = [
  "getrandom 0.2.10",
  "light-macros",
  "light-merkle-tree",
+ "light-utils",
  "solana-security-txt",
  "spl-token",
 ]
@@ -1590,6 +1591,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-utils"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
 name = "light-verifier-sdk"
 version = "0.3.1"
 dependencies = [
@@ -1604,6 +1612,7 @@ dependencies = [
  "groth16-solana",
  "light-merkle-tree",
  "light-merkle-tree-program",
+ "light-utils",
  "spl-token",
 ]
 

--- a/psp-examples/rock-paper-scissors/Cargo.lock
+++ b/psp-examples/rock-paper-scissors/Cargo.lock
@@ -1516,10 +1516,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "light-byteutils"
-version = "0.1.0"
-
-[[package]]
 name = "light-macros"
 version = "0.3.1"
 dependencies = [
@@ -1561,9 +1557,9 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "getrandom 0.2.10",
- "light-byteutils",
  "light-macros",
  "light-merkle-tree",
+ "light-utils",
  "solana-security-txt",
  "spl-token",
 ]
@@ -1595,6 +1591,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-utils"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
 name = "light-verifier-sdk"
 version = "0.3.1"
 dependencies = [
@@ -1607,9 +1610,9 @@ dependencies = [
  "ark-std 0.3.0",
  "borsh 0.9.3",
  "groth16-solana",
- "light-byteutils",
  "light-merkle-tree",
  "light-merkle-tree-program",
+ "light-utils",
  "spl-token",
 ]
 

--- a/psp-examples/streaming-payments/Cargo.lock
+++ b/psp-examples/streaming-payments/Cargo.lock
@@ -1515,10 +1515,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "light-byteutils"
-version = "0.1.0"
-
-[[package]]
 name = "light-macros"
 version = "0.3.1"
 dependencies = [
@@ -1560,9 +1556,9 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "getrandom 0.2.10",
- "light-byteutils",
  "light-macros",
  "light-merkle-tree",
+ "light-utils",
  "solana-security-txt",
  "spl-token",
 ]
@@ -1594,6 +1590,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-utils"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
 name = "light-verifier-sdk"
 version = "0.3.1"
 dependencies = [
@@ -1606,9 +1609,9 @@ dependencies = [
  "ark-std 0.3.0",
  "borsh 0.9.3",
  "groth16-solana",
- "light-byteutils",
  "light-merkle-tree",
  "light-merkle-tree-program",
+ "light-utils",
  "spl-token",
 ]
 

--- a/psp-examples/swap/Cargo.lock
+++ b/psp-examples/swap/Cargo.lock
@@ -1516,10 +1516,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "light-byteutils"
-version = "0.1.0"
-
-[[package]]
 name = "light-macros"
 version = "0.3.1"
 dependencies = [
@@ -1561,9 +1557,9 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "getrandom 0.2.10",
- "light-byteutils",
  "light-macros",
  "light-merkle-tree",
+ "light-utils",
  "solana-security-txt",
  "spl-token",
 ]
@@ -1595,6 +1591,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-utils"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
 name = "light-verifier-sdk"
 version = "0.3.1"
 dependencies = [
@@ -1607,9 +1610,9 @@ dependencies = [
  "ark-std 0.3.0",
  "borsh 0.9.3",
  "groth16-solana",
- "light-byteutils",
  "light-merkle-tree",
  "light-merkle-tree-program",
+ "light-utils",
  "spl-token",
 ]
 

--- a/relayer/tests/browser_test.ts
+++ b/relayer/tests/browser_test.ts
@@ -38,6 +38,11 @@ describe("Browser tests", () => {
   const connection = new Connection(RPC_URL, "confirmed");
 
   before(async () => {
+    // Enable atomic transactions if they weren't explicitly disabled.
+    if (process.env.LIGHT_PROTOCOL_ATOMIC_TRANSACTIONS !== "false") {
+      process.env.LIGHT_PROTOCOL_ATOMIC_TRANSACTIONS = "true";
+    }
+
     poseidon = await circomlibjs.buildPoseidonOpt();
 
     await createTestAccounts(connection);

--- a/relayer/tests/functional_test.ts
+++ b/relayer/tests/functional_test.ts
@@ -59,6 +59,10 @@ describe("API tests", () => {
   before(async () => {
     process.env.ANCHOR_WALLET = process.env.HOME + "/.config/solana/id.json";
     process.env.ANCHOR_PROVIDER_URL = "http://127.0.0.1:8899";
+    // Enable atomic transactions if they weren't explicitly disabled.
+    if (process.env.LIGHT_PROTOCOL_ATOMIC_TRANSACTIONS !== "false") {
+      process.env.LIGHT_PROTOCOL_ATOMIC_TRANSACTIONS = "true";
+    }
     anchorProvider = AnchorProvider.local(
       "http://127.0.0.1:8899",
       confirmConfig,

--- a/relayer/tests/runTestCli.sh
+++ b/relayer/tests/runTestCli.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env sh
 set -eux
+
 if [ ! -f ".env" ]
 then
     cp .env.example .env
 fi
+
+if [ -z "${LIGHT_PROTOCOL_ATOMIC_TRANSACTIONS+x}" ] || \
+    [ "$LIGHT_PROTOCOL_ATOMIC_TRANSACTIONS" != "false" ]; then
+    export LIGHT_PROTOCOL_ATOMIC_TRANSACTIONS="true"
+fi
+ 
 mkdir -p .logs
 echo "starting redis server"
 redis-server > .logs/redis-logs.txt &

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -246,6 +246,11 @@ download_file_github \
     macro-circom \
     "${PREFIX}/bin"
 
+echo "📦 Installing pnpm dependencies"
+pnpm install
+
+echo "📦 Installing Playwright"
+pnpm exec playwright install
 
 if [ "$ENABLE_REDIS" = true ] ; then
     echo "📥 Downloading Redis"

--- a/scripts/test-atomic-tx.sh
+++ b/scripts/test-atomic-tx.sh
@@ -4,4 +4,5 @@ set -e
 export LIGHT_PROTOCOL_ATOMIC_TRANSACTIONS=true
 
 npx nx build @lightprotocol/programs --skip-nx-cache
+npx nx build @lightprotocol/cli --skip-nx-cache
 $(dirname $0)/test.sh

--- a/scripts/test-atomic-tx.sh
+++ b/scripts/test-atomic-tx.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -e
+
+export LIGHT_PROTOCOL_ATOMIC_TRANSACTIONS=true
+
+npx nx build @lightprotocol/programs --skip-nx-cache
+$(dirname $0)/test.sh

--- a/scripts/test-no-atomic-tx.sh
+++ b/scripts/test-no-atomic-tx.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -e
+
+export LIGHT_PROTOCOL_ATOMIC_TRANSACTIONS=false
+
+npx nx build @lightprotocol/programs --skip-nx-cache
+$(dirname $0)/test.sh

--- a/scripts/test-no-atomic-tx.sh
+++ b/scripts/test-no-atomic-tx.sh
@@ -4,4 +4,6 @@ set -e
 export LIGHT_PROTOCOL_ATOMIC_TRANSACTIONS=false
 
 npx nx build @lightprotocol/programs --skip-nx-cache
+npx nx build @lightprotocol/cli --skip-nx-cache
+npx nx run --project @lightprotocol/zk.js test-sp-merkle-tree-legacy
 $(dirname $0)/test.sh


### PR DESCRIPTION
pnpm is not aware of Rust features and there is no sane way to tell pnpm or nx to rebuild program without "atomic-transactions" feature.

However, we can try to distinguish the caches.