### PR TITLE
refactor(zk.js): account - prefix hash derivation

### DIFF
--- a/psp-examples/streaming-payments/Cargo.lock
+++ b/psp-examples/streaming-payments/Cargo.lock
@@ -1515,6 +1515,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-hasher"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "ark-bn254 0.4.0",
+ "light-poseidon",
+ "thiserror",
+]
+
+[[package]]
 name = "light-macros"
 version = "0.3.1"
 dependencies = [
@@ -1522,17 +1532,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "light-merkle-tree"
-version = "0.1.1"
-dependencies = [
- "anchor-lang",
- "ark-bn254 0.4.0",
- "bytemuck",
- "light-poseidon",
- "thiserror",
 ]
 
 [[package]]
@@ -1556,8 +1555,9 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "getrandom 0.2.10",
+ "light-hasher",
  "light-macros",
- "light-merkle-tree",
+ "light-sparse-merkle-tree",
  "light-utils",
  "solana-security-txt",
  "spl-token",
@@ -1590,6 +1590,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-sparse-merkle-tree"
+version = "0.1.1"
+dependencies = [
+ "anchor-lang",
+ "bytemuck",
+ "light-hasher",
+ "thiserror",
+]
+
+[[package]]
 name = "light-utils"
 version = "0.1.0"
 dependencies = [
@@ -1609,8 +1619,8 @@ dependencies = [
  "ark-std 0.3.0",
  "borsh 0.9.3",
  "groth16-solana",
- "light-merkle-tree",
  "light-merkle-tree-program",
+ "light-sparse-merkle-tree",
  "light-utils",
  "spl-token",
 ]

--- a/psp-examples/swap/Cargo.lock
+++ b/psp-examples/swap/Cargo.lock
@@ -1516,6 +1516,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-hasher"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "ark-bn254 0.4.0",
+ "light-poseidon",
+ "thiserror",
+]
+
+[[package]]
 name = "light-macros"
 version = "0.3.1"
 dependencies = [
@@ -1523,17 +1533,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "light-merkle-tree"
-version = "0.1.1"
-dependencies = [
- "anchor-lang",
- "ark-bn254 0.4.0",
- "bytemuck",
- "light-poseidon",
- "thiserror",
 ]
 
 [[package]]
@@ -1557,8 +1556,9 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "getrandom 0.2.10",
+ "light-hasher",
  "light-macros",
- "light-merkle-tree",
+ "light-sparse-merkle-tree",
  "light-utils",
  "solana-security-txt",
  "spl-token",
@@ -1591,6 +1591,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-sparse-merkle-tree"
+version = "0.1.1"
+dependencies = [
+ "anchor-lang",
+ "bytemuck",
+ "light-hasher",
+ "thiserror",
+]
+
+[[package]]
 name = "light-utils"
 version = "0.1.0"
 dependencies = [
@@ -1610,8 +1620,8 @@ dependencies = [
  "ark-std 0.3.0",
  "borsh 0.9.3",
  "groth16-solana",
- "light-merkle-tree",
  "light-merkle-tree-program",
+ "light-sparse-merkle-tree",
  "light-utils",
  "spl-token",
 ]

--- a/zk.js/src/wallet/buildBalance.ts
+++ b/zk.js/src/wallet/buildBalance.ts
@@ -198,29 +198,17 @@ export async function decryptAddUtxoToBalance({
   assetLookupTable: string[];
   merkleProof: string[];
 }): Promise<void> {
-  const decryptedUtxo = aes
-    ? await Utxo.decrypt({
-        hasher,
-        encBytes: encBytes,
-        account: account,
-        index: index,
-        commitment,
-        aes,
-        merkleTreePdaPublicKey,
-        assetLookupTable,
-        merkleProof,
-      })
-    : await Utxo.decryptUnchecked({
-        hasher,
-        encBytes: encBytes,
-        account: account,
-        index: index,
-        commitment,
-        aes,
-        merkleTreePdaPublicKey,
-        assetLookupTable,
-        merkleProof,
-      });
+  const decryptedUtxo = await Utxo.decryptUnchecked({
+    hasher,
+    encBytes: encBytes,
+    account: account,
+    index: index,
+    commitment,
+    aes,
+    merkleTreePdaPublicKey,
+    assetLookupTable,
+    merkleProof,
+  });
 
   // null if utxo did not decrypt -> return nothing and continue
   if (!decryptedUtxo.value || decryptedUtxo.error) return;

--- a/zk.js/src/wallet/user.ts
+++ b/zk.js/src/wallet/user.ts
@@ -1570,41 +1570,22 @@ export class User {
         let index = data.firstLeafIndex.toNumber();
         for (const [, leaf] of data.leaves.entries()) {
           try {
-            if (aes) {
-              decryptedUtxo = await Utxo.decrypt({
-                hasher: this.provider.hasher,
-                account: this.account,
-                encBytes: Uint8Array.from(data.message),
-                appDataIdl: idl,
-                aes: true,
-                index: index,
-                commitment: Uint8Array.from(leaf),
-                merkleTreePdaPublicKey:
-                  MerkleTreeConfig.getTransactionMerkleTreePda(),
-                compressed: false,
-                assetLookupTable,
-                merkleProof:
-                  this.provider.solMerkleTree!.merkleTree.path(index)
-                    .pathElements,
-              });
-            } else {
-              decryptedUtxo = await Utxo.decryptUnchecked({
-                hasher: this.provider.hasher,
-                account: this.account,
-                encBytes: Uint8Array.from(data.message),
-                appDataIdl: idl,
-                aes: false,
-                index: index,
-                commitment: Uint8Array.from(leaf),
-                merkleTreePdaPublicKey:
-                  MerkleTreeConfig.getTransactionMerkleTreePda(),
-                compressed: false,
-                assetLookupTable,
-                merkleProof:
-                  this.provider.solMerkleTree!.merkleTree.path(index)
-                    .pathElements,
-              });
-            }
+            decryptedUtxo = await Utxo.decryptUnchecked({
+              hasher: this.provider.hasher,
+              account: this.account,
+              encBytes: Uint8Array.from(data.message),
+              appDataIdl: idl,
+              aes,
+              index: index,
+              commitment: Uint8Array.from(leaf),
+              merkleTreePdaPublicKey:
+                MerkleTreeConfig.getTransactionMerkleTreePda(),
+              compressed: false,
+              assetLookupTable,
+              merkleProof:
+                this.provider.solMerkleTree!.merkleTree.path(index)
+                  .pathElements,
+            });
 
             if (decryptedUtxo.value) {
               const utxo = decryptedUtxo.value;

--- a/zk.js/tests/account.test.ts
+++ b/zk.js/tests/account.test.ts
@@ -6,6 +6,9 @@ import {
   AccountError,
   AccountErrorCode,
   ADMIN_AUTH_KEYPAIR,
+  BN_0,
+  BN_1,
+  MerkleTreeConfig,
   newNonce,
   useWallet,
 } from "../src";
@@ -369,24 +372,47 @@ describe("Test Account Functional", () => {
   });
 
   it("Should correctly generate UTXO prefix hash", () => {
-    const commitmentHash = new Uint8Array(32).fill(1);
     const prefixLength = 4;
-    const expectedOutput: Uint8Array = new Uint8Array([55, 154, 4, 63]);
+    const expectedOutput: Uint8Array = new Uint8Array([240, 73, 165, 83]);
     const currentOutput = k0.generateUtxoPrefixHash(
-      commitmentHash,
+      MerkleTreeConfig.getTransactionMerkleTreePda(),
+      BN_0,
       prefixLength,
       hasher,
     );
-    return expect(currentOutput).to.eql(expectedOutput);
+    expect(currentOutput).to.eql(expectedOutput);
+
+    const currentOutput1 = k0.generateUtxoPrefixHash(
+      MerkleTreeConfig.getTransactionMerkleTreePda(),
+      BN_1,
+      prefixLength,
+      hasher,
+    );
+    expect(currentOutput1).to.not.eq(expectedOutput);
+
+    const currentOutput0 = k0.generateLatestUtxoPrefixHash(
+      MerkleTreeConfig.getTransactionMerkleTreePda(),
+      prefixLength,
+      hasher,
+    );
+    expect(currentOutput).to.eql(currentOutput0);
+    expect(k0.prefixCounter.toString()).to.eql("1");
+
+    const currentOutputLatest1 = k0.generateLatestUtxoPrefixHash(
+      MerkleTreeConfig.getTransactionMerkleTreePda(),
+      prefixLength,
+      hasher,
+    );
+    expect(currentOutput1).to.deep.eq(currentOutputLatest1);
   });
 
   it("Should fail UTXO prefix hash generation test for wrong expected output", () => {
-    const commitmentHash = new Uint8Array(32).fill(1);
-    const prefix_length = 4;
+    const prefixLength = 4;
     const incorrectExpectedOutput: Uint8Array = new Uint8Array([1, 2, 3, 4]);
     const currentOutput = k0.generateUtxoPrefixHash(
-      commitmentHash,
-      prefix_length,
+      MerkleTreeConfig.getTransactionMerkleTreePda(),
+      BN_0,
+      prefixLength,
       hasher,
     );
     return expect(currentOutput).to.not.eql(incorrectExpectedOutput);

--- a/zk.js/tests/balance.test.ts
+++ b/zk.js/tests/balance.test.ts
@@ -165,7 +165,7 @@ describe("Utxo Functional", () => {
                 UTXO_PREFIX_LENGTH,
             ),
           );
-          let decryptedUtxo = await Utxo.decrypt({
+          let decryptedUtxo = await Utxo.decryptUnchecked({
             hasher,
             encBytes,
             account,
@@ -175,6 +175,7 @@ describe("Utxo Functional", () => {
             merkleTreePdaPublicKey:
               MerkleTreeConfig.getTransactionMerkleTreePda(),
             assetLookupTable,
+            merkleProof: [],
           });
           assert(decryptedUtxo.error === null, "Can't decrypt utxo");
           if (decryptedUtxo.value !== null) {
@@ -190,7 +191,7 @@ describe("Utxo Functional", () => {
                 UTXO_PREFIX_LENGTH,
             ),
           );
-          decryptedUtxo = await Utxo.decrypt({
+          decryptedUtxo = await Utxo.decryptUnchecked({
             hasher,
             encBytes,
             account,
@@ -200,6 +201,7 @@ describe("Utxo Functional", () => {
             merkleTreePdaPublicKey:
               MerkleTreeConfig.getTransactionMerkleTreePda(),
             assetLookupTable,
+            merkleProof: [],
           });
           assert(decryptedUtxo.error === null, "Can't decrypt utxo");
           if (decryptedUtxo.value !== null) {


### PR DESCRIPTION
### Issue:
- for rpc refactor we need to be able to compute prefixes without knowledge of the commitment hash of a utxo

### Changes:
- account.ts
  - add prefixCounter - to keep track of the latest derived prefix hash
  - remove commitment hash from prefix hash derivation
  - add merkle tree public key to prefix hash derivation
- utxo.ts
  - remove prefix check and checked decryption
- replace decrypt with decryptUnchecked