### PR TITLE
chore(merkle-tree): Make dependency on `solana-program` optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2710,7 +2710,9 @@ dependencies = [
  "light-hasher",
  "light-merkle-tree-reference",
  "rand 0.8.5",
+ "solana-program",
  "spl-concurrent-merkle-tree",
+ "thiserror",
  "tokio",
 ]
 
@@ -2718,9 +2720,11 @@ dependencies = [
 name = "light-hasher"
 version = "0.1.0"
 dependencies = [
- "anchor-lang",
  "ark-bn254 0.4.0",
  "light-poseidon 0.2.0",
+ "sha2 0.10.8",
+ "sha3 0.10.8",
+ "solana-program",
  "thiserror",
 ]
 
@@ -2736,6 +2740,7 @@ dependencies = [
  "light-merkle-tree-reference",
  "light-utils",
  "num-traits",
+ "solana-program",
  "thiserror",
 ]
 

--- a/merkle-tree/concurrent/Cargo.toml
+++ b/merkle-tree/concurrent/Cargo.toml
@@ -5,9 +5,17 @@ edition = "2021"
 description = "Concurrent Merkle tree implementation"
 license = "Apache-2.0"
 
+[features]
+solana = [
+  "light-hasher/solana",
+  "solana-program"
+]
+
 [dependencies]
 bytemuck = "1.14"
 light-hasher = { path = "../hasher", version = "0.1.0" }
+solana-program = { version = ">=1.17, <1.18", optional = true }
+thiserror = "1.0"
 
 [dev-dependencies]
 ark-bn254 = "0.4"

--- a/merkle-tree/concurrent/src/errors.rs
+++ b/merkle-tree/concurrent/src/errors.rs
@@ -1,0 +1,59 @@
+use light_hasher::errors::HasherError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ConcurrentMerkleTreeError {
+    #[error("Invalid height, it has to be greater than 0")]
+    HeightZero,
+    #[error("Invalid height, it cannot exceed the maximum allowed height")]
+    HeightHigherThanMax,
+    #[error("Invalid number of roots, it has to be greater than 0")]
+    RootsZero,
+    #[error("Invalid root index, it exceeds the root buffer size")]
+    RootHigherThanMax,
+    #[error("Merkle tree is full, cannot append more leaves.")]
+    TreeFull,
+    #[error("Provided proof is larger than the height of the tree.")]
+    ProofTooLarge,
+    #[error("Invalid Merkle proof, stopping the update operation.")]
+    InvalidProof,
+    #[error("Attempting to update the leaf which was updated by an another newest change.")]
+    CannotUpdateLeaf,
+    #[error("Cannot update tree without changelog, only `append` is supported.")]
+    AppendOnly,
+    #[error("The batch of leaves is empty")]
+    EmptyLeaves,
+    #[error("The vector of changelog entries is empty")]
+    EmptyChangelogEntries,
+    #[error("Hasher error: {0}")]
+    Hasher(#[from] HasherError),
+}
+
+// NOTE(vadorovsky): Unfortunately, we need to do it by hand. `num_derive::ToPrimitive`
+// doesn't support data-carrying enums.
+#[cfg(feature = "solana")]
+impl From<ConcurrentMerkleTreeError> for u32 {
+    fn from(e: ConcurrentMerkleTreeError) -> u32 {
+        match e {
+            ConcurrentMerkleTreeError::HeightZero => 2001,
+            ConcurrentMerkleTreeError::HeightHigherThanMax => 2002,
+            ConcurrentMerkleTreeError::RootsZero => 2003,
+            ConcurrentMerkleTreeError::RootHigherThanMax => 2004,
+            ConcurrentMerkleTreeError::TreeFull => 2005,
+            ConcurrentMerkleTreeError::ProofTooLarge => 2006,
+            ConcurrentMerkleTreeError::InvalidProof => 2007,
+            ConcurrentMerkleTreeError::CannotUpdateLeaf => 2008,
+            ConcurrentMerkleTreeError::AppendOnly => 2009,
+            ConcurrentMerkleTreeError::EmptyLeaves => 2010,
+            ConcurrentMerkleTreeError::EmptyChangelogEntries => 2011,
+            ConcurrentMerkleTreeError::Hasher(e) => e.into(),
+        }
+    }
+}
+
+#[cfg(feature = "solana")]
+impl From<ConcurrentMerkleTreeError> for solana_program::program_error::ProgramError {
+    fn from(e: ConcurrentMerkleTreeError) -> Self {
+        solana_program::program_error::ProgramError::Custom(e.into())
+    }
+}

--- a/merkle-tree/concurrent/tests/tests.rs
+++ b/merkle-tree/concurrent/tests/tests.rs
@@ -1,7 +1,9 @@
 use ark_bn254::Fr;
 use ark_ff::{BigInteger, PrimeField, UniformRand};
-use light_concurrent_merkle_tree::{changelog::ChangelogEntry, ConcurrentMerkleTree};
-use light_hasher::{errors::HasherError, Hasher, Keccak, Poseidon, Sha256};
+use light_concurrent_merkle_tree::{
+    changelog::ChangelogEntry, errors::ConcurrentMerkleTreeError, ConcurrentMerkleTree,
+};
+use light_hasher::{Hasher, Keccak, Poseidon, Sha256};
 use rand::thread_rng;
 
 /// Tests whether append operations work as expected.
@@ -457,7 +459,7 @@ where
     }
     assert!(matches!(
         merkle_tree.append(&[4; 32]),
-        Err(HasherError::TreeFull)
+        Err(ConcurrentMerkleTreeError::TreeFull)
     ));
 }
 
@@ -614,7 +616,7 @@ where
 
         assert!(matches!(
             merkle_tree.update(changelog_index, &old_leaf, &new_leaf, i, &proof),
-            Err(HasherError::AppendOnly),
+            Err(ConcurrentMerkleTreeError::AppendOnly),
         ));
     }
 }

--- a/merkle-tree/hasher/Cargo.toml
+++ b/merkle-tree/hasher/Cargo.toml
@@ -3,10 +3,15 @@ name = "light-hasher"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+solana = ["solana-program"]
+
 [dependencies]
-anchor-lang = "0.29.0"
+light-poseidon = "0.2.0"
+solana-program = { version = ">=1.17, <1.18", optional = true }
 thiserror = "1.0"
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 ark-bn254 = "0.4.0"
-light-poseidon = "0.2.0"
+sha2 = "0.10"
+sha3 = "0.10"

--- a/merkle-tree/hasher/src/keccak.rs
+++ b/merkle-tree/hasher/src/keccak.rs
@@ -1,5 +1,3 @@
-use anchor_lang::solana_program::keccak::{hash, hashv};
-
 use crate::{
     errors::HasherError,
     zero_bytes::{keccak::ZERO_BYTES, ZeroBytes},
@@ -12,11 +10,35 @@ pub struct Keccak;
 
 impl Hasher for Keccak {
     fn hash(val: &[u8]) -> Result<Hash, HasherError> {
-        Ok(hash(val).to_bytes())
+        Self::hashv(&[val])
     }
 
     fn hashv(vals: &[&[u8]]) -> Result<Hash, HasherError> {
-        Ok(hashv(vals).to_bytes())
+        #[cfg(not(target_os = "solana"))]
+        {
+            use sha3::{Digest, Keccak256};
+
+            let mut hasher = Keccak256::default();
+            for val in vals {
+                hasher.update(val);
+            }
+            Ok(hasher.finalize().into())
+        }
+        // Call via a system call to perform the calculation
+        #[cfg(target_os = "solana")]
+        {
+            use crate::HASH_BYTES;
+
+            let mut hash_result = [0; HASH_BYTES];
+            unsafe {
+                crate::syscalls::sol_keccak256(
+                    vals as *const _ as *const u8,
+                    vals.len() as u64,
+                    &mut hash_result as *mut _ as *mut u8,
+                );
+            }
+            Ok(hash_result)
+        }
     }
 
     fn zero_bytes() -> ZeroBytes {

--- a/merkle-tree/hasher/src/syscalls/definitions.rs
+++ b/merkle-tree/hasher/src/syscalls/definitions.rs
@@ -1,9 +1,6 @@
 //! This module is a partial copy from
 //! [solana-program](https://github.com/solana-labs/solana/blob/master/sdk/program/src/syscalls/definitions.rs),
 //! which is licensed under Apache License 2.0.
-//!
-//! The purpose of the module is to provide definition of Poseidon syscall
-//! without upgrading solana-program and Anchor just yet.
 
 #[cfg(target_feature = "static-syscalls")]
 macro_rules! define_syscall {
@@ -38,4 +35,6 @@ macro_rules! define_syscall {
 	}
 }
 
+define_syscall!(fn sol_sha256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
+define_syscall!(fn sol_keccak256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_poseidon(parameters: u64, endianness: u64, vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);

--- a/merkle-tree/indexed/Cargo.toml
+++ b/merkle-tree/indexed/Cargo.toml
@@ -3,6 +3,13 @@ name = "light-indexed-merkle-tree"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+solana = [
+  "light-concurrent-merkle-tree/solana",
+  "light-hasher/solana",
+  "solana-program"
+]
+
 [dependencies]
 ark-ff = "0.4"
 borsh = { version = "0.10" }
@@ -11,6 +18,8 @@ light-hasher = { path = "../hasher", version = "0.1.0" }
 light-merkle-tree-reference = { path = "../reference", version = "0.1.0" }
 light-utils = { path = "../../utils", version = "0.1.0" }
 num-traits = "0.2"
+solana-program = { version = ">=1.17, <1.18", optional = true }
+thiserror = "1.0"
 
 [dev-dependencies]
 ark-bn254 = "0.4"

--- a/merkle-tree/indexed/src/errors.rs
+++ b/merkle-tree/indexed/src/errors.rs
@@ -1,0 +1,45 @@
+use light_concurrent_merkle_tree::errors::ConcurrentMerkleTreeError;
+use light_hasher::errors::HasherError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum IndexedMerkleTreeError {
+    #[error("Integer overflow")]
+    IntegerOverflow,
+    #[error("Invalid index, it exceeds the number of elements.")]
+    IndexHigherThanMax,
+    #[error("Could not find the low element.")]
+    LowElementNotFound,
+    #[error("Low element is greater or equal to the provided new element.")]
+    LowElementGreaterOrEqualToNewElement,
+    #[error("The provided new element is greater or equal to the next element.")]
+    NewElementGreaterOrEqualToNextElement,
+    #[error("Hasher error: {0}")]
+    Hasher(#[from] HasherError),
+    #[error("Concurrent Merkle tree error: {0}")]
+    ConcurrentMerkleTree(#[from] ConcurrentMerkleTreeError),
+}
+
+// NOTE(vadorovsky): Unfortunately, we need to do it by hand. `num_derive::ToPrimitive`
+// doesn't support data-carrying enums.
+#[cfg(feature = "solana")]
+impl From<IndexedMerkleTreeError> for u32 {
+    fn from(e: IndexedMerkleTreeError) -> u32 {
+        match e {
+            IndexedMerkleTreeError::IntegerOverflow => 3001,
+            IndexedMerkleTreeError::IndexHigherThanMax => 3002,
+            IndexedMerkleTreeError::LowElementNotFound => 3003,
+            IndexedMerkleTreeError::LowElementGreaterOrEqualToNewElement => 3004,
+            IndexedMerkleTreeError::NewElementGreaterOrEqualToNextElement => 3005,
+            IndexedMerkleTreeError::Hasher(e) => e.into(),
+            IndexedMerkleTreeError::ConcurrentMerkleTree(e) => e.into(),
+        }
+    }
+}
+
+#[cfg(feature = "solana")]
+impl From<IndexedMerkleTreeError> for solana_program::program_error::ProgramError {
+    fn from(e: IndexedMerkleTreeError) -> Self {
+        solana_program::program_error::ProgramError::Custom(e.into())
+    }
+}

--- a/merkle-tree/indexed/src/reference.rs
+++ b/merkle-tree/indexed/src/reference.rs
@@ -1,11 +1,11 @@
 use std::marker::PhantomData;
 
 use ark_ff::BigInteger;
-use light_hasher::{errors::HasherError, Hasher};
+use light_hasher::Hasher;
 use light_merkle_tree_reference::MerkleTree;
 use num_traits::{CheckedAdd, CheckedSub, ToBytes, Unsigned};
 
-use crate::array::IndexingElement;
+use crate::{array::IndexingElement, errors::IndexedMerkleTreeError};
 
 #[repr(C)]
 pub struct IndexedMerkleTree<H, I, B, const HEIGHT: usize, const MAX_ROOTS: usize>
@@ -27,7 +27,7 @@ where
     B: BigInteger,
     usize: From<I>,
 {
-    pub fn new() -> Result<Self, HasherError> {
+    pub fn new() -> Result<Self, IndexedMerkleTreeError> {
         let mut merkle_tree = MerkleTree::new()?;
 
         // Append the first low leaf, which has value 0 and does not point
@@ -56,7 +56,7 @@ where
         new_low_element: &IndexingElement<I, B>,
         new_element: &IndexingElement<I, B>,
         new_element_next_value: &B,
-    ) -> Result<(), HasherError> {
+    ) -> Result<(), IndexedMerkleTreeError> {
         // Update the low element.
         let new_low_leaf = new_low_element.hash::<H>(&new_element.value)?;
         self.merkle_tree

--- a/programs/merkle-tree/Cargo.toml
+++ b/programs/merkle-tree/Cargo.toml
@@ -45,8 +45,8 @@ arkworks-gadgets = "0.3.14"
 
 # Light dependencies
 aligned-sized = { version = "0.1.0", path = "../../macros/aligned-sized" }
-light-concurrent-merkle-tree = { version = "0.1.0", path = "../../merkle-tree/concurrent" }
-light-hasher = { path = "../../merkle-tree/hasher", version = "0.1.0" }
+light-concurrent-merkle-tree = { version = "0.1.0", path = "../../merkle-tree/concurrent", features = ["solana"] }
+light-hasher = { path = "../../merkle-tree/hasher", version = "0.1.0", features = ["solana"] }
 light-utils = { version = "0.1.0", path = "../../utils" }
 light-macros = { version = "0.3.1", path = "../../macros/light" }
 

--- a/programs/merkle-tree/src/state/merkle_tree_set.rs
+++ b/programs/merkle-tree/src/state/merkle_tree_set.rs
@@ -79,8 +79,12 @@ impl MerkleTreeSet {
     pub fn init(&mut self, index: u64) -> Result<()> {
         self.index = index;
 
-        state_merkle_tree_from_bytes_mut(&mut self.state_merkle_tree).init()?;
-        event_merkle_tree_from_bytes_mut(&mut self.event_merkle_tree).init()?;
+        state_merkle_tree_from_bytes_mut(&mut self.state_merkle_tree)
+            .init()
+            .map_err(ProgramError::from)?;
+        event_merkle_tree_from_bytes_mut(&mut self.event_merkle_tree)
+            .init()
+            .map_err(ProgramError::from)?;
 
         Ok(())
     }

--- a/programs/merkle-tree/src/verifier_invoked_instructions/insert_two_leaves_event.rs
+++ b/programs/merkle-tree/src/verifier_invoked_instructions/insert_two_leaves_event.rs
@@ -32,7 +32,8 @@ pub fn process_insert_two_leaves_event(
 ) -> Result<()> {
     let mut merkle_tree_set = ctx.accounts.merkle_tree_set.load_mut()?;
     event_merkle_tree_from_bytes_mut(&mut merkle_tree_set.event_merkle_tree)
-        .append_batch(&[&leaf_left, &leaf_right])?;
+        .append_batch(&[&leaf_left, &leaf_right])
+        .map_err(ProgramError::from)?;
 
     Ok(())
 }

--- a/programs/merkle-tree/src/verifier_invoked_instructions/insert_two_leaves_transaction.rs
+++ b/programs/merkle-tree/src/verifier_invoked_instructions/insert_two_leaves_transaction.rs
@@ -46,7 +46,9 @@ pub fn process_insert_two_leaves<'info, 'a>(
         };
 
         // Insert the pair into the merkle tree
-        let changelog_entries = state_merkle_tree.append_batch(&[leaf_left, leaf_right])?;
+        let changelog_entries = state_merkle_tree
+            .append_batch(&[leaf_left, leaf_right])
+            .map_err(ProgramError::from)?;
 
         let changelog_event = ChangelogEvent::V1(ChangelogEventV1::new(
             ctx.accounts.merkle_tree_set.key(),

--- a/zk.js/src/idls/psp_compressed_pda.ts
+++ b/zk.js/src/idls/psp_compressed_pda.ts
@@ -5,7 +5,9 @@ export type PspCompressedPda = {
     {
       "name": "executeCompressedTransaction",
       "docs": [
-        "This function can be used to transfer sol and execute any other compressed transaction."
+        "This function can be used to transfer sol and execute any other compressed transaction.",
+        "Instruction data is not optimized for space.",
+        "This method can be called by cpi so that instruction data can be compressed with a custom algorithm."
       ],
       "accounts": [
         {
@@ -42,6 +44,68 @@ export type PspCompressedPda = {
           "name": "accountCompressionProgram",
           "isMut": false,
           "isSigner": false
+        },
+        {
+          "name": "cpiSignatureAccount",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "inputs",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "executeCompressedTransaction2",
+      "docs": [
+        "This function can be used to transfer sol and execute any other compressed transaction.",
+        "Instruction data is optimized for space."
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "authorityPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "registeredProgramPda",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "noopProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "compressedPdaProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "pspAccountCompressionAuthority",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "accountCompressionProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "cpiSignatureAccount",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
         }
       ],
       "args": [
@@ -53,6 +117,22 @@ export type PspCompressedPda = {
     }
   ],
   "accounts": [
+    {
+      "name": "cpiSignatureAccount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "signatures",
+            "type": {
+              "vec": {
+                "defined": "CpiSignature"
+              }
+            }
+          }
+        ]
+      }
+    },
     {
       "name": "instructionDataTransfer",
       "type": {
@@ -86,21 +166,13 @@ export type PspCompressedPda = {
             }
           },
           {
-            "name": "inUtxos",
-            "type": {
-              "vec": {
-                "defined": "TokenInUtxo"
-              }
-            }
-          },
-          {
-            "name": "lowElementIndexes",
+            "name": "lowElementIndices",
             "type": {
               "vec": "u16"
             }
           },
           {
-            "name": "rootIndexes",
+            "name": "rootIndices",
             "type": {
               "vec": "u64"
             }
@@ -112,10 +184,129 @@ export type PspCompressedPda = {
             }
           },
           {
-            "name": "outUtxo",
+            "name": "inUtxos",
             "type": {
               "vec": {
-                "defined": "TokenOutUtxo"
+                "defined": "Utxo"
+              }
+            }
+          },
+          {
+            "name": "outUtxos",
+            "type": {
+              "vec": {
+                "defined": "OutUtxo"
+              }
+            }
+          },
+          {
+            "name": "inUtxoMerkleTreeRemainingAccountIndex",
+            "type": "bytes"
+          },
+          {
+            "name": "inUtxoNullifierQueueRemainingAccountIndex",
+            "type": "bytes"
+          },
+          {
+            "name": "outUtxoMerkleTreeRemainingAccountIndex",
+            "type": "bytes"
+          }
+        ]
+      }
+    },
+    {
+      "name": "instructionDataTransfer2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proofA",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "proofB",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
+            "name": "proofC",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "lowElementIndices",
+            "type": {
+              "vec": "u16"
+            }
+          },
+          {
+            "name": "rootIndices",
+            "type": {
+              "vec": "u64"
+            }
+          },
+          {
+            "name": "rpcFee",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "utxos",
+            "type": {
+              "defined": "SerializedUtxos"
+            }
+          },
+          {
+            "name": "inUtxoMerkleTreeRemainingAccountIndex",
+            "type": "bytes"
+          },
+          {
+            "name": "inUtxoNullifierQueueRemainingAccountIndex",
+            "type": "bytes"
+          },
+          {
+            "name": "outUtxoMerkleTreeRemainingAccountIndex",
+            "type": "bytes"
+          }
+        ]
+      }
+    },
+    {
+      "name": "inUtxoSerializable",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "u8"
+          },
+          {
+            "name": "leafIndex",
+            "type": "u32"
+          },
+          {
+            "name": "lamports",
+            "type": "u8"
+          },
+          {
+            "name": "data",
+            "type": {
+              "option": {
+                "defined": "TlvSerializable"
               }
             }
           }
@@ -123,7 +314,55 @@ export type PspCompressedPda = {
       }
     },
     {
-      "name": "tokenInUtxo",
+      "name": "outUtxoSerializable",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "u8"
+          },
+          {
+            "name": "lamports",
+            "type": "u8"
+          },
+          {
+            "name": "data",
+            "type": {
+              "option": {
+                "defined": "TlvSerializable"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "outUtxo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "publicKey"
+          },
+          {
+            "name": "lamports",
+            "type": "u64"
+          },
+          {
+            "name": "data",
+            "type": {
+              "option": {
+                "defined": "Tlv"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "utxo",
       "type": {
         "kind": "struct",
         "fields": [
@@ -148,24 +387,26 @@ export type PspCompressedPda = {
             "name": "data",
             "type": {
               "option": {
-                "defined": "TlvData"
+                "defined": "Tlv"
               }
             }
           }
         ]
       }
-    },
+    }
+  ],
+  "types": [
     {
-      "name": "tokenOutUtxo",
+      "name": "CpiSignature",
       "type": {
         "kind": "struct",
         "fields": [
           {
-            "name": "owner",
+            "name": "program",
             "type": "publicKey"
           },
           {
-            "name": "blinding",
+            "name": "tlvHash",
             "type": {
               "array": [
                 "u8",
@@ -174,19 +415,187 @@ export type PspCompressedPda = {
             }
           },
           {
-            "name": "lamports",
-            "type": "u64"
+            "name": "tlvData",
+            "type": {
+              "defined": "TlvDataElement"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SerializedUtxos",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkeyArray",
+            "type": {
+              "vec": "publicKey"
+            }
           },
           {
-            "name": "data",
+            "name": "u64Array",
             "type": {
-              "option": {
-                "defined": "TlvData"
+              "vec": "u64"
+            }
+          },
+          {
+            "name": "inUtxos",
+            "type": {
+              "vec": {
+                "defined": "InUtxoSerializable"
+              }
+            }
+          },
+          {
+            "name": "outUtxos",
+            "type": {
+              "vec": {
+                "defined": "OutUtxoSerializable"
               }
             }
           }
         ]
       }
+    },
+    {
+      "name": "TlvSerializable",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tlvElements",
+            "type": {
+              "vec": {
+                "defined": "TlvDataElementSerializable"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Tlv",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tlvElements",
+            "type": {
+              "vec": {
+                "defined": "TlvDataElement"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TlvDataElementSerializable",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "discriminator",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "owner",
+            "type": "u8"
+          },
+          {
+            "name": "data",
+            "type": "bytes"
+          },
+          {
+            "name": "dataHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TlvDataElement",
+      "docs": [
+        "Time lock escrow example:",
+        "escrow tlv data -> compressed token program",
+        "let escrow_data = {",
+        "owner: Pubkey, // owner is the user pubkey",
+        "release_slot: u64,",
+        "deposit_slot: u64,",
+        "};",
+        "",
+        "let escrow_tlv_data = TlvDataElement {",
+        "discriminator: [1,0,0,0,0,0,0,0],",
+        "owner: escrow_program_id,",
+        "data: escrow_data.try_to_vec()?,",
+        "};",
+        "let token_tlv = TlvDataElement {",
+        "discriminator: [2,0,0,0,0,0,0,0],",
+        "owner: token_program,",
+        "data: token_data.try_to_vec()?,",
+        "};",
+        "let token_data = Account {",
+        "mint,",
+        "owner,",
+        "amount: 10_000_000u64,",
+        "delegate: None,",
+        "state: Initialized, (u64)",
+        "is_native: None,",
+        "delegated_amount: 0u64,",
+        "close_authority: None,",
+        "};",
+        ""
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "discriminator",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "owner",
+            "type": "publicKey"
+          },
+          {
+            "name": "data",
+            "type": "bytes"
+          },
+          {
+            "name": "dataHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "SumCheckFailed",
+      "msg": "Sum check failed"
     }
   ]
 };
@@ -198,7 +607,9 @@ export const IDL: PspCompressedPda = {
     {
       "name": "executeCompressedTransaction",
       "docs": [
-        "This function can be used to transfer sol and execute any other compressed transaction."
+        "This function can be used to transfer sol and execute any other compressed transaction.",
+        "Instruction data is not optimized for space.",
+        "This method can be called by cpi so that instruction data can be compressed with a custom algorithm."
       ],
       "accounts": [
         {
@@ -235,6 +646,68 @@ export const IDL: PspCompressedPda = {
           "name": "accountCompressionProgram",
           "isMut": false,
           "isSigner": false
+        },
+        {
+          "name": "cpiSignatureAccount",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "inputs",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "executeCompressedTransaction2",
+      "docs": [
+        "This function can be used to transfer sol and execute any other compressed transaction.",
+        "Instruction data is optimized for space."
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "authorityPda",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "registeredProgramPda",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "noopProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "compressedPdaProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "pspAccountCompressionAuthority",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "accountCompressionProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "cpiSignatureAccount",
+          "isMut": false,
+          "isSigner": false,
+          "isOptional": true
         }
       ],
       "args": [
@@ -246,6 +719,22 @@ export const IDL: PspCompressedPda = {
     }
   ],
   "accounts": [
+    {
+      "name": "cpiSignatureAccount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "signatures",
+            "type": {
+              "vec": {
+                "defined": "CpiSignature"
+              }
+            }
+          }
+        ]
+      }
+    },
     {
       "name": "instructionDataTransfer",
       "type": {
@@ -279,21 +768,13 @@ export const IDL: PspCompressedPda = {
             }
           },
           {
-            "name": "inUtxos",
-            "type": {
-              "vec": {
-                "defined": "TokenInUtxo"
-              }
-            }
-          },
-          {
-            "name": "lowElementIndexes",
+            "name": "lowElementIndices",
             "type": {
               "vec": "u16"
             }
           },
           {
-            "name": "rootIndexes",
+            "name": "rootIndices",
             "type": {
               "vec": "u64"
             }
@@ -305,10 +786,129 @@ export const IDL: PspCompressedPda = {
             }
           },
           {
-            "name": "outUtxo",
+            "name": "inUtxos",
             "type": {
               "vec": {
-                "defined": "TokenOutUtxo"
+                "defined": "Utxo"
+              }
+            }
+          },
+          {
+            "name": "outUtxos",
+            "type": {
+              "vec": {
+                "defined": "OutUtxo"
+              }
+            }
+          },
+          {
+            "name": "inUtxoMerkleTreeRemainingAccountIndex",
+            "type": "bytes"
+          },
+          {
+            "name": "inUtxoNullifierQueueRemainingAccountIndex",
+            "type": "bytes"
+          },
+          {
+            "name": "outUtxoMerkleTreeRemainingAccountIndex",
+            "type": "bytes"
+          }
+        ]
+      }
+    },
+    {
+      "name": "instructionDataTransfer2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proofA",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "proofB",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
+            "name": "proofC",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "lowElementIndices",
+            "type": {
+              "vec": "u16"
+            }
+          },
+          {
+            "name": "rootIndices",
+            "type": {
+              "vec": "u64"
+            }
+          },
+          {
+            "name": "rpcFee",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "utxos",
+            "type": {
+              "defined": "SerializedUtxos"
+            }
+          },
+          {
+            "name": "inUtxoMerkleTreeRemainingAccountIndex",
+            "type": "bytes"
+          },
+          {
+            "name": "inUtxoNullifierQueueRemainingAccountIndex",
+            "type": "bytes"
+          },
+          {
+            "name": "outUtxoMerkleTreeRemainingAccountIndex",
+            "type": "bytes"
+          }
+        ]
+      }
+    },
+    {
+      "name": "inUtxoSerializable",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "u8"
+          },
+          {
+            "name": "leafIndex",
+            "type": "u32"
+          },
+          {
+            "name": "lamports",
+            "type": "u8"
+          },
+          {
+            "name": "data",
+            "type": {
+              "option": {
+                "defined": "TlvSerializable"
               }
             }
           }
@@ -316,7 +916,55 @@ export const IDL: PspCompressedPda = {
       }
     },
     {
-      "name": "tokenInUtxo",
+      "name": "outUtxoSerializable",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "u8"
+          },
+          {
+            "name": "lamports",
+            "type": "u8"
+          },
+          {
+            "name": "data",
+            "type": {
+              "option": {
+                "defined": "TlvSerializable"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "outUtxo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "publicKey"
+          },
+          {
+            "name": "lamports",
+            "type": "u64"
+          },
+          {
+            "name": "data",
+            "type": {
+              "option": {
+                "defined": "Tlv"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "utxo",
       "type": {
         "kind": "struct",
         "fields": [
@@ -341,24 +989,26 @@ export const IDL: PspCompressedPda = {
             "name": "data",
             "type": {
               "option": {
-                "defined": "TlvData"
+                "defined": "Tlv"
               }
             }
           }
         ]
       }
-    },
+    }
+  ],
+  "types": [
     {
-      "name": "tokenOutUtxo",
+      "name": "CpiSignature",
       "type": {
         "kind": "struct",
         "fields": [
           {
-            "name": "owner",
+            "name": "program",
             "type": "publicKey"
           },
           {
-            "name": "blinding",
+            "name": "tlvHash",
             "type": {
               "array": [
                 "u8",
@@ -367,19 +1017,187 @@ export const IDL: PspCompressedPda = {
             }
           },
           {
-            "name": "lamports",
-            "type": "u64"
+            "name": "tlvData",
+            "type": {
+              "defined": "TlvDataElement"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SerializedUtxos",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pubkeyArray",
+            "type": {
+              "vec": "publicKey"
+            }
           },
           {
-            "name": "data",
+            "name": "u64Array",
             "type": {
-              "option": {
-                "defined": "TlvData"
+              "vec": "u64"
+            }
+          },
+          {
+            "name": "inUtxos",
+            "type": {
+              "vec": {
+                "defined": "InUtxoSerializable"
+              }
+            }
+          },
+          {
+            "name": "outUtxos",
+            "type": {
+              "vec": {
+                "defined": "OutUtxoSerializable"
               }
             }
           }
         ]
       }
+    },
+    {
+      "name": "TlvSerializable",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tlvElements",
+            "type": {
+              "vec": {
+                "defined": "TlvDataElementSerializable"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Tlv",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tlvElements",
+            "type": {
+              "vec": {
+                "defined": "TlvDataElement"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TlvDataElementSerializable",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "discriminator",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "owner",
+            "type": "u8"
+          },
+          {
+            "name": "data",
+            "type": "bytes"
+          },
+          {
+            "name": "dataHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TlvDataElement",
+      "docs": [
+        "Time lock escrow example:",
+        "escrow tlv data -> compressed token program",
+        "let escrow_data = {",
+        "owner: Pubkey, // owner is the user pubkey",
+        "release_slot: u64,",
+        "deposit_slot: u64,",
+        "};",
+        "",
+        "let escrow_tlv_data = TlvDataElement {",
+        "discriminator: [1,0,0,0,0,0,0,0],",
+        "owner: escrow_program_id,",
+        "data: escrow_data.try_to_vec()?,",
+        "};",
+        "let token_tlv = TlvDataElement {",
+        "discriminator: [2,0,0,0,0,0,0,0],",
+        "owner: token_program,",
+        "data: token_data.try_to_vec()?,",
+        "};",
+        "let token_data = Account {",
+        "mint,",
+        "owner,",
+        "amount: 10_000_000u64,",
+        "delegate: None,",
+        "state: Initialized, (u64)",
+        "is_native: None,",
+        "delegated_amount: 0u64,",
+        "close_authority: None,",
+        "};",
+        ""
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "discriminator",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "owner",
+            "type": "publicKey"
+          },
+          {
+            "name": "data",
+            "type": "bytes"
+          },
+          {
+            "name": "dataHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "SumCheckFailed",
+      "msg": "Sum check failed"
     }
   ]
 };

--- a/zk.js/src/idls/psp_compressed_token.ts
+++ b/zk.js/src/idls/psp_compressed_token.ts
@@ -251,14 +251,6 @@ export type PspCompressedToken = {
             }
           },
           {
-            "name": "inUtxos",
-            "type": {
-              "vec": {
-                "defined": "TokenInUtxo"
-              }
-            }
-          },
-          {
             "name": "lowElementIndexes",
             "type": {
               "vec": "u16"
@@ -277,11 +269,9 @@ export type PspCompressedToken = {
             }
           },
           {
-            "name": "outUtxo",
+            "name": "serializedUtxos",
             "type": {
-              "vec": {
-                "defined": "TokenOutUtxo"
-              }
+              "defined": "SerializedUtxos"
             }
           }
         ]
@@ -555,14 +545,6 @@ export const IDL: PspCompressedToken = {
             }
           },
           {
-            "name": "inUtxos",
-            "type": {
-              "vec": {
-                "defined": "TokenInUtxo"
-              }
-            }
-          },
-          {
             "name": "lowElementIndexes",
             "type": {
               "vec": "u16"
@@ -581,11 +563,9 @@ export const IDL: PspCompressedToken = {
             }
           },
           {
-            "name": "outUtxo",
+            "name": "serializedUtxos",
             "type": {
-              "vec": {
-                "defined": "TokenOutUtxo"
-              }
+              "defined": "SerializedUtxos"
             }
           }
         ]


### PR DESCRIPTION
Use `thiserror` for error enums.

Introduce the `solana` feature which:

* Adds `solana-program` as a dependency.
* Makes it possible to convert the custom error types to `ProgramError`.