### PR TITLE
ci: Run Rust liners both on stable and nightly toolchains

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,12 +51,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-      - name: Install dependencies
-        run: |
-          ./scripts/install.sh
-
       - name: Run linters
         run: |
-          pnpm install
+          set -euxo pipefail
+          ./scripts/install.sh
           source ./scripts/devenv.sh
+          # NOTE(vadorovsky): I have no idea why do we need to do this again
+          # here... But without that, the toolchain is just not there!
+          # I will spend more time on debugging this once I can afford burning
+          # more hours.
+          rustup toolchain install nightly --component clippy,rustfmt
           ./scripts/lint.sh

--- a/programs/merkle-tree/src/config_accounts/merkle_tree_authority.rs
+++ b/programs/merkle-tree/src/config_accounts/merkle_tree_authority.rs
@@ -65,7 +65,10 @@ pub struct InitializeMerkleTreeAuthority<'info> {
     )]
     pub event_merkle_tree: AccountLoader<'info, EventMerkleTree>,
     /// CHECK:` Signer is merkle tree init authority.
-    #[account(mut, address=anchor_lang::prelude::Pubkey::try_from(config::INITIAL_MERKLE_TREE_AUTHORITY).map_err(|_| ErrorCode::PubkeyTryFromFailed)? @ErrorCode::InvalidAuthority)]
+    #[account(
+        mut,
+        address=anchor_lang::prelude::Pubkey::from(config::INITIAL_MERKLE_TREE_AUTHORITY) @ErrorCode::InvalidAuthority
+    )]
     pub authority: Signer<'info>,
     pub system_program: Program<'info, System>,
     pub rent: Sysvar<'info, Rent>,

--- a/programs/merkle-tree/src/transaction_merkle_tree/update_merkle_tree_lib/instructions.rs
+++ b/programs/merkle-tree/src/transaction_merkle_tree/update_merkle_tree_lib/instructions.rs
@@ -23,10 +23,10 @@ pub fn insert_0_double(
         msg!("Merkle tree full");
         return Err(ProgramError::InvalidInstructionData);
     }
-    update_state_data.node_left = update_state_data.leaves
-        [usize::try_from(update_state_data.insert_leaves_index).unwrap()][0];
-    update_state_data.node_right = update_state_data.leaves
-        [usize::try_from(update_state_data.insert_leaves_index).unwrap()][1];
+    update_state_data.node_left =
+        update_state_data.leaves[usize::from(update_state_data.insert_leaves_index)][0];
+    update_state_data.node_right =
+        update_state_data.leaves[usize::from(update_state_data.insert_leaves_index)][1];
 
     update_state_data.current_level = 1;
     // increase insert leaves index to insert the next leaf

--- a/programs/merkle-tree/src/verifier_invoked_instructions/insert_two_leaves_transaction.rs
+++ b/programs/merkle-tree/src/verifier_invoked_instructions/insert_two_leaves_transaction.rs
@@ -22,7 +22,7 @@ pub struct InsertTwoLeaves<'info> {
 
 pub fn process_insert_two_leaves<'info, 'a>(
     ctx: Context<'a, '_, '_, 'info, InsertTwoLeaves<'info>>,
-    leaves: &'a Vec<[u8; 32]>,
+    leaves: &'a [[u8; 32]],
 ) -> Result<()> {
     let merkle_tree = &mut ctx.accounts.transaction_merkle_tree.load_mut()?;
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -117,13 +117,6 @@ MACRO_CIRCOM_VERSION=`latest_release Lightprotocol macro-circom`
 LIGHT_PROTOCOL_VERSION=`latest_release Lightprotocol light-protocol`
 ENABLE_REDIS=$(check_flag --enable-redis "$@")
 
-
-if ! rustup toolchain list 2>/dev/null | grep -q "nightly"; then
-    echo "Rust nightly is not installed!"
-    echo "Please install https://rustup.rs/ and then install the nightly toolchain with:"
-    echo "    rustup toolchain install nightly" 
-fi
-
 case "${OS}" in
     "Darwin")
         case "${ARCH}" in
@@ -181,10 +174,13 @@ export RUSTUP_HOME="${PREFIX}/rustup"
 export CARGO_HOME="${PREFIX}/cargo"
 curl --retry 5 --retry-delay 10 --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     --no-modify-path # We want to control the PATH ourselves.
-. "${CARGO_HOME}/env"
-cargo install cargo-expand wasm-pack
+export PATH="${PREFIX}/cargo/bin:${PATH}"
 
+rustup component add clippy
 rustup component add rustfmt
+rustup toolchain install nightly --component clippy,rustfmt
+
+cargo install cargo-expand wasm-pack
 
 echo "📥 Downloading Node.js"
 download_and_extract \

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -3,4 +3,11 @@
 set -e
 npx nx run-many --target=format:check --all
 npx nx run-many --target=lint --all
-cargo fmt --all -- --check && cargo clippy --workspace --exclude macro-circom --all -- -A clippy::result_large_err -D warnings
+
+for rust_toolchain in stable nightly; do
+    cargo +"$rust_toolchain" fmt --all -- --check
+    cargo +"$rust_toolchain" clippy \
+      --workspace \
+      --exclude macro-circom \
+      --all -- -A clippy::result_large_err -D warnings
+done


### PR DESCRIPTION
Running clippy nightly is often necessary on macOS (thiserror[0] fails to build on Rust stable on macOS, we need to investigate why, it's not in the scope of this change).

But well, new features of clippy nightly are also pointing out some good coding practices, so we can also enable it anyway and just keep it.

[0] https://crates.io/crates/thiserror