### PR TITLE
feat: add proof compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,9 +2253,12 @@ dependencies = [
 [[package]]
 name = "groth16-solana"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5650595f0c8cf8b45ddaa0d9ede9ae54b45f36352afde98e0face95ccee4854c"
+source = "git+https://github.com/Lightprotocol/groth16-solana?branch=master#d1165a03aed6150576c38160797c9f9a1ae630a1"
 dependencies = [
+ "ark-bn254 0.4.0",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
  "solana-program",
  "thiserror",
 ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -853,58 +853,6 @@ importers:
         specifier: 5.3.2
         version: 5.3.2
 
-  psp-examples/tmp-test-circom:
-    dependencies:
-      '@coral-xyz/anchor':
-        specifier: ^0.28.0
-        version: 0.28.0
-      '@lightprotocol/account.rs':
-        specifier: workspace:*
-        version: link:../../account.rs
-      '@lightprotocol/circuit-lib.circom':
-        specifier: 0.1.0-alpha.1
-        version: link:../../circuit-lib/circuit-lib.circom
-      '@lightprotocol/prover.js':
-        specifier: 0.1.0-alpha.3
-        version: link:../../prover.js
-      '@lightprotocol/zk.js':
-        specifier: 0.3.2-alpha.16
-        version: link:../../zk.js
-      '@project-serum/anchor':
-        specifier: ^0.26.0
-        version: 0.26.0
-      circomlib:
-        specifier: ^2.0.5
-        version: 2.0.5
-      circomlibjs:
-        specifier: ^0.1.7
-        version: 0.1.7
-    devDependencies:
-      '@types/bn.js':
-        specifier: ^5.1.0
-        version: 5.1.2
-      '@types/chai':
-        specifier: ^4.3.0
-        version: 4.3.9
-      '@types/mocha':
-        specifier: ^9.0.0
-        version: 9.1.1
-      chai:
-        specifier: ^4.3.4
-        version: 4.3.10
-      mocha:
-        specifier: ^9.0.3
-        version: 9.2.2
-      prettier:
-        specifier: ^2.6.2
-        version: 2.8.8
-      ts-mocha:
-        specifier: ^10.0.0
-        version: 10.0.0(mocha@9.2.2)
-      typescript:
-        specifier: ^4.3.5
-        version: 4.9.5
-
   psp-examples/tmp-test-psp:
     dependencies:
       '@coral-xyz/anchor':

--- a/programs/psp10in2out/Cargo.toml
+++ b/programs/psp10in2out/Cargo.toml
@@ -23,7 +23,8 @@ light-merkle-tree-program = { version = "0.3.1", path = "../merkle-tree", featur
 solana-security-txt = "1.1.0"
 
 # Light Deps
-groth16-solana = "0.0.2"
+groth16-solana = { git= "https://github.com/Lightprotocol/groth16-solana", branch="master"}
+
 light-macros = { version = "0.3.1", path = "../../macros/light" }
 light-verifier-sdk = { version = "0.3.1", path = "../../verifier-sdk" }
 

--- a/programs/psp10in2out/src/lib.rs
+++ b/programs/psp10in2out/src/lib.rs
@@ -33,7 +33,7 @@ impl Config for TransactionConfig {
 pub mod light_psp10in2out {
     use std::marker::PhantomData;
 
-    use light_verifier_sdk::light_transaction::{Amounts, Proof};
+    use light_verifier_sdk::light_transaction::{Amounts, ProofCompressed};
 
     use super::*;
 
@@ -89,7 +89,7 @@ pub mod light_psp10in2out {
             InstructionDataCompressedTransferSecond::try_deserialize_unchecked(
                 &mut [vec![0u8; 8], inputs].concat().as_slice(),
             )?;
-        let proof = Proof {
+        let proof = ProofCompressed {
             a: inputs.proof_a,
             b: inputs.proof_b,
             c: inputs.proof_c,
@@ -218,9 +218,9 @@ pub struct LightInstructionSecond<
 #[derive(Debug)]
 #[account]
 pub struct InstructionDataCompressedTransferSecond {
-    proof_a: [u8; 64],
-    proof_b: [u8; 128],
-    proof_c: [u8; 64],
+    proof_a: [u8; 32],
+    proof_b: [u8; 64],
+    proof_c: [u8; 32],
 }
 
 #[derive(Accounts)]

--- a/programs/psp2in2out-storage/Cargo.toml
+++ b/programs/psp2in2out-storage/Cargo.toml
@@ -22,7 +22,8 @@ anchor-spl = "0.28.0"
 
 # Light deps
 aligned-sized = { version = "0.1.0", path = "../../macros/aligned-sized" }
-groth16-solana = "0.0.2"
+groth16-solana = { git= "https://github.com/Lightprotocol/groth16-solana", branch="master"}
+
 light-macros = { version = "0.3.1", path = "../../macros/light" }
 light-merkle-tree-program = { version = "0.3.1", path = "../merkle-tree", features = ["cpi"] }
 light-verifier-sdk = { version = "0.3.1", path = "../../verifier-sdk" }

--- a/programs/psp2in2out-storage/src/lib.rs
+++ b/programs/psp2in2out-storage/src/lib.rs
@@ -2,7 +2,7 @@ use aligned_sized::aligned_sized;
 use anchor_lang::prelude::*;
 use light_macros::light_verifier_accounts;
 use light_verifier_sdk::light_transaction::{
-    Amounts, Message, Proof, Transaction, TransactionInput, VERIFIER_STATE_SEED,
+    Amounts, Message, Transaction, TransactionInput, VERIFIER_STATE_SEED,
 };
 
 pub mod verifying_key;
@@ -36,6 +36,8 @@ pub enum VerifierError {
 
 #[program]
 pub mod light_psp2in2out_storage {
+    use light_verifier_sdk::light_transaction::ProofCompressed;
+
     use super::*;
 
     /// Saves the provided message in a temporary PDA.
@@ -87,7 +89,7 @@ pub mod light_psp2in2out_storage {
                 &mut [vec![0u8; 8], inputs, vec![0u8; 16]].concat().as_slice(),
             )?;
         let message = Message::new(&ctx.accounts.verifier_state.msg);
-        let proof = Proof {
+        let proof = ProofCompressed {
             a: inputs.proof_a,
             b: inputs.proof_b,
             c: inputs.proof_c,
@@ -168,9 +170,9 @@ pub struct LightInstructionSecond<'info> {
 #[derive(Debug)]
 #[account]
 pub struct InstructionDataCompressedTransferSecond {
-    proof_a: [u8; 64],
-    proof_b: [u8; 128],
-    proof_c: [u8; 64],
+    proof_a: [u8; 32],
+    proof_b: [u8; 64],
+    proof_c: [u8; 32],
     input_nullifier: [[u8; 32]; 2],
     output_commitment: [[u8; 32]; 2],
     public_amount_sol: [u8; 32],

--- a/programs/psp2in2out/Cargo.toml
+++ b/programs/psp2in2out/Cargo.toml
@@ -23,7 +23,7 @@ light-merkle-tree-program = { version = "0.3.1", path = "../merkle-tree", featur
 solana-security-txt = "1.1.0"
 
 # Light Deps
-groth16-solana = "0.0.2"
+groth16-solana = { git= "https://github.com/Lightprotocol/groth16-solana", branch="master"}
 light-macros = { version = "0.3.1", path = "../../macros/light" }
 light-verifier-sdk = { version = "0.3.1", path = "../../verifier-sdk" }
 

--- a/programs/psp2in2out/src/lib.rs
+++ b/programs/psp2in2out/src/lib.rs
@@ -1,6 +1,8 @@
 use anchor_lang::prelude::*;
 use light_macros::light_verifier_accounts;
-use light_verifier_sdk::light_transaction::{Amounts, Proof, Transaction, TransactionInput};
+use light_verifier_sdk::light_transaction::{
+    Amounts, ProofCompressed, Transaction, TransactionInput,
+};
 
 pub mod verifying_key;
 use verifying_key::VERIFYINGKEY_TRANSACTION_MASP2_MAIN;
@@ -21,6 +23,7 @@ pub const PROGRAM_ID: &str = "J1RRetZ4ujphU75LP8RadjXMf3sA12yC2R44CF7PmU7i";
 
 #[program]
 pub mod light_psp2in2out {
+
     use super::*;
 
     /// This instruction is the first step of a compressed transaction.
@@ -39,7 +42,7 @@ pub mod light_psp2in2out {
         let len_missing_bytes = 256 - inputs.encrypted_utxos.len();
         let mut enc_utxos = inputs.encrypted_utxos;
         enc_utxos.append(&mut vec![0u8; len_missing_bytes]);
-        let proof = Proof {
+        let proof = ProofCompressed {
             a: inputs.proof_a,
             b: inputs.proof_b,
             c: inputs.proof_c,
@@ -76,9 +79,9 @@ pub struct LightInstruction<'info> {}
 #[derive(Debug)]
 #[account]
 pub struct InstructionDataCompressedTransferFirst {
-    proof_a: [u8; 64],
-    proof_b: [u8; 128],
-    proof_c: [u8; 64],
+    proof_a: [u8; 32],
+    proof_b: [u8; 64],
+    proof_c: [u8; 32],
     public_amount_spl: [u8; 32],
     input_nullifier: [[u8; 32]; 2],
     output_commitment: [[u8; 32]; 2],

--- a/programs/psp4in4out-app-storage/Cargo.toml
+++ b/programs/psp4in4out-app-storage/Cargo.toml
@@ -23,7 +23,8 @@ light-merkle-tree-program = { version = "0.3.1", path = "../merkle-tree", featur
 solana-security-txt = "1.1.0"
 
 # Light Deps
-groth16-solana = "0.0.2"
+groth16-solana = { git= "https://github.com/Lightprotocol/groth16-solana", branch="master"}
+
 light-macros = { version = "0.3.1", path = "../../macros/light" }
 light-verifier-sdk = { version = "0.3.1", path = "../../verifier-sdk" }
 bytemuck = "1.14.0"

--- a/prover.js/package.json
+++ b/prover.js/package.json
@@ -24,6 +24,7 @@
     "test:nodejs": "vitest run",
     "test:browser": "vitest run --browser.name=firefox --browser.provider=playwright --browser.headless",
     "test": "pnpm test-prepare-circom && pnpm test:nodejs && pnpm test:browser",
+    "test-skip-compile": "pnpm test:nodejs",
     "test:types": "tsc",
     "build": "rm -rf dist && pnpm build:bundle",
     "build:bundle": "rollup -c --bundleConfigAsCjs",

--- a/prover.js/tests/prover.test.ts
+++ b/prover.js/tests/prover.test.ts
@@ -2,9 +2,48 @@ import { Prover } from "../src";
 import { IDL } from "./circuits/idl";
 import { describe, it, expect, afterAll } from "vitest";
 import { WasmFactory } from "@lightprotocol/account.rs";
+import { assert } from "chai";
+import { BN } from "@coral-xyz/anchor";
 
 describe("Prover Functionality Tests", () => {
-  it("Valid proof test", async () => {
+  it("Valid proof test no compression", async () => {
+    const lightWasm = await WasmFactory.getInstance();
+    const hash = lightWasm.poseidonHashString(["123"]);
+    const circuitsPath: string = "./tests/circuits/build-circuits";
+    const proofInputs: any = {
+      x: "123",
+      hash: hash,
+    };
+
+    const prover = new Prover(IDL, circuitsPath, "poseidon");
+
+    await prover.addProofInputs(proofInputs);
+
+    console.time("Proof generation + Parsing");
+    await prover.fullProveAndParse(false);
+    console.timeEnd("Proof generation + Parsing");
+  });
+
+  it("Testing invalid proof", async () => {
+    const hasher = await WasmFactory.getInstance();
+    const hash = hasher.poseidonHashString(["123"]);
+
+    const circuitsPath: string = "./tests/circuits/build-circuits";
+    const proofInputs: any = {
+      x: 1,
+      hash: hash,
+    };
+
+    const prover = new Prover(IDL, circuitsPath);
+
+    await prover.addProofInputs(proofInputs);
+
+    console.time("Proof generation + Parsing");
+    await expect(prover.fullProveAndParse(false)).rejects.toThrow(Error);
+    console.timeEnd("Proof generation + Parsing");
+  });
+
+  it("Valid proof test proof compression", async () => {
     const lightWasm = await WasmFactory.getInstance();
     const hash = lightWasm.poseidonHashString(["123"]);
     const circuitsPath: string = "./tests/circuits/build-circuits";
@@ -39,6 +78,67 @@ describe("Prover Functionality Tests", () => {
     console.time("Proof generation + Parsing");
     await expect(prover.fullProveAndParse()).rejects.toThrow(Error);
     console.timeEnd("Proof generation + Parsing");
+  });
+
+  it("testing proof compression ", async () => {
+    const proofA = [
+      45, 206, 255, 166, 152, 55, 128, 138, 79, 217, 145, 164, 25, 74, 120, 234,
+      234, 217, 68, 149, 162, 44, 133, 120, 184, 205, 12, 44, 175, 98, 168, 172,
+      20, 24, 216, 15, 209, 175, 106, 75, 147, 236, 90, 101, 123, 219, 245, 151,
+      209, 202, 218, 104, 148, 8, 32, 254, 243, 191, 218, 122, 42, 81, 193, 84,
+    ];
+
+    let proofACompressed = proofA.slice(0, 32);
+    const proofAY = new BN(proofACompressed.slice(32), 32, "be");
+    const proofAYIsPositive = Prover.yElementIsPositiveG1(proofAY);
+    assert.isTrue(proofAYIsPositive);
+    proofACompressed[0] = Prover.addBitmaskToByte(
+      proofACompressed[0],
+      proofAYIsPositive,
+    );
+    assert.equal(proofACompressed[0], proofA[0]);
+
+    const proofC = [
+      41, 139, 183, 208, 246, 198, 118, 127, 89, 160, 9, 27, 61, 26, 123, 180,
+      221, 108, 17, 166, 47, 115, 82, 48, 132, 139, 253, 65, 152, 92, 209, 53,
+      37, 25, 83, 61, 252, 42, 181, 243, 16, 21, 2, 199, 123, 96, 218, 151, 253,
+      86, 69, 181, 202, 109, 64, 129, 124, 254, 192, 25, 177, 199, 26, 50,
+    ];
+    let proofCCompressed = proofC.slice(0, 32);
+    const proofCY = new BN(proofC.slice(32, 64), 32, "be");
+    const proofCYIsPositive = Prover.yElementIsPositiveG1(proofCY);
+    assert.isNotTrue(proofCYIsPositive);
+    proofCCompressed[0] = Prover.addBitmaskToByte(
+      proofCCompressed[0],
+      proofCYIsPositive,
+    );
+    assert.equal(proofCCompressed[0], 169);
+
+    const proofB = [
+      40, 57, 233, 205, 180, 46, 35, 111, 215, 5, 23, 93, 12, 71, 118, 225, 7,
+      46, 247, 147, 47, 130, 106, 189, 184, 80, 146, 103, 141, 52, 242, 25, 0,
+      203, 124, 176, 110, 34, 151, 212, 66, 180, 238, 151, 236, 189, 133, 209,
+      17, 137, 205, 183, 168, 196, 92, 159, 75, 174, 81, 168, 18, 86, 176, 56,
+      16, 26, 210, 20, 18, 81, 122, 142, 104, 62, 251, 169, 98, 141, 21, 253,
+      50, 130, 182, 15, 33, 109, 228, 31, 79, 183, 88, 147, 174, 108, 4, 22, 14,
+      129, 168, 6, 80, 246, 254, 100, 218, 131, 94, 49, 247, 211, 3, 245, 22,
+      200, 177, 91, 60, 144, 147, 174, 90, 17, 19, 189, 62, 147, 152, 18,
+    ];
+    let proofBCompressed = proofB.slice(0, 64);
+    const proofBY = [
+      new BN(proofB.slice(64, 96), 32, "be"),
+      new BN(proofB.slice(96, 128), 32, "be"),
+    ];
+    const proofBYIsPositive = Prover.yElementIsPositiveG2(
+      proofBY[0],
+      proofBY[1],
+    );
+    assert.isTrue(proofBYIsPositive);
+    proofBCompressed[0] = Prover.addBitmaskToByte(
+      proofBCompressed[0],
+      proofBYIsPositive,
+    );
+    assert.equal(proofBCompressed[0], 40);
   });
 
   afterAll(async () => {

--- a/prover.js/tests/prover.test.ts
+++ b/prover.js/tests/prover.test.ts
@@ -88,7 +88,7 @@ describe("Prover Functionality Tests", () => {
       209, 202, 218, 104, 148, 8, 32, 254, 243, 191, 218, 122, 42, 81, 193, 84,
     ];
 
-    let proofACompressed = proofA.slice(0, 32);
+    const proofACompressed = proofA.slice(0, 32);
     const proofAY = new BN(proofACompressed.slice(32), 32, "be");
     const proofAYIsPositive = Prover.yElementIsPositiveG1(proofAY);
     assert.isTrue(proofAYIsPositive);
@@ -104,7 +104,7 @@ describe("Prover Functionality Tests", () => {
       37, 25, 83, 61, 252, 42, 181, 243, 16, 21, 2, 199, 123, 96, 218, 151, 253,
       86, 69, 181, 202, 109, 64, 129, 124, 254, 192, 25, 177, 199, 26, 50,
     ];
-    let proofCCompressed = proofC.slice(0, 32);
+    const proofCCompressed = proofC.slice(0, 32);
     const proofCY = new BN(proofC.slice(32, 64), 32, "be");
     const proofCYIsPositive = Prover.yElementIsPositiveG1(proofCY);
     assert.isNotTrue(proofCYIsPositive);
@@ -124,7 +124,7 @@ describe("Prover Functionality Tests", () => {
       129, 168, 6, 80, 246, 254, 100, 218, 131, 94, 49, 247, 211, 3, 245, 22,
       200, 177, 91, 60, 144, 147, 174, 90, 17, 19, 189, 62, 147, 152, 18,
     ];
-    let proofBCompressed = proofB.slice(0, 64);
+    const proofBCompressed = proofB.slice(0, 64);
     const proofBY = [
       new BN(proofB.slice(64, 96), 32, "be"),
       new BN(proofB.slice(96, 128), 32, "be"),

--- a/psp-examples/multisig/programs/multisig/Cargo.toml
+++ b/psp-examples/multisig/programs/multisig/Cargo.toml
@@ -23,7 +23,8 @@ verifier_program_two = { git = "https://github.com/lightprotocol/light-protocol"
 light-macros = "0.1.0"
 light-verifier-sdk = { git = "https://github.com/lightprotocol/light-protocol", tag = "v0.3.2" }
 solana-program = "1.16.4"
-groth16-solana = "0.0.2"
+groth16-solana = { git= "https://github.com/Lightprotocol/groth16-solana", branch="master"}
+
 
 # TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
 ahash = "=0.8.6"

--- a/psp-examples/private-compressed-account/programs/private-compressed-account/Cargo.toml
+++ b/psp-examples/private-compressed-account/programs/private-compressed-account/Cargo.toml
@@ -23,7 +23,8 @@ light-psp4in4out-app-storage = { path = "../../../../programs/psp4in4out-app-sto
 light-macros = { path = "../../../../macros/light" }
 light-verifier-sdk = { path = "../../../../verifier-sdk" }
 solana-program = "1.16.4"
-groth16-solana = "0.0.2"
+groth16-solana = { git= "https://github.com/Lightprotocol/groth16-solana", branch="master"}
+
 bytemuck = { version = "1.4.0", features = ["derive", "min_const_generics"]}
 memoffset = "0.9.0"
 

--- a/psp-examples/rock-paper-scissors/programs/rock-paper-scissors/Cargo.toml
+++ b/psp-examples/rock-paper-scissors/programs/rock-paper-scissors/Cargo.toml
@@ -23,7 +23,8 @@ light-psp4in4out-app-storage = { path = "../../../../programs/psp4in4out-app-sto
 light-macros = { path = "../../../../macros/light" }
 light-verifier-sdk = { path = "../../../../verifier-sdk" }
 solana-program = "1.16.4"
-groth16-solana = "0.0.2"
+groth16-solana = { git= "https://github.com/Lightprotocol/groth16-solana", branch="master"}
+
 bytemuck = { version = "1.4.0", features = ["derive", "min_const_generics"]}
 memoffset = "0.9.0"
 

--- a/psp-examples/streaming-payments/Cargo.lock
+++ b/psp-examples/streaming-payments/Cargo.lock
@@ -1290,9 +1290,12 @@ dependencies = [
 [[package]]
 name = "groth16-solana"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5650595f0c8cf8b45ddaa0d9ede9ae54b45f36352afde98e0face95ccee4854c"
+source = "git+https://github.com/Lightprotocol/groth16-solana?branch=master#d1165a03aed6150576c38160797c9f9a1ae630a1"
 dependencies = [
+ "ark-bn254 0.4.0",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
  "solana-program",
  "thiserror",
 ]
@@ -2274,9 +2277,9 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.16.5"
+version = "1.16.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15610c43f150a99322c295c903cc521fa6921002ceed29fc419b7832c4ce4a4c"
+checksum = "d229588852b514378c88ea74ef6fb93c5575758d2aa3a6a300872ccf5be51772"
 dependencies = [
  "ahash 0.8.6",
  "blake3",
@@ -2307,9 +2310,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.16.5"
+version = "1.16.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5a146d452c451b052034ac9bb3fe7fe323fe0c891c3e71dcda50d944c5ad1"
+checksum = "ad75a8290906967a9737c76bb5cc9769cee2097a6a6fbda08017562454ead020"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2319,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.16.5"
+version = "1.16.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9302be0d873cdd53768fae0eb0edb339337831fab45490fae0c2871ef720ad31"
+checksum = "f4896bca227a92b31c7be15f524850aba3255d94dcb837a4097daba723a84757"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -2330,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.16.5"
+version = "1.16.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ad3f1977e6bf4f3f2bbf3d8988c58b8729c6aa1086b908eb50b138ddc6a812c"
+checksum = "de52673b07eda66299b6ff858c54f3d08bdf4addc5c56969f0a94a09bb63f853"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",
@@ -2344,6 +2347,7 @@ dependencies = [
  "bitflags",
  "blake3",
  "borsh 0.10.3",
+ "borsh 0.9.3",
  "bs58 0.4.0",
  "bv",
  "bytemuck",
@@ -2384,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.16.5"
+version = "1.16.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e86f3523fa2612c7c7748b6fdbc16006e84a2bfda06c5835c9389bdf151621"
+checksum = "96d5e51b30ff694f1353755b0e1672bc01a6b72ad12353fac4e53957a2a1f783"
 dependencies = [
  "assert_matches",
  "base64 0.21.2",
@@ -2437,9 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.16.5"
+version = "1.16.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3673ef415e5d2673f00b78b4115536144c98f3253cc07b63b0df6b42720dc6"
+checksum = "d5c5ae1f2b5e7dec7dcab0199a642e1900b981c156547942156c5c4fbcc3eafa"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2",
@@ -2456,9 +2460,9 @@ checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.16.5"
+version = "1.16.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796023a165cc5c656a951ce667d746e24f599bfa76e0b4cc1e07513578d4322d"
+checksum = "d66b682b70d18374f8619a1e61ec461d481d5ee7dc2057d53d7370176f41027c"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.2",

--- a/psp-examples/streaming-payments/programs/streaming-payments/Cargo.toml
+++ b/psp-examples/streaming-payments/programs/streaming-payments/Cargo.toml
@@ -22,8 +22,9 @@ light-merkle-tree-program = { path = "../../../../programs/merkle-tree", feature
 light-psp4in4out-app-storage = { path = "../../../../programs/psp4in4out-app-storage", features = ["cpi"] }
 light-macros = { path = "../../../../macros/light" }
 light-verifier-sdk = { path = "../../../../verifier-sdk" }
-solana-program = "1.16.4"
-groth16-solana = "0.0.2"
+solana-program = "1.16.15"
+groth16-solana = { git= "https://github.com/Lightprotocol/groth16-solana", branch="master"}
+
 memoffset = "0.9.0"
 bytemuck = "1.14.0"
 

--- a/psp-examples/streaming-payments/programs/streaming-payments/src/processor.rs
+++ b/psp-examples/streaming-payments/programs/streaming-payments/src/processor.rs
@@ -2,7 +2,7 @@ use crate::verifying_key_streaming_payments::VERIFYINGKEY_STREAMING_PAYMENTS;
 use crate::LightInstructionThird;
 use anchor_lang::prelude::*;
 use light_macros::pubkey;
-use light_verifier_sdk::light_transaction::Proof;
+use light_verifier_sdk::light_transaction::ProofCompressed;
 use light_verifier_sdk::light_transaction::VERIFIER_STATE_SEED;
 use light_verifier_sdk::{light_app_transaction::AppTransaction, light_transaction::Config};
 
@@ -16,10 +16,10 @@ pub fn cpi_verifier_two<'a, 'b, 'c, 'info, const NR_CHECKED_INPUTS: usize>(
     ctx: &'a Context<'a, 'b, 'c, 'info, LightInstructionThird<'info, NR_CHECKED_INPUTS>>,
     inputs: &'a Vec<u8>,
 ) -> Result<()> {
-    let proof_verifier = Proof {
-        a: inputs[256..256 + 64].try_into().unwrap(),
-        b: inputs[256 + 64..256 + 192].try_into().unwrap(),
-        c: inputs[256 + 192..256 + 256].try_into().unwrap(),
+    let proof_verifier = ProofCompressed {
+        a: inputs[128..128 + 32].try_into().unwrap(),
+        b: inputs[128 + 32..128 + 96].try_into().unwrap(),
+        c: inputs[128 + 96..128 + 128].try_into().unwrap(),
     };
     let verifier_state = ctx.accounts.verifier_state.load()?;
 
@@ -79,10 +79,10 @@ pub fn verify_program_proof<'a, 'b, 'c, 'info, const NR_CHECKED_INPUTS: usize>(
     inputs: &'a Vec<u8>,
 ) -> Result<()> {
     let verifier_state = ctx.accounts.verifier_state.load()?;
-    let proof_app = Proof {
-        a: inputs[0..64].try_into().unwrap(),
-        b: inputs[64..192].try_into().unwrap(),
-        c: inputs[192..256].try_into().unwrap(),
+    let proof_app = ProofCompressed {
+        a: inputs[0..32].try_into().unwrap(),
+        b: inputs[32..96].try_into().unwrap(),
+        c: inputs[96..128].try_into().unwrap(),
     };
     // Is necessary otherwise the const generic throws an error
     const NR_CHECKED_INPUTS: usize = VERIFYINGKEY_STREAMING_PAYMENTS.nr_pubinputs;

--- a/psp-examples/streaming-payments/programs/streaming-payments/src/psp_accounts.rs
+++ b/psp-examples/streaming-payments/programs/streaming-payments/src/psp_accounts.rs
@@ -86,12 +86,12 @@ pub struct LightInstructionThird<'info, const NR_CHECKED_INPUTS: usize> {
 #[derive(Debug)]
 #[account]
 pub struct InstructionDataLightInstructionThird {
-    pub proof_a_app: [u8; 64],
-    pub proof_b_app: [u8; 128],
-    pub proof_c_app: [u8; 64],
-    pub proof_a: [u8; 64],
-    pub proof_b: [u8; 128],
-    pub proof_c: [u8; 64],
+    pub proof_a_app: [u8; 32],
+    pub proof_b_app: [u8; 64],
+    pub proof_c_app: [u8; 32],
+    pub proof_a: [u8; 32],
+    pub proof_b: [u8; 64],
+    pub proof_c: [u8; 32],
 }
 
 #[derive(Accounts)]

--- a/psp-examples/swap/Cargo.lock
+++ b/psp-examples/swap/Cargo.lock
@@ -1291,9 +1291,12 @@ dependencies = [
 [[package]]
 name = "groth16-solana"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5650595f0c8cf8b45ddaa0d9ede9ae54b45f36352afde98e0face95ccee4854c"
+source = "git+https://github.com/Lightprotocol/groth16-solana?branch=master#d1165a03aed6150576c38160797c9f9a1ae630a1"
 dependencies = [
+ "ark-bn254 0.4.0",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
  "solana-program",
  "thiserror",
 ]
@@ -2258,9 +2261,9 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.16.6"
+version = "1.16.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33ec119dc1bb0395b50d389d31ee6015cc81570d31f19cb3dca0ffff5f8f117"
+checksum = "d229588852b514378c88ea74ef6fb93c5575758d2aa3a6a300872ccf5be51772"
 dependencies = [
  "ahash 0.8.6",
  "blake3",
@@ -2291,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.16.6"
+version = "1.16.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1feba80a564f52092da4c8a93bebc66f39665ebefd02d93bd54ef10453f179d"
+checksum = "ad75a8290906967a9737c76bb5cc9769cee2097a6a6fbda08017562454ead020"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2303,9 +2306,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.16.6"
+version = "1.16.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "853aab82ead804a201f0edb036e5ff73b9bc8e97d9c1b9b91aeee2f6435073a2"
+checksum = "f4896bca227a92b31c7be15f524850aba3255d94dcb837a4097daba723a84757"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -2314,9 +2317,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.16.6"
+version = "1.16.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afaa80737c3f26927df136e46b568525709371a5e161e1f490f1dd5defe9698"
+checksum = "de52673b07eda66299b6ff858c54f3d08bdf4addc5c56969f0a94a09bb63f853"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",
@@ -2328,6 +2331,7 @@ dependencies = [
  "bitflags",
  "blake3",
  "borsh 0.10.3",
+ "borsh 0.9.3",
  "bs58 0.4.0",
  "bv",
  "bytemuck",
@@ -2368,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.16.6"
+version = "1.16.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f53c6ffc2ce2fd2594f6dc1eb1e459843b5f9b008aae10e1cb3d6fef58e63706"
+checksum = "96d5e51b30ff694f1353755b0e1672bc01a6b72ad12353fac4e53957a2a1f783"
 dependencies = [
  "assert_matches",
  "base64 0.21.2",
@@ -2421,9 +2425,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.16.6"
+version = "1.16.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e11e29d859ffa265e1abb6f7aa12afe6c34b64c75b56a80b777f8f957074ac"
+checksum = "d5c5ae1f2b5e7dec7dcab0199a642e1900b981c156547942156c5c4fbcc3eafa"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2",
@@ -2440,9 +2444,9 @@ checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.16.6"
+version = "1.16.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dec0724d3b8c469aafe87c97703ed1f9ddde5ce5df1419fd3d7018d3a41486e"
+checksum = "d66b682b70d18374f8619a1e61ec461d481d5ee7dc2057d53d7370176f41027c"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.2",

--- a/psp-examples/swap/programs/swaps/Cargo.toml
+++ b/psp-examples/swap/programs/swaps/Cargo.toml
@@ -22,8 +22,9 @@ light-merkle-tree-program = { path = "../../../../programs/merkle-tree", feature
 light-psp4in4out-app-storage = { path = "../../../../programs/psp4in4out-app-storage", features = ["cpi"] }
 light-macros = { path = "../../../../macros/light" }
 light-verifier-sdk = { path = "../../../../verifier-sdk" }
-solana-program = "1.16.4"
-groth16-solana = "0.0.2"
+solana-program = "1.16.15"
+groth16-solana = { git= "https://github.com/Lightprotocol/groth16-solana", branch="master"}
+
 bytemuck = { version = "1.4.0", features = ["derive", "min_const_generics"]}
 memoffset = "0.9.0"
 

--- a/psp-examples/swap/programs/swaps/src/processor.rs
+++ b/psp-examples/swap/programs/swaps/src/processor.rs
@@ -2,7 +2,7 @@ use crate::verifying_key_swaps::VERIFYINGKEY_SWAPS;
 use crate::LightInstructionThird;
 use anchor_lang::prelude::*;
 use light_macros::pubkey;
-use light_verifier_sdk::light_transaction::Proof;
+use light_verifier_sdk::light_transaction::ProofCompressed;
 use light_verifier_sdk::light_transaction::VERIFIER_STATE_SEED;
 use light_verifier_sdk::{light_app_transaction::AppTransaction, light_transaction::Config};
 
@@ -16,10 +16,10 @@ pub fn cpi_verifier_two<'a, 'b, 'c, 'info, const NR_CHECKED_INPUTS: usize>(
     ctx: &'a Context<'a, 'b, 'c, 'info, LightInstructionThird<'info, NR_CHECKED_INPUTS>>,
     inputs: &'a Vec<u8>,
 ) -> Result<()> {
-    let proof_verifier = Proof {
-        a: inputs[256..256 + 64].try_into().unwrap(),
-        b: inputs[256 + 64..256 + 192].try_into().unwrap(),
-        c: inputs[256 + 192..256 + 256].try_into().unwrap(),
+    let proof_verifier = ProofCompressed {
+        a: inputs[128..128 + 32].try_into().unwrap(),
+        b: inputs[128 + 32..128 + 96].try_into().unwrap(),
+        c: inputs[128 + 96..128 + 128].try_into().unwrap(),
     };
 
     let (_, bump) = anchor_lang::prelude::Pubkey::find_program_address(
@@ -79,10 +79,10 @@ pub fn verify_program_proof<'a, 'b, 'c, 'info, const NR_CHECKED_INPUTS: usize>(
     ctx: &'a Context<'a, 'b, 'c, 'info, LightInstructionThird<'info, NR_CHECKED_INPUTS>>,
     inputs: &'a Vec<u8>,
 ) -> Result<()> {
-    let proof_app = Proof {
-        a: inputs[0..64].try_into().unwrap(),
-        b: inputs[64..192].try_into().unwrap(),
-        c: inputs[192..256].try_into().unwrap(),
+    let proof_app = ProofCompressed {
+        a: inputs[0..32].try_into().unwrap(),
+        b: inputs[32..96].try_into().unwrap(),
+        c: inputs[96..128].try_into().unwrap(),
     };
     let verifier_state = ctx.accounts.verifier_state.load()?;
     const NR_CHECKED_INPUTS: usize = VERIFYINGKEY_SWAPS.nr_pubinputs;

--- a/psp-examples/swap/programs/swaps/src/psp_accounts.rs
+++ b/psp-examples/swap/programs/swaps/src/psp_accounts.rs
@@ -178,12 +178,12 @@ impl Swap {
 #[derive(Debug)]
 #[account]
 pub struct InstructionDataLightInstructionThird {
-    pub proof_a_app: [u8; 64],
-    pub proof_b_app: [u8; 128],
-    pub proof_c_app: [u8; 64],
-    pub proof_a: [u8; 64],
-    pub proof_b: [u8; 128],
-    pub proof_c: [u8; 64],
+    pub proof_a_app: [u8; 32],
+    pub proof_b_app: [u8; 64],
+    pub proof_c_app: [u8; 32],
+    pub proof_a: [u8; 32],
+    pub proof_b: [u8; 64],
+    pub proof_c: [u8; 32],
 }
 
 #[derive(Accounts)]

--- a/psp-template/psp-template/programs_circom/program_name/Cargo.toml
+++ b/psp-template/psp-template/programs_circom/program_name/Cargo.toml
@@ -17,12 +17,7 @@ default = []
 
 [dependencies]
 anchor-lang = "0.28.0"
-groth16-solana = "0.0.2"
-
-ark-ff = { version = "^0.3.0", default-features = false }
-ark-ec = { version = "0.3.0" }
-ark-bn254 = "0.3.0"
-ark-std = { version = "^0.3.0", default-features = false }
+groth16-solana = { git= "https://github.com/Lightprotocol/groth16-solana", branch="master"}
 
 # TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
 ahash = "=0.8.6"

--- a/psp-template/psp-template/programs_circom/program_name/src/lib.rs
+++ b/psp-template/psp-template/programs_circom/program_name/src/lib.rs
@@ -1,5 +1,11 @@
 use anchor_lang::prelude::*;
-use groth16_solana::groth16::Groth16Verifier;
+use groth16_solana::{
+    decompression::{
+        decompress_g1,
+        decompress_g2
+    },
+    groth16::Groth16Verifier
+};
 pub mod errors;
 pub mod utils;
 pub mod verifying_key_{{circom-name}};
@@ -13,22 +19,22 @@ pub const PROGRAM_ID: &str = "{{program-id}}";
 pub mod {{rust-name}} {
     use super::*;
     use crate::errors::VerifierError;
-    use crate::utils::negate_proof_a;
     use crate::verifying_key_{{circom-name}}::VERIFYINGKEY_{{VERIFYING_KEY_NAME}};
     #[allow(clippy::result_large_err)]
     pub fn verify_proof(
         _ctx: Context<Verifier>,
         public_inputs: [[u8; 32]; 1],
-        proof_a: [u8; 64],
-        proof_b: [u8; 128],
-        proof_c: [u8; 64],
+        proof_a: [u8; 32],
+        proof_b: [u8; 64],
+        proof_c: [u8; 32],
     ) -> Result<()> {
         msg!("Verifying proof...");
-
-        let proof_a_neg = negate_proof_a(proof_a);
+        let proof_a = decompress_g1(&proof_a).unwrap();
+        let proof_b = decompress_g2(&proof_b).unwrap();
+        let proof_c = decompress_g1(&proof_c).unwrap();
 
         let mut verifier = Groth16Verifier::new(
-            &proof_a_neg,
+            &proof_a,
             &proof_b,
             &proof_c,
             &public_inputs,

--- a/psp-template/psp-template/programs_circom/program_name/src/utils.rs
+++ b/psp-template/psp-template/programs_circom/program_name/src/utils.rs
@@ -1,21 +1,3 @@
-use ark_ff::bytes::FromBytes;
-use ark_ff::bytes::ToBytes;
-use std::ops::Neg;
-
-type G1 = ark_ec::short_weierstrass_jacobian::GroupAffine<ark_bn254::g1::Parameters>;
-
-pub fn negate_proof_a(proof_a: [u8; 64]) -> [u8; 64] {
-    let proof_a_neg_g1: G1 =
-        <G1 as FromBytes>::read(&*[&change_endianness(&proof_a)[..], &[0u8][..]].concat()).unwrap();
-    let mut proof_a_neg_buf = [0u8; 65];
-    <G1 as ToBytes>::write(&proof_a_neg_g1.neg(), &mut proof_a_neg_buf[..]).unwrap();
-    let mut proof_a_neg = [0u8; 64];
-    proof_a_neg.copy_from_slice(&proof_a_neg_buf[..64]);
-
-    let proof_a_neg = change_endianness(&proof_a_neg);
-    proof_a_neg
-}
-
 const CHUNK_SIZE: usize = 32;
 pub fn change_endianness<const SIZE: usize>(bytes: &[u8; SIZE]) -> [u8; SIZE] {
     let mut arr = [0u8; SIZE];

--- a/psp-template/psp-template/programs_psp/program_name/Cargo.toml
+++ b/psp-template/psp-template/programs_psp/program_name/Cargo.toml
@@ -23,7 +23,8 @@ light-merkle-tree-program = {{ light-merkle-tree-program-version }}
 light-macros = {{ light-macros-version }}
 light-verifier-sdk = {{ light-verifier-sdk-version }}
 solana-program = "1.16.4"
-groth16-solana = "0.0.2"
+groth16-solana = { git= "https://github.com/Lightprotocol/groth16-solana", branch="master"}
+
 bytemuck = "1.14.0"
 memoffset = "0.9.0"
 

--- a/psp-template/psp-template/programs_psp/program_name/src/processor.rs
+++ b/psp-template/psp-template/programs_psp/program_name/src/processor.rs
@@ -2,7 +2,7 @@ use crate::verifying_key_{{circom-name}}::VERIFYINGKEY_{{VERIFYING_KEY_NAME}};
 use crate::LightInstructionThird;
 use anchor_lang::prelude::*;
 use light_macros::pubkey;
-use light_verifier_sdk::light_transaction::Proof;
+use light_verifier_sdk::light_transaction::ProofCompressed;
 use light_verifier_sdk::light_transaction::VERIFIER_STATE_SEED;
 use light_verifier_sdk::{
     light_app_transaction::AppTransaction,
@@ -32,10 +32,10 @@ pub fn cpi_system_verifier<
     >,
     inputs: &'a Vec<u8>,
 ) -> Result<()> {
-    let proof_verifier = Proof {
-        a: inputs[256..256 + 64].try_into().unwrap(),
-        b: inputs[256 + 64..256 + 192].try_into().unwrap(),
-        c: inputs[256 + 192..256 + 256].try_into().unwrap(),
+    let proof_verifier = ProofCompressed {
+        a: inputs[128..128 +32].try_into().unwrap(),
+        b: inputs[128 + 32..128 + 96].try_into().unwrap(),
+        c: inputs[128 + 96..128 + 128].try_into().unwrap(),
     };
 
     let (_, bump) = anchor_lang::prelude::Pubkey::find_program_address(
@@ -93,6 +93,7 @@ pub fn cpi_system_verifier<
         memoffset::offset_of!(crate::psp_accounts::VerifierState, verifier_state_data),
     )
 }
+
 #[inline(never)]
 pub fn verify_program_proof<
     'a,
@@ -111,10 +112,10 @@ pub fn verify_program_proof<
     inputs: &'a Vec<u8>,
 ) -> Result<()> {
     let verifier_state = ctx.accounts.verifier_state.load()?;
-    let proof_app = Proof {
-        a: inputs[0..64].try_into().unwrap(),
-        b: inputs[64..192].try_into().unwrap(),
-        c: inputs[192..256].try_into().unwrap(),
+    let proof_app = ProofCompressed {
+        a: inputs[0..32].try_into().unwrap(),
+        b: inputs[32..96].try_into().unwrap(),
+        c: inputs[96..128].try_into().unwrap(),
     };
     const NR_CHECKED_INPUTS: usize = VERIFYINGKEY_{{VERIFYING_KEY_NAME}}.nr_pubinputs;
     let mut app_verifier = AppTransaction::<NR_CHECKED_INPUTS, TransactionsConfig>::new(

--- a/psp-template/psp-template/programs_psp/program_name/src/psp_accounts.rs
+++ b/psp-template/psp-template/programs_psp/program_name/src/psp_accounts.rs
@@ -53,12 +53,12 @@ pub struct LightInstructionThird<'info, const NR_CHECKED_INPUTS: usize> {
 #[derive(Debug)]
 #[account]
 pub struct InstructionDataLightInstructionThird {
-    pub proof_a_app: [u8; 64],
-    pub proof_b_app: [u8; 128],
-    pub proof_c_app: [u8; 64],
-    pub proof_a: [u8; 64],
-    pub proof_b: [u8; 128],
-    pub proof_c: [u8; 64],
+    pub proof_a_app: [u8; 32],
+    pub proof_b_app: [u8; 64],
+    pub proof_c_app: [u8; 32],
+    pub proof_a: [u8; 32],
+    pub proof_b: [u8; 64],
+    pub proof_c: [u8; 32],
 }
 
 #[derive(Accounts)]

--- a/verifier-sdk/Cargo.toml
+++ b/verifier-sdk/Cargo.toml
@@ -21,6 +21,6 @@ ark-bn254 = "0.3.0"
 ark-std = { version = "^0.3.0", default-features = false }
 spl-token = "3.3.0"
 borsh = "0.9.3"
-groth16-solana = "0.0.2"
+groth16-solana = { git= "https://github.com/Lightprotocol/groth16-solana", branch="master"}
 light-utils = { path = "../utils", version = "0.1.0" }
 light-sparse-merkle-tree = { path = "../merkle-tree/sparse", version = "0.1.1" }

--- a/zk.js/src/idls/light_psp10in2out.ts
+++ b/zk.js/src/idls/light_psp10in2out.ts
@@ -247,7 +247,7 @@ export type LightPsp10in2out = {
             "type": {
               "array": [
                 "u8",
-                64
+                32
               ]
             }
           },
@@ -256,7 +256,7 @@ export type LightPsp10in2out = {
             "type": {
               "array": [
                 "u8",
-                128
+                64
               ]
             }
           },
@@ -265,7 +265,7 @@ export type LightPsp10in2out = {
             "type": {
               "array": [
                 "u8",
-                64
+                32
               ]
             }
           }
@@ -893,7 +893,7 @@ export const IDL: LightPsp10in2out = {
             "type": {
               "array": [
                 "u8",
-                64
+                32
               ]
             }
           },
@@ -902,7 +902,7 @@ export const IDL: LightPsp10in2out = {
             "type": {
               "array": [
                 "u8",
-                128
+                64
               ]
             }
           },
@@ -911,7 +911,7 @@ export const IDL: LightPsp10in2out = {
             "type": {
               "array": [
                 "u8",
-                64
+                32
               ]
             }
           }

--- a/zk.js/src/idls/light_psp2in2out.ts
+++ b/zk.js/src/idls/light_psp2in2out.ts
@@ -124,7 +124,7 @@ export type LightPsp2in2out = {
             "type": {
               "array": [
                 "u8",
-                64
+                32
               ]
             }
           },
@@ -133,7 +133,7 @@ export type LightPsp2in2out = {
             "type": {
               "array": [
                 "u8",
-                128
+                64
               ]
             }
           },
@@ -142,7 +142,7 @@ export type LightPsp2in2out = {
             "type": {
               "array": [
                 "u8",
-                64
+                32
               ]
             }
           },
@@ -814,7 +814,7 @@ export const IDL: LightPsp2in2out = {
             "type": {
               "array": [
                 "u8",
-                64
+                32
               ]
             }
           },
@@ -823,7 +823,7 @@ export const IDL: LightPsp2in2out = {
             "type": {
               "array": [
                 "u8",
-                128
+                64
               ]
             }
           },
@@ -832,7 +832,7 @@ export const IDL: LightPsp2in2out = {
             "type": {
               "array": [
                 "u8",
-                64
+                32
               ]
             }
           },

--- a/zk.js/src/idls/light_psp2in2out_storage.ts
+++ b/zk.js/src/idls/light_psp2in2out_storage.ts
@@ -207,7 +207,7 @@ export type LightPsp2in2outStorage = {
             "type": {
               "array": [
                 "u8",
-                64
+                32
               ]
             }
           },
@@ -216,7 +216,7 @@ export type LightPsp2in2outStorage = {
             "type": {
               "array": [
                 "u8",
-                128
+                64
               ]
             }
           },
@@ -225,7 +225,7 @@ export type LightPsp2in2outStorage = {
             "type": {
               "array": [
                 "u8",
-                64
+                32
               ]
             }
           },
@@ -884,7 +884,7 @@ export const IDL: LightPsp2in2outStorage = {
             "type": {
               "array": [
                 "u8",
-                64
+                32
               ]
             }
           },
@@ -893,7 +893,7 @@ export const IDL: LightPsp2in2outStorage = {
             "type": {
               "array": [
                 "u8",
-                128
+                64
               ]
             }
           },
@@ -902,7 +902,7 @@ export const IDL: LightPsp2in2outStorage = {
             "type": {
               "array": [
                 "u8",
-                64
+                32
               ]
             }
           },

--- a/zk.js/src/idls/light_psp4in4out_app_storage.ts
+++ b/zk.js/src/idls/light_psp4in4out_app_storage.ts
@@ -112,7 +112,7 @@ export type LightPsp4in4outAppStorage = {
           "type": {
             "array": [
               "u8",
-              64
+              32
             ]
           }
         },
@@ -121,7 +121,7 @@ export type LightPsp4in4outAppStorage = {
           "type": {
             "array": [
               "u8",
-              128
+              64
             ]
           }
         },
@@ -130,7 +130,7 @@ export type LightPsp4in4outAppStorage = {
           "type": {
             "array": [
               "u8",
-              64
+              32
             ]
           }
         },
@@ -751,7 +751,7 @@ export const IDL: LightPsp4in4outAppStorage = {
           "type": {
             "array": [
               "u8",
-              64
+              32
             ]
           }
         },
@@ -760,7 +760,7 @@ export const IDL: LightPsp4in4outAppStorage = {
           "type": {
             "array": [
               "u8",
-              128
+              64
             ]
           }
         },
@@ -769,7 +769,7 @@ export const IDL: LightPsp4in4outAppStorage = {
           "type": {
             "array": [
               "u8",
-              64
+              32
             ]
           }
         },

--- a/zk.js/tests/system-programs/functional_tests.ts
+++ b/zk.js/tests/system-programs/functional_tests.ts
@@ -187,7 +187,7 @@ describe("verifier_program", () => {
 
     const utxo = createOutUtxo({
       lightWasm: WASM,
-      publicKey: inputUtxos[0].publicKey,
+      publicKey: new anchor.BN(inputUtxos[0].publicKey),
       assets: inputUtxos[0].assets,
       amounts: [BN_0, inputUtxos[0].amounts[1]],
     });
@@ -300,7 +300,6 @@ describe("verifier_program", () => {
       verifierIdl,
       systemProofInputs,
     });
-
     const remainingSolanaAccounts = getSolanaRemainingAccounts(
       systemProof.parsedPublicInputsObject as any,
     );


### PR DESCRIPTION
This pr is ready for review.
However, I want to do a new release with groth16-solana before merging because right now the groth16 solana version is tied to a commit in a branch.

Changes:
- verifier sdk:
  - added ProofCompressed for serialized compressed G1 and G2 elements
  - remove negation code, since we now negate in the client
- prover-js
  - added compression and bitmask
- programs & psps:
  - adjusted for compressed proof length