### PR TITLE
fix: update source path in copy-circuits.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ node_modules
 **/target/
 
 **/.pnpm-store/
+/web/webapp/public/build-circuits

--- a/web/webapp/copy-circuits.sh
+++ b/web/webapp/copy-circuits.sh
@@ -3,7 +3,7 @@ set -eux
 
 echo "ensure that all node_modules are installed before running copy-circuits!"
 
-SOURCE="./node_modules/@lightprotocol/zk.js/build-circuits/"
+SOURCE="./node_modules/@lightprotocol/zk.js/build-circuits"
 DESTINATION="./public/"
 cp -LR "$SOURCE" "$DESTINATION"
 sync "$DESTINATION"


### PR DESCRIPTION
• webapp expect existence of `public/build-circuits/` path. If we enable -R flag for `cp`, and source_file for `cp` ends in a /, the contents of the directory are copied rather than the directory itself. This is not what we expect. 
• .gitignore updated, /web/webapp/public/build-circuits included.