### PR TITLE
chore: Add "LIGHT_PROTOCOL_ATOMIC_TRANSACTIONS" to build inputs in nx.json.

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -12,7 +12,7 @@
   },
   "targetDefaults": {
     "build": {
-      "inputs": ["noMarkdown", "^noMarkdown"],
+      "inputs": ["noMarkdown", "^noMarkdown", { "env": "LIGHT_PROTOCOL_ATOMIC_TRANSACTIONS"}],
       "dependsOn": ["^build"]
     },
     "test": {


### PR DESCRIPTION
Ignore nx on LIGHT_PROTOCOL_ATOMIC_TRANSACTIONS env change.
https://nx.dev/recipes/running-tasks/customizing-inputs#include-environment-variables-in-cache-hash