### PR TITLE
style: Fix naming in the concurrent Merkle tree module

### DIFF
--- a/merkle-tree/concurrent/src/changelog.rs
+++ b/merkle-tree/concurrent/src/changelog.rs
@@ -1,26 +1,26 @@
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(C)]
-pub struct ChangelogEntry<const MAX_HEIGHT: usize> {
+pub struct ChangelogEntry<const HEIGHT: usize> {
     /// Root.
     pub root: [u8; 32],
     // Path of the changelog.
-    pub path: [[u8; 32]; MAX_HEIGHT],
+    pub path: [[u8; 32]; HEIGHT],
     // Index.
     pub index: u64,
 }
 
-impl<const MAX_HEIGHT: usize> Default for ChangelogEntry<MAX_HEIGHT> {
+impl<const HEIGHT: usize> Default for ChangelogEntry<HEIGHT> {
     fn default() -> Self {
         Self {
             root: [0u8; 32],
-            path: [[0u8; 32]; MAX_HEIGHT],
+            path: [[0u8; 32]; HEIGHT],
             index: 0,
         }
     }
 }
 
-impl<const MAX_HEIGHT: usize> ChangelogEntry<MAX_HEIGHT> {
-    pub fn new(root: [u8; 32], path: [[u8; 32]; MAX_HEIGHT], index: usize) -> Self {
+impl<const HEIGHT: usize> ChangelogEntry<HEIGHT> {
+    pub fn new(root: [u8; 32], path: [[u8; 32]; HEIGHT], index: usize) -> Self {
         let index = index as u64;
         Self { root, path, index }
     }

--- a/merkle-tree/concurrent/src/hash.rs
+++ b/merkle-tree/concurrent/src/hash.rs
@@ -1,54 +1,54 @@
 use light_hasher::{errors::HasherError, Hasher};
 
-/// Returns the hash of the parent node based on the provided `node` (and its
-/// index `i_node`) and `sibling` (and its index `i_sibling`).
+/// Returns the hash of the parent node based on the provided `node` (with its
+/// `node_index`) and `sibling` (with its `sibling_index`).
 pub fn compute_parent_node<H>(
-    leaf: &[u8; 32],
+    node: &[u8; 32],
     sibling: &[u8; 32],
-    leaf_index: usize,
+    node_index: usize,
     sibling_index: usize,
 ) -> Result<[u8; 32], HasherError>
 where
     H: Hasher,
 {
-    let is_left = (leaf_index >> sibling_index) & 1 == 0;
+    let is_left = (node_index >> sibling_index) & 1 == 0;
     if is_left {
-        H::hashv(&[leaf, sibling])
+        H::hashv(&[node, sibling])
     } else {
-        H::hashv(&[sibling, leaf])
+        H::hashv(&[sibling, node])
     }
 }
 
 /// Computes the root for the given `leaf` (with index `i`) and `proof`. It
 /// doesn't perform the validation of the provided `proof`.
-pub fn compute_root<H, const MAX_HEIGHT: usize>(
+pub fn compute_root<H, const HEIGHT: usize>(
     leaf: &[u8; 32],
     leaf_index: usize,
-    proof: &[[u8; 32]; MAX_HEIGHT],
+    proof: &[[u8; 32]; HEIGHT],
 ) -> Result<[u8; 32], HasherError>
 where
     H: Hasher,
 {
-    let mut leaf = *leaf;
+    let mut node = *leaf;
     for (j, sibling) in proof.iter().enumerate() {
-        leaf = compute_parent_node::<H>(&leaf, sibling, leaf_index, j)?;
+        node = compute_parent_node::<H>(&node, sibling, leaf_index, j)?;
     }
-    Ok(leaf)
+    Ok(node)
 }
 
 /// Checks whether the given Merkle `proof` for the given `node` (with index
 /// `i`) is valid. The proof is valid when computing parent node hashes using
 /// the whole path of the proof gives the same result as the given `root`.
-pub fn validate_proof<H, const MAX_HEIGHT: usize>(
+pub fn validate_proof<H, const HEIGHT: usize>(
     root: &[u8; 32],
     leaf: &[u8; 32],
     leaf_index: usize,
-    proof: &[[u8; 32]; MAX_HEIGHT],
+    proof: &[[u8; 32]; HEIGHT],
 ) -> Result<(), HasherError>
 where
     H: Hasher,
 {
-    let computed_root = compute_root::<H, MAX_HEIGHT>(leaf, leaf_index, proof)?;
+    let computed_root = compute_root::<H, HEIGHT>(leaf, leaf_index, proof)?;
     if computed_root == *root {
         Ok(())
     } else {


### PR DESCRIPTION
* Stick to `HEIGHT` instead of `MAX_HEIGHT`.
* Make sure that variables containing "leaf" in name are actual leaves - in case of variables where upper nodes can be assigned, use "node".