### PR TITLE
chore: Remove patched arkworks crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7960,23 +7960,3 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "ark-bn254"
-version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/curves?branch=release-0.3.0#7c901afc3ec80bf3eaea654237ffe73356f68c86"
-
-[[patch.unused]]
-name = "ark-ec"
-version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/algebra?branch=release-0.3.0#d45d741649114ab36dca7a88d08c044174f6b8b5"
-
-[[patch.unused]]
-name = "ark-ff"
-version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/algebra?branch=release-0.3.0#d45d741649114ab36dca7a88d08c044174f6b8b5"
-
-[[patch.unused]]
-name = "ark-serialize"
-version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/algebra?branch=release-0.3.0#d45d741649114ab36dca7a88d08c044174f6b8b5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,6 @@ members = [
     "xtask",
 ]
 
-[patch.crates-io]
-ark-ff = { git = "https://github.com/Lightprotocol/algebra", branch="release-0.3.0" }
-ark-bn254 = { git = "https://github.com/Lightprotocol/curves", branch="release-0.3.0" }
-ark-ec = { git = "https://github.com/Lightprotocol/algebra", branch="release-0.3.0" }
-ark-serialize = { git = "https://github.com/Lightprotocol/algebra", branch="release-0.3.0" }
-
 [profile.release]
 overflow-checks = true
 


### PR DESCRIPTION
We are using only upstream 0.4.0 arkworks crates now, there is no need to point to patched 0.3.0 crates.