### PR TITLE
perf: Append 10 leaves per changelog event, allow dozens of mints per TX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,6 +2679,7 @@ dependencies = [
  "light-concurrent-merkle-tree",
  "light-hasher",
  "light-heap",
+ "light-macros",
  "light-merkle-tree-reference",
  "light-test-utils",
  "light-utils",

--- a/programs/account-compression/Cargo.toml
+++ b/programs/account-compression/Cargo.toml
@@ -16,7 +16,7 @@ no-log-ix-name = []
 cpi = ["no-entrypoint"]
 custom-heap = ["light-heap"]
 mem-profiling = []
-default = ["custom-heap", "mem-profiling"]
+default = ["custom-heap"]
 test-sbf = []
 
 [dependencies]

--- a/programs/account-compression/src/instructions/append_leaves.rs
+++ b/programs/account-compression/src/instructions/append_leaves.rs
@@ -1,15 +1,18 @@
-use std::collections::HashMap;
+use std::{cmp, collections::BTreeMap};
 
 use anchor_lang::{prelude::*, solana_program::pubkey::Pubkey};
-use light_concurrent_merkle_tree::event::Changelogs;
+use light_concurrent_merkle_tree::event::{ChangelogEvent, ChangelogEventV1, Changelogs, PathNode};
 use light_macros::heap_neutral;
 
 use crate::{
     emit_indexer_event,
+    errors::AccountCompressionErrorCode,
     state::StateMerkleTreeAccount,
     utils::check_registered_or_signer::{check_registered_or_signer, GroupAccess, GroupAccounts},
     RegisteredProgram,
 };
+
+const BATCH_SIZE: usize = 7;
 
 #[derive(Accounts)]
 pub struct AppendLeaves<'info> {
@@ -40,7 +43,23 @@ impl<'info> GroupAccounts<'info> for AppendLeaves<'info> {
     }
 }
 
-/// for every leaf one Merkle tree account has to be passed as remaining account
+fn build_merkle_tree_map<'a, 'c: 'info, 'info>(
+    leaves: &'a [[u8; 32]],
+    remaining_accounts: &'c [AccountInfo<'info>],
+) -> BTreeMap<Pubkey, (&'c AccountInfo<'info>, Vec<&'a [u8; 32]>)> {
+    let mut merkle_tree_map = BTreeMap::new();
+
+    for (i, merkle_tree) in remaining_accounts.iter().enumerate() {
+        merkle_tree_map
+            .entry(merkle_tree.key())
+            .or_insert_with(|| (merkle_tree, Vec::new()))
+            .1
+            .push(&leaves[i]);
+    }
+
+    merkle_tree_map
+}
+
 /// for every leaf could be inserted into a different Merkle tree account
 /// 1. deduplicate Merkle trees and identify into which tree to insert what leaf
 /// 2. iterate over every unique Merkle tree and batch insert leaves
@@ -49,55 +68,146 @@ pub fn process_append_leaves_to_merkle_trees<'a, 'b, 'c: 'info, 'info>(
     ctx: Context<'a, 'b, 'c, 'info, AppendLeaves<'info>>,
     leaves: &'a [[u8; 32]],
 ) -> Result<()> {
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("append_leaves: start");
+
     if leaves.len() != ctx.remaining_accounts.len() {
         return err!(crate::errors::AccountCompressionErrorCode::NumberOfLeavesMismatch);
     }
-    let mut merkle_tree_map = HashMap::<Pubkey, (&AccountInfo, Vec<&[u8; 32]>)>::new();
-    for (i, mt) in ctx.remaining_accounts.iter().enumerate() {
-        match merkle_tree_map.get(&mt.key()) {
-            Some(_) => {}
-            None => {
-                merkle_tree_map.insert(mt.key(), (mt, Vec::new()));
+
+    let mut merkle_tree_map = build_merkle_tree_map(leaves, ctx.remaining_accounts);
+
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("append_leaves: merkle tree map");
+
+    let mut leaves_start = 0;
+    while !merkle_tree_map.is_empty() {
+        process_batch(&ctx, &mut leaves_start, &mut merkle_tree_map)?;
+    }
+
+    Ok(())
+}
+
+#[heap_neutral]
+#[inline(never)]
+fn process_batch<'a, 'c: 'info, 'info>(
+    ctx: &Context<'a, '_, 'c, 'info, AppendLeaves<'info>>,
+    leaves_start: &mut usize,
+    merkle_tree_map: &mut BTreeMap<Pubkey, (&'c AccountInfo<'info>, Vec<&'a [u8; 32]>)>,
+) -> Result<()> {
+    let mut leaves_in_batch = 0;
+    let mut changelog_events = Vec::with_capacity(BATCH_SIZE);
+
+    // A vector of trees which become fully processed and should be removed
+    // from the `merkle_tree_map`.
+    let mut processed_merkle_trees = Vec::new();
+
+    {
+        let mut merkle_tree_map_iter = merkle_tree_map.values();
+        let mut merkle_tree_map_pair = merkle_tree_map_iter.next();
+
+        while let Some((merkle_tree, leaves)) = merkle_tree_map_pair {
+            let leaves_to_process =
+                cmp::min(leaves.len() - *leaves_start, BATCH_SIZE - leaves_in_batch);
+            let leaves_end = *leaves_start + leaves_to_process;
+
+            let merkle_tree =
+                AccountLoader::<StateMerkleTreeAccount>::try_from(merkle_tree).unwrap();
+            let merkle_tree_pubkey = merkle_tree.key();
+            let mut merkle_tree = merkle_tree.load_mut()?;
+
+            check_registered_or_signer::<AppendLeaves, StateMerkleTreeAccount>(ctx, &merkle_tree)?;
+
+            // Insert leaves to the Merkle tree.
+            let merkle_tree = merkle_tree.load_merkle_tree_mut()?;
+            let (first_changelog_index, first_sequence_number) = merkle_tree
+                .append_batch(&leaves[*leaves_start..leaves_end])
+                .map_err(ProgramError::from)?;
+
+            let mut paths = Vec::with_capacity(leaves_to_process);
+
+            // TODO: Move this code somewhere else, without affecting the feap neutrality.
+            for changelog_index in first_changelog_index..first_changelog_index + leaves_to_process
+            {
+                let mut path = Vec::with_capacity(merkle_tree.height);
+
+                for (level, node) in merkle_tree.changelog[changelog_index]
+                    .path
+                    .iter()
+                    .enumerate()
+                {
+                    let level = u32::try_from(level)
+                        .map_err(|_| AccountCompressionErrorCode::IntegerOverflow)?;
+                    let index = (1 << (merkle_tree.height as u32 - level))
+                        + (merkle_tree.changelog[changelog_index].index as u32 >> level);
+                    path.push(PathNode {
+                        node: node.to_owned(),
+                        index,
+                    });
+                }
+
+                paths.push(path);
             }
-        };
-        merkle_tree_map
-            .get_mut(&mt.key())
-            .unwrap()
-            .1
-            .push(&leaves[i]);
+
+            changelog_events.push(ChangelogEvent::V1(ChangelogEventV1 {
+                id: merkle_tree_pubkey.to_bytes(),
+                paths,
+                seq: first_sequence_number as u64,
+                index: merkle_tree.changelog[first_changelog_index].index as u32,
+            }));
+            // END
+
+            leaves_in_batch += leaves_to_process;
+            *leaves_start += leaves_to_process;
+
+            if *leaves_start == leaves.len() {
+                // We processed all the leaves from the current Merkle tree.
+                // Move to the next one.
+                *leaves_start = 0;
+                merkle_tree_map_pair = merkle_tree_map_iter.next();
+                processed_merkle_trees.push(merkle_tree_pubkey.to_owned());
+            }
+
+            if leaves_in_batch == BATCH_SIZE {
+                // We reached the batch limit.
+                break;
+            }
+        }
     }
 
-    let mut changelog_events = Vec::new();
-    for (mt, leaves) in merkle_tree_map.values() {
-        let merkle_tree_account = AccountLoader::<StateMerkleTreeAccount>::try_from(mt).unwrap();
-        let merkle_tree_pubkey = merkle_tree_account.key();
-        let mut merkle_tree = merkle_tree_account.load_mut()?;
+    emit_event(ctx, changelog_events)?;
 
-        check_registered_or_signer::<AppendLeaves, StateMerkleTreeAccount>(&ctx, &merkle_tree)?;
-
-        msg!("inserting leaves: {:?}", leaves);
-        let merkle_tree = merkle_tree.load_merkle_tree_mut()?;
-        let (first_changelog_index, first_sequence_number) = merkle_tree
-            .append_batch(&leaves[..])
-            .map_err(ProgramError::from)?;
-        let changelog_event = merkle_tree
-            .get_changelog_event(
-                merkle_tree_pubkey.to_bytes(),
-                first_changelog_index,
-                first_sequence_number,
-                leaves.len(),
-            )
-            .map_err(ProgramError::from)?;
-        changelog_events.push(changelog_event);
+    for processed_merkle_tree in processed_merkle_trees {
+        merkle_tree_map.remove(&processed_merkle_tree);
     }
+
+    Ok(())
+}
+
+#[heap_neutral]
+#[inline(never)]
+fn emit_event<'a, 'b, 'c: 'info, 'info>(
+    ctx: &Context<'a, 'b, 'c, 'info, AppendLeaves<'info>>,
+    changelog_events: Vec<ChangelogEvent>,
+) -> Result<()> {
+    // Emit the event.
     let changelog_event = Changelogs {
         changelogs: changelog_events,
     };
-    emit_indexer_event(
-        changelog_event.try_to_vec()?,
-        &ctx.accounts.log_wrapper,
-        &ctx.accounts.authority,
-    )?;
+
+    // Calling `try_to_vec` allocates too much memory. Allocate the memory, up
+    // to the instruction limit, manually.
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("before borsh serialization");
+    let mut data = Vec::with_capacity(10240);
+    changelog_event.serialize(&mut data)?;
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("after borsh serialization");
+
+    emit_indexer_event(data, &ctx.accounts.log_wrapper, &ctx.accounts.authority)?;
+
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("after invoke");
 
     Ok(())
 }

--- a/programs/compressed-pda/src/append_state.rs
+++ b/programs/compressed-pda/src/append_state.rs
@@ -2,25 +2,53 @@ use std::collections::HashMap;
 
 use account_compression::StateMerkleTreeAccount;
 use anchor_lang::{prelude::*, solana_program::pubkey::Pubkey};
+#[cfg(target_os = "solana")]
+use light_heap::GLOBAL_ALLOCATOR;
 use light_macros::heap_neutral;
 
 use crate::instructions::{InstructionDataTransfer, TransferInstruction};
 
 #[heap_neutral]
-pub fn insert_output_compressed_accounts_into_state_merkle_tree<'a, 'b, 'c: 'info, 'info>(
+pub fn insert_output_compressed_accounts_into_state_merkle_tree<
+    'a,
+    'b,
+    'c: 'info,
+    'info,
+    const ITER_SIZE: usize,
+>(
     inputs: &'a InstructionDataTransfer,
     ctx: &'a Context<'a, 'b, 'c, 'info, TransferInstruction<'info>>,
     output_compressed_account_indices: &'a mut [u32],
     output_compressed_account_hashes: &'a mut [[u8; 32]],
     addresses: &'a mut Vec<Option<[u8; 32]>>,
+    global_iter: &'a mut usize,
 ) -> Result<()> {
-    let mut merkle_tree_indices = HashMap::<Pubkey, usize>::new();
+    // msg!(
+    //     "accountinfo mem size: {:?}",
+    //     mem::size_of::<AccountInfo>() * ITER_SIZE
+    // );
+    // #[cfg(target_os = "solana")]
+    // let pos = GLOBAL_ALLOCATOR.log_total_heap("OutputCompressedAccou1");
     let mut out_merkle_trees_account_infos = Vec::<AccountInfo>::new();
-    for (j, mt_index) in inputs
-        .output_state_merkle_tree_account_indices
-        .iter()
-        .enumerate()
-    {
+    // #[cfg(target_os = "solana")]
+    // let pos = GLOBAL_ALLOCATOR.log_total_heap("OutputCompressedAccou");
+    #[cfg(target_os = "solana")]
+    let pos = GLOBAL_ALLOCATOR.get_heap_pos();
+    let mut merkle_tree_indices = HashMap::<Pubkey, usize>::new();
+    // #[cfg(target_os = "solana")]
+    // GLOBAL_ALLOCATOR.log_total_heap("past hash set merkle_tree_indices");
+
+    let initial_index = *global_iter;
+    let end = if *global_iter + ITER_SIZE > inputs.output_state_merkle_tree_account_indices.len() {
+        inputs.output_state_merkle_tree_account_indices.len()
+    } else {
+        *global_iter + ITER_SIZE
+    };
+    for mt_index in inputs.output_state_merkle_tree_account_indices[initial_index..end].iter() {
+        let j = *global_iter;
+        // #[cfg(target_os = "solana")]
+        // GLOBAL_ALLOCATOR.log_total_heap(format!("in loop : {:?}", j).as_str());
+        *global_iter += 1;
         let index = merkle_tree_indices.get_mut(&ctx.remaining_accounts[*mt_index as usize].key());
         out_merkle_trees_account_infos.push(ctx.remaining_accounts[*mt_index as usize].clone());
         match index {
@@ -43,12 +71,7 @@ pub fn insert_output_compressed_accounts_into_state_merkle_tree<'a, 'b, 'c: 'inf
         }
         // Address has to be created or a compressed account with this address has to be provided as transaction input.
         if let Some(address) = inputs.output_compressed_accounts[j].address {
-            msg!("addresses {:?}", addresses);
-            if let Some(position) = addresses
-                .iter()
-                .filter(|x| x.is_some())
-                .position(|&x| x.unwrap() == address)
-            {
+            if let Some(position) = addresses.iter().position(|&x| x.unwrap() == address) {
                 addresses.remove(position);
             } else {
                 msg!("Address {:?}, has not been created and no compressed account with this address was provided as transaction input", address);
@@ -61,7 +84,8 @@ pub fn insert_output_compressed_accounts_into_state_merkle_tree<'a, 'b, 'c: 'inf
             &output_compressed_account_indices[j],
         )?;
     }
-
+    #[cfg(target_os = "solana")]
+    GLOBAL_ALLOCATOR.free_heap(pos);
     append_leaves_cpi(
         ctx.program_id,
         &ctx.accounts.account_compression_program,
@@ -69,7 +93,7 @@ pub fn insert_output_compressed_accounts_into_state_merkle_tree<'a, 'b, 'c: 'inf
         &ctx.accounts.registered_program_pda.to_account_info(),
         &ctx.accounts.noop_program,
         out_merkle_trees_account_infos,
-        output_compressed_account_hashes.to_vec(),
+        output_compressed_account_hashes[initial_index..*global_iter].to_vec(),
     )?;
 
     Ok(())
@@ -78,6 +102,7 @@ pub fn insert_output_compressed_accounts_into_state_merkle_tree<'a, 'b, 'c: 'inf
 #[allow(clippy::too_many_arguments)]
 #[allow(unused_variables)]
 #[inline(never)]
+#[heap_neutral]
 pub fn append_leaves_cpi<'a, 'b>(
     program_id: &Pubkey,
     account_compression_program_id: &'b AccountInfo<'a>,
@@ -92,15 +117,32 @@ pub fn append_leaves_cpi<'a, 'b>(
     let bump = &[bump];
     let seeds = &[&[b"cpi_authority".as_slice(), bump][..]];
 
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("cpi 1");
+
     let accounts = account_compression::cpi::accounts::AppendLeaves {
         authority: authority.to_account_info(),
         registered_program_pda: Some(registered_program_pda.to_account_info()),
         log_wrapper: log_wrapper.to_account_info(),
     };
 
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("cpi 2");
+
     let mut cpi_ctx =
         CpiContext::new_with_signer(account_compression_program_id.clone(), accounts, seeds);
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("cpi 3");
     cpi_ctx.remaining_accounts = out_merkle_trees_account_infos;
+    // cpi_ctx.remaining_accounts = out_merkle_trees_account_infos
+    //     .iter()
+    //     .map(|acc| acc.to_owned().to_owned())
+    //     .collect::<Vec<AccountInfo>>();
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("cpi 4");
     account_compression::cpi::append_leaves_to_merkle_trees(cpi_ctx, leaves)?;
+
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("cpi 5");
     Ok(())
 }

--- a/programs/compressed-token/Cargo.toml
+++ b/programs/compressed-token/Cargo.toml
@@ -29,6 +29,7 @@ bytemuck = "1.14"
 solana-security-txt = "1.1.0"
 light-hasher = { version = "0.1.0", path = "../../merkle-tree/hasher" }
 light-heap = { version = "0.1.0", path = "../../heap", optional = true }
+light-macros = { version = "0.3.1", path = "../../macros/light" }
 light-utils = { version = "0.1.0", path = "../../utils" }
 
 spl-token = "3.5.0"

--- a/programs/compressed-token/src/process_mint.rs
+++ b/programs/compressed-token/src/process_mint.rs
@@ -1,3 +1,5 @@
+use std::mem;
+
 use anchor_lang::prelude::*;
 use anchor_spl::token::{Mint, Token, TokenAccount};
 use light_compressed_pda::{
@@ -5,6 +7,7 @@ use light_compressed_pda::{
     InstructionDataTransfer,
 };
 use light_hasher::DataHasher;
+use light_macros::heap_neutral;
 
 use crate::{AccountState, TokenData};
 pub const POOL_SEED: &[u8] = b"pool";
@@ -55,61 +58,7 @@ pub fn process_mint_to<'info>(
     }
 
     mint_spl_to_pool_pda(&ctx, &amounts)?;
-    let output_compressed_accounts = create_output_compressed_accounts(
-        ctx.accounts.mint.to_account_info().key(),
-        compression_public_keys.as_slice(),
-        &amounts,
-        None,
-    );
-    cpi_execute_compressed_transaction_mint_to(&ctx, &output_compressed_accounts)?;
-    Ok(())
-}
 
-pub fn create_output_compressed_accounts(
-    mint_pubkey: Pubkey,
-    pubkeys: &[Pubkey],
-    amounts: &[u64],
-    lamports: Option<&[Option<u64>]>,
-) -> Vec<CompressedAccount> {
-    let default = vec![None; pubkeys.len()];
-    let lamports = lamports.unwrap_or(default.as_slice());
-    pubkeys
-        .iter()
-        .zip(amounts.iter())
-        .zip(lamports.iter())
-        .map(|((pubkey, amount), lamports_amount)| {
-            let token_data = TokenData {
-                mint: mint_pubkey,
-                owner: *pubkey,
-                amount: *amount,
-                delegate: None,
-                state: AccountState::Initialized,
-                is_native: None,
-                delegated_amount: 0,
-            };
-
-            let mut token_data_bytes = Vec::new();
-            token_data.serialize(&mut token_data_bytes).unwrap();
-            let data: CompressedAccountData = CompressedAccountData {
-                discriminator: 2u64.to_le_bytes(),
-                data: token_data_bytes,
-                data_hash: token_data.hash().unwrap(),
-            };
-            CompressedAccount {
-                owner: crate::ID,
-                lamports: lamports_amount.unwrap_or(0u64),
-                data: Some(data),
-                address: None,
-            }
-        })
-        .collect()
-}
-
-#[inline(never)]
-pub fn cpi_execute_compressed_transaction_mint_to<'info>(
-    ctx: &Context<'_, '_, '_, 'info, MintToInstruction<'info>>,
-    output_compressed_accounts: &[CompressedAccount],
-) -> Result<()> {
     let authority_bytes = ctx.accounts.authority.key().to_bytes();
     let mint_bytes = ctx.accounts.mint.key().to_bytes();
     let seeds = [
@@ -118,30 +67,153 @@ pub fn cpi_execute_compressed_transaction_mint_to<'info>(
         mint_bytes.as_slice(),
     ];
     let (_, bump) = Pubkey::find_program_address(seeds.as_slice(), ctx.program_id);
-    let bump = &[bump];
     let seeds = [
         MINT_AUTHORITY_SEED,
         authority_bytes.as_slice(),
         mint_bytes.as_slice(),
-        bump,
+        &[bump],
     ];
+
+    let instruction_data_vec_size =
+        // struct
+        mem::size_of::<InstructionDataTransfer>()
+        // `output_compressed_accounts`
+        + mem::size_of::<CompressedAccount>() * amounts.len()
+        // `output_state_merkle_tree_account_indices`
+        + amounts.len()
+        // seeds
+        + MINT_AUTHORITY_SEED.len() + authority_bytes.len() + mint_bytes.len();
+
+    let mut instruction_data_vec = Vec::<u8>::with_capacity(instruction_data_vec_size);
+
+    serialize_instruction_data(
+        ctx.accounts.mint.to_account_info().key(),
+        compression_public_keys.as_slice(),
+        &amounts,
+        None,
+        // &output_compressed_accounts,
+        &mut instruction_data_vec,
+        &seeds,
+    )?;
+    cpi_execute_compressed_transaction_mint_to(&ctx, instruction_data_vec, &seeds)?;
+
+    Ok(())
+}
+
+#[inline(never)]
+#[heap_neutral]
+pub fn create_output_compressed_accounts(
+    compressed_accounts: &mut [CompressedAccount],
+    mint_pubkey: Pubkey,
+    pubkeys: &[Pubkey],
+    amounts: &[u64],
+    lamports: Option<&[Option<u64>]>,
+) {
+    for (i, (pubkey, amount)) in pubkeys.iter().zip(amounts.iter()).enumerate() {
+        let token_data = TokenData {
+            mint: mint_pubkey,
+            owner: *pubkey,
+            amount: *amount,
+            delegate: None,
+            state: AccountState::Initialized,
+            is_native: None,
+            delegated_amount: 0,
+        };
+
+        let mut token_data_bytes = Vec::with_capacity(mem::size_of::<TokenData>());
+        token_data.serialize(&mut token_data_bytes).unwrap();
+        let data: CompressedAccountData = CompressedAccountData {
+            discriminator: 2u64.to_le_bytes(),
+            data: token_data_bytes,
+            data_hash: token_data.hash().unwrap(),
+        };
+        let lamports = lamports.and_then(|lamports| lamports[i]).unwrap_or(0);
+        compressed_accounts[i] = CompressedAccount {
+            owner: crate::ID,
+            lamports,
+            data: Some(data),
+            address: None,
+        }
+    }
+}
+
+#[inline(never)]
+#[heap_neutral]
+fn serialize_instruction_data<'info>(
+    // output_compressed_accounts: &[CompressedAccount],
+    mint_pubkey: Pubkey,
+    pubkeys: &[Pubkey],
+    amounts: &[u64],
+    lamports: Option<&[Option<u64>]>,
+    instruction_data_vec: &mut Vec<u8>,
+    seeds: &[&[u8]],
+) -> Result<()> {
+    let mut output_compressed_accounts = vec![CompressedAccount::default(); pubkeys.len()];
+
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("serialize 1");
+
+    #[cfg(target_os = "solana")]
+    let pos = light_heap::GLOBAL_ALLOCATOR.get_heap_pos();
+
+    create_output_compressed_accounts(
+        &mut output_compressed_accounts,
+        mint_pubkey,
+        pubkeys,
+        &amounts,
+        lamports,
+    );
+
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.free_heap(pos);
+
+    msg!("ayy lmao");
+
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("serialize 2");
+
+    // let mut output_compressed_accounts_vec = Vec::with_capacity(output_compressed_accounts.len());
+    // output_compressed_accounts_vec.extend_from_slice(output_compressed_accounts);
+
     let inputs_struct = InstructionDataTransfer {
         relay_fee: None,
-        input_compressed_accounts_with_merkle_context: Vec::new(),
-        output_compressed_accounts: output_compressed_accounts.to_vec(),
-        output_state_merkle_tree_account_indices: vec![0u8; output_compressed_accounts.len()],
-        input_root_indices: Vec::new(),
+        input_compressed_accounts_with_merkle_context: Vec::with_capacity(0),
+        output_compressed_accounts,
+        output_state_merkle_tree_account_indices: vec![0u8; pubkeys.len()],
+        input_root_indices: Vec::with_capacity(0),
         proof: None,
-        new_address_params: Vec::new(),
+        new_address_params: Vec::with_capacity(0),
         compression_lamports: None,
         is_compress: false,
         signer_seeds: Some(seeds.iter().map(|seed| seed.to_vec()).collect()),
     };
 
-    let mut inputs = Vec::new();
-    InstructionDataTransfer::serialize(&inputs_struct, &mut inputs).unwrap();
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("serialize 3");
+
+    InstructionDataTransfer::serialize(&inputs_struct, instruction_data_vec)?;
+
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("serialize 4");
+
+    Ok(())
+}
+
+#[inline(never)]
+#[heap_neutral]
+pub fn cpi_execute_compressed_transaction_mint_to<'info>(
+    ctx: &Context<'_, '_, '_, 'info, MintToInstruction<'info>>,
+    instruction_data_vec: Vec<u8>,
+    seeds: &[&[u8]],
+) -> Result<()> {
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("cpi 1");
 
     let signer_seeds = &[&seeds[..]];
+
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("cpi 2");
+
     let cpi_accounts = light_compressed_pda::cpi::accounts::TransferInstruction {
         signer: ctx.accounts.mint_authority_pda.to_account_info(),
         registered_program_pda: ctx.accounts.registered_program_pda.to_account_info(),
@@ -154,14 +226,25 @@ pub fn cpi_execute_compressed_transaction_mint_to<'info>(
         system_program: None,
         cpi_signature_account: None,
     };
+
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("cpi 3");
+
     let mut cpi_ctx = CpiContext::new_with_signer(
         ctx.accounts.compressed_pda_program.to_account_info(),
         cpi_accounts,
         signer_seeds,
     );
 
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("cpi 4");
+
     cpi_ctx.remaining_accounts = vec![ctx.accounts.merkle_tree.to_account_info()];
-    light_compressed_pda::cpi::execute_compressed_transaction(cpi_ctx, inputs, None)?;
+    light_compressed_pda::cpi::execute_compressed_transaction(cpi_ctx, instruction_data_vec, None)?;
+
+    #[cfg(target_os = "solana")]
+    light_heap::GLOBAL_ALLOCATOR.log_total_heap("cpi 5");
+
     Ok(())
 }
 

--- a/programs/compressed-token/src/process_transfer.rs
+++ b/programs/compressed-token/src/process_transfer.rs
@@ -49,7 +49,10 @@ pub fn process_transfer<'a, 'b, 'c, 'info: 'b + 'c>(
     )?;
     process_compression(&inputs, &ctx)?;
 
-    let output_compressed_accounts = crate::create_output_compressed_accounts(
+    let mut output_compressed_accounts =
+        vec![CompressedAccount::default(); inputs.output_compressed_accounts.len()];
+    crate::create_output_compressed_accounts(
+        &mut output_compressed_accounts,
         inputs.mint,
         inputs
             .output_compressed_accounts

--- a/programs/compressed-token/tests/test.rs
+++ b/programs/compressed-token/tests/test.rs
@@ -239,6 +239,11 @@ async fn test_mint_to_15() {
 }
 
 #[tokio::test]
+async fn test_mint_to_20() {
+    test_mint_to::<20>().await
+}
+
+#[tokio::test]
 async fn test_transfer() {
     let (mut context, env) = setup_test_programs_with_accounts(None).await;
     let payer = context.payer.insecure_clone();

--- a/programs/compressed-token/tests/test.rs
+++ b/programs/compressed-token/tests/test.rs
@@ -166,8 +166,7 @@ async fn create_mint_helper(context: &mut ProgramTestContext, payer: &Keypair) -
     mint.pubkey()
 }
 
-#[tokio::test]
-async fn test_mint_to() {
+async fn test_mint_to<const MINTS_AMOUNT: usize>() {
     let (mut context, env) = setup_test_programs_with_accounts(None).await;
     let payer = context.payer.insecure_clone();
     let payer_pubkey = payer.pubkey();
@@ -186,8 +185,8 @@ async fn test_mint_to() {
         &payer_pubkey,
         &mint,
         &merkle_tree_pubkey,
-        vec![amount; 1],
-        vec![recipient_keypair.pubkey(); 1],
+        vec![amount; MINTS_AMOUNT],
+        vec![recipient_keypair.pubkey(); MINTS_AMOUNT],
     );
     let old_merkle_tree_account =
         AccountZeroCopy::<StateMerkleTreeAccount>::new(&mut context, env.merkle_tree_pubkey).await;
@@ -213,9 +212,30 @@ async fn test_mint_to() {
         &recipient_keypair,
         mint,
         amount,
+        MINTS_AMOUNT,
         &old_merkle_tree,
     )
     .await;
+}
+
+#[tokio::test]
+async fn test_mint_to_1() {
+    test_mint_to::<1>().await
+}
+
+#[tokio::test]
+async fn test_mint_to_5() {
+    test_mint_to::<5>().await
+}
+
+#[tokio::test]
+async fn test_mint_to_10() {
+    test_mint_to::<10>().await
+}
+
+#[tokio::test]
+async fn test_mint_to_15() {
+    test_mint_to::<15>().await
 }
 
 #[tokio::test]
@@ -264,6 +284,7 @@ async fn test_transfer() {
         &recipient_keypair,
         mint,
         amount,
+        1,
         &old_merkle_tree,
     )
     .await;
@@ -409,6 +430,7 @@ async fn test_decompression() {
         &recipient_keypair,
         mint,
         amount,
+        1,
         &old_merkle_tree,
     )
     .await;
@@ -599,6 +621,7 @@ async fn test_invalid_inputs() {
         &recipient_keypair,
         mint,
         amount,
+        1,
         &old_merkle_tree,
     )
     .await;
@@ -998,6 +1021,7 @@ async fn assert_mint_to<'a>(
     recipient_keypair: &Keypair,
     mint: Pubkey,
     amount: u64,
+    mints_amount: usize,
     old_merkle_tree: &light_concurrent_merkle_tree::ConcurrentMerkleTree26<'a, Poseidon>,
 ) {
     let token_compressed_account_data = mock_indexer.token_compressed_accounts[0].token_data;
@@ -1025,7 +1049,7 @@ async fn assert_mint_to<'a>(
         mock_indexer.merkle_tree.root(),
         "merkle tree root update failed"
     );
-    assert_eq!(merkle_tree.root_index(), 1);
+    assert_eq!(merkle_tree.root_index(), mints_amount);
     assert_ne!(
         old_merkle_tree.root().unwrap(),
         merkle_tree.root().unwrap(),
@@ -1041,7 +1065,7 @@ async fn assert_mint_to<'a>(
             .data,
     )
     .unwrap();
-    assert_eq!(mint_account.supply, amount);
+    assert_eq!(mint_account.supply, amount * mints_amount as u64);
 
     let pool = get_token_pool_pda(&mint);
     let pool_account = spl_token::state::Account::unpack(
@@ -1054,7 +1078,7 @@ async fn assert_mint_to<'a>(
             .data,
     )
     .unwrap();
-    assert_eq!(pool_account.amount, amount);
+    assert_eq!(pool_account.amount, amount * mints_amount as u64);
 }
 
 async fn assert_transfer<'a>(

--- a/programs/registry/Cargo.toml
+++ b/programs/registry/Cargo.toml
@@ -16,7 +16,7 @@ no-log-ix-name = []
 cpi = ["no-entrypoint"]
 custom-heap = ["light-heap"]
 mem-profiling = []
-default = ["custom-heap", "mem-profiling"]
+default = ["custom-heap"]
 test-sbf = []
 
 [dependencies]


### PR DESCRIPTION
This is possible thanks to:

* Using the custom heap allocator and `#[heap_neutral]` macro.
* Not logging leaves when appending. Constructing strings for `msg!` consumes heap too!
* Being careful and explicit with allocation. Always using `Vec::with_capacity` instead of `Vec::new()` - Rust runtime might be
  trigger happy with reallocations without specific capacity.
* Using `borsh::BorshSerialize::serialize()` with a custom, capped vector, instead of using `try_to_vec()`. Again, the latter doesn't add any capacity to the vector, so we ended up on mercy of Rust runtime guessing the capacity. It's better to avoid that.
* Batching leaves in 10 per changelog event. Unfortunately, we are limited by the instruction data to 10240 bytes. However, we can still do more CPI calls (up to 63), so we can just emit multiple events with 10 leaves each.