### PR TITLE
perf: Avoid `try_to_vec`, define the capacity of buffers manually

### DIFF
--- a/programs/compressed-pda/src/event.rs
+++ b/programs/compressed-pda/src/event.rs
@@ -1,9 +1,10 @@
-use std::str::FromStr;
+use std::{mem, str::FromStr};
 
 use anchor_lang::{
     prelude::*,
     solana_program::{instruction::Instruction, program::invoke},
 };
+use light_macros::heap_neutral;
 
 use crate::{
     compressed_account::{CompressedAccount, CompressedAccountWithMerkleContext},
@@ -26,42 +27,66 @@ pub struct PublicTransactionEvent {
     pub message: Option<Vec<u8>>,
 }
 
+pub trait SizedEvent {
+    fn event_size(&self) -> usize;
+}
+
+impl SizedEvent for PublicTransactionEvent {
+    fn event_size(&self) -> usize {
+        mem::size_of::<Self>()
+            + self.input_compressed_account_hashes.len() * mem::size_of::<[u8; 32]>()
+            + self.output_compressed_account_hashes.len() * mem::size_of::<[u8; 32]>()
+            + self.input_compressed_accounts.len()
+                * mem::size_of::<CompressedAccountWithMerkleContext>()
+            + self.output_compressed_accounts.len() * mem::size_of::<CompressedAccount>()
+            + self.output_state_merkle_tree_account_indices.len()
+            + self.output_leaf_indices.len() * mem::size_of::<u32>()
+            + self.pubkey_array.len() * mem::size_of::<Pubkey>()
+            + self
+                .message
+                .as_ref()
+                .map(|message| message.len())
+                .unwrap_or(0)
+    }
+}
+
 #[inline(never)]
 pub fn invoke_indexer_transaction_event<T>(event: &T, noop_program: &AccountInfo) -> Result<()>
 where
-    T: AnchorSerialize,
+    T: AnchorSerialize + SizedEvent,
 {
     if noop_program.key()
         != Pubkey::from_str("noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV").unwrap()
     {
         return err!(crate::ErrorCode::InvalidNoopPubkey);
     }
+    let mut data = Vec::with_capacity(event.event_size());
+    event.serialize(&mut data)?;
     let instruction = Instruction {
         program_id: noop_program.key(),
         accounts: vec![],
-        data: event.try_to_vec()?,
+        data,
     };
     invoke(&instruction, &[noop_program.to_account_info()])?;
     Ok(())
 }
 
+#[heap_neutral]
 pub fn emit_state_transition_event<'a, 'b, 'c: 'info, 'info>(
-    inputs: &'a InstructionDataTransfer,
+    inputs: InstructionDataTransfer,
     ctx: &'a Context<'a, 'b, 'c, 'info, TransferInstruction<'info>>,
-    input_compressed_account_hashes: &[[u8; 32]],
-    output_compressed_account_hashes: &[[u8; 32]],
-    output_leaf_indices: &[u32],
+    input_compressed_account_hashes: Vec<[u8; 32]>,
+    output_compressed_account_hashes: Vec<[u8; 32]>,
+    output_leaf_indices: Vec<u32>,
 ) -> Result<()> {
     // TODO: add message and compression_lamports
     let event = PublicTransactionEvent {
-        input_compressed_account_hashes: input_compressed_account_hashes.to_vec(),
-        output_compressed_account_hashes: output_compressed_account_hashes.to_vec(),
-        input_compressed_accounts: inputs.input_compressed_accounts_with_merkle_context.clone(),
-        output_compressed_accounts: inputs.output_compressed_accounts.to_vec(),
-        output_state_merkle_tree_account_indices: inputs
-            .output_state_merkle_tree_account_indices
-            .to_vec(),
-        output_leaf_indices: output_leaf_indices.to_vec(),
+        input_compressed_account_hashes,
+        output_compressed_account_hashes,
+        input_compressed_accounts: inputs.input_compressed_accounts_with_merkle_context,
+        output_compressed_accounts: inputs.output_compressed_accounts,
+        output_state_merkle_tree_account_indices: inputs.output_state_merkle_tree_account_indices,
+        output_leaf_indices,
         relay_fee: inputs.relay_fee,
         pubkey_array: ctx.remaining_accounts.iter().map(|x| x.key()).collect(),
         compression_lamports: None,

--- a/programs/compressed-pda/src/lib.rs
+++ b/programs/compressed-pda/src/lib.rs
@@ -121,16 +121,10 @@ pub mod light_compressed_pda {
         cpi_context: Option<CompressedCpiContext>,
     ) -> Result<()> {
         // TODO: remove manual deserialization
-        let mut inputs: InstructionDataTransfer =
+        let inputs: InstructionDataTransfer =
             InstructionDataTransfer::deserialize(&mut inputs.as_slice())?;
         inputs.check_input_lengths()?;
-        match process_execute_compressed_transaction(&mut inputs, ctx, cpi_context) {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                msg!("inputs: {:?}", inputs);
-                Err(e)
-            }
-        }
+        process_execute_compressed_transaction(inputs, ctx, cpi_context)
     }
 
     // /// This function can be used to transfer sol and execute any other compressed transaction.

--- a/programs/compressed-token/src/process_transfer.rs
+++ b/programs/compressed-token/src/process_transfer.rs
@@ -1,3 +1,5 @@
+use std::mem;
+
 use crate::{spl_compression::process_compression, ErrorCode};
 use anchor_lang::{prelude::*, AnchorDeserialize};
 use anchor_spl::token::{Token, TokenAccount};
@@ -101,9 +103,11 @@ pub fn add_token_data_to_input_compressed_accounts(
         .iter_mut()
         .enumerate()
     {
+        let mut data = Vec::with_capacity(mem::size_of::<TokenData>());
+        input_token_data[i].serialize(&mut data)?;
         let data = CompressedAccountData {
             discriminator: 2u64.to_le_bytes(),
-            data: input_token_data[i].try_to_vec().unwrap(),
+            data,
             data_hash: input_token_data[i].hash().unwrap(),
         };
         compressed_account_with_context.compressed_account.data = Some(data);


### PR DESCRIPTION
Borsh's `try_to_vec` often allocates more memory than necessary.