### PR TITLE
ci: Run rustfmt with Rust nigthly

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -6,4 +6,10 @@ npx nx run-many --target=format --all
 npx nx run-many --target=lint:fix --all
 
 cargo +nightly-2024-02-01 fmt --all
-cargo clippy --exclude macro-circom --all -- -A clippy::result_large_err -D warnings
+
+for rust_toolchain in stable nightly-2024-02-01; do
+    cargo +"$rust_toolchain" clippy \
+      --workspace \
+      --exclude macro-circom \
+      --all -- -A clippy::result_large_err -D warnings
+done

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -4,8 +4,9 @@ set -e
 npx nx run-many --target=format:check --all
 npx nx run-many --target=lint --all
 
+cargo +nightly-2024-02-01 fmt --all -- --check
+
 for rust_toolchain in stable nightly-2024-02-01; do
-    cargo +"$rust_toolchain" fmt --all -- --check
     cargo +"$rust_toolchain" clippy \
       --workspace \
       --exclude macro-circom \


### PR DESCRIPTION
We are using rustfmt features which are not stabilized yet, but are convenient for us - precisely - import sorting.

Running rustfmt stable with these option triggers annoying warnings, which can often obfuscate actual errors. Therefore, let's run only rustfmt nightly.