### PR TITLE
feat: Add concurrent Merkle tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "bs58 0.5.0",
  "console_error_panic_hook",
  "crypto_box",
+ "getrandom 0.2.10",
  "hex",
  "js-sys",
  "light-poseidon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2701,9 +2701,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libm"
@@ -2757,6 +2757,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
 dependencies = [
  "libsecp256k1-core",
+]
+
+[[package]]
+name = "light-concurrent-merkle-tree"
+version = "0.1.0"
+dependencies = [
+ "ark-bn254 0.4.0",
+ "ark-ff 0.4.2",
+ "light-hasher",
+ "light-merkle-tree-reference",
+ "rand 0.8.5",
+ "spl-concurrent-merkle-tree",
+ "tokio",
 ]
 
 [[package]]
@@ -3075,9 +3088,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -4471,9 +4484,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -5533,6 +5546,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-concurrent-merkle-tree"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "141eaea58588beae81b71d101373a53f096737739873de42d6b1368bc2b8fc30"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "thiserror",
+]
+
+[[package]]
 name = "spl-memo"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5902,9 +5926,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5914,16 +5938,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2 1.0.68",
  "quote 1.0.33",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ name = "account-wasm"
 version = "0.1.0"
 dependencies = [
  "aes-gcm-siv",
+ "ahash 0.8.6",
  "ark-bn254 0.4.0",
  "ark-ff 0.4.2",
  "blake2b_simd",
@@ -97,14 +98,15 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.10",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2322,7 +2324,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
 ]
 
 [[package]]
@@ -2798,6 +2800,7 @@ dependencies = [
 name = "light-merkle-tree-program"
 version = "0.3.1"
 dependencies = [
+ "ahash 0.8.6",
  "aligned-sized",
  "anchor-lang",
  "anchor-spl",
@@ -2851,6 +2854,7 @@ dependencies = [
 name = "light-psp10in2out"
 version = "0.3.1"
 dependencies = [
+ "ahash 0.8.6",
  "anchor-lang",
  "anchor-spl",
  "groth16-solana",
@@ -2864,6 +2868,7 @@ dependencies = [
 name = "light-psp2in2out"
 version = "0.3.1"
 dependencies = [
+ "ahash 0.8.6",
  "anchor-lang",
  "anchor-spl",
  "groth16-solana",
@@ -2877,6 +2882,7 @@ dependencies = [
 name = "light-psp2in2out-storage"
 version = "0.3.1"
 dependencies = [
+ "ahash 0.8.6",
  "aligned-sized",
  "anchor-lang",
  "anchor-spl",
@@ -2890,6 +2896,7 @@ dependencies = [
 name = "light-psp4in4out-app-storage"
 version = "0.3.1"
 dependencies = [
+ "ahash 0.8.6",
  "anchor-lang",
  "anchor-spl",
  "bytemuck",
@@ -2915,6 +2922,7 @@ dependencies = [
 name = "light-user-registry"
 version = "0.3.0"
 dependencies = [
+ "ahash 0.8.6",
  "aligned-sized",
  "anchor-lang",
  "bytemuck",
@@ -4722,7 +4730,7 @@ version = "1.16.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361cc834e5fbbe1a73f1d904fcb8ab052a665e5be6061bd1ba7ab478d7d17c9c"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
  "blake3",
  "block-buffer 0.10.4",
  "bs58 0.4.0",
@@ -4838,7 +4846,7 @@ version = "1.16.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4d44a4998ba6d9b37e89399d9ce2812e84489dd4665df619fb23366e1c2ec1b"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
  "bincode",
  "bv",
  "caps",
@@ -6789,6 +6797,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/account.rs/src/wasm/Cargo.toml
+++ b/account.rs/src/wasm/Cargo.toml
@@ -24,6 +24,7 @@ zeroize = { version = "1.3", default-features = false }
 num-bigint = "0.4.4"
 num-traits = "0.2"
 console_error_panic_hook = "0.1.7"
+getrandom = { version = "0.2", features = ["js"] }
 
 # TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
 ahash = "=0.8.6"

--- a/account.rs/src/wasm/Cargo.toml
+++ b/account.rs/src/wasm/Cargo.toml
@@ -25,5 +25,8 @@ num-bigint = "0.4.4"
 num-traits = "0.2"
 console_error_panic_hook = "0.1.7"
 
+# TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
+ahash = "=0.8.6"
+
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/merkle-tree/concurrent/Cargo.toml
+++ b/merkle-tree/concurrent/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "light-concurrent-merkle-tree"
+version = "0.1.0"
+edition = "2021"
+description = "Concurrent Merkle tree implementation"
+license = "Apache-2.0"
+
+[dependencies]
+light-hasher = { path = "../hasher", version = "0.1.0" }
+
+[dev-dependencies]
+ark-bn254 = "0.4"
+ark-ff = "0.4"
+light-merkle-tree-reference = { path = "../reference", version = "0.1.0" }
+rand = "0.8"
+spl-concurrent-merkle-tree = "0.2.0"
+tokio = { version = "1.35", features = ["full"] }

--- a/merkle-tree/concurrent/src/changelog.rs
+++ b/merkle-tree/concurrent/src/changelog.rs
@@ -1,0 +1,27 @@
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(C)]
+pub struct ChangelogEntry<const MAX_HEIGHT: usize> {
+    /// Root.
+    pub root: [u8; 32],
+    // Path of the changelog.
+    pub path: [[u8; 32]; MAX_HEIGHT],
+    // Index.
+    pub index: u64,
+}
+
+impl<const MAX_HEIGHT: usize> Default for ChangelogEntry<MAX_HEIGHT> {
+    fn default() -> Self {
+        Self {
+            root: [0u8; 32],
+            path: [[0u8; 32]; MAX_HEIGHT],
+            index: 0,
+        }
+    }
+}
+
+impl<const MAX_HEIGHT: usize> ChangelogEntry<MAX_HEIGHT> {
+    pub fn new(root: [u8; 32], path: [[u8; 32]; MAX_HEIGHT], index: usize) -> Self {
+        let index = index as u64;
+        Self { root, path, index }
+    }
+}

--- a/merkle-tree/concurrent/src/hash.rs
+++ b/merkle-tree/concurrent/src/hash.rs
@@ -1,0 +1,57 @@
+use light_hasher::{errors::HasherError, Hasher};
+
+/// Returns the hash of the parent node based on the provided `node` (and its
+/// index `i_node`) and `sibling` (and its index `i_sibling`).
+pub fn compute_parent_node<H>(
+    leaf: &[u8; 32],
+    sibling: &[u8; 32],
+    leaf_index: usize,
+    sibling_index: usize,
+) -> Result<[u8; 32], HasherError>
+where
+    H: Hasher,
+{
+    let is_left = (leaf_index >> sibling_index) & 1 == 0;
+    if is_left {
+        H::hashv(&[leaf, sibling])
+    } else {
+        H::hashv(&[sibling, leaf])
+    }
+}
+
+/// Computes the root for the given `leaf` (with index `i`) and `proof`. It
+/// doesn't perform the validation of the provided `proof`.
+pub fn compute_root<H, const MAX_HEIGHT: usize>(
+    leaf: &[u8; 32],
+    leaf_index: usize,
+    proof: &[[u8; 32]; MAX_HEIGHT],
+) -> Result<[u8; 32], HasherError>
+where
+    H: Hasher,
+{
+    let mut leaf = *leaf;
+    for (j, sibling) in proof.iter().enumerate() {
+        leaf = compute_parent_node::<H>(&leaf, sibling, leaf_index, j)?;
+    }
+    Ok(leaf)
+}
+
+/// Checks whether the given Merkle `proof` for the given `node` (with index
+/// `i`) is valid. The proof is valid when computing parent node hashes using
+/// the whole path of the proof gives the same result as the given `root`.
+pub fn validate_proof<H, const MAX_HEIGHT: usize>(
+    root: &[u8; 32],
+    leaf: &[u8; 32],
+    leaf_index: usize,
+    proof: &[[u8; 32]; MAX_HEIGHT],
+) -> Result<(), HasherError>
+where
+    H: Hasher,
+{
+    let computed_root = compute_root::<H, MAX_HEIGHT>(leaf, leaf_index, proof)?;
+    if computed_root == *root {
+        Ok(())
+    } else {
+        Err(HasherError::InvalidProof)
+    }
+}

--- a/merkle-tree/concurrent/src/lib.rs
+++ b/merkle-tree/concurrent/src/lib.rs
@@ -1,0 +1,356 @@
+use std::{cmp::Ordering, marker::PhantomData};
+
+use light_hasher::{errors::HasherError, Hasher};
+
+pub mod changelog;
+pub mod hash;
+
+use crate::{
+    changelog::ChangelogEntry,
+    hash::{compute_parent_node, validate_proof},
+};
+
+/// [Concurrent Merkle tree](https://drive.google.com/file/d/1BOpa5OFmara50fTvL0VIVYjtg-qzHCVc/view)
+/// which allows for multiple requests of updating leaves, without making any
+/// of the requests invalid, as long as they are not:
+///
+/// * Modyfing the same leaf.
+/// * Exceeding the capacity of the `changelog` (`MAX_CHANGELOG`).
+///
+/// When any of the above happens, some of the concurrent requests are going to
+/// be invalid, forcing the clients to re-generate the Merkle proof. But that's
+/// still better than having such a failure after any update happening in the
+/// middle of requesting the update.
+///
+/// Due to ability to make a decent number of concurrent update requests to be
+/// valid, no lock is necessary.
+#[repr(C)]
+pub struct ConcurrentMerkleTree<
+    H,
+    const HEIGHT: usize,
+    const MAX_CHANGELOG: usize,
+    const MAX_ROOTS: usize,
+> where
+    H: Hasher,
+{
+    /// History of Merkle proofs.
+    pub changelog: [ChangelogEntry<HEIGHT>; MAX_CHANGELOG],
+    /// Index of the newest changelog.
+    pub current_changelog_index: u64,
+    /// History of roots.
+    pub roots: [[u8; 32]; MAX_ROOTS],
+    /// Index of the newest root.
+    pub current_root_index: u64,
+    /// The newest Merkle proof.
+    pub rightmost_proof: [[u8; 32]; HEIGHT],
+    /// Index of the newest non-empty leaf.
+    pub rightmost_index: u64,
+    /// The newest non-empty leaf.
+    pub rightmost_leaf: [u8; 32],
+
+    _hasher: PhantomData<H>,
+}
+
+impl<H, const MAX_HEIGHT: usize, const MAX_CHANGELOG: usize, const MAX_ROOTS: usize> Default
+    for ConcurrentMerkleTree<H, MAX_HEIGHT, MAX_CHANGELOG, MAX_ROOTS>
+where
+    H: Hasher,
+{
+    fn default() -> Self {
+        Self {
+            changelog: [ChangelogEntry::default(); MAX_CHANGELOG],
+            current_changelog_index: 0,
+            roots: [[0u8; 32]; MAX_ROOTS],
+            current_root_index: 0,
+            rightmost_proof: [[0u8; 32]; MAX_HEIGHT],
+            rightmost_index: 0,
+            rightmost_leaf: [0u8; 32],
+            _hasher: PhantomData,
+        }
+    }
+}
+
+impl<H, const MAX_HEIGHT: usize, const MAX_CHANGELOG: usize, const MAX_ROOTS: usize>
+    ConcurrentMerkleTree<H, MAX_HEIGHT, MAX_CHANGELOG, MAX_ROOTS>
+where
+    H: Hasher,
+{
+    /// Initializes the Merkle tree.
+    pub fn init(&mut self) -> Result<(), HasherError> {
+        // Initialize changelog.
+        let root = H::zero_bytes()[MAX_HEIGHT];
+        let mut changelog_path = [[0u8; 32]; MAX_HEIGHT];
+        for (i, node) in changelog_path.iter_mut().enumerate() {
+            *node = H::zero_bytes()[i];
+        }
+        let changelog_entry = ChangelogEntry::new(root, changelog_path, 0);
+        if let Some(changelog_element) = self.changelog.get_mut(0) {
+            *changelog_element = changelog_entry;
+        }
+
+        // Initialize root.
+        *self.roots.get_mut(0).ok_or(HasherError::RootsZero)? = root;
+
+        // Initialize rightmost proof.
+        for (i, node) in self.rightmost_proof.iter_mut().enumerate() {
+            *node = H::zero_bytes()[i];
+        }
+
+        Ok(())
+    }
+
+    /// Increments the changelog counter. If it reaches the limit, it starts
+    /// from the beginning.
+    fn inc_current_changelog_index(&mut self) {
+        // NOTE(vadorovsky): Apparenty, Rust doesn't have `checked_remainder`
+        // or anything like that.
+        self.current_changelog_index = if MAX_CHANGELOG > 0 {
+            (self.current_changelog_index + 1) % MAX_CHANGELOG as u64
+        } else {
+            0
+        };
+    }
+
+    /// Increments the root counter. If it reaches the limit, it starts from
+    /// the beginning.
+    fn inc_current_root_index(&mut self) {
+        self.current_root_index = (self.current_root_index + 1) % MAX_ROOTS as u64;
+    }
+
+    /// Returns the index of the current changelog entry.
+    pub fn changelog_index(&self) -> usize {
+        self.current_changelog_index as usize
+    }
+
+    /// Returns the index of the current root in the tree's root buffer.
+    pub fn root_index(&self) -> usize {
+        self.current_root_index as usize
+    }
+
+    /// Returns the current root.
+    pub fn root(&self) -> Result<[u8; 32], HasherError> {
+        self.roots
+            .get(self.current_root_index as usize)
+            .ok_or(HasherError::RootHigherThanMax)
+            .map(|&value| value)
+    }
+
+    /// Returns an intersection index in the changelog entry which affects the
+    ///
+    /// Determining it can be done by taking a XOR of the leaf index (which was
+    /// directly updated in the changelog entry) and the leaf index we are
+    /// trying to update.
+    ///
+    /// The number of bytes in the binary representations of the indexes is
+    /// determined by the height of the tree. For example, for the tree with
+    /// height 4, update attempt of leaf under index 2 and changelog affecting
+    /// index 4, critbit would be:
+    ///
+    /// 2 ^ 4 = 0b_0010 ^ 0b_0100 = 0b_0110 = 6
+    fn intersection_index(&self, leaf_index: usize, changelog_entry_index: usize) -> usize {
+        let padding = 64 - MAX_HEIGHT;
+        let common_path_len =
+            ((leaf_index ^ changelog_entry_index) << padding).leading_zeros() as usize;
+
+        (MAX_HEIGHT - 1) - common_path_len
+    }
+
+    /// Returns an updated Merkle proof.
+    ///
+    /// The update is performed by checking whether there are any new changelog
+    /// entries and whether they contain changes which affect the current
+    /// proof. To be precise, for each changelog entry, it's done in the
+    /// following steps:
+    ///
+    /// * Check if the changelog entry was directly updating the `leaf_index`
+    ///   we are trying to update.
+    ///   * If no (we check that condition first, since it's more likely),
+    ///     it means that there is a change affecting the proof, but not the
+    ///     leaf.
+    ///     Check which element from our proof was affected by the change
+    ///     (using the `critbit_index` method) and update it (copy the new
+    ///     element from the changelog to our updated proof).
+    ///   * If yes, it means that the same leaf we want to update was already
+    ///     updated. In such case, updating the proof is not possible and we
+    ///     return an error.
+    fn update_proof(
+        &self,
+        changelog_index: usize,
+        leaf_index: usize,
+        proof: &[[u8; 32]; MAX_HEIGHT],
+    ) -> Result<[[u8; 32]; MAX_HEIGHT], HasherError> {
+        let mut updated_proof = proof.to_owned();
+        let mut k = changelog_index;
+
+        while k != self.current_changelog_index as usize {
+            let changelog_entry = self.changelog[k];
+            let changelog_entry_index = changelog_entry.index as usize;
+            if leaf_index != changelog_entry_index {
+                let intersection_index = self.intersection_index(leaf_index, changelog_entry_index);
+                updated_proof[intersection_index] = changelog_entry.path[intersection_index];
+            } else {
+                return Err(HasherError::CannotUpdateLeaf);
+            }
+
+            k = (k + 1) % MAX_ROOTS;
+        }
+
+        Ok(updated_proof)
+    }
+
+    /// Updates the leaf under `leaf_index` with the `new_leaf` value.
+    ///
+    /// 1. Computes the new path and root from `new_leaf` and Merkle proof
+    ///    (`proof`).
+    /// 2. Stores the new path as the latest changelog entry and increments the
+    ///    latest changelog index.
+    /// 3. Stores the latest root and increments the latest root index.
+    /// 4. If new leaf is at the rightmost index, stores it as the new
+    ///    rightmost leaft and stores the Merkle proof as the new rightmost
+    ///    proof.
+    ///
+    /// # Validation
+    ///
+    /// This method doesn't validate the proof. Caller is responsible for
+    /// doing that before.
+    fn update_leaf_in_tree(
+        &mut self,
+        new_leaf: &[u8; 32],
+        leaf_index: usize,
+        proof: &[[u8; 32]; MAX_HEIGHT],
+    ) -> Result<(), HasherError> {
+        let mut node = *new_leaf;
+        let mut changelog_path = [[0u8; 32]; MAX_HEIGHT];
+
+        for (j, sibling) in proof.iter().enumerate() {
+            changelog_path[j] = node;
+            node = compute_parent_node::<H>(&node, sibling, leaf_index, j)?;
+        }
+
+        let changelog_entry = ChangelogEntry::new(node, changelog_path, leaf_index);
+        self.inc_current_changelog_index();
+        if let Some(changelog_element) = self
+            .changelog
+            .get_mut(self.current_changelog_index as usize)
+        {
+            *changelog_element = changelog_entry
+        }
+
+        self.inc_current_root_index();
+        *self
+            .roots
+            .get_mut(self.current_root_index as usize)
+            .ok_or(HasherError::RootsZero)? = node;
+
+        if self.rightmost_index > 0 && leaf_index == self.rightmost_index as usize - 1 {
+            self.rightmost_proof.copy_from_slice(proof);
+            self.rightmost_leaf = *new_leaf;
+        }
+
+        Ok(())
+    }
+
+    /// Replaces the `old_leaf` under the `leaf_index` with a `new_leaf`, using
+    /// the given `proof` and `changelog_index` (pointing to the changelog entry
+    /// which was the newest at the time of preparing the proof).
+    pub fn update(
+        &mut self,
+        changelog_index: usize,
+        old_leaf: &[u8; 32],
+        new_leaf: &[u8; 32],
+        leaf_index: usize,
+        proof: &[[u8; 32]; MAX_HEIGHT],
+    ) -> Result<(), HasherError> {
+        let updated_proof = self.update_proof(changelog_index, leaf_index, proof)?;
+
+        validate_proof::<H, MAX_HEIGHT>(
+            &self.roots[self.current_root_index as usize],
+            old_leaf,
+            leaf_index,
+            proof,
+        )?;
+        self.update_leaf_in_tree(new_leaf, leaf_index, &updated_proof)
+    }
+
+    /// Appends a new leaf to the tree.
+    pub fn append(&mut self, leaf: &[u8; 32]) -> Result<(), HasherError> {
+        if self.rightmost_index >= 1 << MAX_HEIGHT {
+            return Err(HasherError::TreeFull);
+        }
+
+        let mut changelog_path = [[0u8; 32]; MAX_HEIGHT];
+        let mut intersection_node = self.rightmost_leaf;
+        let intersection_index = self.rightmost_index.trailing_zeros() as usize;
+
+        if self.rightmost_index == 0 {
+            // NOTE(vadorovsky): This is not mentioned in the whitepaper, but
+            // appending to an empty Merkle tree is a special case, where
+            // `computer_parent_node` can't be called, because the usual
+            // `self.rightmost_index - 1` used as a sibling index would be a
+            //  negative value.
+            //
+            // [spl-concurrent-merkle-tree](https://github.com/solana-labs/solana-program-library/blob/da94833aa16d756aed49ee1a7aa295295b41d19a/libraries/concurrent-merkle-tree/src/concurrent_merkle_tree.rs#L263-L265)
+            // handles this case by:
+            //
+            // * Valitating a proof.
+            // * Performing procedures which usually are done by `replace_leaf`
+            //   algorithm.
+            //
+            // Here, we just call `update` directly, because we wrote it in a
+            // way which allows an "update" of the 1st leaf in the empty tree.
+            let proof = self.rightmost_proof;
+            self.update(0, &H::zero_bytes()[0], leaf, 0, &proof)?;
+        } else {
+            let mut current_node = *leaf;
+
+            for (i, item) in changelog_path.iter_mut().enumerate() {
+                *item = current_node;
+
+                match i.cmp(&intersection_index) {
+                    Ordering::Less => {
+                        let empty_node = H::zero_bytes()[i];
+                        current_node = H::hashv(&[&current_node, &empty_node])?;
+                        intersection_node = compute_parent_node::<H>(
+                            &intersection_node,
+                            &self.rightmost_proof[i],
+                            self.rightmost_index as usize - 1,
+                            i,
+                        )?;
+                        self.rightmost_proof[i] = empty_node;
+                    }
+                    Ordering::Equal => {
+                        current_node = H::hashv(&[&intersection_node, &current_node])?;
+                        self.rightmost_proof[i] = intersection_node;
+                    }
+                    Ordering::Greater => {
+                        current_node = compute_parent_node::<H>(
+                            &current_node,
+                            &self.rightmost_proof[i],
+                            self.rightmost_index as usize - 1,
+                            i,
+                        )?;
+                    }
+                }
+            }
+
+            self.inc_current_changelog_index();
+            if let Some(changelog_element) = self
+                .changelog
+                .get_mut(self.current_changelog_index as usize)
+            {
+                *changelog_element =
+                    ChangelogEntry::new(current_node, changelog_path, self.rightmost_index as usize)
+            }
+            self.inc_current_root_index();
+            *self
+                .roots
+                .get_mut(self.current_root_index as usize)
+                .ok_or(HasherError::RootsZero)? = current_node;
+        }
+
+        self.rightmost_index += 1;
+        self.rightmost_leaf = *leaf;
+
+        Ok(())
+    }
+}

--- a/merkle-tree/concurrent/tests/tests.rs
+++ b/merkle-tree/concurrent/tests/tests.rs
@@ -1,0 +1,734 @@
+use ark_bn254::Fr;
+use ark_ff::{BigInteger, PrimeField, UniformRand};
+use light_concurrent_merkle_tree::{changelog::ChangelogEntry, ConcurrentMerkleTree};
+use light_hasher::{errors::HasherError, Hasher, Keccak, Poseidon, Sha256};
+use rand::thread_rng;
+
+/// Tests whether append operations work as expected.
+fn append<H>()
+where
+    H: Hasher,
+{
+    const HEIGHT: usize = 4;
+    const CHANGELOG: usize = 32;
+    const ROOTS: usize = 256;
+
+    let mut merkle_tree = ConcurrentMerkleTree::<H, HEIGHT, CHANGELOG, ROOTS>::default();
+    merkle_tree.init().unwrap();
+
+    let leaf1 = H::hash(&[1u8; 32]).unwrap();
+
+    // The hash of our new leaf and its sibling (a zero value).
+    //
+    //    H1
+    //  /    \
+    // L1   Z[0]
+    let h1 = H::hashv(&[&leaf1, &H::zero_bytes()[0]]).unwrap();
+
+    // The hash of `h1` and its sibling (a subtree represented by `Z[1]`).
+    //
+    //          H2
+    //      /-/    \-\
+    //    H1          Z[1]
+    //  /    \      /      \
+    // L1   Z[0]   Z[0]   Z[0]
+    //
+    // `Z[1]` represents the whole subtree on the right from `h2`. In the next
+    // examples, we are just going to show empty subtrees instead of the whole
+    // hierarchy.
+    let h2 = H::hashv(&[&h1, &H::zero_bytes()[1]]).unwrap();
+
+    // The hash of `h3` and its sibling (a subtree represented by `Z[2]`).
+    //
+    //          H3
+    //        /    \
+    //       H2   Z[2]
+    //     /    \
+    //    H1   Z[1]
+    //  /    \
+    // L1   Z[0]
+    let h3 = H::hashv(&[&h2, &H::zero_bytes()[2]]).unwrap();
+
+    // The hash of `h4` and its sibling (a subtree represented by `Z[3]`),
+    // which is the root.
+    //
+    //              R
+    //           /     \
+    //          H3    Z[3]
+    //        /    \
+    //       H2   Z[2]
+    //     /    \
+    //    H1   Z[1]
+    //  /    \
+    // L1   Z[0]
+    let expected_root = H::hashv(&[&h3, &H::zero_bytes()[3]]).unwrap();
+    let expected_changelog_path = [leaf1, h1, h2, h3];
+    let expected_proof = [
+        H::zero_bytes()[0],
+        H::zero_bytes()[1],
+        H::zero_bytes()[2],
+        H::zero_bytes()[3],
+    ];
+
+    merkle_tree.append(&leaf1).unwrap();
+
+    assert_eq!(merkle_tree.changelog_index(), 1);
+    assert_eq!(
+        merkle_tree.changelog[merkle_tree.changelog_index()],
+        ChangelogEntry::<HEIGHT>::new(expected_root, expected_changelog_path, 0)
+    );
+    assert_eq!(merkle_tree.root().unwrap(), expected_root);
+    assert_eq!(merkle_tree.current_root_index, 1);
+    assert_eq!(merkle_tree.rightmost_proof, expected_proof);
+    assert_eq!(merkle_tree.rightmost_index, 1);
+    assert_eq!(merkle_tree.rightmost_leaf, leaf1);
+
+    // Appending the 2nd leaf should result in recomputing the root due to the
+    // change of the `h1`, which now is a hash of the two non-zero leafs. So
+    // when computing all hashes up to the root, we are still going to use
+    // zero bytes from 1 to 8.
+    //
+    // The other subtrees still remain the same.
+    //
+    //              R
+    //           /     \
+    //          H3    Z[3]
+    //        /    \
+    //       H2   Z[2]
+    //     /    \
+    //   H1    Z[1]
+    //  /  \
+    // L1  L2
+    let leaf2 = H::hash(&[2u8; 32]).unwrap();
+
+    let h1 = H::hashv(&[&leaf1, &leaf2]).unwrap();
+    let h2 = H::hashv(&[&h1, &H::zero_bytes()[1]]).unwrap();
+    let h3 = H::hashv(&[&h2, &H::zero_bytes()[2]]).unwrap();
+    let expected_root = H::hashv(&[&h3, &H::zero_bytes()[3]]).unwrap();
+    let expected_changelog_path = [leaf2, h1, h2, h3];
+    let expected_proof = [
+        leaf1,
+        H::zero_bytes()[1],
+        H::zero_bytes()[2],
+        H::zero_bytes()[3],
+    ];
+
+    merkle_tree.append(&leaf2).unwrap();
+
+    assert_eq!(merkle_tree.changelog_index(), 2);
+    assert_eq!(
+        merkle_tree.changelog[merkle_tree.changelog_index()],
+        ChangelogEntry::<HEIGHT>::new(expected_root, expected_changelog_path, 1),
+    );
+    assert_eq!(merkle_tree.root().unwrap(), expected_root);
+    assert_eq!(merkle_tree.current_root_index, 2);
+    assert_eq!(merkle_tree.rightmost_proof, expected_proof);
+    assert_eq!(merkle_tree.rightmost_index, 2);
+    assert_eq!(merkle_tree.rightmost_leaf, leaf2);
+
+    // Appending the 3rd leaf alters the next subtree on the right.
+    // Instead of using Z[1], we will end up with the hash of the new leaf and
+    // Z[0].
+    //
+    // The other subtrees still remain the same.
+    //
+    //               R
+    //            /     \
+    //           H4    Z[3]
+    //         /    \
+    //       H3    Z[2]
+    //     /    \
+    //   H1      H2
+    //  /  \    /  \
+    // L1  L2  L3  Z[0]
+    let leaf3 = H::hash(&[3u8; 32]).unwrap();
+
+    let h1 = H::hashv(&[&leaf1, &leaf2]).unwrap();
+    let h2 = H::hashv(&[&leaf3, &H::zero_bytes()[0]]).unwrap();
+    let h3 = H::hashv(&[&h1, &h2]).unwrap();
+    let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
+    let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    let expected_changelog_path = [leaf3, h2, h3, h4];
+    let expected_proof = [
+        H::zero_bytes()[0],
+        h1,
+        H::zero_bytes()[2],
+        H::zero_bytes()[3],
+    ];
+
+    merkle_tree.append(&leaf3).unwrap();
+
+    assert_eq!(merkle_tree.changelog_index(), 3);
+    assert_eq!(
+        merkle_tree.changelog[merkle_tree.changelog_index()],
+        ChangelogEntry::<HEIGHT>::new(expected_root, expected_changelog_path, 2),
+    );
+    assert_eq!(merkle_tree.root().unwrap(), expected_root);
+    assert_eq!(merkle_tree.current_root_index, 3);
+    assert_eq!(merkle_tree.rightmost_proof, expected_proof);
+    assert_eq!(merkle_tree.rightmost_index, 3);
+    assert_eq!(merkle_tree.rightmost_leaf, leaf3);
+
+    // Appending the 4th leaf alters the next subtree on the right.
+    // Instead of using Z[1], we will end up with the hash of the new leaf and
+    // Z[0].
+    //
+    // The other subtrees still remain the same.
+    //
+    //               R
+    //            /     \
+    //           H4    Z[3]
+    //         /    \
+    //       H3    Z[2]
+    //     /    \
+    //   H1      H2
+    //  /  \    /  \
+    // L1  L2  L3  L4
+    let leaf4 = H::hash(&[4u8; 32]).unwrap();
+
+    let h1 = H::hashv(&[&leaf1, &leaf2]).unwrap();
+    let h2 = H::hashv(&[&leaf3, &leaf4]).unwrap();
+    let h3 = H::hashv(&[&h1, &h2]).unwrap();
+    let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
+    let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    let expected_changelog_path = [leaf4, h2, h3, h4];
+    let expected_proof = [leaf3, h1, H::zero_bytes()[2], H::zero_bytes()[3]];
+
+    merkle_tree.append(&leaf4).unwrap();
+
+    assert_eq!(merkle_tree.changelog_index(), 4);
+    assert_eq!(
+        merkle_tree.changelog[merkle_tree.changelog_index()],
+        ChangelogEntry::<HEIGHT>::new(expected_root, expected_changelog_path, 3),
+    );
+    assert_eq!(merkle_tree.root().unwrap(), expected_root);
+    assert_eq!(merkle_tree.current_root_index, 4);
+    assert_eq!(merkle_tree.rightmost_proof, expected_proof);
+    assert_eq!(merkle_tree.rightmost_index, 4);
+    assert_eq!(merkle_tree.rightmost_leaf, leaf4);
+}
+
+/// Tests whether update operations work as expected.
+fn update<H>()
+where
+    H: Hasher,
+{
+    const HEIGHT: usize = 4;
+    const CHANGELOG: usize = 32;
+    const ROOTS: usize = 256;
+
+    let mut merkle_tree = ConcurrentMerkleTree::<H, HEIGHT, CHANGELOG, ROOTS>::default();
+    merkle_tree.init().unwrap();
+
+    let leaf1 = H::hash(&[1u8; 32]).unwrap();
+    let leaf2 = H::hash(&[2u8; 32]).unwrap();
+    let leaf3 = H::hash(&[3u8; 32]).unwrap();
+    let leaf4 = H::hash(&[4u8; 32]).unwrap();
+
+    // Append 4 leaves.
+    //
+    //               R
+    //            /     \
+    //           H4    Z[3]
+    //         /    \
+    //       H3    Z[2]
+    //     /    \
+    //   H1      H2
+    //  /  \    /  \
+    // L1  L2  L3  L4
+    let h1 = H::hashv(&[&leaf1, &leaf2]).unwrap();
+    let h2 = H::hashv(&[&leaf3, &leaf4]).unwrap();
+    let h3 = H::hashv(&[&h1, &h2]).unwrap();
+    let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
+    let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    let expected_changelog_path = [leaf4, h2, h3, h4];
+    let expected_proof = [leaf3, h1, H::zero_bytes()[2], H::zero_bytes()[3]];
+
+    merkle_tree.append(&leaf1).unwrap();
+    merkle_tree.append(&leaf2).unwrap();
+    merkle_tree.append(&leaf3).unwrap();
+    merkle_tree.append(&leaf4).unwrap();
+
+    assert_eq!(merkle_tree.changelog_index(), 4);
+    assert_eq!(
+        merkle_tree.changelog[merkle_tree.changelog_index()],
+        ChangelogEntry::<HEIGHT>::new(expected_root, expected_changelog_path, 3),
+    );
+    assert_eq!(merkle_tree.root().unwrap(), expected_root);
+    assert_eq!(merkle_tree.current_root_index, 4);
+    assert_eq!(merkle_tree.rightmost_proof, expected_proof);
+    assert_eq!(merkle_tree.rightmost_index, 4);
+    assert_eq!(merkle_tree.rightmost_leaf, leaf4);
+
+    // Replace `leaf1`.
+    let new_leaf1 = [9u8; 32];
+
+    // Replacing L1 affects H1 and all parent hashes up to the root.
+    //
+    //                R
+    //             /     \
+    //           *H4*   Z[3]
+    //          /    \
+    //       *H3*   Z[2]
+    //      /    \
+    //   *H1*     H2
+    //   /  \    /  \
+    // *L1* L2  L3  L4
+    //
+    // Merkle proof for the replaced leaf L1 is:
+    // [L2, H2, Z[2], Z[3]]
+    let proof = &[leaf2, h2, H::zero_bytes()[2], H::zero_bytes()[3]];
+
+    let changelog_index = merkle_tree.changelog_index();
+    merkle_tree
+        .update(changelog_index, &leaf1, &new_leaf1, 0, proof)
+        .unwrap();
+
+    let h1 = H::hashv(&[&new_leaf1, &leaf2]).unwrap();
+    let h2 = H::hashv(&[&leaf3, &leaf4]).unwrap();
+    let h3 = H::hashv(&[&h1, &h2]).unwrap();
+    let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
+    let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    let expected_changelog_path = [new_leaf1, h1, h3, h4];
+
+    assert_eq!(merkle_tree.changelog_index(), 5);
+    assert_eq!(
+        merkle_tree.changelog[merkle_tree.changelog_index()],
+        ChangelogEntry::<HEIGHT>::new(expected_root, expected_changelog_path, 0),
+    );
+    assert_eq!(merkle_tree.root().unwrap(), expected_root);
+    assert_eq!(merkle_tree.current_root_index, 5);
+    // `rightmost_*` variables should remain unchanged.
+    // Note that we didn't create a new `expected_proof` here. We just re-used
+    // the previous one.
+    assert_eq!(merkle_tree.rightmost_proof, expected_proof);
+    assert_eq!(merkle_tree.rightmost_index, 4);
+    assert_eq!(merkle_tree.rightmost_leaf, leaf4);
+
+    // Replace `leaf2`.
+    let new_leaf2 = H::hash(&[8u8; 32]).unwrap();
+
+    // Replacing L2 affects H1 and all parent hashes up to the root.
+    //
+    //               R
+    //            /     \
+    //          *H4*   Z[3]
+    //         /    \
+    //      *H3*   Z[2]
+    //     /    \
+    //  *H1*     H2
+    //  /  \    /  \
+    // L1 *L2* L3  L4
+    //
+    // Merkle proof for the replaced leaf L2 is:
+    // [L1, H2, Z[2], Z[3]]
+    let proof = &[new_leaf1, h2, H::zero_bytes()[2], H::zero_bytes()[3]];
+
+    let changelog_index = merkle_tree.changelog_index();
+    merkle_tree
+        .update(changelog_index, &leaf2, &new_leaf2, 1, proof)
+        .unwrap();
+
+    let h1 = H::hashv(&[&new_leaf1, &new_leaf2]).unwrap();
+    let h2 = H::hashv(&[&leaf3, &leaf4]).unwrap();
+    let h3 = H::hashv(&[&h1, &h2]).unwrap();
+    let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
+    let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    let expected_changelog_path = [new_leaf2, h1, h3, h4];
+
+    assert_eq!(merkle_tree.changelog_index(), 6);
+    assert_eq!(
+        merkle_tree.changelog[merkle_tree.changelog_index()],
+        ChangelogEntry::<HEIGHT>::new(expected_root, expected_changelog_path, 1),
+    );
+    assert_eq!(merkle_tree.root().unwrap(), expected_root);
+    assert_eq!(merkle_tree.current_root_index, 6);
+    assert_eq!(merkle_tree.rightmost_proof, expected_proof);
+    assert_eq!(merkle_tree.rightmost_index, 4);
+    assert_eq!(merkle_tree.rightmost_leaf, leaf4);
+
+    // Replace `leaf3`.
+    let new_leaf3 = H::hash(&[7u8; 32]).unwrap();
+
+    // Replacing L3 affects H1 and all parent hashes up to the root.
+    //
+    //               R
+    //            /     \
+    //          *H4*   Z[3]
+    //         /    \
+    //      *H3*   Z[2]
+    //     /    \
+    //   H1     *H2*
+    //  /  \    /  \
+    // L1  L2 *L3* L4
+    //
+    // Merkle proof for the replaced leaf L3 is:
+    // [L4, H1, Z[2], Z[3]]
+    let proof = &[leaf4, h1, H::zero_bytes()[2], H::zero_bytes()[3]];
+
+    let changelog_index = merkle_tree.changelog_index();
+    merkle_tree
+        .update(changelog_index, &leaf3, &new_leaf3, 2, proof)
+        .unwrap();
+
+    let h1 = H::hashv(&[&new_leaf1, &new_leaf2]).unwrap();
+    let h2 = H::hashv(&[&new_leaf3, &leaf4]).unwrap();
+    let h3 = H::hashv(&[&h1, &h2]).unwrap();
+    let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
+    let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    let expected_changelog_path = [new_leaf3, h2, h3, h4];
+
+    assert_eq!(merkle_tree.changelog_index(), 7);
+    assert_eq!(
+        merkle_tree.changelog[merkle_tree.changelog_index()],
+        ChangelogEntry::<HEIGHT>::new(expected_root, expected_changelog_path, 2)
+    );
+    assert_eq!(merkle_tree.root().unwrap(), expected_root);
+    assert_eq!(merkle_tree.current_root_index, 7);
+    assert_eq!(merkle_tree.rightmost_proof, expected_proof);
+    assert_eq!(merkle_tree.rightmost_index, 4);
+    assert_eq!(merkle_tree.rightmost_leaf, leaf4);
+
+    // Replace `leaf4`.
+    let new_leaf4 = H::hash(&[6u8; 32]).unwrap();
+
+    // Replacing L4 affects H1 and all parent hashes up to the root.
+    //
+    //               R
+    //            /     \
+    //          *H4*   Z[3]
+    //         /    \
+    //      *H3*   Z[2]
+    //     /    \
+    //   H1     *H2*
+    //  /  \    /  \
+    // L1  L2  L3 *L4*
+    //
+    // Merkle proof for the replaced leaf L4 is:
+    // [L3, H1, Z[2], Z[3]]
+    let proof = &[new_leaf3, h1, H::zero_bytes()[2], H::zero_bytes()[3]];
+
+    let changelog_index = merkle_tree.root_index();
+    merkle_tree
+        .update(changelog_index, &leaf4, &new_leaf4, 3, proof)
+        .unwrap();
+
+    let h1 = H::hashv(&[&new_leaf1, &new_leaf2]).unwrap();
+    let h2 = H::hashv(&[&new_leaf3, &new_leaf4]).unwrap();
+    let h3 = H::hashv(&[&h1, &h2]).unwrap();
+    let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
+    let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    let expected_changelog_path = [new_leaf4, h2, h3, h4];
+    let expected_proof = [new_leaf3, h1, H::zero_bytes()[2], H::zero_bytes()[3]];
+
+    assert_eq!(merkle_tree.changelog_index(), 8);
+    assert_eq!(
+        merkle_tree.changelog[merkle_tree.changelog_index()],
+        ChangelogEntry::<HEIGHT>::new(expected_root, expected_changelog_path, 3)
+    );
+    assert_eq!(merkle_tree.root().unwrap(), expected_root);
+    assert_eq!(merkle_tree.current_root_index, 8);
+    // This time `rightmost_*` fields should be changed.
+    assert_eq!(merkle_tree.rightmost_proof, expected_proof);
+    assert_eq!(merkle_tree.rightmost_index, 4);
+    assert_eq!(merkle_tree.rightmost_leaf, new_leaf4);
+}
+
+/// Tests whether appending leaves over the limit results in an explicit error.
+fn overfill_tree<H>()
+where
+    H: Hasher,
+{
+    const HEIGHT: usize = 2;
+    const CHANGELOG: usize = 32;
+    const ROOTS: usize = 32;
+
+    let mut merkle_tree = ConcurrentMerkleTree::<H, HEIGHT, CHANGELOG, ROOTS>::default();
+    merkle_tree.init().unwrap();
+
+    for _ in 0..4 {
+        merkle_tree.append(&[4; 32]).unwrap();
+    }
+    assert!(matches!(
+        merkle_tree.append(&[4; 32]),
+        Err(HasherError::TreeFull)
+    ));
+}
+
+/// Tests whether performing enough updates to overfill the changelog and root
+/// buffer results in graceful reset of the counters.
+fn overfill_changelog_and_roots<H>()
+where
+    H: Hasher,
+{
+    const HEIGHT: usize = 2;
+    const CHANGELOG: usize = 6;
+    const ROOTS: usize = 8;
+
+    // Our implementation of concurrent Merkle tree.
+    let mut merkle_tree = ConcurrentMerkleTree::<H, HEIGHT, CHANGELOG, ROOTS>::default();
+    merkle_tree.init().unwrap();
+
+    // Reference implementation of Merkle tree which Solana Labs uses for
+    // testing (and therefore, we as well). We use it mostly to get the Merkle
+    // proofs.
+    // let leaves = vec![spl_concurrent_merkle_tree::node::EMPTY; 1 << HEIGHT];
+    let mut reference_tree =
+        light_merkle_tree_reference::MerkleTree::<H, HEIGHT, ROOTS>::new().unwrap();
+
+    let mut rng = thread_rng();
+
+    // Fill up the tree, producing 4 roots and changelog entries.
+    for i in 0..(1 << HEIGHT) {
+        let leaf: [u8; 32] = Fr::rand(&mut rng)
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .unwrap();
+        merkle_tree.append(&leaf).unwrap();
+        reference_tree.update(&leaf, i).unwrap();
+    }
+
+    assert_eq!(merkle_tree.current_changelog_index, 4);
+    assert_eq!(merkle_tree.current_root_index, 4);
+
+    // Update 2 leaves to fill up the changelog. Its counter should reach the
+    // modulus and get reset.
+    for i in 0..2 {
+        let new_leaf: [u8; 32] = Fr::rand(&mut rng)
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .unwrap();
+
+        let changelog_index = merkle_tree.changelog_index();
+        let old_leaf = reference_tree.leaf(i);
+        let proof = reference_tree.get_proof_of_leaf(i);
+
+        merkle_tree
+            .update(changelog_index, &old_leaf, &new_leaf, i, &proof)
+            .unwrap();
+        reference_tree.update(&new_leaf, i).unwrap();
+    }
+
+    assert_eq!(merkle_tree.current_changelog_index, 0);
+    assert_eq!(merkle_tree.current_root_index, 6);
+
+    // Update another 2 leaves to fill up the root. Its counter should reach
+    // the modulus and get reset. The previously reset counter should get
+    // incremented.
+    for i in 0..2 {
+        let new_leaf: [u8; 32] = Fr::rand(&mut rng)
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .unwrap();
+
+        let changelog_index = merkle_tree.changelog_index();
+        let old_leaf = reference_tree.leaf(i);
+        let proof = reference_tree.get_proof_of_leaf(i);
+
+        merkle_tree
+            .update(changelog_index, &old_leaf, &new_leaf, i, &proof)
+            .unwrap();
+        reference_tree.update(&new_leaf, i).unwrap();
+    }
+
+    assert_eq!(merkle_tree.current_changelog_index, 2);
+    assert_eq!(merkle_tree.current_root_index, 0);
+
+    // The latter updates should keep incrementing the counters.
+    for i in 0..3 {
+        let new_leaf: [u8; 32] = Fr::rand(&mut rng)
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .unwrap();
+
+        let changelog_index = merkle_tree.changelog_index();
+        let old_leaf = reference_tree.leaf(i);
+        let proof = reference_tree.get_proof_of_leaf(i);
+
+        merkle_tree
+            .update(changelog_index, &old_leaf, &new_leaf, i, &proof)
+            .unwrap();
+        reference_tree.update(&new_leaf, i).unwrap();
+    }
+
+    assert_eq!(merkle_tree.current_changelog_index, 5);
+    assert_eq!(merkle_tree.current_root_index, 3);
+}
+
+/// Tests the Merkle tree without changelog, which in fact takes away the
+/// support for concurrent updates. But that's alright in case we want to use
+/// the tree as append-only (e.g. transactions).
+fn without_changelog<H>()
+where
+    H: Hasher,
+{
+    const HEIGHT: usize = 2;
+    const CHANGELOG: usize = 0;
+    const ROOTS: usize = 8;
+
+    // Our implementation of concurrent Merkle tree.
+    let mut merkle_tree = ConcurrentMerkleTree::<H, HEIGHT, CHANGELOG, ROOTS>::default();
+    merkle_tree.init().unwrap();
+
+    // Reference implementation of Merkle tree which Solana Labs uses for
+    // testing (and therefore, we as well). We use it mostly to get the Merkle
+    // proofs.
+    let mut reference_tree =
+        light_merkle_tree_reference::MerkleTree::<H, HEIGHT, ROOTS>::new().unwrap();
+
+    let mut rng = thread_rng();
+
+    for i in 0..(1 << HEIGHT) {
+        let leaf: [u8; 32] = Fr::rand(&mut rng)
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .unwrap();
+        merkle_tree.append(&leaf).unwrap();
+        reference_tree.update(&leaf, i).unwrap();
+    }
+
+    for i in 0..32 {
+        let new_leaf: [u8; 32] = Fr::rand(&mut rng)
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .unwrap();
+
+        // If `ì` is greater than possible number of leaves, apply a modulus.
+        let i = i % (1 << HEIGHT);
+
+        let changelog_index = merkle_tree.changelog_index();
+        let old_leaf = reference_tree.leaf(i);
+        let proof = reference_tree.get_proof_of_leaf(i);
+
+        merkle_tree
+            .update(changelog_index, &old_leaf, &new_leaf, i, &proof)
+            .unwrap();
+        reference_tree.update(&new_leaf, i).unwrap();
+    }
+}
+
+#[test]
+fn test_append_keccak() {
+    append::<Keccak>()
+}
+
+#[test]
+fn test_append_poseidon() {
+    append::<Poseidon>()
+}
+
+#[test]
+fn test_append_sha256() {
+    append::<Sha256>()
+}
+
+#[test]
+fn test_update_keccak() {
+    update::<Keccak>()
+}
+
+#[test]
+fn test_update_poseidon() {
+    update::<Poseidon>()
+}
+
+#[test]
+fn test_update_sha256() {
+    update::<Sha256>()
+}
+
+#[test]
+fn test_overfill_tree_keccak() {
+    overfill_tree::<Keccak>()
+}
+
+#[test]
+fn test_overfill_tree_poseidon() {
+    overfill_tree::<Poseidon>()
+}
+
+#[test]
+fn test_overfill_tree_sha256() {
+    overfill_tree::<Sha256>()
+}
+
+#[test]
+fn test_overfill_changelog_keccak() {
+    overfill_changelog_and_roots::<Keccak>()
+}
+
+#[test]
+fn test_without_changelog_keccak() {
+    without_changelog::<Keccak>()
+}
+
+/// Checks whether our `append` and `update` implementations are compatible
+/// with `append` and `set_leaf` from `spl-concurrent-merkle-tree` crate.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_spl_compat() {
+    const HEIGHT: usize = 4;
+    const CHANGELOG: usize = 64;
+    const ROOTS: usize = 256;
+
+    let mut rng = thread_rng();
+
+    // Our implementation of concurrent Merkle tree.
+    let mut concurrent_mt = ConcurrentMerkleTree::<Keccak, HEIGHT, CHANGELOG, ROOTS>::default();
+    concurrent_mt.init().unwrap();
+
+    // Solana Labs implementation of concurrent Merkle tree.
+    let mut spl_concurrent_mt = spl_concurrent_merkle_tree::concurrent_merkle_tree::ConcurrentMerkleTree::<HEIGHT, ROOTS>::new();
+    spl_concurrent_mt.initialize().unwrap();
+
+    // Reference implemenetation of Merkle tree which Solana Labs uses for
+    // testing (and therefore, we as well). We use it mostly to get the Merkle
+    // proofs.
+    let mut reference_tree =
+        light_merkle_tree_reference::MerkleTree::<Keccak, HEIGHT, ROOTS>::new().unwrap();
+
+    for i in 0..(1 << HEIGHT) {
+        let leaf: [u8; 32] = Fr::rand(&mut rng)
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .unwrap();
+        concurrent_mt.append(&leaf).unwrap();
+        spl_concurrent_mt.append(leaf).unwrap();
+        reference_tree.update(&leaf, i).unwrap();
+
+        let root = concurrent_mt.root().unwrap();
+        assert_eq!(root, spl_concurrent_mt.get_change_log().root,);
+        assert_eq!(root, reference_tree.root().unwrap());
+    }
+
+    for i in 0..(1 << HEIGHT) {
+        let new_leaf: [u8; 32] = Fr::rand(&mut rng)
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .unwrap();
+
+        let root = concurrent_mt.root().unwrap();
+        let root_index = concurrent_mt.root_index();
+        let old_leaf = reference_tree.leaf(i);
+        let proof = reference_tree.get_proof_of_leaf(i);
+
+        concurrent_mt
+            .update(root_index, &old_leaf, &new_leaf, i, &proof)
+            .unwrap();
+        spl_concurrent_mt
+            .set_leaf(root, old_leaf, new_leaf, proof.as_slice(), i as u32)
+            .unwrap();
+        reference_tree.update(&new_leaf, i).unwrap();
+
+        let root = concurrent_mt.root().unwrap();
+        assert_eq!(root, spl_concurrent_mt.get_change_log().root,);
+        assert_eq!(root, reference_tree.root().unwrap());
+    }
+}

--- a/merkle-tree/hasher/src/errors.rs
+++ b/merkle-tree/hasher/src/errors.rs
@@ -6,6 +6,18 @@ pub enum HasherError {
     HeightZero,
     #[msg("Invalid height, it cannot exceed the maximum allowed height")]
     HeightHigherThanMax,
+    #[msg("Invalid number of roots, it has to be greater than 0")]
+    RootsZero,
+    #[msg("Invalid root index, it exceeds the root buffer size")]
+    RootHigherThanMax,
+    #[msg("Merkle tree is full, cannot append more leaves.")]
+    TreeFull,
+    #[msg("Provided proof is larger than the height of the tree.")]
+    ProofTooLarge,
+    #[msg("Invalid Merkle proof, stopping the update operation.")]
+    InvalidProof,
+    #[msg("Attempting to update the leaf which was updated by an another newest change.")]
+    CannotUpdateLeaf,
     #[msg("Invalid number of inputs.")]
     PoseidonInvalidNumberOfInputs,
     #[msg("Input is an empty slice.")]

--- a/merkle-tree/reference/tests/tests.rs
+++ b/merkle-tree/reference/tests/tests.rs
@@ -8,7 +8,7 @@ where
     const HEIGHT: usize = 4;
     const ROOTS: usize = 256;
 
-    let mut merkle_tree = MerkleTree::<H, ROOTS>::new(HEIGHT).unwrap();
+    let mut merkle_tree = MerkleTree::<H, HEIGHT, ROOTS>::new().unwrap();
 
     let leaf1 = H::hash(&[1u8; 32]).unwrap();
 
@@ -56,7 +56,7 @@ where
     //  /    \
     // L1   Z[0]
     let expected_root = H::hashv(&[&h3, &H::zero_bytes()[3]]).unwrap();
-    let expected_proof = vec![
+    let expected_proof = [
         H::zero_bytes()[0],
         H::zero_bytes()[1],
         H::zero_bytes()[2],
@@ -90,7 +90,7 @@ where
     let h2 = H::hashv(&[&h1, &H::zero_bytes()[1]]).unwrap();
     let h3 = H::hashv(&[&h2, &H::zero_bytes()[2]]).unwrap();
     let expected_root = H::hashv(&[&h3, &H::zero_bytes()[3]]).unwrap();
-    let expected_proof = vec![
+    let expected_proof = [
         leaf1,
         H::zero_bytes()[1],
         H::zero_bytes()[2],

--- a/programs/merkle-tree/Cargo.toml
+++ b/programs/merkle-tree/Cargo.toml
@@ -51,6 +51,9 @@ light-utils = { version = "0.1.0", path = "../../utils" }
 light-macros = { version = "0.3.1", path = "../../macros/light" }
 light-sparse-merkle-tree = { path = "../../merkle-tree/sparse", version = "0.1.1" }
 
+# TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
+ahash = "=0.8.6"
+
 [dev-dependencies]
 solana-program-test = "1.9.16"
 solana-sdk = "1.16"

--- a/programs/psp10in2out/Cargo.toml
+++ b/programs/psp10in2out/Cargo.toml
@@ -26,3 +26,6 @@ solana-security-txt = "1.1.0"
 groth16-solana = "0.0.2"
 light-macros = { version = "0.3.1", path = "../../macros/light" }
 light-verifier-sdk = { version = "0.3.1", path = "../../verifier-sdk" }
+
+# TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
+ahash = "=0.8.6"

--- a/programs/psp2in2out-storage/Cargo.toml
+++ b/programs/psp2in2out-storage/Cargo.toml
@@ -26,3 +26,6 @@ groth16-solana = "0.0.2"
 light-macros = { version = "0.3.1", path = "../../macros/light" }
 light-merkle-tree-program = { version = "0.3.1", path = "../merkle-tree", features = ["cpi"] }
 light-verifier-sdk = { version = "0.3.1", path = "../../verifier-sdk" }
+
+# TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
+ahash = "=0.8.6"

--- a/programs/psp2in2out/Cargo.toml
+++ b/programs/psp2in2out/Cargo.toml
@@ -26,3 +26,6 @@ solana-security-txt = "1.1.0"
 groth16-solana = "0.0.2"
 light-macros = { version = "0.3.1", path = "../../macros/light" }
 light-verifier-sdk = { version = "0.3.1", path = "../../verifier-sdk" }
+
+# TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
+ahash = "=0.8.6"

--- a/programs/psp4in4out-app-storage/Cargo.toml
+++ b/programs/psp4in4out-app-storage/Cargo.toml
@@ -27,3 +27,6 @@ groth16-solana = "0.0.2"
 light-macros = { version = "0.3.1", path = "../../macros/light" }
 light-verifier-sdk = { version = "0.3.1", path = "../../verifier-sdk" }
 bytemuck = "1.14.0"
+
+# TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
+ahash = "=0.8.6"

--- a/programs/user-registry/Cargo.toml
+++ b/programs/user-registry/Cargo.toml
@@ -20,3 +20,6 @@ default = []
 aligned-sized = { version = "0.1.0", path = "../../macros/aligned-sized" }
 anchor-lang = "0.28.0"
 bytemuck = "1.14"
+
+# TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
+ahash = "=0.8.6"

--- a/psp-examples/multisig/programs/multisig/Cargo.toml
+++ b/psp-examples/multisig/programs/multisig/Cargo.toml
@@ -24,3 +24,6 @@ light-macros = "0.1.0"
 light-verifier-sdk = { git = "https://github.com/lightprotocol/light-protocol", tag = "v0.3.2" }
 solana-program = "1.16.4"
 groth16-solana = "0.0.2"
+
+# TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
+ahash = "=0.8.6"

--- a/psp-examples/private-compressed-account/programs/private-compressed-account/Cargo.toml
+++ b/psp-examples/private-compressed-account/programs/private-compressed-account/Cargo.toml
@@ -26,3 +26,6 @@ solana-program = "1.16.4"
 groth16-solana = "0.0.2"
 bytemuck = { version = "1.4.0", features = ["derive", "min_const_generics"]}
 memoffset = "0.9.0"
+
+# TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
+ahash = "=0.8.6"

--- a/psp-examples/rock-paper-scissors/programs/rock-paper-scissors/Cargo.toml
+++ b/psp-examples/rock-paper-scissors/programs/rock-paper-scissors/Cargo.toml
@@ -26,3 +26,6 @@ solana-program = "1.16.4"
 groth16-solana = "0.0.2"
 bytemuck = { version = "1.4.0", features = ["derive", "min_const_generics"]}
 memoffset = "0.9.0"
+
+# TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
+ahash = "=0.8.6"

--- a/psp-examples/streaming-payments/programs/streaming-payments/Cargo.toml
+++ b/psp-examples/streaming-payments/programs/streaming-payments/Cargo.toml
@@ -26,3 +26,6 @@ solana-program = "1.16.4"
 groth16-solana = "0.0.2"
 memoffset = "0.9.0"
 bytemuck = "1.14.0"
+
+# TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
+ahash = "=0.8.6"

--- a/psp-examples/swap/programs/swaps/Cargo.toml
+++ b/psp-examples/swap/programs/swaps/Cargo.toml
@@ -26,3 +26,6 @@ solana-program = "1.16.4"
 groth16-solana = "0.0.2"
 bytemuck = { version = "1.4.0", features = ["derive", "min_const_generics"]}
 memoffset = "0.9.0"
+
+# TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
+ahash = "=0.8.6"

--- a/psp-template/psp-template/programs_circom/program_name/Cargo.toml
+++ b/psp-template/psp-template/programs_circom/program_name/Cargo.toml
@@ -23,3 +23,6 @@ ark-ff = { version = "^0.3.0", default-features = false }
 ark-ec = { version = "0.3.0" }
 ark-bn254 = "0.3.0"
 ark-std = { version = "^0.3.0", default-features = false }
+
+# TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
+ahash = "=0.8.6"

--- a/psp-template/psp-template/programs_psp/program_name/Cargo.toml
+++ b/psp-template/psp-template/programs_psp/program_name/Cargo.toml
@@ -26,3 +26,6 @@ solana-program = "1.16.4"
 groth16-solana = "0.0.2"
 bytemuck = "1.14.0"
 memoffset = "0.9.0"
+
+# TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
+ahash = "=0.8.6"


### PR DESCRIPTION
Concurrent Merkle tree is the concept of updateable MT which is described in the whitepaper[0] written by gigabrains from Solana Labs and Metaplex.

It allows for concurrent updates (of already inserted leaves) of the tree without any locks and queues.

Incorporating it into Light Protocol is a huge upgrade from our previous append-only sparse Merkle Tree implementations.

Although we don't need updates for transactions (append-only is sufficient there), we are going to need updates when imlementing indexed Merkle tree for nullifiers[1]. This feature is a preparatory change for implementing indexed Merkle tree.

[0] https://drive.google.com/file/d/1BOpa5OFmara50fTvL0VIVYjtg-qzHCVc/view
[1] https://docs.aztec.network/concepts/advanced/data_structures/indexed_merkle_tree