### PR TITLE
ci: Detect uncommited changes after build

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -67,3 +67,20 @@ runs:
         solana-keygen new --no-bip39-passphrase -o /home/runner/.config/solana/id.json
         npx nx build @lightprotocol/account.rs
         npx nx build @lightprotocol/cli
+
+    - name: Check for git changes
+      shell: bash
+      run: |
+        # Check for unstaged changes
+        if ! git diff --quiet; then
+          echo "There are unstaged changes after build!"
+          exit 1
+        fi
+
+        # Check for uncommitted changes
+        if ! git diff --staged --quiet; then
+          echo "There are uncommitted changes after build!"
+          exit 1
+        fi
+
+        echo "No changes detected."

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,10 +99,6 @@ importers:
         specifier: ^0.34.6
         version: 0.34.6(@vitest/browser@0.34.6)(playwright@1.40.1)
 
-  account.rs/src/main/wasm: {}
-
-  account.rs/src/main/wasm-simd: {}
-
   circuit-lib/circuit-lib.circom:
     devDependencies:
       '@coral-xyz/anchor':
@@ -849,58 +845,6 @@ importers:
       typescript:
         specifier: 5.3.2
         version: 5.3.2
-
-  psp-examples/tmp-test-psp:
-    dependencies:
-      '@coral-xyz/anchor':
-        specifier: ^0.28.0
-        version: 0.28.0
-      '@lightprotocol/account.rs':
-        specifier: workspace:*
-        version: link:../../account.rs
-      '@lightprotocol/circuit-lib.circom':
-        specifier: workspace:*
-        version: link:../../circuit-lib/circuit-lib.circom
-      '@lightprotocol/prover.js':
-        specifier: workspace:*
-        version: link:../../prover.js
-      '@lightprotocol/zk.js':
-        specifier: workspace:*
-        version: link:../../zk.js
-      '@project-serum/anchor':
-        specifier: ^0.26.0
-        version: 0.26.0
-      circomlib:
-        specifier: ^2.0.5
-        version: 2.0.5
-      circomlibjs:
-        specifier: ^0.1.7
-        version: 0.1.7
-    devDependencies:
-      '@types/bn.js':
-        specifier: ^5.1.0
-        version: 5.1.2
-      '@types/chai':
-        specifier: ^4.3.0
-        version: 4.3.9
-      '@types/mocha':
-        specifier: ^9.0.0
-        version: 9.1.1
-      chai:
-        specifier: ^4.3.4
-        version: 4.3.10
-      mocha:
-        specifier: ^9.0.3
-        version: 9.2.2
-      prettier:
-        specifier: ^2.6.2
-        version: 2.8.8
-      ts-mocha:
-        specifier: ^10.0.0
-        version: 10.0.0(mocha@9.2.2)
-      typescript:
-        specifier: ^4.3.5
-        version: 4.9.5
 
   relayer:
     dependencies:
@@ -5966,10 +5910,6 @@ packages:
     resolution: {integrity: sha512-RsOPImTriV/OE4A9qKjMtk2MnXiuLLbcO3nCXK+kvq4nr0iMfFgpjaX3MPLb6f7+EL1FGSelYvuJMV6REH+ZPQ==}
     dev: true
 
-  /@types/mocha@9.1.1:
-    resolution: {integrity: sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==}
-    dev: true
-
   /@types/node-fetch@2.6.6:
     resolution: {integrity: sha512-95X8guJYhfqiuVVhRFxVQcf4hW/2bCuoPwDasMf/531STFoNoWTT7YDnWdXHEZKqAGUigmpG31r2FE70LwnzJw==}
     dependencies:
@@ -6363,10 +6303,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.7.4
       eslint-visitor-keys: 3.4.3
-
-  /@ungap/promise-all-settled@1.1.2:
-    resolution: {integrity: sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==}
-    dev: true
 
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
@@ -8264,19 +8200,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
-      supports-color: 8.1.1
-    dev: true
-
-  /debug@4.3.3(supports-color@8.1.1):
-    resolution: {integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
       supports-color: 8.1.1
     dev: true
 
@@ -10405,11 +10328,6 @@ packages:
   /grouped-queue@2.0.0:
     resolution: {integrity: sha512-/PiFUa7WIsl48dUeCvhIHnwNmAAzlI/eHoJl0vu3nsFA366JleY7Ff8EVTplZu5kO0MIdZjKTTnzItL61ahbnw==}
     engines: {node: '>=8.0.0'}
-    dev: true
-
-  /growl@1.10.5:
-    resolution: {integrity: sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==}
-    engines: {node: '>=4.x'}
     dev: true
 
   /has-bigints@1.0.2:
@@ -12740,13 +12658,6 @@ packages:
     dependencies:
       brace-expansion: 1.1.11
 
-  /minimatch@4.2.1:
-    resolution: {integrity: sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==}
-    engines: {node: '>=10'}
-    dependencies:
-      brace-expansion: 1.1.11
-    dev: true
-
   /minimatch@5.0.1:
     resolution: {integrity: sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==}
     engines: {node: '>=10'}
@@ -12931,37 +12842,6 @@ packages:
       yargs-parser: 20.2.4
       yargs-unparser: 2.0.0
 
-  /mocha@9.2.2:
-    resolution: {integrity: sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==}
-    engines: {node: '>= 12.0.0'}
-    hasBin: true
-    dependencies:
-      '@ungap/promise-all-settled': 1.1.2
-      ansi-colors: 4.1.1
-      browser-stdout: 1.3.1
-      chokidar: 3.5.3
-      debug: 4.3.3(supports-color@8.1.1)
-      diff: 5.0.0
-      escape-string-regexp: 4.0.0
-      find-up: 5.0.0
-      glob: 7.2.0
-      growl: 1.10.5
-      he: 1.2.0
-      js-yaml: 4.1.0
-      log-symbols: 4.1.0
-      minimatch: 4.2.1
-      ms: 2.1.3
-      nanoid: 3.3.1
-      serialize-javascript: 6.0.0
-      strip-json-comments: 3.1.1
-      supports-color: 8.1.1
-      which: 2.0.2
-      workerpool: 6.2.0
-      yargs: 16.2.0
-      yargs-parser: 20.2.4
-      yargs-unparser: 2.0.0
-    dev: true
-
   /mock-stdin@1.0.0:
     resolution: {integrity: sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==}
     dev: true
@@ -13034,12 +12914,6 @@ packages:
 
   /nanoassert@2.0.0:
     resolution: {integrity: sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==}
-
-  /nanoid@3.3.1:
-    resolution: {integrity: sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-    dev: true
 
   /nanoid@3.3.3:
     resolution: {integrity: sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==}
@@ -14227,12 +14101,6 @@ packages:
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
-
-  /prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    dev: true
 
   /prettier@3.0.3:
     resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
@@ -16129,19 +15997,6 @@ packages:
     optionalDependencies:
       tsconfig-paths: 3.14.2
 
-  /ts-mocha@10.0.0(mocha@9.2.2):
-    resolution: {integrity: sha512-VRfgDO+iiuJFlNB18tzOfypJ21xn2xbuZyDvJvqpTbWgkAgD17ONGr8t+Tl8rcBtOBdjXp5e/Rk+d39f7XBHRw==}
-    engines: {node: '>= 6.X.X'}
-    hasBin: true
-    peerDependencies:
-      mocha: ^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X
-    dependencies:
-      mocha: 9.2.2
-      ts-node: 7.0.1
-    optionalDependencies:
-      tsconfig-paths: 3.14.2
-    dev: true
-
   /ts-node@10.9.1(@types/node@20.10.3)(typescript@5.3.2):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
@@ -16374,12 +16229,6 @@ packages:
 
   /typescript-collections@1.3.3:
     resolution: {integrity: sha512-7sI4e/bZijOzyURng88oOFZCISQPTHozfE2sUu5AviFYk5QV7fYGb6YiDl+vKjF/pICA354JImBImL9XJWUvdQ==}
-
-  /typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: true
 
   /typescript@5.3.2:
     resolution: {integrity: sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==}
@@ -17050,10 +16899,6 @@ packages:
 
   /wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
-
-  /workerpool@6.2.0:
-    resolution: {integrity: sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==}
-    dev: true
 
   /workerpool@6.2.1:
     resolution: {integrity: sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==}

--- a/zk.js/src/idls/light_psp2in2out.ts
+++ b/zk.js/src/idls/light_psp2in2out.ts
@@ -271,50 +271,6 @@ export type LightPsp2in2out = {
       }
     },
     {
-      "name": "transactionParameters",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "message",
-            "type": "bytes"
-          },
-          {
-            "name": "inputUtxosBytes",
-            "type": {
-              "vec": "bytes"
-            }
-          },
-          {
-            "name": "outputUtxosBytes",
-            "type": {
-              "vec": "bytes"
-            }
-          },
-          {
-            "name": "recipientSpl",
-            "type": "publicKey"
-          },
-          {
-            "name": "recipientSol",
-            "type": "publicKey"
-          },
-          {
-            "name": "relayerPubkey",
-            "type": "publicKey"
-          },
-          {
-            "name": "relayerFee",
-            "type": "u64"
-          },
-          {
-            "name": "transactionNonce",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
       "name": "zKtransactionMasp2MainProofInputs",
       "type": {
         "kind": "struct",
@@ -954,50 +910,6 @@ export const IDL: LightPsp2in2out = {
                 32
               ]
             }
-          }
-        ]
-      }
-    },
-    {
-      "name": "transactionParameters",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "message",
-            "type": "bytes"
-          },
-          {
-            "name": "inputUtxosBytes",
-            "type": {
-              "vec": "bytes"
-            }
-          },
-          {
-            "name": "outputUtxosBytes",
-            "type": {
-              "vec": "bytes"
-            }
-          },
-          {
-            "name": "recipientSpl",
-            "type": "publicKey"
-          },
-          {
-            "name": "recipientSol",
-            "type": "publicKey"
-          },
-          {
-            "name": "relayerPubkey",
-            "type": "publicKey"
-          },
-          {
-            "name": "relayerFee",
-            "type": "u64"
-          },
-          {
-            "name": "transactionNonce",
-            "type": "u64"
           }
         ]
       }


### PR DESCRIPTION
If there are any dirty, uncommited changes after build, it means that some autogenerated file (IDL, lock files of Cargo or pnpm etc.) was not commited, even though it should've been. Detect such changes in CI.