### PR TITLE
feat: add SOL compression and decompression cli commands

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -96,9 +96,11 @@
     "test-mint-to": "mocha ./test/commands/mint-to/index.test.ts -t 10000000 --exit",
     "test-transfer": "mocha ./test/commands/transfer/index.test.ts -t 10000000 --exit",
     "test-balance": "mocha ./test/commands/balance/index.test.ts -t 10000000 --exit",
+    "test-compress-sol": "mocha ./test/commands/compress-sol/index.test.ts -t 10000000 --exit",
+    "test-decompress-sol": "mocha ./test/commands/decompress-sol/index.test.ts -t 10000000 --exit",
     "kill": "killall solana-test-validator || true && killall solana-test-val || true && sleep 1",
     "test-cli": "pnpm test-config && pnpm kill",
-    "test": "pnpm kill && pnpm test-cli && pnpm test-utils && pnpm test-create-mint && pnpm test-mint-to && pnpm test-transfer && pnpm test-balance",
+    "test": "pnpm kill && pnpm test-cli && pnpm test-utils && pnpm test-create-mint && pnpm test-mint-to && pnpm test-transfer && pnpm test-balance  && pnpm test-compress-sol && pnpm test-decompress-sol",
     "install-local": "pnpm build && pnpm global remove @lightprotocol/cli || true && pnpm global add $PWD",
     "version": "oclif readme && git add README.md"
   },

--- a/cli/src/commands/compress-sol/index.ts
+++ b/cli/src/commands/compress-sol/index.ts
@@ -6,7 +6,7 @@ import {
   getSolanaRpcUrl,
 } from "../../utils/utils";
 import { Connection, PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import { Rpc, compressLamports } from "@lightprotocol/stateless.js";
+import { Rpc, compressLamports, getTestRpc } from "@lightprotocol/stateless.js";
 
 class MintToCommand extends Command {
   static summary = "Compress SOL.";
@@ -41,10 +41,9 @@ class MintToCommand extends Command {
       const toPublicKey = new PublicKey(to);
       const payer = defaultSolanaWalletKeypair();
 
-      const connection = new Connection(getSolanaRpcUrl());
-
+      const rpc = await getTestRpc(getSolanaRpcUrl());
       const txId = await compressLamports(
-        connection as Rpc,
+        rpc,
         payer,
         amount * LAMPORTS_PER_SOL,
         toPublicKey,

--- a/cli/src/commands/compress-sol/index.ts
+++ b/cli/src/commands/compress-sol/index.ts
@@ -1,0 +1,64 @@
+import { Command, Flags } from "@oclif/core";
+import {
+  CustomLoader,
+  defaultSolanaWalletKeypair,
+  generateSolanaTransactionURL,
+  getSolanaRpcUrl,
+} from "../../utils/utils";
+import { Connection, PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { Rpc, compressLamports } from "@lightprotocol/stateless.js";
+
+class MintToCommand extends Command {
+  static summary = "Compress SOL.";
+
+  static examples = ["$ light compress-sol --to PublicKey --amount 10"];
+
+  static flags = {
+    to: Flags.string({
+      description: "Specify the recipient address.",
+      required: true,
+    }),
+    amount: Flags.integer({
+      description: "Amount to mint, in SOL.",
+      required: true,
+    }),
+  };
+
+  static args = {};
+
+  async run() {
+    const { flags } = await this.parse(MintToCommand);
+    const to = flags["to"];
+    const amount = flags["amount"];
+    if (!to || !amount) {
+      throw new Error("Invalid arguments");
+    }
+
+    const loader = new CustomLoader(`Performing compress-sol...\n`);
+    loader.start();
+
+    try {
+      const toPublicKey = new PublicKey(to);
+      const payer = defaultSolanaWalletKeypair();
+
+      const connection = new Connection(getSolanaRpcUrl());
+
+      const txId = await compressLamports(
+        connection as Rpc,
+        payer,
+        amount * LAMPORTS_PER_SOL,
+        toPublicKey,
+      );
+      loader.stop(false);
+      console.log(
+        "\x1b[compress-sol:\x1b[0m ",
+        generateSolanaTransactionURL("tx", txId, "custom"),
+      );
+      console.log("compress-sol successful");
+    } catch (error) {
+      this.error(`Failed to compress-sol!\n${error}`);
+    }
+  }
+}
+
+export default MintToCommand;

--- a/cli/src/commands/decompress-sol/index.ts
+++ b/cli/src/commands/decompress-sol/index.ts
@@ -6,7 +6,11 @@ import {
   getSolanaRpcUrl,
 } from "../../utils/utils";
 import { Connection, PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import { Rpc, decompressLamports } from "@lightprotocol/stateless.js";
+import {
+  Rpc,
+  decompressLamports,
+  getTestRpc,
+} from "@lightprotocol/stateless.js";
 
 class MintToCommand extends Command {
   static summary = "Decompress SOL.";
@@ -41,10 +45,9 @@ class MintToCommand extends Command {
       const toPublicKey = new PublicKey(to);
       const payer = defaultSolanaWalletKeypair();
 
-      const connection = new Connection(getSolanaRpcUrl());
-
+      const rpc = await getTestRpc(getSolanaRpcUrl());
       const txId = await decompressLamports(
-        connection as Rpc,
+        rpc,
         payer,
         amount * LAMPORTS_PER_SOL,
         toPublicKey,

--- a/cli/src/commands/decompress-sol/index.ts
+++ b/cli/src/commands/decompress-sol/index.ts
@@ -1,0 +1,64 @@
+import { Command, Flags } from "@oclif/core";
+import {
+  CustomLoader,
+  defaultSolanaWalletKeypair,
+  generateSolanaTransactionURL,
+  getSolanaRpcUrl,
+} from "../../utils/utils";
+import { Connection, PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { Rpc, decompressLamports } from "@lightprotocol/stateless.js";
+
+class MintToCommand extends Command {
+  static summary = "Decompress SOL.";
+
+  static examples = ["$ light decompress-sol --to PublicKey --amount 10"];
+
+  static flags = {
+    to: Flags.string({
+      description: "Specify the recipient address.",
+      required: true,
+    }),
+    amount: Flags.integer({
+      description: "Amount to mint, in SOL.",
+      required: true,
+    }),
+  };
+
+  static args = {};
+
+  async run() {
+    const { flags } = await this.parse(MintToCommand);
+    const to = flags["to"];
+    const amount = flags["amount"];
+    if (!to || !amount) {
+      throw new Error("Invalid arguments");
+    }
+
+    const loader = new CustomLoader(`Performing compress-sol...\n`);
+    loader.start();
+
+    try {
+      const toPublicKey = new PublicKey(to);
+      const payer = defaultSolanaWalletKeypair();
+
+      const connection = new Connection(getSolanaRpcUrl());
+
+      const txId = await decompressLamports(
+        connection as Rpc,
+        payer,
+        amount * LAMPORTS_PER_SOL,
+        toPublicKey,
+      );
+      loader.stop(false);
+      console.log(
+        "\x1b[decompress-sol:\x1b[0m ",
+        generateSolanaTransactionURL("tx", txId, "custom"),
+      );
+      console.log("decompress-sol successful");
+    } catch (error) {
+      this.error(`Failed to decompress-sol!\n${error}`);
+    }
+  }
+}
+
+export default MintToCommand;

--- a/cli/test/commands/compress-sol/index.test.ts
+++ b/cli/test/commands/compress-sol/index.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "@oclif/test";
+import { initTestEnvIfNeeded } from "../../../src/utils/initTestEnv";
+import { defaultSolanaWalletKeypair } from "../../../src";
+import { Keypair } from "@solana/web3.js";
+import { requestAirdrop } from "../../helpers/helpers";
+
+describe("compress-sol", () => {
+  test.it(async () => {
+    await initTestEnvIfNeeded();
+    const keypair = defaultSolanaWalletKeypair() || Keypair.generate();
+    await requestAirdrop(keypair.publicKey);
+    const to = keypair.publicKey.toBase58();
+    const amount = 0.5;
+
+    return test
+      .stdout()
+      .command(["compress-sol", `--amount=${amount}`, `--to=${to}`])
+      .it(`compress-sol ${amount} SOL to ${to}`, (ctx: any) => {
+        expect(ctx.stdout).to.contain("mint-to successful");
+      });
+  });
+});

--- a/cli/test/commands/decompress-sol/index.test.ts
+++ b/cli/test/commands/decompress-sol/index.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "@oclif/test";
+import { initTestEnvIfNeeded } from "../../../src/utils/initTestEnv";
+import { defaultSolanaWalletKeypair, getSolanaRpcUrl } from "../../../src";
+import { Keypair } from "@solana/web3.js";
+import { requestAirdrop } from "../../helpers/helpers";
+import { getTestRpc } from "@lightprotocol/stateless.js";
+
+describe("decompress-sol", () => {
+  test.it(async () => {
+    await initTestEnvIfNeeded();
+    const keypair = defaultSolanaWalletKeypair() || Keypair.generate();
+    await requestAirdrop(keypair.publicKey);
+    const to = keypair.publicKey.toBase58();
+    const amount = 0.5;
+    const rpc = await getTestRpc(getSolanaRpcUrl());
+    return test
+      .stdout()
+      .command(["compress-sol", `--amount=${amount}`, `--to=${to}`])
+      .command(["decompress-sol", `--amount=${amount}`, `--to=${to}`])
+      .it(`decompress-sol ${amount} SOL to ${to}`, (ctx: any) => {
+        expect(ctx.stdout).to.contain("decompress-sol successful");
+      });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,10 +380,6 @@ importers:
         specifier: ^0.34.6
         version: 0.34.6(@vitest/browser@0.34.6)(playwright@1.40.1)
 
-  hasher.rs/src/main/wasm: {}
-
-  hasher.rs/src/main/wasm-simd: {}
-
   js/compressed-token:
     dependencies:
       '@coral-xyz/anchor':


### PR DESCRIPTION
New CLI commands `compress-sol` and `decompress-sol` have been added:

• `compress-sol --amount <value> --to <value>`: compress SOL to an account.
• `decompress-sol --amount <value> --to <value>`: decompress SOL to an account.
