### PR TITLE
refactor: cli test-validator initialization

### DIFF
--- a/cli/scripts/photon2bin.sh
+++ b/cli/scripts/photon2bin.sh
@@ -5,4 +5,4 @@ set -eux
 root_dir="$(git rev-parse --show-toplevel)";
 cli_dir="${root_dir}/cli"
 
-cargo install --force --root "$cli_dir" photon-indexer
+cargo install --root "$cli_dir" photon-indexer

--- a/cli/src/commands/test-validator/index.ts
+++ b/cli/src/commands/test-validator/index.ts
@@ -10,10 +10,15 @@ class SetupCommand extends Command {
   }
 
   static flags = {
-    photon: Flags.boolean({
+    without_indexer: Flags.boolean({
+      char: "i",
+      description: "Runs a test validator without indexer service.",
+      default: false,
+    }),
+    without_prover: Flags.boolean({
       char: "p",
-      description: "Runs a test validator with photon indexer.",
-      default: true,
+      description: "Runs a test validator without prover service.",
+      default: false,
     }),
     skip_system_accounts: Flags.boolean({
       char: "s",
@@ -30,7 +35,8 @@ class SetupCommand extends Command {
     loader.start();
     await initTestEnv({
       skipSystemAccounts: flags.skip_system_accounts,
-      photon: flags.photon,
+      indexer: !flags.without_indexer,
+      prover: !flags.without_prover,
     });
 
     this.log("\nSetup tasks completed successfully \x1b[32m✔\x1b[0m");

--- a/cli/src/psp-utils/process.ts
+++ b/cli/src/psp-utils/process.ts
@@ -30,7 +30,7 @@ export async function executeCommand({
         PATH: childPathEnv,
       },
     };
-    console.log(`Executing command ${commandBase}...`);
+    console.log(`Executing command ${commandBase} ${args}...`);
     let childProcess;
     try {
       childProcess = spawn(command, args, options);


### PR DESCRIPTION
Flags updated:
```
FLAGS
  -i, --without_indexer       Runs a test validator without indexer service.
  -p, --without_prover        Runs a test validator without prover service.
```