### PR TITLE
chore: remove comments

### DIFF
--- a/merkle-tree/indexed/src/reference.rs
+++ b/merkle-tree/indexed/src/reference.rs
@@ -59,6 +59,9 @@ where
         })
     }
 
+    /// Initializes the reference indexed merkle tree on par with the
+    /// on-chain indexed concurrent merkle tree.
+    /// Inserts the ranges 0 - BN254 Field Size - 1 into the tree.
     pub fn init(&mut self) -> Result<(), IndexedReferenceMerkleTreeError> {
         let mut indexed_array = IndexedArray::<H, I, 2>::default();
         let init_value = BigUint::from_str_radix(FIELD_SIZE_SUB_ONE, 10).unwrap();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,6 +481,10 @@ importers:
         specifier: ^0.34.6
         version: 0.34.6(@vitest/browser@0.34.6)(playwright@1.40.1)
 
+  hasher.rs/src/main/wasm: {}
+
+  hasher.rs/src/main/wasm-simd: {}
+
   js/compressed-token:
     dependencies:
       '@coral-xyz/anchor':

--- a/programs/account-compression/src/instructions/append_leaves.rs
+++ b/programs/account-compression/src/instructions/append_leaves.rs
@@ -253,8 +253,6 @@ pub fn transfer_lamports<'info>(
     to: &AccountInfo<'info>,
     lamports: u64,
 ) -> Result<()> {
-    msg!("transfer_lamports from {:?} to {:?}", from.key, to.key);
-    msg!("transfer_lamports lamports {:?}", lamports);
     let compressed_sol_pda_lamports = from.as_ref().lamports();
 
     **from.as_ref().try_borrow_mut_lamports()? =
@@ -269,8 +267,6 @@ pub fn transfer_lamports_cpi<'info>(
     to: &AccountInfo<'info>,
     lamports: u64,
 ) -> Result<()> {
-    msg!("transfer_lamports from {:?} to {:?}", from.key, to.key);
-    msg!("transfer_lamports lamports {:?}", lamports);
     let instruction =
         anchor_lang::solana_program::system_instruction::transfer(from.key, to.key, lamports);
     anchor_lang::solana_program::program::invoke(&instruction, &[from.clone(), to.clone()])?;

--- a/programs/compressed-pda/src/verify_state.rs
+++ b/programs/compressed-pda/src/verify_state.rs
@@ -153,7 +153,7 @@ pub fn sum_check(
 }
 
 #[inline(never)]
-// #[heap_neutral]
+#[heap_neutral]
 pub fn signer_check(
     inputs: &InstructionDataTransfer,
     ctx: &Context<'_, '_, '_, '_, TransferInstruction<'_>>,

--- a/programs/compressed-pda/tests/test.rs
+++ b/programs/compressed-pda/tests/test.rs
@@ -690,21 +690,6 @@ async fn test_with_compression() {
         true,
         false,
     );
-    // let instruction_data = light_compressed_pda::instruction::InitCompressSolPda {};
-    // let accounts = light_compressed_pda::accounts::InitializeCompressedSolPda {
-    //     fee_payer: payer.pubkey(),
-    //     compressed_sol_pda: get_compressed_sol_pda(),
-    //     system_program: anchor_lang::solana_program::system_program::ID,
-    // };
-    // let instruction = Instruction {
-    //     program_id: light_compressed_pda::ID,
-    //     accounts: accounts.to_account_metas(Some(true)),
-    //     data: instruction_data.data(),
-    // };
-    // create_and_send_transaction(&mut context, &[instruction], &payer_pubkey, &[&payer])
-    //     .await
-    //     .unwrap();
-
     let compress_amount = 1_000_000;
     let output_compressed_accounts = vec![CompressedAccount {
         lamports: compress_amount,

--- a/programs/compressed-token/src/spl_compression.rs
+++ b/programs/compressed-token/src/spl_compression.rs
@@ -85,9 +85,8 @@ pub fn transfer<'info>(
     token_program: &AccountInfo<'info>,
     amount: u64,
 ) -> Result<()> {
-    let (key, bump) =
+    let (_, bump) =
         anchor_lang::prelude::Pubkey::find_program_address(&[b"cpi_authority"], &crate::ID);
-    msg!("cpi authority key {:?}", key);
     let bump = &[bump];
     let seeds = &[&[b"cpi_authority".as_slice(), bump][..]];
     let accounts = Transfer {


### PR DESCRIPTION
addresses comments from https://github.com/Lightprotocol/light-protocol/pull/630

Changes:
- enable heap neutrality again for signer check
- removed multiple leftover comments