### PR TITLE
fix(merkle-tree): Update the rightmost proof and leaf correctly

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,3 +37,4 @@ jobs:
             light-macros
             aligned-sized
             macro-circom
+            merkle-tree

--- a/merkle-tree/concurrent/src/changelog.rs
+++ b/merkle-tree/concurrent/src/changelog.rs
@@ -24,4 +24,42 @@ impl<const HEIGHT: usize> ChangelogEntry<HEIGHT> {
         let index = index as u64;
         Self { root, path, index }
     }
+
+    /// Returns an intersection index in the changelog entry which affects the
+    ///
+    /// Determining it can be done by taking a XOR of the leaf index (which was
+    /// directly updated in the changelog entry) and the leaf index we are
+    /// trying to update.
+    ///
+    /// The number of bytes in the binary representations of the indexes is
+    /// determined by the height of the tree. For example, for the tree with
+    /// height 4, update attempt of leaf under index 2 and changelog affecting
+    /// index 4, critbit would be:
+    ///
+    /// 2 ^ 4 = 0b_0010 ^ 0b_0100 = 0b_0110 = 6
+    fn intersection_index(&self, leaf_index: usize, changelog_entry_index: usize) -> usize {
+        let padding = 64 - HEIGHT;
+        let common_path_len =
+            ((leaf_index ^ changelog_entry_index) << padding).leading_zeros() as usize;
+
+        (HEIGHT - 1) - common_path_len
+    }
+
+    pub fn update_proof(
+        &self,
+        leaf_index: usize,
+        proof: &[[u8; 32]; HEIGHT],
+    ) -> Option<[[u8; 32]; HEIGHT]> {
+        let mut updated_proof = proof.to_owned();
+
+        let changelog_entry_index = self.index as usize;
+        if leaf_index != changelog_entry_index {
+            let intersection_index = self.intersection_index(leaf_index, changelog_entry_index);
+            updated_proof[intersection_index] = self.path[intersection_index];
+        } else {
+            return None;
+        }
+
+        Some(updated_proof)
+    }
 }

--- a/merkle-tree/hasher/src/errors.rs
+++ b/merkle-tree/hasher/src/errors.rs
@@ -18,6 +18,8 @@ pub enum HasherError {
     InvalidProof,
     #[msg("Attempting to update the leaf which was updated by an another newest change.")]
     CannotUpdateLeaf,
+    #[msg("Cannot update tree without changelog, only `append` is supported.")]
+    AppendOnly,
     #[msg("Invalid number of inputs.")]
     PoseidonInvalidNumberOfInputs,
     #[msg("Input is an empty slice.")]


### PR DESCRIPTION
This change fixes couple of mistakes in the concurrent Merkle tree implementation, which resulted in the rightmost proofs being corrupt:

* The newest changelog entry was never used (iteration was done until `self.current_changelog_index`, adding `1` fixed that).
* We were not updating the rightmost proof on update operations affecting the non-rightmost leafs, even though they can affect the rightmost proof.
* We were returning an error when any changelog entry was affecting the currently updated leaf. That's a correct thing to do then updating proofs provided by the user. But in case of evaluating rightmost proofs, a correct thing to do is updating the rightmost leaf.
* After fixing the issues above, the proof update needed to be guarded by a check which skips it when the tree has no changelog (is append-only).

All these issues have been detected by a simple use case related to indexed Merkle trees[0] - updating the lowest leaf together with appending new leafs, in a loop.

[0] https://docs.aztec.network/concepts/advanced/data_structures/indexed_merkle_tree