### PR TITLE
feat: cli: get keypairs by file paths when using create-mint, mint-to & transfer commands

### DIFF
--- a/cli/src/commands/transfer/index.ts
+++ b/cli/src/commands/transfer/index.ts
@@ -8,6 +8,7 @@ import {
 } from "../../utils/utils";
 import { transfer } from "@lightprotocol/compressed-token";
 import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import { getKeypairFromFile } from "@solana-developers/helpers";
 
 class TransferCommand extends Command {
   static summary = "Transfer tokens from one account to another.";
@@ -37,7 +38,7 @@ class TransferCommand extends Command {
   };
 
   async run() {
-    const { args, flags } = await this.parse(TransferCommand);
+    const { flags } = await this.parse(TransferCommand);
 
     const loader = new CustomLoader(`Performing mint-to...\n`);
     loader.start();
@@ -54,9 +55,8 @@ class TransferCommand extends Command {
       const toPublicKey = new PublicKey(to);
 
       let payer = defaultSolanaWalletKeypair();
-      if (flags["fee-payer"]) {
-        const decoded = bs58.decode(<string>flags["fee-payer"]);
-        payer = Keypair.fromSecretKey(decoded);
+      if (flags["fee-payer"] !== undefined) {
+        payer = await getKeypairFromFile(flags["fee-payer"]);
       }
       const connection = new Connection(getSolanaRpcUrl());
 

--- a/cli/test/commands/create-mint/index.test.ts
+++ b/cli/test/commands/create-mint/index.test.ts
@@ -18,7 +18,7 @@ describe("create-mint", () => {
         "create-mint",
         `--mint-decimals=${mintDecimals}`,
         `--mint-authority=${mintAuthority.publicKey.toBase58()}`,
-        `--mint-secret-key=${mintSecretKey}`,
+        `--mint-keypair=${mintSecretKey}`,
       ])
       .it(`create mint for ${mintAuthority} with 2 decimals`, (ctx: any) => {
         expect(ctx.stdout).to.contain("create-mint successful");


### PR DESCRIPTION
Flags updated:
1. create-mint: --mint-keypair flag expects file path to the keypair (optional).
2. mint-to: --mint-authority flag expects file path to the keypair (optional, defaults to $HOME/.config/solana/id.json).
3. transfer: --fee-payer flag expects file path to the keypair (optional, defaults to $HOME/.config/solana/id.json).
