### PR TITLE
feat: Add reference Merkle tree implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2816,6 +2816,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-merkle-tree-reference"
+version = "0.1.0"
+dependencies = [
+ "light-hasher",
+]
+
+[[package]]
 name = "light-poseidon"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/merkle-tree/reference/Cargo.toml
+++ b/merkle-tree/reference/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "light-merkle-tree-reference"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+light-hasher = { path = "../hasher", version = "0.1.0" }

--- a/merkle-tree/reference/src/lib.rs
+++ b/merkle-tree/reference/src/lib.rs
@@ -1,0 +1,207 @@
+use std::{cell::RefCell, collections::VecDeque, marker::PhantomData, rc::Rc};
+
+use light_hasher::{errors::HasherError, Hasher};
+
+pub fn build_root<H>(leaves: &[Rc<RefCell<TreeNode<H>>>]) -> Result<[u8; 32], HasherError>
+where
+    H: Hasher,
+{
+    let mut tree = VecDeque::from_iter(leaves.iter().map(Rc::clone));
+    let mut seq_num = leaves.len();
+    while tree.len() > 1 {
+        let left = tree.pop_front().unwrap();
+        let level = left.borrow().level;
+        let right = if level != tree[0].borrow().level {
+            let node = Rc::new(RefCell::new(TreeNode::new_empty(level, seq_num)));
+            seq_num += 1;
+            node
+        } else {
+            tree.pop_front().unwrap()
+        };
+        let mut hashed_parent = [0u8; 32];
+
+        hashed_parent
+            .copy_from_slice(H::hashv(&[&left.borrow().node, &right.borrow().node])?.as_ref());
+        let parent = Rc::new(RefCell::new(TreeNode::new(
+            hashed_parent,
+            left.clone(),
+            right.clone(),
+            level + 1,
+            seq_num,
+        )));
+        left.borrow_mut().assign_parent(parent.clone());
+        right.borrow_mut().assign_parent(parent.clone());
+        tree.push_back(parent);
+        seq_num += 1;
+    }
+
+    let root = tree[0].borrow().node;
+    Ok(root)
+}
+
+/// Reference implementation of Merkle tree used for testing.
+pub struct MerkleTree<H, const MAX_ROOTS: usize>
+where
+    H: Hasher,
+{
+    pub leaf_nodes: Vec<Rc<RefCell<TreeNode<H>>>>,
+    pub roots: Vec<[u8; 32]>,
+
+    _hasher: PhantomData<H>,
+}
+
+impl<H, const MAX_ROOTS: usize> Default for MerkleTree<H, MAX_ROOTS>
+where
+    H: Hasher,
+{
+    fn default() -> Self {
+        Self {
+            leaf_nodes: Vec::new(),
+            roots: Vec::new(),
+            _hasher: PhantomData,
+        }
+    }
+}
+
+impl<H, const MAX_ROOTS: usize> MerkleTree<H, MAX_ROOTS>
+where
+    H: Hasher,
+{
+    pub fn new(height: usize) -> Result<Self, HasherError> {
+        let mut leaf_nodes = vec![];
+        for i in 0..(1 << height) {
+            let tree_node = TreeNode::new_empty(0, i);
+            leaf_nodes.push(Rc::new(RefCell::new(tree_node)));
+        }
+        let root = build_root(leaf_nodes.as_slice())?;
+        let roots = vec![root];
+        Ok(Self {
+            leaf_nodes,
+            roots,
+            _hasher: PhantomData,
+        })
+    }
+
+    /// Getch the Merkle proof of the leaf under the given `ìndex`.
+    pub fn get_proof_of_leaf(&self, index: usize) -> Vec<[u8; 32]> {
+        let mut proof = vec![];
+        let mut node = self.leaf_nodes[index].clone();
+        loop {
+            let ref_node = node.clone();
+            if ref_node.borrow().parent.is_none() {
+                break;
+            }
+            let parent = ref_node.borrow().parent.as_ref().unwrap().clone();
+            if parent.borrow().left.as_ref().unwrap().borrow().id == ref_node.borrow().id {
+                proof.push(parent.borrow().right.as_ref().unwrap().borrow().node);
+            } else {
+                proof.push(parent.borrow().left.as_ref().unwrap().borrow().node);
+            }
+            node = parent;
+        }
+        proof
+    }
+
+    /// Updates root from an updated leaf node set at index: `idx`
+    fn update_root_from_leaf(&mut self, leaf_idx: usize) -> Result<(), HasherError> {
+        let mut node = self.leaf_nodes[leaf_idx].clone();
+        loop {
+            let ref_node = node.clone();
+            if ref_node.borrow().parent.is_none() {
+                self.roots.push(ref_node.borrow().node);
+                break;
+            }
+            let parent = ref_node.borrow().parent.as_ref().unwrap().clone();
+            let hash = if parent.borrow().left.as_ref().unwrap().borrow().id == ref_node.borrow().id
+            {
+                H::hashv(&[
+                    &ref_node.borrow().node,
+                    &parent.borrow().right.as_ref().unwrap().borrow().node,
+                ])?
+            } else {
+                H::hashv(&[
+                    &parent.borrow().left.as_ref().unwrap().borrow().node,
+                    &ref_node.borrow().node,
+                ])?
+            };
+            node = parent;
+            node.borrow_mut().node.copy_from_slice(hash.as_ref());
+        }
+
+        Ok(())
+    }
+
+    pub fn node(&self, idx: usize) -> [u8; 32] {
+        self.leaf_nodes[idx].borrow().node
+    }
+
+    pub fn root(&self) -> Option<[u8; 32]> {
+        self.roots.last().copied()
+    }
+
+    pub fn update(&mut self, leaf: &[u8; 32], leaf_idx: usize) -> Result<(), HasherError> {
+        self.leaf_nodes[leaf_idx].borrow_mut().node = *leaf;
+        self.update_root_from_leaf(leaf_idx)
+    }
+
+    pub fn leaf(&self, leaf_idx: usize) -> [u8; 32] {
+        self.leaf_nodes[leaf_idx].borrow().node
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TreeNode<H>
+where
+    H: Hasher,
+{
+    pub node: [u8; 32],
+    left: Option<Rc<RefCell<TreeNode<H>>>>,
+    right: Option<Rc<RefCell<TreeNode<H>>>>,
+    parent: Option<Rc<RefCell<TreeNode<H>>>>,
+    level: usize,
+    /// ID needed to figure out whether we came from left or right child node
+    /// when hashing path upwards
+    id: usize,
+
+    _hasher: PhantomData<H>,
+}
+
+impl<H> TreeNode<H>
+where
+    H: Hasher,
+{
+    pub fn new(
+        node: [u8; 32],
+        left: Rc<RefCell<TreeNode<H>>>,
+        right: Rc<RefCell<TreeNode<H>>>,
+        level: usize,
+        id: usize,
+    ) -> Self {
+        Self {
+            node,
+            left: Some(left),
+            right: Some(right),
+            parent: None,
+            level,
+            id,
+            _hasher: PhantomData,
+        }
+    }
+
+    pub fn new_empty(level: usize, id: usize) -> Self {
+        Self {
+            node: H::zero_bytes()[level],
+            left: None,
+            right: None,
+            parent: None,
+            level,
+            id,
+            _hasher: PhantomData,
+        }
+    }
+
+    /// Allows to propagate parent assignment
+    pub fn assign_parent(&mut self, parent: Rc<RefCell<TreeNode<H>>>) {
+        self.parent = Some(parent);
+    }
+}

--- a/merkle-tree/reference/tests/tests.rs
+++ b/merkle-tree/reference/tests/tests.rs
@@ -1,0 +1,302 @@
+use light_hasher::{Hasher, Keccak, Poseidon, Sha256};
+use light_merkle_tree_reference::MerkleTree;
+
+fn update<H>()
+where
+    H: Hasher,
+{
+    const HEIGHT: usize = 4;
+    const ROOTS: usize = 256;
+
+    let mut merkle_tree = MerkleTree::<H, ROOTS>::new(HEIGHT).unwrap();
+
+    let leaf1 = H::hash(&[1u8; 32]).unwrap();
+
+    // The hash of our new leaf and its sibling (a zero value).
+    //
+    //    H1
+    //  /    \
+    // L1   Z[0]
+    let h1 = H::hashv(&[&leaf1, &H::zero_bytes()[0]]).unwrap();
+
+    // The hash of `h1` and its sibling (a subtree represented by `Z[1]`).
+    //
+    //          H2
+    //      /-/    \-\
+    //    H1          Z[1]
+    //  /    \      /      \
+    // L1   Z[0]   Z[0]   Z[0]
+    //
+    // `Z[1]` represents the whole subtree on the right from `h2`. In the next
+    // examples, we are just going to show empty subtrees instead of the whole
+    // hierarchy.
+    let h2 = H::hashv(&[&h1, &H::zero_bytes()[1]]).unwrap();
+
+    // The hash of `h3` and its sibling (a subtree represented by `Z[2]`).
+    //
+    //          H3
+    //        /    \
+    //       H2   Z[2]
+    //     /    \
+    //    H1   Z[1]
+    //  /    \
+    // L1   Z[0]
+    let h3 = H::hashv(&[&h2, &H::zero_bytes()[2]]).unwrap();
+
+    // The hash of `h4` and its sibling (a subtree represented by `Z[3]`),
+    // which is the root.
+    //
+    //              R
+    //           /     \
+    //          H3    Z[3]
+    //        /    \
+    //       H2   Z[2]
+    //     /    \
+    //    H1   Z[1]
+    //  /    \
+    // L1   Z[0]
+    let expected_root = H::hashv(&[&h3, &H::zero_bytes()[3]]).unwrap();
+    let expected_proof = vec![
+        H::zero_bytes()[0],
+        H::zero_bytes()[1],
+        H::zero_bytes()[2],
+        H::zero_bytes()[3],
+    ];
+
+    merkle_tree.update(&leaf1, 0).unwrap();
+
+    assert_eq!(merkle_tree.root().unwrap(), expected_root);
+    assert_eq!(merkle_tree.get_proof_of_leaf(0), expected_proof);
+
+    // Appending the 2nd leaf should result in recomputing the root due to the
+    // change of the `h1`, which now is a hash of the two non-zero leafs. So
+    // when computing all hashes up to the root, we are still going to use
+    // zero bytes from 1 to 8.
+    //
+    // The other subtrees still remain the same.
+    //
+    //              R
+    //           /     \
+    //          H3    Z[3]
+    //        /    \
+    //       H2   Z[2]
+    //     /    \
+    //   H1    Z[1]
+    //  /  \
+    // L1  L2
+    let leaf2 = H::hash(&[2u8; 32]).unwrap();
+
+    let h1 = H::hashv(&[&leaf1, &leaf2]).unwrap();
+    let h2 = H::hashv(&[&h1, &H::zero_bytes()[1]]).unwrap();
+    let h3 = H::hashv(&[&h2, &H::zero_bytes()[2]]).unwrap();
+    let expected_root = H::hashv(&[&h3, &H::zero_bytes()[3]]).unwrap();
+    let expected_proof = vec![
+        leaf1,
+        H::zero_bytes()[1],
+        H::zero_bytes()[2],
+        H::zero_bytes()[3],
+    ];
+
+    merkle_tree.update(&leaf2, 1).unwrap();
+
+    assert_eq!(merkle_tree.root().unwrap(), expected_root);
+    assert_eq!(merkle_tree.get_proof_of_leaf(1), expected_proof);
+
+    // Appending the 3rd leaf alters the next subtree on the right.
+    // Instead of using Z[1], we will end up with the hash of the new leaf and
+    // Z[0].
+    //
+    // The other subtrees still remain the same.
+    //
+    //               R
+    //            /     \
+    //           H4    Z[3]
+    //         /    \
+    //       H3    Z[2]
+    //     /    \
+    //   H1      H2
+    //  /  \    /  \
+    // L1  L2  L3  Z[0]
+    let leaf3 = H::hash(&[3u8; 32]).unwrap();
+
+    let h1 = H::hashv(&[&leaf1, &leaf2]).unwrap();
+    let h2 = H::hashv(&[&leaf3, &H::zero_bytes()[0]]).unwrap();
+    let h3 = H::hashv(&[&h1, &h2]).unwrap();
+    let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
+    let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    let expected_proof = [
+        H::zero_bytes()[0],
+        h1,
+        H::zero_bytes()[2],
+        H::zero_bytes()[3],
+    ];
+
+    merkle_tree.update(&leaf3, 2).unwrap();
+
+    assert_eq!(merkle_tree.root().unwrap(), expected_root);
+    assert_eq!(merkle_tree.get_proof_of_leaf(2), expected_proof);
+
+    // Appending the 4th leaf alters the next subtree on the right.
+    // Instead of using Z[1], we will end up with the hash of the new leaf and
+    // Z[0].
+    //
+    // The other subtrees still remain the same.
+    //
+    //               R
+    //            /     \
+    //           H4    Z[3]
+    //         /    \
+    //       H3    Z[2]
+    //     /    \
+    //   H1      H2
+    //  /  \    /  \
+    // L1  L2  L3  L4
+    let leaf4 = H::hash(&[4u8; 32]).unwrap();
+
+    let h1 = H::hashv(&[&leaf1, &leaf2]).unwrap();
+    let h2 = H::hashv(&[&leaf3, &leaf4]).unwrap();
+    let h3 = H::hashv(&[&h1, &h2]).unwrap();
+    let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
+    let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    let expected_proof = [leaf3, h1, H::zero_bytes()[2], H::zero_bytes()[3]];
+
+    merkle_tree.update(&leaf4, 3).unwrap();
+
+    assert_eq!(merkle_tree.root().unwrap(), expected_root);
+    assert_eq!(merkle_tree.get_proof_of_leaf(3), expected_proof);
+
+    // Update `leaf1`.
+    let new_leaf1 = [9u8; 32];
+
+    // Updating L1 affects H1 and all parent hashes up to the root.
+    //
+    //                R
+    //             /     \
+    //           *H4*   Z[3]
+    //          /    \
+    //       *H3*   Z[2]
+    //      /    \
+    //   *H1*     H2
+    //   /  \    /  \
+    // *L1* L2  L3  L4
+    //
+    // Merkle proof for the replaced leaf L1 is:
+    // [L2, H2, Z[2], Z[3]]
+    //
+    // Our Merkle tree implementation should be smart enough to fill up the
+    // proof with zero bytes, so we can skip them and just define the proof as:
+    // [L2, H2]
+    merkle_tree.update(&new_leaf1, 0).unwrap();
+
+    let h1 = H::hashv(&[&new_leaf1, &leaf2]).unwrap();
+    let h2 = H::hashv(&[&leaf3, &leaf4]).unwrap();
+    let h3 = H::hashv(&[&h1, &h2]).unwrap();
+    let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
+    let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    let expected_proof = [leaf2, h2, H::zero_bytes()[2], H::zero_bytes()[3]];
+
+    assert_eq!(merkle_tree.root().unwrap(), expected_root);
+    assert_eq!(merkle_tree.get_proof_of_leaf(0), expected_proof);
+
+    // Update `leaf2`.
+    let new_leaf2 = H::hash(&[8u8; 32]).unwrap();
+
+    // Updating L2 affects H1 and all parent hashes up to the root.
+    //
+    //               R
+    //            /     \
+    //          *H4*   Z[3]
+    //         /    \
+    //      *H3*   Z[2]
+    //     /    \
+    //  *H1*     H2
+    //  /  \    /  \
+    // L1 *L2* L3  L4
+    //
+    // Merkle proof for the replaced leaf L2 is:
+    // [L1, H2]
+    merkle_tree.update(&new_leaf2, 1).unwrap();
+
+    let h1 = H::hashv(&[&new_leaf1, &new_leaf2]).unwrap();
+    let h2 = H::hashv(&[&leaf3, &leaf4]).unwrap();
+    let h3 = H::hashv(&[&h1, &h2]).unwrap();
+    let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
+    let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    let expected_proof = [new_leaf1, h2, H::zero_bytes()[2], H::zero_bytes()[3]];
+
+    assert_eq!(merkle_tree.root().unwrap(), expected_root);
+    assert_eq!(merkle_tree.get_proof_of_leaf(1), expected_proof);
+
+    // Update `leaf3`.
+    let new_leaf3 = H::hash(&[7u8; 32]).unwrap();
+
+    // Updating L3 affects H1 and all parent hashes up to the root.
+    //
+    //               R
+    //            /     \
+    //          *H4*   Z[3]
+    //         /    \
+    //      *H3*   Z[2]
+    //     /    \
+    //   H1     *H2*
+    //  /  \    /  \
+    // L1  L2 *L3* L4
+    //
+    // Merkle proof for the replaced leaf L3 is:
+    // [L4, H1]
+    merkle_tree.update(&new_leaf3, 2).unwrap();
+
+    let h1 = H::hashv(&[&new_leaf1, &new_leaf2]).unwrap();
+    let h2 = H::hashv(&[&new_leaf3, &leaf4]).unwrap();
+    let h3 = H::hashv(&[&h1, &h2]).unwrap();
+    let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
+    let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    let expected_proof = [leaf4, h1, H::zero_bytes()[2], H::zero_bytes()[3]];
+
+    assert_eq!(merkle_tree.root().unwrap(), expected_root);
+    assert_eq!(merkle_tree.get_proof_of_leaf(2), expected_proof);
+
+    // Update `leaf4`.
+    let new_leaf4 = H::hash(&[6u8; 32]).unwrap();
+
+    // Updating L4 affects H1 and all parent hashes up to the root.
+    //
+    //               R
+    //            /     \
+    //          *H4*   Z[3]
+    //         /    \
+    //      *H3*   Z[2]
+    //     /    \
+    //   H1     *H2*
+    //  /  \    /  \
+    // L1  L2  L3 *L4*
+    //
+    // Merkle proof for the replaced leaf L4 is:
+    // [L3, H1]
+    merkle_tree.update(&new_leaf4, 3).unwrap();
+
+    let h1 = H::hashv(&[&new_leaf1, &new_leaf2]).unwrap();
+    let h2 = H::hashv(&[&new_leaf3, &new_leaf4]).unwrap();
+    let h3 = H::hashv(&[&h1, &h2]).unwrap();
+    let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
+    let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    let expected_proof = [new_leaf3, h1, H::zero_bytes()[2], H::zero_bytes()[3]];
+
+    assert_eq!(merkle_tree.root().unwrap(), expected_root);
+    assert_eq!(merkle_tree.get_proof_of_leaf(3), expected_proof);
+}
+
+#[test]
+fn test_append_keccak() {
+    update::<Keccak>()
+}
+
+#[test]
+fn test_append_poseidon() {
+    update::<Poseidon>()
+}
+
+#[test]
+fn test_append_sha256() {
+    update::<Sha256>()
+}


### PR DESCRIPTION
It's going to be useful for testing and building off-chain MT instances in Rust.

It aims to be similar to spl-merkle-tree-reference[0], but the difference is that it supports multiple hash algorithms.

[0] https://crates.io/crates/spl-merkle-tree-reference