### PR TITLE
feat: enable acp group access control

### DIFF
--- a/merkle-tree/concurrent/src/lib.rs
+++ b/merkle-tree/concurrent/src/lib.rs
@@ -6,10 +6,6 @@ use light_hasher::Hasher;
 pub mod changelog;
 pub mod errors;
 pub mod hash;
-
-#[cfg(target_os = "solana")]
-use solana_program::msg;
-
 use crate::{
     changelog::{ChangelogEntry, MerklePaths},
     errors::ConcurrentMerkleTreeError,
@@ -770,8 +766,6 @@ where
         // with the following print set the expected and computed roots are the same
         // comment the statment to reproduce the error with test programs/account-compression/tests/merkle_tree_tests.rs
         // in accounts-compression run cargo test-sbf test_nullify_leaves
-        #[cfg(target_os = "solana")]
-        msg!("leaf: {:?}", leaf);
         if computed_root == expected_root {
             Ok(())
         } else {

--- a/merkle-tree/concurrent/src/lib.rs
+++ b/merkle-tree/concurrent/src/lib.rs
@@ -766,6 +766,8 @@ where
         // with the following print set the expected and computed roots are the same
         // comment the statment to reproduce the error with test programs/account-compression/tests/merkle_tree_tests.rs
         // in accounts-compression run cargo test-sbf test_nullify_leaves
+        #[cfg(target_os = "solana")]
+        solana_program::msg!("leaf: {:?}", leaf);
         if computed_root == expected_root {
             Ok(())
         } else {

--- a/programs/account-compression/src/errors.rs
+++ b/programs/account-compression/src/errors.rs
@@ -38,4 +38,12 @@ pub enum AccountCompressionErrorCode {
     ElementAlreadyExists,
     #[msg("HashSetFull")]
     HashSetFull,
+    #[msg("NumberOfProofsMismatch")]
+    NumberOfProofsMismatch,
+    #[msg("InvalidMerkleProof")]
+    InvalidMerkleProof,
+    #[msg("InvalidIndexedArray")]
+    InvalidIndexedArray,
+    #[msg("InvalidMerkleTree")]
+    InvalidMerkleTree,
 }

--- a/programs/account-compression/src/instructions/initialize_concurrent_merkle_tree.rs
+++ b/programs/account-compression/src/instructions/initialize_concurrent_merkle_tree.rs
@@ -21,6 +21,7 @@ pub fn process_initialize_state_merkle_tree(
     changelog_size: u64,
     roots_size: u64,
     canopy_depth: u64,
+    associated_queue: Option<Pubkey>,
 ) -> Result<()> {
     // Initialize new Merkle trees.
     let mut merkle_tree = ctx.accounts.merkle_tree.load_init()?;
@@ -28,6 +29,7 @@ pub fn process_initialize_state_merkle_tree(
     merkle_tree.index = index;
     merkle_tree.owner = owner;
     merkle_tree.delegate = delegate.unwrap_or(owner);
+    merkle_tree.associated_queue = associated_queue.unwrap_or_default();
 
     // TODO: think about whether and if how to use the Merkle tree index in the future
     // we could create a group which has ownership over a set of Merkle trees same registration process as for pool program

--- a/programs/account-compression/src/instructions/insert_into_indexed_array.rs
+++ b/programs/account-compression/src/instructions/insert_into_indexed_array.rs
@@ -80,7 +80,7 @@ pub fn process_initialize_indexed_array<'info>(
     indexed_array_account.owner = owner;
     indexed_array_account.delegate = delegate.unwrap_or(owner);
     indexed_array_account.associated_merkle_tree = associated_merkle_tree.unwrap_or_default();
-    // Explicitly initializing the indexed array is not necessary as defautl values are all zero.
+    // Explicitly initializing the indexed array is not necessary as default values are all zero.
     Ok(())
 }
 

--- a/programs/account-compression/src/instructions/nullify_leaves.rs
+++ b/programs/account-compression/src/instructions/nullify_leaves.rs
@@ -36,15 +36,15 @@ pub fn process_nullify_leaves<'a, 'b, 'c: 'info, 'info>(
     let mut merkle_tree_account = ctx.accounts.merkle_tree.load_mut()?;
     if array_account.associated_merkle_tree != ctx.accounts.merkle_tree.key() {
         msg!(
-            "merkle tree and indexed array are not associated {} != {}",
+            "Nullifier queue and Merkle tree are not associated. Associated mt of nullifier queue {} != merkle tree {}",
             array_account.associated_merkle_tree,
-            ctx.accounts.merkle_tree.key()
+            ctx.accounts.merkle_tree.key(),
         );
         return Err(AccountCompressionErrorCode::InvalidMerkleTree.into());
     }
     if merkle_tree_account.associated_queue != ctx.accounts.indexed_array.key() {
         msg!(
-            "merkle tree and indexed array are not associated {} != {}",
+            "Merkle tree and nullifier queue are not associated. Merkle tree associated nullifier queue {} != nullifier queue {}",
             merkle_tree_account.associated_queue,
             ctx.accounts.indexed_array.key()
         );

--- a/programs/account-compression/src/instructions/register_program.rs
+++ b/programs/account-compression/src/instructions/register_program.rs
@@ -3,6 +3,7 @@ use anchor_lang::prelude::*;
 
 use crate::{errors::AccountCompressionErrorCode, GroupAuthority};
 
+#[derive(Debug)]
 #[account]
 #[aligned_sized(anchor)]
 pub struct RegisteredProgram {

--- a/programs/account-compression/src/lib.rs
+++ b/programs/account-compression/src/lib.rs
@@ -109,7 +109,8 @@ pub mod account_compression {
     }
 
     /// Initializes a new Merkle tree from config bytes.
-    /// Can only be called from the merkle_tree_authority.
+    /// Index is an optional identifier and not checked by the program.
+    /// TODO: think the index over
     pub fn initialize_state_merkle_tree(
         ctx: Context<InitializeStateMerkleTree>,
         index: u64,
@@ -119,6 +120,7 @@ pub mod account_compression {
         changelog_size: u64,
         roots_size: u64,
         canopy_depth: u64,
+        associated_queue: Option<Pubkey>,
     ) -> Result<()> {
         process_initialize_state_merkle_tree(
             ctx,
@@ -129,6 +131,7 @@ pub mod account_compression {
             changelog_size,
             roots_size,
             canopy_depth,
+            associated_queue,
         )
     }
 
@@ -142,14 +145,14 @@ pub mod account_compression {
     pub fn nullify_leaves<'a, 'b, 'c: 'info, 'info>(
         ctx: Context<'a, 'b, 'c, 'info, NullifyLeaves<'info>>,
         change_log_indices: Vec<u64>,
-        leaves_indices: Vec<u16>,
+        leaves_queue_indices: Vec<u16>,
         indices: Vec<u64>,
         proofs: Vec<Vec<[u8; 32]>>,
     ) -> Result<()> {
         process_nullify_leaves(
             &ctx,
             &change_log_indices,
-            &leaves_indices,
+            &leaves_queue_indices,
             &indices,
             &proofs,
         )
@@ -161,8 +164,9 @@ pub mod account_compression {
         index: u64,
         owner: Pubkey,
         delegate: Option<Pubkey>,
+        associated_merkle_tree: Option<Pubkey>,
     ) -> Result<()> {
-        process_initialize_indexed_array(ctx, index, owner, delegate)
+        process_initialize_indexed_array(ctx, index, owner, delegate, associated_merkle_tree)
     }
 
     pub fn insert_into_indexed_arrays<'a, 'b, 'c: 'info, 'info>(

--- a/programs/account-compression/src/state/public_state_merkle_tree.rs
+++ b/programs/account-compression/src/state/public_state_merkle_tree.rs
@@ -19,6 +19,7 @@ pub struct StateMerkleTreeAccount {
     pub owner: Pubkey,
     /// Delegate of the Merkle tree. This will be used for program owned Merkle trees.
     pub delegate: Pubkey,
+    pub associated_queue: Pubkey,
 
     /// Merkle tree for the transaction state.
     pub state_merkle_tree_struct: [u8; 256],
@@ -136,6 +137,7 @@ mod test {
             next_merkle_tree: Pubkey::new_from_array([0u8; 32]),
             owner: Pubkey::new_from_array([2u8; 32]),
             delegate: Pubkey::new_from_array([3u8; 32]),
+            associated_queue: Pubkey::new_from_array([4u8; 32]),
             state_merkle_tree_struct: [0u8; 256],
             state_merkle_tree_filled_subtrees: [0u8; 832],
             state_merkle_tree_changelog: [0u8; 1220800],

--- a/programs/account-compression/src/utils/check_registered_or_signer.rs
+++ b/programs/account-compression/src/utils/check_registered_or_signer.rs
@@ -28,15 +28,19 @@ pub fn check_registered_or_signer<
     match ctx.accounts.get_registered_program_pda() {
         Some(account) => {
             let derived_address = Pubkey::find_program_address(
-                &[ctx.program_id.to_bytes().as_ref()],
+                &[b"cpi_authority", ctx.program_id.to_bytes().as_ref()],
                 &account.pubkey,
             )
             .0;
-            if ctx.accounts.get_signing_address().key() == derived_address
-                && derived_address == *checked_account.get_owner()
-            {
+            if ctx.accounts.get_signing_address().key() == derived_address {
                 Ok(())
             } else {
+                msg!("registered program check failed");
+                msg!("derived_address: {:?}", account.key());
+                msg!(
+                    "signing_address: {:?}",
+                    ctx.accounts.get_signing_address().key()
+                );
                 Err(AccountCompressionErrorCode::InvalidAuthority.into())
             }
         }

--- a/programs/account-compression/tests/group_authority_tests.rs
+++ b/programs/account-compression/tests/group_authority_tests.rs
@@ -1,0 +1,188 @@
+#![cfg(feature = "test-sbf")]
+
+use std::str::FromStr;
+
+use account_compression::{self, utils::constants::GROUP_AUTHORITY_SEED, GroupAuthority, ID};
+use anchor_lang::{system_program, InstructionData};
+use light_test_utils::{airdrop_lamports, get_account};
+use solana_program_test::ProgramTest;
+use solana_sdk::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+
+/// Tests:
+/// 1. Create group authority
+/// 2. Update group authority
+/// 3. Cannot update with invalid authority
+/// 4. Add program to group
+/// 5. Cannot add program to group with invalid authority
+#[tokio::test]
+async fn test_create_and_update_group() {
+    let mut program_test = ProgramTest::default();
+    program_test.add_program("account_compression", ID, None);
+    let compressed_pda_id =
+        Pubkey::from_str("6UqiSPd2mRCTTwkzhcs1M6DGYsqHWd5jiPueX3LwDMXQ").unwrap();
+    program_test.add_program("psp_compressed_pda", compressed_pda_id, None);
+
+    program_test.set_compute_max_units(1_400_000u64);
+    let mut context = program_test.start_with_context().await;
+
+    let seed = [1u8; 32];
+    let group_accounts = anchor_lang::prelude::Pubkey::find_program_address(
+        &[GROUP_AUTHORITY_SEED, seed.as_slice()],
+        &account_compression::ID,
+    );
+
+    let instruction_data = account_compression::instruction::InitializeGroupAuthority {
+        _seed: seed,
+        authority: context.payer.pubkey(),
+    };
+
+    let instruction = Instruction {
+        program_id: account_compression::ID,
+        accounts: vec![
+            AccountMeta::new(context.payer.pubkey(), true),
+            AccountMeta::new(group_accounts.0, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        data: instruction_data.data(),
+    };
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &vec![&context.payer],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let group_authority = get_account::<GroupAuthority>(&mut context, group_accounts.0).await;
+    assert_eq!(group_authority.authority, context.payer.pubkey());
+    assert_eq!(group_authority.seed, seed);
+
+    let updated_keypair = Keypair::new();
+    let update_group_authority_ix = account_compression::instruction::UpdateGroupAuthority {
+        authority: updated_keypair.pubkey(),
+    };
+
+    // update with new authority
+    let instruction = Instruction {
+        program_id: account_compression::ID,
+        accounts: vec![
+            AccountMeta::new(context.payer.pubkey(), true),
+            AccountMeta::new(group_accounts.0, false),
+            AccountMeta::new_readonly(updated_keypair.pubkey(), false),
+        ],
+        data: update_group_authority_ix.data(),
+    };
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &vec![&context.payer],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    let group_authority = get_account::<GroupAuthority>(&mut context, group_accounts.0).await;
+
+    assert_eq!(group_authority.authority, updated_keypair.pubkey());
+    assert_eq!(group_authority.seed, seed);
+
+    // update with old authority should fail
+    let update_group_authority_ix = account_compression::instruction::UpdateGroupAuthority {
+        authority: context.payer.pubkey(),
+    };
+    let instruction = Instruction {
+        program_id: account_compression::ID,
+        accounts: vec![
+            AccountMeta::new(context.payer.pubkey(), true),
+            AccountMeta::new(group_accounts.0, false),
+            AccountMeta::new_readonly(updated_keypair.pubkey(), false),
+        ],
+        data: update_group_authority_ix.data(),
+    };
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &vec![&context.payer],
+        context.last_blockhash,
+    );
+    let update_error = context.banks_client.process_transaction(transaction).await;
+    assert!(update_error.is_err());
+
+    airdrop_lamports(&mut context, &updated_keypair.pubkey(), 1_000_000_000)
+        .await
+        .unwrap();
+    // add new program to group
+    let registered_program_pda =
+        Pubkey::find_program_address(&[compressed_pda_id.to_bytes().as_slice()], &ID).0;
+
+    let register_program_ix = account_compression::instruction::RegisterProgramToGroup {
+        program_id: compressed_pda_id,
+    };
+    let instruction = Instruction {
+        program_id: account_compression::ID,
+        accounts: vec![
+            AccountMeta::new(updated_keypair.pubkey(), true),
+            AccountMeta::new(registered_program_pda, false),
+            AccountMeta::new(group_accounts.0, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        data: register_program_ix.data(),
+    };
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&updated_keypair.pubkey()),
+        &vec![&updated_keypair],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+    // add new program to group with invalid authority
+    let other_program_id = Pubkey::new_unique();
+    let registered_program_pda =
+        Pubkey::find_program_address(&[other_program_id.to_bytes().as_slice()], &ID).0;
+
+    let register_program_ix = account_compression::instruction::RegisterProgramToGroup {
+        program_id: other_program_id,
+    };
+    let instruction = Instruction {
+        program_id: account_compression::ID,
+        accounts: vec![
+            AccountMeta::new(context.payer.pubkey(), true),
+            AccountMeta::new(registered_program_pda, false),
+            AccountMeta::new(group_accounts.0, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        data: register_program_ix.data(),
+    };
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &vec![&context.payer],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_err();
+}

--- a/programs/account-compression/tests/merkle_tree_tests.rs
+++ b/programs/account-compression/tests/merkle_tree_tests.rs
@@ -1,172 +1,31 @@
 #![cfg(feature = "test-sbf")]
 
-use std::str::FromStr;
-
 use account_compression::{
-    self, from_vec,
+    self,
     indexed_array_sdk::create_initialize_indexed_array_instruction,
     instructions::append_leaves::sdk::{
         create_initialize_merkle_tree_instruction, create_insert_leaves_instruction,
     },
-    utils::constants::GROUP_AUTHORITY_SEED,
-    GroupAuthority, StateMerkleTreeAccount, ID,
+    Pubkey, StateMerkleTreeAccount, ID,
 };
-use anchor_lang::{system_program, InstructionData, ToAccountMetas};
-use light_concurrent_merkle_tree::{ConcurrentMerkleTree, ConcurrentMerkleTree26};
+use anchor_lang::{InstructionData, ToAccountMetas};
+use light_concurrent_merkle_tree::ConcurrentMerkleTree26;
 use light_hasher::{zero_bytes::poseidon::ZERO_BYTES, Poseidon};
 use light_test_utils::{
-    airdrop_lamports, create_account_instruction, create_and_send_transaction, get_account,
-    AccountZeroCopy,
+    airdrop_lamports, create_account_instruction, create_and_send_transaction, AccountZeroCopy,
 };
-use solana_program_test::ProgramTest;
+use solana_program_test::{BanksClientError, ProgramTest, ProgramTestContext};
 use solana_sdk::{
     instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
 
-#[tokio::test]
-async fn test_create_and_update_group() {
-    let mut program_test = ProgramTest::default();
-    program_test.add_program("account_compression", ID, None);
-    let compressed_pda_id =
-        Pubkey::from_str("6UqiSPd2mRCTTwkzhcs1M6DGYsqHWd5jiPueX3LwDMXQ").unwrap();
-    program_test.add_program("psp_compressed_pda", compressed_pda_id, None);
-
-    program_test.set_compute_max_units(1_400_000u64);
-
-    let mut context = program_test.start_with_context().await;
-
-    let seed = [1u8; 32];
-    let group_accounts = anchor_lang::prelude::Pubkey::find_program_address(
-        &[GROUP_AUTHORITY_SEED, seed.as_slice()],
-        &account_compression::ID,
-    );
-
-    let instruction_data = account_compression::instruction::InitializeGroupAuthority {
-        _seed: seed,
-        authority: context.payer.pubkey(),
-    };
-
-    let instruction = Instruction {
-        program_id: account_compression::ID,
-        accounts: vec![
-            AccountMeta::new(context.payer.pubkey(), true),
-            AccountMeta::new(group_accounts.0, false),
-            AccountMeta::new_readonly(system_program::ID, false),
-        ],
-        data: instruction_data.data(),
-    };
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&context.payer.pubkey()),
-        &vec![&context.payer],
-        context.last_blockhash,
-    );
-    context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap();
-
-    let group_authority = get_account::<GroupAuthority>(&mut context, group_accounts.0).await;
-    assert_eq!(group_authority.authority, context.payer.pubkey());
-    assert_eq!(group_authority.seed, seed);
-
-    let updated_keypair = Keypair::new();
-    let update_group_authority_ix = account_compression::instruction::UpdateGroupAuthority {
-        authority: updated_keypair.pubkey(),
-    };
-
-    // update with new authority
-    let instruction = Instruction {
-        program_id: account_compression::ID,
-        accounts: vec![
-            AccountMeta::new(context.payer.pubkey(), true),
-            AccountMeta::new(group_accounts.0, false),
-            AccountMeta::new_readonly(updated_keypair.pubkey(), false),
-        ],
-        data: update_group_authority_ix.data(),
-    };
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&context.payer.pubkey()),
-        &vec![&context.payer],
-        context.last_blockhash,
-    );
-    context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap();
-
-    let group_authority = get_account::<GroupAuthority>(&mut context, group_accounts.0).await;
-
-    assert_eq!(group_authority.authority, updated_keypair.pubkey());
-    assert_eq!(group_authority.seed, seed);
-
-    // update with old authority should fail
-    let update_group_authority_ix = account_compression::instruction::UpdateGroupAuthority {
-        authority: context.payer.pubkey(),
-    };
-    let instruction = Instruction {
-        program_id: account_compression::ID,
-        accounts: vec![
-            AccountMeta::new(context.payer.pubkey(), true),
-            AccountMeta::new(group_accounts.0, false),
-            AccountMeta::new_readonly(updated_keypair.pubkey(), false),
-        ],
-        data: update_group_authority_ix.data(),
-    };
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&context.payer.pubkey()),
-        &vec![&context.payer],
-        context.last_blockhash,
-    );
-    let update_error = context.banks_client.process_transaction(transaction).await;
-    assert!(update_error.is_err());
-
-    airdrop_lamports(&mut context, &updated_keypair.pubkey(), 1_000_000_000)
-        .await
-        .unwrap();
-    // add new program to group
-    let registered_program_pda =
-        Pubkey::find_program_address(&[compressed_pda_id.to_bytes().as_slice()], &ID).0;
-
-    let register_program_ix = account_compression::instruction::RegisterProgramToGroup {
-        program_id: compressed_pda_id,
-    };
-
-    // update with new authority
-    let instruction = Instruction {
-        program_id: account_compression::ID,
-        accounts: vec![
-            AccountMeta::new(updated_keypair.pubkey(), true),
-            AccountMeta::new(registered_program_pda, false),
-            AccountMeta::new(group_accounts.0, false),
-            AccountMeta::new_readonly(system_program::ID, false),
-        ],
-        data: register_program_ix.data(),
-    };
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&updated_keypair.pubkey()),
-        &vec![&updated_keypair],
-        context.last_blockhash,
-    );
-    context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap();
-}
-
+/// Tests:
+/// 1. Functional: Initialize merkle tree
+/// 2. Failing: Append with invalid inputs
+/// 3. Functional: Append leaves to merkle tree
+/// 4. Failing: Append leaves with invalid authority
 #[tokio::test]
 async fn test_init_and_insert_leaves_into_merkle_tree() {
     let mut program_test = ProgramTest::default();
@@ -180,9 +39,23 @@ async fn test_init_and_insert_leaves_into_merkle_tree() {
     program_test.set_compute_max_units(1_400_000u64);
     let mut context = program_test.start_with_context().await;
 
-    let payer = context.payer.insecure_clone();
     let payer_pubkey = context.payer.pubkey();
 
+    let merkle_tree_pubkey =
+        functional_1_initialize_state_merkle_tree(&mut context, &payer_pubkey, None).await;
+
+    fail_2_append_leaves_with_invalid_inputs(&mut context, &merkle_tree_pubkey).await;
+
+    functional_3_append_leaves_to_merkle_tree(&mut context, &merkle_tree_pubkey).await;
+
+    fail_4_append_leaves_with_invalid_authority(&mut context, &merkle_tree_pubkey).await;
+}
+
+async fn functional_1_initialize_state_merkle_tree(
+    context: &mut ProgramTestContext,
+    payer_pubkey: &Pubkey,
+    associated_queue: Option<Pubkey>,
+) -> Pubkey {
     let merkle_tree_keypair = Keypair::new();
     let account_create_ix = create_account_instruction(
         &context.payer.pubkey(),
@@ -198,8 +71,11 @@ async fn test_init_and_insert_leaves_into_merkle_tree() {
     );
     let merkle_tree_pubkey = merkle_tree_keypair.pubkey();
 
-    let instruction =
-        create_initialize_merkle_tree_instruction(context.payer.pubkey(), merkle_tree_pubkey);
+    let instruction = create_initialize_merkle_tree_instruction(
+        context.payer.pubkey(),
+        merkle_tree_pubkey,
+        associated_queue,
+    );
 
     let transaction = Transaction::new_signed_with_payer(
         &[account_create_ix, instruction],
@@ -213,15 +89,20 @@ async fn test_init_and_insert_leaves_into_merkle_tree() {
         .await
         .unwrap();
     let merkle_tree = AccountZeroCopy::<account_compression::StateMerkleTreeAccount>::new(
-        &mut context,
+        context,
         merkle_tree_pubkey,
     )
     .await;
-    assert_eq!(merkle_tree.deserialized().owner, payer_pubkey);
-    assert_eq!(merkle_tree.deserialized().delegate, payer_pubkey);
+    assert_eq!(merkle_tree.deserialized().owner, *payer_pubkey);
+    assert_eq!(merkle_tree.deserialized().delegate, *payer_pubkey);
     assert_eq!(merkle_tree.deserialized().index, 1);
+    merkle_tree_keypair.pubkey()
+}
 
-    // insertions with merkle tree leaves missmatch should fail
+pub async fn fail_2_append_leaves_with_invalid_inputs(
+    context: &mut ProgramTestContext,
+    merkle_tree_pubkey: &Pubkey,
+) {
     let instruction_data = account_compression::instruction::AppendLeavesToMerkleTrees {
         leaves: vec![[1u8; 32], [2u8; 32]],
     };
@@ -236,7 +117,7 @@ async fn test_init_and_insert_leaves_into_merkle_tree() {
         program_id: account_compression::ID,
         accounts: vec![
             accounts.to_account_metas(Some(true)),
-            vec![AccountMeta::new(merkle_tree_pubkey, false)],
+            vec![AccountMeta::new(*merkle_tree_pubkey, false)],
         ]
         .concat(),
         data: instruction_data.data(),
@@ -251,10 +132,16 @@ async fn test_init_and_insert_leaves_into_merkle_tree() {
     let remaining_accounts_missmatch_error =
         context.banks_client.process_transaction(transaction).await;
     assert!(remaining_accounts_missmatch_error.is_err());
+}
 
+pub async fn functional_3_append_leaves_to_merkle_tree(
+    context: &mut ProgramTestContext,
+    merkle_tree_pubkey: &Pubkey,
+) {
+    let payer = context.payer.insecure_clone();
     let old_merkle_tree = AccountZeroCopy::<account_compression::StateMerkleTreeAccount>::new(
-        &mut context,
-        merkle_tree_pubkey,
+        context,
+        *merkle_tree_pubkey,
     )
     .await;
     let old_merkle_tree = old_merkle_tree.deserialized().copy_merkle_tree().unwrap();
@@ -262,16 +149,16 @@ async fn test_init_and_insert_leaves_into_merkle_tree() {
     let instruction = [create_insert_leaves_instruction(
         vec![[1u8; 32], [2u8; 32]],
         context.payer.pubkey(),
-        vec![merkle_tree_pubkey, merkle_tree_pubkey],
+        vec![*merkle_tree_pubkey, *merkle_tree_pubkey],
     )];
 
-    create_and_send_transaction(&mut context, &instruction, &payer.pubkey(), &[&payer])
+    create_and_send_transaction(context, &instruction, &payer.pubkey(), &[&payer])
         .await
         .unwrap();
 
     let merkle_tree = AccountZeroCopy::<account_compression::StateMerkleTreeAccount>::new(
-        &mut context,
-        merkle_tree_pubkey,
+        context,
+        *merkle_tree_pubkey,
     )
     .await;
     let merkle_tree = merkle_tree.deserialized().copy_merkle_tree().unwrap();
@@ -293,108 +180,51 @@ async fn test_init_and_insert_leaves_into_merkle_tree() {
     );
 }
 
-#[tokio::test]
-async fn test_init_and_insert_into_indexed_array() {
-    let mut program_test = ProgramTest::default();
-    program_test.add_program("account_compression", ID, None);
-    program_test.add_program(
-        "spl_noop",
-        account_compression::state::change_log_event::NOOP_PROGRAM_ID,
-        None,
-    );
-
-    program_test.set_compute_max_units(1_400_000u64);
-    let mut context = program_test.start_with_context().await;
-    let payer = context.payer.insecure_clone();
-    let payer_pubkey = payer.pubkey();
-
-    let indexed_array_keypair = Keypair::new();
-
-    let account_create_ix = create_account_instruction(
-        &payer_pubkey,
-        account_compression::IndexedArrayAccount::LEN,
-        context
-            .banks_client
-            .get_rent()
-            .await
-            .unwrap()
-            .minimum_balance(account_compression::IndexedArrayAccount::LEN),
-        &ID,
-        Some(&indexed_array_keypair),
-    );
-    let indexed_array_pubkey = indexed_array_keypair.pubkey();
-
-    let instruction =
-        create_initialize_indexed_array_instruction(payer_pubkey, indexed_array_pubkey, 1u64);
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[account_create_ix, instruction],
-        Some(&context.payer.pubkey()),
-        &vec![&context.payer, &indexed_array_keypair],
-        context.last_blockhash,
-    );
-    context
-        .banks_client
-        .process_transaction(transaction.clone())
+pub async fn fail_4_append_leaves_with_invalid_authority(
+    context: &mut ProgramTestContext,
+    merkle_tree_pubkey: &Pubkey,
+) {
+    let invalid_autority = Keypair::new();
+    airdrop_lamports(context, &invalid_autority.pubkey(), 1_000_000_000)
         .await
         .unwrap();
-
-    let array = AccountZeroCopy::<account_compression::IndexedArrayAccount>::new(
-        &mut context,
-        indexed_array_pubkey,
-    )
-    .await;
-    assert_eq!(array.deserialized().owner, payer_pubkey);
-    assert_eq!(array.deserialized().delegate, payer_pubkey);
-    assert_eq!(array.deserialized().index, 1);
-    let indexed_array = array.deserialized().indexed_array;
-    assert_eq!(indexed_array[0].element, [0u8; 32]);
-    assert_eq!(indexed_array[0].merkle_tree_overwrite_sequence_number, 0);
-
-    // TODO: investigate why this fails with 0 0
-    let instruction_data = account_compression::instruction::InsertIntoIndexedArrays {
-        elements: vec![[1u8; 32], [2u8; 32]],
+    let instruction_data = account_compression::instruction::AppendLeavesToMerkleTrees {
+        leaves: vec![[1u8; 32]],
     };
-    let accounts = account_compression::accounts::InsertIntoIndexedArrays {
-        authority: context.payer.pubkey(),
+
+    let accounts = account_compression::accounts::AppendLeaves {
+        authority: invalid_autority.pubkey(),
         registered_program_pda: None,
+        log_wrapper: account_compression::state::change_log_event::NOOP_PROGRAM_ID,
     };
+
     let instruction = Instruction {
         program_id: account_compression::ID,
         accounts: vec![
             accounts.to_account_metas(Some(true)),
-            vec![
-                AccountMeta::new(indexed_array_pubkey, false),
-                AccountMeta::new(indexed_array_pubkey, false),
-            ],
+            vec![AccountMeta::new(*merkle_tree_pubkey, false)],
         ]
         .concat(),
         data: instruction_data.data(),
     };
     let transaction = Transaction::new_signed_with_payer(
         &[instruction],
-        Some(&context.payer.pubkey()),
-        &vec![&context.payer],
+        Some(&invalid_autority.pubkey()),
+        &vec![&invalid_autority],
         context.last_blockhash,
     );
-    context
-        .banks_client
-        .process_transaction(transaction.clone())
-        .await
-        .unwrap();
-    let array = AccountZeroCopy::<account_compression::IndexedArrayAccount>::new(
-        &mut context,
-        indexed_array_pubkey,
-    )
-    .await;
-
-    let indexed_array = array.deserialized().indexed_array;
-    assert_eq!(indexed_array[0].element, [1u8; 32]);
-    assert_eq!(indexed_array[1].element, [2u8; 32]);
-    assert_eq!(indexed_array[0].merkle_tree_overwrite_sequence_number, 0);
-    assert_eq!(indexed_array[1].merkle_tree_overwrite_sequence_number, 0);
+    let remaining_accounts_missmatch_error =
+        context.banks_client.process_transaction(transaction).await;
+    assert!(remaining_accounts_missmatch_error.is_err());
 }
 
+/// Tests:
+/// 1. Functional: nullify leaf
+/// 2. Failing: nullify leaf with invalid leaf index
+/// 3. Failing: nullify leaf with invalid leaf queue index
+/// 4. Failing: nullify leaf with invalid change log index
+/// 5. Functional: nullify other leaf
+/// 6. Failing: nullify leaf with indexed array that is not associated with the merkle tree
 #[tokio::test]
 async fn test_nullify_leaves() {
     let mut program_test = ProgramTest::default();
@@ -410,131 +240,44 @@ async fn test_nullify_leaves() {
 
     let payer = context.payer.insecure_clone();
     let payer_pubkey = context.payer.pubkey();
-
-    let merkle_tree_keypair = Keypair::new();
-    let account_create_ix = create_account_instruction(
-        &context.payer.pubkey(),
-        StateMerkleTreeAccount::LEN,
-        context
-            .banks_client
-            .get_rent()
-            .await
-            .unwrap()
-            .minimum_balance(account_compression::StateMerkleTreeAccount::LEN),
-        &ID,
-        Some(&merkle_tree_keypair),
-    );
-    let merkle_tree_pubkey = merkle_tree_keypair.pubkey();
-
-    let instruction =
-        create_initialize_merkle_tree_instruction(context.payer.pubkey(), merkle_tree_pubkey);
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[account_create_ix, instruction],
-        Some(&context.payer.pubkey()),
-        &vec![&context.payer, &merkle_tree_keypair],
-        context.last_blockhash,
-    );
-    context
-        .banks_client
-        .process_transaction(transaction.clone())
-        .await
-        .unwrap();
-    let merkle_tree = AccountZeroCopy::<account_compression::StateMerkleTreeAccount>::new(
-        &mut context,
-        merkle_tree_pubkey,
-    )
-    .await;
-    assert_eq!(merkle_tree.deserialized().owner, payer_pubkey);
-    assert_eq!(merkle_tree.deserialized().delegate, payer_pubkey);
-    assert_eq!(merkle_tree.deserialized().index, 1);
-
     let indexed_array_keypair = Keypair::new();
-    let account_create_ix = crate::create_account_instruction(
-        &payer.pubkey(),
-        account_compression::IndexedArrayAccount::LEN,
-        context
-            .banks_client
-            .get_rent()
-            .await
-            .unwrap()
-            .minimum_balance(account_compression::IndexedArrayAccount::LEN),
-        &account_compression::ID,
-        Some(&indexed_array_keypair),
-    );
-    let indexed_array_pubkey = indexed_array_keypair.pubkey();
-    let instruction = create_initialize_indexed_array_instruction(
-        payer.pubkey(),
-        indexed_array_keypair.pubkey(),
-        0,
-    );
-    let transaction = Transaction::new_signed_with_payer(
-        &[account_create_ix, instruction],
-        Some(&payer.pubkey()),
-        &vec![&payer, &indexed_array_keypair],
-        context.last_blockhash,
-    );
-    context
-        .banks_client
-        .process_transaction(transaction.clone())
-        .await
-        .unwrap();
 
-    // insertions with merkle tree leaves missmatch should fail
-    let instruction_data = account_compression::instruction::AppendLeavesToMerkleTrees {
-        leaves: vec![[1u8; 32], [2u8; 32]],
-    };
-
-    let accounts = account_compression::accounts::AppendLeaves {
-        authority: context.payer.pubkey(),
-        registered_program_pda: None,
-        log_wrapper: account_compression::state::change_log_event::NOOP_PROGRAM_ID,
-    };
-
-    let instruction = Instruction {
-        program_id: account_compression::ID,
-        accounts: vec![
-            accounts.to_account_metas(Some(true)),
-            vec![AccountMeta::new(merkle_tree_pubkey, false)],
-        ]
-        .concat(),
-        data: instruction_data.data(),
-    };
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&context.payer.pubkey()),
-        &vec![&context.payer],
-        context.last_blockhash,
-    );
-    let remaining_accounts_missmatch_error =
-        context.banks_client.process_transaction(transaction).await;
-    assert!(remaining_accounts_missmatch_error.is_err());
-
-    let old_merkle_tree = AccountZeroCopy::<account_compression::StateMerkleTreeAccount>::new(
+    let merkle_tree_pubkey = functional_1_initialize_state_merkle_tree(
         &mut context,
-        merkle_tree_pubkey,
+        &payer_pubkey,
+        Some(indexed_array_keypair.pubkey()),
     )
     .await;
-    let old_merkle_tree = old_merkle_tree.deserialized().copy_merkle_tree().unwrap();
 
-    let instruction = [create_insert_leaves_instruction(
-        vec![[1u8; 32], [2u8; 32]],
-        context.payer.pubkey(),
-        vec![merkle_tree_pubkey, merkle_tree_pubkey],
-    )];
-
-    create_and_send_transaction(&mut context, &instruction, &payer.pubkey(), &[&payer])
-        .await
-        .unwrap();
-
-    let merkle_tree = AccountZeroCopy::<account_compression::StateMerkleTreeAccount>::new(
+    let indexed_array_pubkey = functional_1_initialize_indexed_array(
         &mut context,
-        merkle_tree_pubkey,
+        &payer_pubkey,
+        &indexed_array_keypair,
+        Some(merkle_tree_pubkey),
     )
     .await;
-    let merkle_tree = merkle_tree.deserialized().copy_merkle_tree().unwrap();
-    assert_eq!(merkle_tree.next_index, old_merkle_tree.next_index + 2);
+    let other_merkle_tree_pubkey = functional_1_initialize_state_merkle_tree(
+        &mut context,
+        &payer_pubkey,
+        Some(indexed_array_keypair.pubkey()),
+    )
+    .await;
+    let invalid_indexed_array_keypair = Keypair::new();
+    let invalid_indexed_array_pubkey = functional_1_initialize_indexed_array(
+        &mut context,
+        &payer_pubkey,
+        &invalid_indexed_array_keypair,
+        Some(other_merkle_tree_pubkey),
+    )
+    .await;
+
+    functional_3_append_leaves_to_merkle_tree(&mut context, &merkle_tree_pubkey).await;
+
+    let elements = vec![[1u8; 32], [2u8; 32]];
+
+    insert_into_indexed_arrays(&elements, &payer, &indexed_array_pubkey, &mut context)
+        .await
+        .unwrap();
 
     let mut reference_merkle_tree = light_merkle_tree_reference::MerkleTree::<Poseidon>::new(
         account_compression::utils::constants::STATE_MERKLE_TREE_HEIGHT,
@@ -542,105 +285,133 @@ async fn test_nullify_leaves() {
         account_compression::utils::constants::STATE_MERKLE_TREE_CANOPY_DEPTH,
     )
     .unwrap();
-    reference_merkle_tree.append(&[1u8; 32]).unwrap();
-    reference_merkle_tree.append(&[2u8; 32]).unwrap();
-    assert_eq!(
-        merkle_tree.root().unwrap(),
-        reference_merkle_tree.root().unwrap()
-    );
+    reference_merkle_tree.append(&elements[0]).unwrap();
+    reference_merkle_tree.append(&elements[1]).unwrap();
 
-    // TODO: investigate why this fails with 0 0
-    let instruction_data = account_compression::instruction::InsertIntoIndexedArrays {
-        elements: vec![[1u8; 32], [2u8; 32]],
-    };
-    let accounts = account_compression::accounts::InsertIntoIndexedArrays {
-        authority: context.payer.pubkey(),
-        registered_program_pda: None,
-    };
-    let instruction = Instruction {
-        program_id: account_compression::ID,
-        accounts: vec![
-            accounts.to_account_metas(Some(true)),
-            vec![
-                AccountMeta::new(indexed_array_pubkey, false),
-                AccountMeta::new(indexed_array_pubkey, false),
-            ],
-        ]
-        .concat(),
-        data: instruction_data.data(),
-    };
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&context.payer.pubkey()),
-        &vec![&context.payer],
-        context.last_blockhash,
-    );
-    context
-        .banks_client
-        .process_transaction(transaction.clone())
-        .await
-        .unwrap();
-    let array = AccountZeroCopy::<account_compression::IndexedArrayAccount>::new(
+    let element_index = reference_merkle_tree.get_leaf_index(&elements[0]).unwrap() as u64;
+    nullify(
         &mut context,
-        indexed_array_pubkey,
+        &merkle_tree_pubkey,
+        &indexed_array_pubkey,
+        &mut reference_merkle_tree,
+        &elements[0],
+        2,
+        0,
+        element_index,
     )
-    .await;
+    .await
+    .unwrap();
 
-    let indexed_array = array.deserialized().indexed_array;
-    assert_eq!(indexed_array[0].element, [1u8; 32]);
-    assert_eq!(indexed_array[1].element, [2u8; 32]);
-    assert_eq!(indexed_array[0].merkle_tree_overwrite_sequence_number, 0);
-    assert_eq!(indexed_array[1].merkle_tree_overwrite_sequence_number, 0);
+    // nullify with invalid leaf index
+    let invalid_element_index = 0;
+    let valid_changelog_index = 3;
+    let valid_leaf_queue_index = 1;
+    nullify(
+        &mut context,
+        &merkle_tree_pubkey,
+        &indexed_array_pubkey,
+        &mut reference_merkle_tree,
+        &elements[1],
+        valid_changelog_index,
+        valid_leaf_queue_index,
+        invalid_element_index,
+    )
+    .await
+    .unwrap_err();
+    let valid_element_index = 1;
+    let invalid_leaf_queue_index = 0;
+    nullify(
+        &mut context,
+        &merkle_tree_pubkey,
+        &indexed_array_pubkey,
+        &mut reference_merkle_tree,
+        &elements[1],
+        valid_changelog_index,
+        invalid_leaf_queue_index,
+        valid_element_index,
+    )
+    .await
+    .unwrap_err();
+    let invalid_change_log_index = 0;
+    nullify(
+        &mut context,
+        &merkle_tree_pubkey,
+        &indexed_array_pubkey,
+        &mut reference_merkle_tree,
+        &elements[1],
+        invalid_change_log_index,
+        valid_leaf_queue_index,
+        valid_element_index,
+    )
+    .await
+    .unwrap_err();
+    nullify(
+        &mut context,
+        &merkle_tree_pubkey,
+        &indexed_array_pubkey,
+        &mut reference_merkle_tree,
+        &elements[1],
+        valid_changelog_index,
+        valid_leaf_queue_index,
+        valid_element_index,
+    )
+    .await
+    .unwrap();
 
-    let mut concurrent_merkle_tree = ConcurrentMerkleTree::<Poseidon, 26>::new(
-        account_compression::utils::constants::STATE_MERKLE_TREE_HEIGHT,
-        account_compression::utils::constants::STATE_MERKLE_TREE_CHANGELOG,
-        account_compression::utils::constants::STATE_MERKLE_TREE_ROOTS,
-        account_compression::utils::constants::STATE_MERKLE_TREE_CANOPY_DEPTH,
-    );
-    concurrent_merkle_tree.init().unwrap();
-    concurrent_merkle_tree
-        .append_batch(&[&[1u8; 32], &[2u8; 32]])
-        .unwrap();
-    concurrent_merkle_tree.root().unwrap();
+    nullify(
+        &mut context,
+        &merkle_tree_pubkey,
+        &invalid_indexed_array_pubkey,
+        &mut reference_merkle_tree,
+        &elements[0],
+        2,
+        0,
+        element_index,
+    )
+    .await
+    .unwrap_err();
+}
 
+pub async fn nullify(
+    context: &mut ProgramTestContext,
+    merkle_tree_pubkey: &Pubkey,
+    indexed_array_pubkey: &Pubkey,
+    reference_merkle_tree: &mut light_merkle_tree_reference::MerkleTree<Poseidon>,
+    element: &[u8; 32],
+    change_log_index: u64,
+    leaf_queue_index: u16,
+    element_index: u64,
+) -> std::result::Result<(), BanksClientError> {
     let proof: Vec<[u8; 32]> = reference_merkle_tree
-        .get_proof_of_leaf(0, false)
+        .get_proof_of_leaf(element_index as usize, false)
         .unwrap()
         .to_array::<16>()
         .unwrap()
         .to_vec();
 
-    let mut bounded_vec = from_vec(&proof).unwrap();
-    concurrent_merkle_tree
-        .update_proof_from_canopy(0, &mut bounded_vec)
-        .unwrap();
-    concurrent_merkle_tree
-        .validate_proof(&[1u8; 32], 0, &bounded_vec)
-        .unwrap();
-
     let instructions = [
         account_compression::nullify_leaves::sdk_nullify::create_nullify_instruction(
-            vec![2u64].as_slice(),
-            vec![0u16].as_slice(),
-            vec![0u64].as_slice(),
+            vec![change_log_index].as_slice(),
+            vec![leaf_queue_index.clone()].as_slice(),
+            vec![element_index as u64].as_slice(),
             vec![proof].as_slice(),
             &context.payer.pubkey(),
-            &merkle_tree_pubkey,
-            &indexed_array_pubkey,
+            merkle_tree_pubkey,
+            indexed_array_pubkey,
         ),
     ];
+    let payer = context.payer.insecure_clone();
 
-    create_and_send_transaction(&mut context, &instructions, &payer.pubkey(), &[&payer])
-        .await
-        .unwrap();
+    create_and_send_transaction(context, &instructions, &payer.pubkey(), &[&payer]).await?;
 
     let merkle_tree = AccountZeroCopy::<account_compression::StateMerkleTreeAccount>::new(
-        &mut context,
-        merkle_tree_pubkey,
+        context,
+        *merkle_tree_pubkey,
     )
     .await;
-    reference_merkle_tree.update(&ZERO_BYTES[0], 0).unwrap();
+    reference_merkle_tree
+        .update(&ZERO_BYTES[0], element_index as usize)
+        .unwrap();
     assert_eq!(
         merkle_tree
             .deserialized()
@@ -652,12 +423,12 @@ async fn test_nullify_leaves() {
     );
 
     let array = AccountZeroCopy::<account_compression::IndexedArrayAccount>::new(
-        &mut context,
-        indexed_array_pubkey,
+        context,
+        *indexed_array_pubkey,
     )
     .await;
     let indexed_array = array.deserialized().indexed_array;
-    assert_eq!(indexed_array[0].element, [1u8; 32]);
+    assert_eq!(indexed_array[leaf_queue_index as usize].element, *element);
     assert_eq!(
         indexed_array[0].merkle_tree_overwrite_sequence_number,
         merkle_tree
@@ -667,4 +438,210 @@ async fn test_nullify_leaves() {
             .sequence_number as u64
             + account_compression::utils::constants::STATE_MERKLE_TREE_ROOTS as u64
     );
+    Ok(())
+}
+
+/// Tests:
+/// 1. Functional: Initialize indexed array
+/// 2. Functional: Insert into indexed array
+/// 3. Failing: Insert the same elements into indexed array again (3 and 1 element(s))
+/// 4. Failing: Insert into indexed array with invalid authority
+/// 5. Functional: Insert one element into into indexed array
+#[tokio::test]
+async fn test_init_and_insert_into_indexed_array() {
+    let mut program_test = ProgramTest::default();
+    program_test.add_program("account_compression", ID, None);
+    program_test.add_program(
+        "spl_noop",
+        account_compression::state::change_log_event::NOOP_PROGRAM_ID,
+        None,
+    );
+
+    program_test.set_compute_max_units(1_400_000u64);
+    let mut context = program_test.start_with_context().await;
+    let payer = context.payer.insecure_clone();
+    let payer_pubkey = payer.pubkey();
+    let indexed_array_keypair = Keypair::new();
+    let indexed_array_pubkey = functional_1_initialize_indexed_array(
+        &mut context,
+        &payer_pubkey,
+        &indexed_array_keypair,
+        None,
+    )
+    .await;
+
+    functional_2_test_insert_into_indexed_arrays(&mut context, &indexed_array_pubkey).await;
+
+    fail_3_insert_same_elements_into_indexed_array(
+        &mut context,
+        &indexed_array_pubkey,
+        vec![[3u8; 32], [1u8; 32], [1u8; 32]],
+    )
+    .await;
+    fail_3_insert_same_elements_into_indexed_array(
+        &mut context,
+        &indexed_array_pubkey,
+        vec![[1u8; 32]],
+    )
+    .await;
+    fail_4_insert_with_invalid_signer(&mut context, &indexed_array_pubkey, vec![[3u8; 32]]).await;
+
+    functional_5_test_insert_into_indexed_arrays(&mut context, &indexed_array_pubkey).await;
+}
+
+async fn functional_1_initialize_indexed_array(
+    context: &mut ProgramTestContext,
+    payer_pubkey: &Pubkey,
+    indexed_array_keypair: &Keypair,
+    associated_merkle_tree: Option<Pubkey>,
+) -> Pubkey {
+    let account_create_ix = create_account_instruction(
+        payer_pubkey,
+        account_compression::IndexedArrayAccount::LEN,
+        context
+            .banks_client
+            .get_rent()
+            .await
+            .unwrap()
+            .minimum_balance(account_compression::IndexedArrayAccount::LEN),
+        &ID,
+        Some(&indexed_array_keypair),
+    );
+    let indexed_array_pubkey = indexed_array_keypair.pubkey();
+
+    let instruction = create_initialize_indexed_array_instruction(
+        *payer_pubkey,
+        indexed_array_pubkey,
+        1u64,
+        associated_merkle_tree,
+    );
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[account_create_ix, instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &indexed_array_keypair],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction.clone())
+        .await
+        .unwrap();
+    let indexed_array = AccountZeroCopy::<account_compression::IndexedArrayAccount>::new(
+        context,
+        indexed_array_pubkey,
+    )
+    .await
+    .deserialized();
+    assert_eq!(
+        indexed_array.associated_merkle_tree,
+        associated_merkle_tree.unwrap_or(Pubkey::default())
+    );
+    assert_eq!(indexed_array.index, 1);
+    assert_eq!(indexed_array.owner, *payer_pubkey);
+    assert_eq!(indexed_array.delegate, *payer_pubkey);
+
+    indexed_array_pubkey
+}
+
+async fn functional_2_test_insert_into_indexed_arrays(
+    context: &mut ProgramTestContext,
+    indexed_array_pubkey: &Pubkey,
+) {
+    let payer = context.payer.insecure_clone();
+
+    let elements = vec![[1u8; 32], [2u8; 32]];
+    insert_into_indexed_arrays(&elements, &payer, indexed_array_pubkey, context)
+        .await
+        .unwrap();
+    let array = AccountZeroCopy::<account_compression::IndexedArrayAccount>::new(
+        context,
+        *indexed_array_pubkey,
+    )
+    .await;
+    let indexed_array = array.deserialized().indexed_array;
+    assert_eq!(indexed_array[0].element, elements[0]);
+    assert_eq!(indexed_array[1].element, elements[1]);
+    assert_eq!(indexed_array[0].merkle_tree_overwrite_sequence_number, 0);
+    assert_eq!(indexed_array[1].merkle_tree_overwrite_sequence_number, 0);
+}
+
+async fn fail_3_insert_same_elements_into_indexed_array(
+    context: &mut ProgramTestContext,
+    indexed_array_pubkey: &Pubkey,
+    elements: Vec<[u8; 32]>,
+) {
+    let payer = context.payer.insecure_clone();
+
+    insert_into_indexed_arrays(&elements, &payer, indexed_array_pubkey, context)
+        .await
+        .unwrap_err();
+}
+
+async fn fail_4_insert_with_invalid_signer(
+    context: &mut ProgramTestContext,
+    indexed_array_pubkey: &Pubkey,
+    elements: Vec<[u8; 32]>,
+) {
+    let invalid_signer = Keypair::new();
+    airdrop_lamports(context, &invalid_signer.pubkey(), 1_000_000_000)
+        .await
+        .unwrap();
+    insert_into_indexed_arrays(&elements, &invalid_signer, indexed_array_pubkey, context)
+        .await
+        .unwrap_err();
+}
+
+async fn functional_5_test_insert_into_indexed_arrays(
+    context: &mut ProgramTestContext,
+    indexed_array_pubkey: &Pubkey,
+) {
+    let payer = context.payer.insecure_clone();
+
+    let elements = vec![[3u8; 32]];
+    insert_into_indexed_arrays(&elements, &payer, indexed_array_pubkey, context)
+        .await
+        .unwrap();
+    let array = AccountZeroCopy::<account_compression::IndexedArrayAccount>::new(
+        context,
+        *indexed_array_pubkey,
+    )
+    .await;
+    let indexed_array = array.deserialized().indexed_array;
+    assert_eq!(indexed_array[2].element, elements[0]);
+    assert_eq!(indexed_array[2].merkle_tree_overwrite_sequence_number, 0);
+}
+
+async fn insert_into_indexed_arrays(
+    elements: &Vec<[u8; 32]>,
+    payer: &Keypair,
+    indexed_array_pubkey: &Pubkey,
+    context: &mut ProgramTestContext,
+) -> std::result::Result<(), BanksClientError> {
+    let instruction_data = account_compression::instruction::InsertIntoIndexedArrays {
+        elements: elements.to_vec(),
+    };
+    let accounts = account_compression::accounts::InsertIntoIndexedArrays {
+        authority: payer.pubkey(),
+        registered_program_pda: None,
+    };
+    let instruction = Instruction {
+        program_id: account_compression::ID,
+        accounts: vec![
+            accounts.to_account_metas(Some(true)),
+            vec![AccountMeta::new(*indexed_array_pubkey, false); elements.len()],
+        ]
+        .concat(),
+        data: instruction_data.data(),
+    };
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&payer.pubkey()),
+        &vec![payer],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction.clone())
+        .await
 }

--- a/programs/compressed-pda/src/append_state.rs
+++ b/programs/compressed-pda/src/append_state.rs
@@ -48,7 +48,7 @@ pub fn insert_output_compressed_accounts_into_state_merkle_tree<'a, 'b, 'c: 'inf
         ctx.program_id,
         &ctx.accounts.account_compression_program,
         &ctx.accounts.psp_account_compression_authority,
-        &ctx.accounts.registered_program_pda,
+        &ctx.accounts.registered_program_pda.to_account_info(),
         &ctx.accounts.noop_program,
         out_merkle_trees_account_infos,
         output_compressed_account_hashes.to_vec(),
@@ -83,6 +83,7 @@ pub fn append_leaves_cpi<'a, 'b>(
     account_compression::cpi::append_leaves_to_merkle_trees(cpi_ctx, leaves)?;
     Ok(())
 }
+
 #[inline(never)]
 pub fn get_seeds<'a>(program_id: &'a Pubkey, cpi_signer: &'a Pubkey) -> Result<([u8; 32], u8)> {
     let seed = account_compression::ID.key().to_bytes();

--- a/programs/compressed-pda/src/compressed_account.rs
+++ b/programs/compressed-pda/src/compressed_account.rs
@@ -53,7 +53,7 @@ impl CompressedAccount {
 
         if let Some(data) = &self.data {
             // TODO: double check that it is impossible to create a hash collisions for different sized poseidon hash inputs
-            // Otherwise we could use padding so prevent a theoretical attack producing a hash collision
+            // Otherwise we could use padding to prevent a theoretical attack producing a hash collision
             // if self.address.is_none() {
             //     vec.push(&[0u8; 32]);
             // }

--- a/programs/compressed-pda/src/compressed_account.rs
+++ b/programs/compressed-pda/src/compressed_account.rs
@@ -52,6 +52,11 @@ impl CompressedAccount {
         }
 
         if let Some(data) = &self.data {
+            // TODO: double check that it is impossible to create a hash collisions for different sized poseidon hash inputs
+            // Otherwise we could use padding so prevent a theoretical attack producing a hash collision
+            // if self.address.is_none() {
+            //     vec.push(&[0u8; 32]);
+            // }
             vec.push(&data.discriminator);
             vec.push(&data.data_hash);
         }

--- a/programs/compressed-pda/src/instructions.rs
+++ b/programs/compressed-pda/src/instructions.rs
@@ -3,7 +3,6 @@ use std::borrow::Borrow;
 use account_compression::program::AccountCompression;
 use anchor_lang::prelude::*;
 
-// use light_verifier_sdk::light_transaction::CompressedProof;
 use crate::{
     append_state::insert_output_compressed_accounts_into_state_merkle_tree,
     compressed_account::{CompressedAccount, CompressedAccountWithMerkleContext},
@@ -34,7 +33,7 @@ pub fn process_execute_compressed_transaction<'a, 'b, 'c: 'info, 'info>(
     // TODO: add check that if compressed account is program owned that it is signed by the program (if an account has data it is program owned, if the program account is set compressed accounts are program owned)
     match ctx.accounts.cpi_signature_account.borrow() {
         Some(_cpi_signature_account) => {
-            // needs to check every compredssed account and make sure that signaures exist in cpi_signature_account
+            // needs to check every compressed account and make sure that signaures exist in cpi_signature_account
             msg!("cpi_signature check is not implemented");
             err!(ErrorCode::CpiSignerCheckFailed)
         }
@@ -142,8 +141,11 @@ pub fn process_execute_compressed_transaction<'a, 'b, 'c: 'info, 'info>(
 pub struct TransferInstruction<'info> {
     pub signer: Signer<'info>,
     /// CHECK: this account
-    #[account(mut)]
-    pub registered_program_pda: UncheckedAccount<'info>,
+    #[account(
+    seeds = [&crate::ID.to_bytes()], bump, seeds::program = &account_compression::ID,
+    )]
+    pub registered_program_pda:
+        Account<'info, account_compression::instructions::register_program::RegisteredProgram>,
     /// CHECK: this account
     pub noop_program: UncheckedAccount<'info>,
     /// CHECK: this account in psp account compression program

--- a/programs/compressed-pda/src/nullify_state.rs
+++ b/programs/compressed-pda/src/nullify_state.rs
@@ -19,7 +19,7 @@ pub fn insert_nullifiers<'a, 'b, 'c: 'info, 'info>(
         ctx.program_id,
         &ctx.accounts.account_compression_program,
         &ctx.accounts.psp_account_compression_authority,
-        &ctx.accounts.registered_program_pda,
+        &ctx.accounts.registered_program_pda.to_account_info(),
         indexed_array_account_infos,
         nullifiers.to_vec(),
     )

--- a/programs/compressed-pda/src/verify_state.rs
+++ b/programs/compressed-pda/src/verify_state.rs
@@ -47,6 +47,13 @@ pub fn hash_input_compressed_accounts<'a, 'b, 'c: 'info, 'info>(
         .iter()
         .enumerate()
     {
+        if input_compressed_account_with_context
+            .compressed_account
+            .address
+            .is_some()
+        {
+            unimplemented!("Address is not supported yet")
+        }
         leaves[j] = input_compressed_account_with_context
             .compressed_account
             .hash(

--- a/test-utils/src/test_env.rs
+++ b/test-utils/src/test_env.rs
@@ -160,9 +160,11 @@ pub async fn setup_test_programs_with_accounts() -> EnvWithAccounts {
         Some(&merkle_tree_keypair),
     );
     let merkle_tree_pubkey = merkle_tree_keypair.pubkey();
+    let indexed_array_keypair = Keypair::from_bytes(&INDEXED_ARRAY_TEST_KEYPAIR).unwrap();
+    let indexed_array_pubkey = indexed_array_keypair.pubkey();
 
     let instruction =
-        account_compression::instructions::append_leaves::sdk::create_initialize_merkle_tree_instruction(payer.pubkey(), merkle_tree_pubkey);
+        account_compression::instructions::append_leaves::sdk::create_initialize_merkle_tree_instruction(payer.pubkey(), merkle_tree_pubkey, Some(indexed_array_pubkey));
 
     let transaction = Transaction::new_signed_with_payer(
         &[account_create_ix, instruction],
@@ -175,7 +177,6 @@ pub async fn setup_test_programs_with_accounts() -> EnvWithAccounts {
         .process_transaction(transaction.clone())
         .await
         .unwrap();
-    let indexed_array_keypair = Keypair::from_bytes(&INDEXED_ARRAY_TEST_KEYPAIR).unwrap();
     let account_create_ix = crate::create_account_instruction(
         &payer.pubkey(),
         account_compression::IndexedArrayAccount::LEN,
@@ -188,11 +189,11 @@ pub async fn setup_test_programs_with_accounts() -> EnvWithAccounts {
         &ACCOUNT_COMPRESSION_ID,
         Some(&indexed_array_keypair),
     );
-    let indexed_array_pubkey = indexed_array_keypair.pubkey();
     let instruction = create_initialize_indexed_array_instruction(
         payer.pubkey(),
         indexed_array_keypair.pubkey(),
         0,
+        Some(merkle_tree_pubkey),
     );
     let transaction = Transaction::new_signed_with_payer(
         &[account_create_ix, instruction],


### PR DESCRIPTION
Changes:
- account compression program:
  - enabled group access control
  - moved group tests to separate file
  - added failing tests for merkle tree append, nullify, insert into indexed array
  - linked merkle tree account and indexed array by pubkey and checking these in nullify instruction