### PR TITLE
chore: force solana 1.18.2 in install.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.tgz
 
+light-zk.js/
 **/test-ledger/
 
 # CLI

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -111,7 +111,7 @@ check_flag() {
 GO_VERSION="1.21.7"
 NODE_VERSION="20.9.0"
 PNPM_VERSION="8.8.0"
-SOLANA_VERSION="1.17.5"
+SOLANA_VERSION="1.18.2"
 ANCHOR_VERSION="anchor-v0.29.0"
 JQ_VERSION="jq-1.7.1"
 CIRCOM_VERSION=`latest_release Lightprotocol circom`


### PR DESCRIPTION
* rayon-core will fail to compile for compressed-pda unless we force people to be on >=1.18.2