### PR TITLE
ci: Pin Rust nightly to 2024-02-01

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,5 +60,5 @@ jobs:
           # here... But without that, the toolchain is just not there!
           # I will spend more time on debugging this once I can afford burning
           # more hours.
-          rustup toolchain install nightly --component clippy,rustfmt
+          rustup toolchain install nightly-2024-02-01 --component clippy,rustfmt
           ./scripts/lint.sh

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -5,5 +5,5 @@ set -e
 npx nx run-many --target=format --all
 npx nx run-many --target=lint:fix --all
 
-cargo +nightly fmt --all
+cargo +nightly-2024-02-01 fmt --all
 cargo clippy --exclude macro-circom --all -- -A clippy::result_large_err -D warnings

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -178,7 +178,7 @@ export PATH="${PREFIX}/cargo/bin:${PATH}"
 
 rustup component add clippy
 rustup component add rustfmt
-rustup toolchain install nightly --component clippy,rustfmt
+rustup toolchain install nightly-2024-02-01 --component clippy,rustfmt
 
 cargo install cargo-expand wasm-pack
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -4,7 +4,7 @@ set -e
 npx nx run-many --target=format:check --all
 npx nx run-many --target=lint --all
 
-for rust_toolchain in stable nightly; do
+for rust_toolchain in stable nightly-2024-02-01; do
     cargo +"$rust_toolchain" fmt --all -- --check
     cargo +"$rust_toolchain" clippy \
       --workspace \


### PR DESCRIPTION
The newest Rust nightly removed the `stdsimd` feature in favor of more grained features (rust-lang/rust#117372).

However, the version of `ahash` we depend on, still requires that feature. New release of `ahash` (0.8.7) contains a fix, but we can't upgrade to it without upgrading Anchor.

Pinning Rust nightly seems to be the less intrusive solution for now.