### PR TITLE
feat: actions for compressLamports, decompressLamports

### DIFF
--- a/js/stateless.js/src/actions/common.ts
+++ b/js/stateless.js/src/actions/common.ts
@@ -1,0 +1,27 @@
+import { Signer, PublicKey } from '@solana/web3.js';
+
+/** @internal */
+export function getSigners(
+    signerOrMultisig: Signer | PublicKey,
+    multiSigners: Signer[],
+): [PublicKey, Signer[]] {
+    // TODO: add multisig support
+    if (multiSigners.length > 0) throw new Error('Multisig not supported yet.');
+
+    if (signerOrMultisig instanceof PublicKey)
+        throw new Error('Multisig not supported yet.');
+
+    return signerOrMultisig instanceof PublicKey
+        ? [signerOrMultisig, multiSigners]
+        : [signerOrMultisig.publicKey, [signerOrMultisig]];
+}
+
+/** @internal remove signer from signers if part of signers */
+export function dedupeSigner(signer: Signer, signers: Signer[]): Signer[] {
+    if (signers.includes(signer)) {
+        return signers.filter(
+            s => s.publicKey.toString() !== signer.publicKey.toString(),
+        );
+    }
+    return signers;
+}

--- a/js/stateless.js/src/actions/compress-lamports.ts
+++ b/js/stateless.js/src/actions/compress-lamports.ts
@@ -1,0 +1,53 @@
+import {
+    ConfirmOptions,
+    PublicKey,
+    Signer,
+    TransactionSignature,
+} from '@solana/web3.js';
+
+import { dedupeSigner } from './common';
+import { LightSystemProgram } from '../programs';
+import { Rpc } from '../rpc';
+import { buildAndSignTx, sendAndConfirmTx } from '../utils';
+import { BN } from '@coral-xyz/anchor';
+import { defaultTestStateTreeAccounts } from '../constants';
+
+/**
+ * Init the SOL omnibus account for Light
+ *
+ * @param rpc             RPC to use
+ * @param payer           Payer of the transaction and initialization fees
+ * @param lamports        Amount of lamports to compress
+ * @param toAddress       Address of the recipient compressed account
+ * @param outputStateTree Optional output state tree. Defaults to a current shared state tree.
+ * @param confirmOptions  Options for confirming the transaction
+ *
+ * @return Transaction signature
+ */
+/// TODO: add multisig support
+/// TODO: add support for payer != owner
+export async function compressLamports(
+    rpc: Rpc,
+    payer: Signer,
+    lamports: number | BN,
+    toAddress: PublicKey,
+    outputStateTree?: PublicKey,
+    confirmOptions?: ConfirmOptions,
+): Promise<TransactionSignature> {
+    const { blockhash } = await rpc.getLatestBlockhash();
+
+    const ixs = await LightSystemProgram.compress({
+        payer: payer.publicKey,
+        toAddress,
+        lamports,
+        outputStateTree: outputStateTree
+            ? outputStateTree
+            : defaultTestStateTreeAccounts().merkleTree, // TODO: should fetch the current shared state tree
+    });
+
+    const tx = buildAndSignTx(ixs, payer, blockhash, []);
+
+    const txId = await sendAndConfirmTx(rpc, tx, confirmOptions);
+
+    return txId;
+}

--- a/js/stateless.js/src/actions/decompress-lamports.ts
+++ b/js/stateless.js/src/actions/decompress-lamports.ts
@@ -1,0 +1,96 @@
+import {
+    ConfirmOptions,
+    PublicKey,
+    Signer,
+    TransactionSignature,
+} from '@solana/web3.js';
+
+import { LightSystemProgram, sumUpLamports } from '../programs';
+import { Rpc } from '../rpc';
+import { buildAndSignTx, sendAndConfirmTx } from '../utils';
+import { BN } from '@coral-xyz/anchor';
+import { defaultTestStateTreeAccounts } from '../constants';
+import {
+    CompressedAccountWithMerkleContext,
+    PublicTransactionEvent,
+    bn,
+} from '../state';
+import { CompressedAccountMerkleProofResult } from '../rpc-interface';
+
+/**
+ * Init the SOL omnibus account for Light
+ *
+ * @param rpc             RPC to use
+ * @param payer           Payer of the transaction and initialization fees
+ * @param lamports        Amount of lamports to compress
+ * @param toAddress       Address of the recipient compressed account
+ * @param outputStateTree Optional output state tree. Defaults to a current shared state tree.
+ * @param confirmOptions  Options for confirming the transaction
+ *
+ * @return Transaction signature
+ */
+/// TODO: add multisig support
+/// TODO: add support for payer != owner
+export async function decompressLamports(
+    rpc: Rpc,
+    payer: Signer,
+    lamports: number | BN,
+    recipient: PublicKey,
+    outputStateTree?: PublicKey,
+    confirmOptions?: ConfirmOptions,
+): Promise<TransactionSignature> {
+    /// TODO: refactor into using rpc.getCompressedAccount
+    /// TODO: use dynamic state tree and nullifier queue
+    // @ts-ignore
+    const indexedEvents = await rpc.getParsedEvents();
+
+    const userEvents = indexedEvents.filter((event: PublicTransactionEvent) => {
+        return event.outputCompressedAccounts.some(account => {
+            return account.owner.equals(payer.publicKey);
+        });
+    });
+
+    const userCompressedAccountsWithMerkleContext: CompressedAccountWithMerkleContext[] =
+        userEvents.flatMap((event: PublicTransactionEvent) =>
+            event.outputCompressedAccounts.map((account, i) => ({
+                ...account,
+                hash: event.outputCompressedAccountHashes[i],
+                leafIndex: event.outputLeafIndices[i],
+                merkleTree: defaultTestStateTreeAccounts().merkleTree,
+                nullifierQueue: defaultTestStateTreeAccounts().nullifierQueue,
+            })),
+        );
+
+    lamports = bn(lamports);
+
+    const inputLamports = sumUpLamports(
+        userCompressedAccountsWithMerkleContext,
+    );
+
+    if (lamports.gt(inputLamports)) {
+        throw new Error(
+            `Not enough compressed lamports. Expected ${lamports}, got ${inputLamports}`,
+        );
+    }
+
+    const proof = await rpc.getValidityProof(
+        userCompressedAccountsWithMerkleContext.map(x => bn(x.hash)),
+    );
+
+    const { blockhash } = await rpc.getLatestBlockhash();
+    const ixs = await LightSystemProgram.decompress({
+        payer: payer.publicKey,
+        toAddress: recipient,
+        outputStateTree: outputStateTree,
+        inputCompressedAccounts: userCompressedAccountsWithMerkleContext,
+        recentValidityProof: proof.compressedProof,
+        recentInputStateRootIndices: proof.rootIndices,
+        lamports,
+    });
+
+    const tx = buildAndSignTx(ixs, payer, blockhash, []);
+
+    const txId = await sendAndConfirmTx(rpc, tx, confirmOptions);
+
+    return txId;
+}

--- a/js/stateless.js/src/actions/index.ts
+++ b/js/stateless.js/src/actions/index.ts
@@ -1,0 +1,3 @@
+export * from './compress-lamports';
+export * from './decompress-lamports';
+export * from './init-sol-omnibus-account';

--- a/js/stateless.js/src/actions/init-sol-omnibus-account.ts
+++ b/js/stateless.js/src/actions/init-sol-omnibus-account.ts
@@ -1,0 +1,41 @@
+import { ConfirmOptions, Signer, TransactionSignature } from '@solana/web3.js';
+
+import { dedupeSigner } from './common';
+import { LightSystemProgram } from '../programs';
+import { Rpc } from '../rpc';
+import { buildAndSignTx, sendAndConfirmTx } from '../utils';
+
+/**
+ * Init the SOL omnibus account for Light
+ *
+ * @param rpc             RPC to use
+ * @param payer           Payer of the transaction and initialization fees
+ * @param initAuthority   Init authority.
+ * @param confirmOptions  Options for confirming the transaction
+ *
+ * @return Transaction signature
+ */
+/// TODO: add multisig support
+export async function initSolOmnibusAccount(
+    rpc: Rpc,
+    payer: Signer,
+    initAuthority?: Signer,
+    confirmOptions?: ConfirmOptions,
+): Promise<TransactionSignature> {
+    const { blockhash } = await rpc.getLatestBlockhash();
+
+    const additionalSigners = dedupeSigner(
+        payer,
+        initAuthority ? [initAuthority] : [],
+    );
+
+    const ix = await LightSystemProgram.initCompressedSolPda(
+        initAuthority ? initAuthority.publicKey : payer.publicKey,
+    );
+
+    const tx = buildAndSignTx([ix], payer, blockhash, additionalSigners);
+
+    const txId = await sendAndConfirmTx(rpc, tx, confirmOptions);
+
+    return txId;
+}

--- a/js/stateless.js/src/index.ts
+++ b/js/stateless.js/src/index.ts
@@ -1,3 +1,4 @@
+export * from './actions';
 export * from './idls';
 export * from './instruction';
 export * from './programs';

--- a/js/stateless.js/src/programs/compressed-pda.ts
+++ b/js/stateless.js/src/programs/compressed-pda.ts
@@ -25,7 +25,9 @@ import {
 } from '../utils/validation';
 import { placeholderValidityProof } from '../test-utils';
 
-const sumUpLamports = (accounts: CompressedAccountWithMerkleContext[]): BN => {
+export const sumUpLamports = (
+    accounts: CompressedAccountWithMerkleContext[],
+): BN => {
     return accounts.reduce(
         (acc, account) => acc.add(bn(account.lamports)),
         bn(0),
@@ -86,7 +88,7 @@ type CompressParams = {
     /**
      * address that the lamports are attached to. also defaults to the recipient owner
      */
-    address: PublicKey;
+    toAddress: PublicKey;
     /**
      * amount of lamports to compress.
      */
@@ -364,15 +366,16 @@ export class LightSystemProgram {
      * Creates a transaction instruction that transfers compressed lamports from
      * one owner to another.
      */
+    // TODO: add support for non-fee-payer owner
     static async compress(
         params: CompressParams,
     ): Promise<TransactionInstruction[]> {
-        const { payer, outputStateTree, address } = params;
+        const { payer, outputStateTree, toAddress } = params;
 
         /// Create output state
         const lamports = bn(params.lamports);
         const outputCompressedAccount = createCompressedAccount(
-            address,
+            toAddress,
             lamports,
         );
 

--- a/js/stateless.js/tests/e2e/compress.test.ts
+++ b/js/stateless.js/tests/e2e/compress.test.ts
@@ -1,20 +1,17 @@
 import { describe, it, assert, beforeAll } from 'vitest';
-import {
-    CompressedAccount,
-    CompressedAccountWithMerkleContext,
-    MerkleContext,
-    bn,
-} from '../../src/state';
-import { sendAndConfirmTx, buildAndSignTx } from '../../src/utils';
-
-import { Keypair, Signer } from '@solana/web3.js';
+import { Signer } from '@solana/web3.js';
 import { defaultTestStateTreeAccounts } from '../../src/constants';
 import { getTestRpc, newAccountWithLamports } from '../../src/test-utils';
-import { LightSystemProgram, Rpc } from '../../src';
+import {
+    Rpc,
+    compressLamports,
+    decompressLamports,
+    initSolOmnibusAccount,
+} from '../../src';
 
 /// TODO: add test case for payer != address
 describe('compress', () => {
-    const { merkleTree, nullifierQueue } = defaultTestStateTreeAccounts();
+    const { merkleTree } = defaultTestStateTreeAccounts();
     let rpc: Rpc;
     let payer: Signer;
     let initAuthority: Signer;
@@ -26,28 +23,20 @@ describe('compress', () => {
     });
 
     it('should compress lamports and then decompress', async () => {
-        const compressLamports = 20;
+        const compressLamportsAmount = 20;
         const preCompressBalance = await rpc.getBalance(payer.publicKey);
         assert.equal(preCompressBalance, 1e9);
 
-        const ix = await LightSystemProgram.initCompressedSolPda(
-            initAuthority.publicKey,
+        /// TODO: add case for payer != initAuthority
+        await initSolOmnibusAccount(rpc, initAuthority, initAuthority);
+
+        await compressLamports(
+            rpc,
+            payer,
+            compressLamportsAmount,
+            payer.publicKey,
+            merkleTree,
         );
-        const { blockhash: initBlockhash } = await rpc.getLatestBlockhash();
-        const signedInitTx = buildAndSignTx([ix], initAuthority, initBlockhash);
-        await sendAndConfirmTx(rpc, signedInitTx);
-
-        const ixs = await LightSystemProgram.compress({
-            payer: payer.publicKey,
-            address: payer.publicKey,
-            lamports: compressLamports,
-            outputStateTree: merkleTree,
-        });
-
-        /// Send
-        const { blockhash } = await rpc.getLatestBlockhash();
-        const signedTx = buildAndSignTx(ixs, payer, blockhash);
-        await sendAndConfirmTx(rpc, signedTx);
 
         rpc = await getTestRpc();
 
@@ -58,7 +47,7 @@ describe('compress', () => {
         assert.equal(indexedEvents[0].outputCompressedAccounts.length, 1);
         assert.equal(
             Number(indexedEvents[0].outputCompressedAccounts[0].lamports),
-            compressLamports,
+            compressLamportsAmount,
         );
         assert.equal(
             indexedEvents[0].outputCompressedAccounts[0].owner.toBase58(),
@@ -68,52 +57,20 @@ describe('compress', () => {
         const postCompressBalance = await rpc.getBalance(payer.publicKey);
         assert.equal(
             postCompressBalance,
-            preCompressBalance - compressLamports - 5000,
+            preCompressBalance - compressLamportsAmount - 5000,
         );
-
-        /// TODO: use test-rpc call to get the account
-        const inputAccount: CompressedAccount =
-            indexedEvents[0].outputCompressedAccounts[0];
-        const inputAccountHash: number[] =
-            indexedEvents[0].outputCompressedAccountHashes[0];
-        const inputAccountLeafIndex: number =
-            indexedEvents[0].outputLeafIndices[0];
-
-        const proof = await rpc.getValidityProof([bn(inputAccountHash)]);
-
-        const merkleCtx: MerkleContext = {
-            merkleTree: merkleTree, // TODO: dynamic
-            nullifierQueue: nullifierQueue, // TODO: dynamic
-            hash: inputAccountHash,
-            leafIndex: inputAccountLeafIndex,
-        };
-        const withCtx: CompressedAccountWithMerkleContext = {
-            ...inputAccount,
-            ...merkleCtx,
-        };
 
         /// Decompress
-        const decompressLamports = 15;
+        const decompressLamportsAmount = 15;
         const decompressRecipient = payer.publicKey;
 
-        const decompressIx = await LightSystemProgram.decompress({
-            payer: payer.publicKey,
-            toAddress: decompressRecipient,
-            outputStateTree: merkleTree,
-            inputCompressedAccounts: [withCtx],
-            recentValidityProof: proof.compressedProof,
-            recentInputStateRootIndices: proof.rootIndices,
-            lamports: decompressLamports,
-        });
-
-        const { blockhash: decompressBlockhash } =
-            await rpc.getLatestBlockhash();
-        const signedDecompressTx = buildAndSignTx(
-            decompressIx,
+        await decompressLamports(
+            rpc,
             payer,
-            decompressBlockhash,
+            decompressLamportsAmount,
+            decompressRecipient,
+            merkleTree,
         );
-        await sendAndConfirmTx(rpc, signedDecompressTx);
 
         //@ts-ignore
         const indexedEvents2 = await rpc.getParsedEvents();
@@ -122,12 +79,12 @@ describe('compress', () => {
         assert.equal(indexedEvents2[0].outputCompressedAccounts.length, 1);
         assert.equal(
             Number(indexedEvents2[0].outputCompressedAccounts[0].lamports),
-            compressLamports - decompressLamports,
+            compressLamportsAmount - decompressLamportsAmount,
         );
         const postDecompressBalance = await rpc.getBalance(decompressRecipient);
         assert.equal(
             postDecompressBalance,
-            postCompressBalance + decompressLamports - 5000,
+            postCompressBalance + decompressLamportsAmount - 5000,
         );
     });
 });


### PR DESCRIPTION
and initSolOmnibusAccount (wraps initCompressSolPda
- we can adapt naming later if we find a better alternative than both this and initCompressSolPda. changing will be low effort.
- using initCompressSolPda would IMO be easy to confuse with the action of actually creating a pda/compressed pda

- includes the happy path tests. will add tests for payer != initAuthority and payer != compressRecipient in a separate pr such as to unblock the cli now.
