### PR TITLE
perf: heap memory optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2659,6 +2659,7 @@ dependencies = [
  "light-verifier",
  "num-bigint 0.4.4",
  "num-traits",
+ "rand 0.8.5",
  "reqwest",
  "serde_json",
  "solana-banks-interface",

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/escrow.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/escrow.rs
@@ -76,6 +76,7 @@ fn cpi_compressed_pda_transfer<'info>(
     let bump = &[bump];
     let signer_bytes = ctx.accounts.signer.key.to_bytes();
     let seeds = [b"escrow".as_slice(), signer_bytes.as_slice(), bump];
+    let ccpi_signature_account_index = cpi_context.cpi_signature_account_index;
     let inputs_struct = InstructionDataTransfer {
         relay_fee: None,
         input_compressed_accounts_with_merkle_context: Vec::new(),
@@ -87,6 +88,7 @@ fn cpi_compressed_pda_transfer<'info>(
         compression_lamports: None,
         is_compress: false,
         signer_seeds: Some(seeds.iter().map(|x| x.to_vec()).collect::<Vec<Vec<u8>>>()),
+        cpi_context: Some(cpi_context),
     };
 
     let mut inputs = Vec::new();
@@ -104,8 +106,7 @@ fn cpi_compressed_pda_transfer<'info>(
         compression_recipient: None,
         system_program: ctx.accounts.system_program.to_account_info(),
         cpi_signature_account: Some(
-            ctx.remaining_accounts[cpi_context.cpi_signature_account_index as usize]
-                .to_account_info(),
+            ctx.remaining_accounts[ccpi_signature_account_index as usize].to_account_info(),
         ),
     };
     let seeds = [seeds.as_slice()];
@@ -117,7 +118,7 @@ fn cpi_compressed_pda_transfer<'info>(
 
     cpi_ctx.remaining_accounts = ctx.remaining_accounts.to_vec();
 
-    light_compressed_pda::cpi::execute_compressed_transaction(cpi_ctx, inputs, Some(cpi_context))?;
+    light_compressed_pda::cpi::execute_compressed_transaction(cpi_ctx, inputs)?;
     Ok(())
 }
 

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/withdrawal.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/withdrawal.rs
@@ -132,6 +132,7 @@ fn cpi_compressed_pda_withdrawal<'info>(
     let bump = &[bump];
     let signer_bytes = ctx.accounts.signer.key.to_bytes();
     let seeds: [&[u8]; 3] = [b"escrow".as_slice(), signer_bytes.as_slice(), bump];
+    let cpi_signature_account_index = cpi_context.cpi_signature_account_index;
     let inputs_struct = InstructionDataTransfer {
         relay_fee: None,
         input_compressed_accounts_with_merkle_context: vec![old_state],
@@ -143,6 +144,7 @@ fn cpi_compressed_pda_withdrawal<'info>(
         compression_lamports: None,
         is_compress: false,
         signer_seeds: Some(seeds.iter().map(|seed| seed.to_vec()).collect()),
+        cpi_context: Some(cpi_context),
     };
 
     let mut inputs = Vec::new();
@@ -160,8 +162,7 @@ fn cpi_compressed_pda_withdrawal<'info>(
         compression_recipient: None,
         system_program: ctx.accounts.system_program.to_account_info(),
         cpi_signature_account: Some(
-            ctx.remaining_accounts[cpi_context.cpi_signature_account_index as usize]
-                .to_account_info(),
+            ctx.remaining_accounts[cpi_signature_account_index as usize].to_account_info(),
         ),
     };
     let signer_seeds: [&[&[u8]]; 1] = [&seeds[..]];
@@ -173,7 +174,7 @@ fn cpi_compressed_pda_withdrawal<'info>(
 
     cpi_ctx.remaining_accounts = ctx.remaining_accounts.to_vec();
 
-    light_compressed_pda::cpi::execute_compressed_transaction(cpi_ctx, inputs, Some(cpi_context))?;
+    light_compressed_pda::cpi::execute_compressed_transaction(cpi_ctx, inputs)?;
     Ok(())
 }
 

--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -556,6 +556,14 @@ export type LightCompressedToken = {
                             };
                         };
                     },
+                    {
+                        name: 'cpiContext';
+                        type: {
+                            option: {
+                                defined: 'CompressedCpiContext';
+                            };
+                        };
+                    },
                 ];
             };
         },
@@ -1486,6 +1494,14 @@ export const IDL: LightCompressedToken = {
                         type: {
                             option: {
                                 vec: 'bytes',
+                            },
+                        },
+                    },
+                    {
+                        name: 'cpiContext',
+                        type: {
+                            option: {
+                                defined: 'CompressedCpiContext',
                             },
                         },
                     },

--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -408,14 +408,6 @@ export type LightCompressedToken = {
                         };
                     },
                     {
-                        name: 'inputCompressedAccounts';
-                        type: {
-                            vec: {
-                                defined: 'CompressedAccountWithMerkleContext';
-                            };
-                        };
-                    },
-                    {
                         name: 'outputCompressedAccounts';
                         type: {
                             vec: {
@@ -1345,14 +1337,6 @@ export const IDL: LightCompressedToken = {
                         type: {
                             vec: {
                                 array: ['u8', 32],
-                            },
-                        },
-                    },
-                    {
-                        name: 'inputCompressedAccounts',
-                        type: {
-                            vec: {
-                                defined: 'CompressedAccountWithMerkleContext',
                             },
                         },
                     },

--- a/js/stateless.js/src/idls/light_compressed_pda.ts
+++ b/js/stateless.js/src/idls/light_compressed_pda.ts
@@ -327,14 +327,6 @@ export type LightCompressedPda = {
                         };
                     },
                     {
-                        name: 'inputCompressedAccounts';
-                        type: {
-                            vec: {
-                                defined: 'CompressedAccountWithMerkleContext';
-                            };
-                        };
-                    },
-                    {
                         name: 'outputCompressedAccounts';
                         type: {
                             vec: {
@@ -1033,14 +1025,6 @@ export const IDL: LightCompressedPda = {
                         type: {
                             vec: {
                                 array: ['u8', 32],
-                            },
-                        },
-                    },
-                    {
-                        name: 'inputCompressedAccounts',
-                        type: {
-                            vec: {
-                                defined: 'CompressedAccountWithMerkleContext',
                             },
                         },
                     },

--- a/js/stateless.js/src/idls/light_compressed_pda.ts
+++ b/js/stateless.js/src/idls/light_compressed_pda.ts
@@ -108,14 +108,6 @@ export type LightCompressedPda = {
                     name: 'inputs';
                     type: 'bytes';
                 },
-                {
-                    name: 'cpiContext';
-                    type: {
-                        option: {
-                            defined: 'CompressedCpiContext';
-                        };
-                    };
-                },
             ];
         },
     ];
@@ -475,6 +467,14 @@ export type LightCompressedPda = {
                             };
                         };
                     },
+                    {
+                        name: 'cpiContext';
+                        type: {
+                            option: {
+                                defined: 'CompressedCpiContext';
+                            };
+                        };
+                    },
                 ];
             };
         },
@@ -809,14 +809,6 @@ export const IDL: LightCompressedPda = {
                 {
                     name: 'inputs',
                     type: 'bytes',
-                },
-                {
-                    name: 'cpiContext',
-                    type: {
-                        option: {
-                            defined: 'CompressedCpiContext',
-                        },
-                    },
                 },
             ],
         },
@@ -1174,6 +1166,14 @@ export const IDL: LightCompressedPda = {
                         type: {
                             option: {
                                 vec: 'bytes',
+                            },
+                        },
+                    },
+                    {
+                        name: 'cpiContext',
+                        type: {
+                            option: {
+                                defined: 'CompressedCpiContext',
                             },
                         },
                     },

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -556,6 +556,14 @@ export type LightCompressedToken = {
                             };
                         };
                     },
+                    {
+                        name: 'cpiContext';
+                        type: {
+                            option: {
+                                defined: 'CompressedCpiContext';
+                            };
+                        };
+                    },
                 ];
             };
         },
@@ -1486,6 +1494,14 @@ export const IDL: LightCompressedToken = {
                         type: {
                             option: {
                                 vec: 'bytes',
+                            },
+                        },
+                    },
+                    {
+                        name: 'cpiContext',
+                        type: {
+                            option: {
+                                defined: 'CompressedCpiContext',
                             },
                         },
                     },

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -408,14 +408,6 @@ export type LightCompressedToken = {
                         };
                     },
                     {
-                        name: 'inputCompressedAccounts';
-                        type: {
-                            vec: {
-                                defined: 'CompressedAccountWithMerkleContext';
-                            };
-                        };
-                    },
-                    {
                         name: 'outputCompressedAccounts';
                         type: {
                             vec: {
@@ -1345,14 +1337,6 @@ export const IDL: LightCompressedToken = {
                         type: {
                             vec: {
                                 array: ['u8', 32],
-                            },
-                        },
-                    },
-                    {
-                        name: 'inputCompressedAccounts',
-                        type: {
-                            vec: {
-                                defined: 'CompressedAccountWithMerkleContext',
                             },
                         },
                     },

--- a/js/stateless.js/src/programs/compressed-pda.ts
+++ b/js/stateless.js/src/programs/compressed-pda.ts
@@ -304,12 +304,13 @@ export class LightSystemProgram {
                 compressionLamports: null,
                 isCompress: false,
                 signerSeeds: null,
+                cpiContext: null,
             },
         );
 
         /// Build anchor instruction
         const instruction = await this.program.methods
-            .executeCompressedTransaction(data, null)
+            .executeCompressedTransaction(data)
             .accounts({
                 ...defaultStaticAccountsStruct(),
                 feePayer: payer,
@@ -366,6 +367,7 @@ export class LightSystemProgram {
             compressionLamports: lamports,
             isCompress: true,
             signerSeeds: null,
+            cpiContext: null,
         };
 
         const data = this.program.coder.types.encode(
@@ -375,7 +377,7 @@ export class LightSystemProgram {
 
         /// Build anchor instruction
         const instruction = await this.program.methods
-            .executeCompressedTransaction(data, null)
+            .executeCompressedTransaction(data)
             .accounts({
                 ...defaultStaticAccountsStruct(),
                 feePayer: payer,
@@ -441,12 +443,13 @@ export class LightSystemProgram {
                 compressionLamports: lamports,
                 isCompress: false,
                 signerSeeds: null,
+                cpiContext: null,
             },
         );
 
         /// Build anchor instruction
         const instruction = await this.program.methods
-            .executeCompressedTransaction(data, null)
+            .executeCompressedTransaction(data)
             .accounts({
                 ...defaultStaticAccountsStruct(),
                 feePayer: payer,

--- a/js/stateless.js/src/state/types.ts
+++ b/js/stateless.js/src/state/types.ts
@@ -38,7 +38,6 @@ export interface CompressedAccountData {
 export interface PublicTransactionEvent {
     inputCompressedAccountHashes: number[][]; // Vec<[u8; 32]>
     outputCompressedAccountHashes: number[][]; // Vec<[u8; 32]>
-    // inputCompressedAccounts: PackedCompressedAccountWithMerkleContext[];
     outputCompressedAccounts: CompressedAccount[];
     outputStateMerkleTreeAccountIndices: Uint8Array; // bytes
     outputLeafIndices: number[]; // Vec<u32>
@@ -60,6 +59,7 @@ export interface InstructionDataTransfer {
     isCompress: boolean; // bool
     newAddressParams: NewAddressParamsPacked[]; // Vec<NewAddressParamsPacked>
     signerSeeds: number[][] | null; // Vec<Vec<u8>>
+    cpiContext: null; // Option<CpiContext>
 }
 
 export interface NewAddressParamsPacked {

--- a/js/stateless.js/src/state/types.ts
+++ b/js/stateless.js/src/state/types.ts
@@ -38,7 +38,7 @@ export interface CompressedAccountData {
 export interface PublicTransactionEvent {
     inputCompressedAccountHashes: number[][]; // Vec<[u8; 32]>
     outputCompressedAccountHashes: number[][]; // Vec<[u8; 32]>
-    inputCompressedAccounts: PackedCompressedAccountWithMerkleContext[];
+    // inputCompressedAccounts: PackedCompressedAccountWithMerkleContext[];
     outputCompressedAccounts: CompressedAccount[];
     outputStateMerkleTreeAccountIndices: Uint8Array; // bytes
     outputLeafIndices: number[]; // Vec<u32>

--- a/js/stateless.js/src/test-helpers/test-rpc/get-compressed-accounts.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/get-compressed-accounts.ts
@@ -69,7 +69,7 @@ export async function getCompressedAccountsForTest(rpc: Rpc) {
         }
         for (
             let index = 0;
-            index < event.inputCompressedAccounts.length;
+            index < event.inputCompressedAccountHashes.length;
             index++
         ) {
             const hash = event.inputCompressedAccountHashes[index];

--- a/js/stateless.js/src/test-helpers/test-rpc/get-compressed-token-accounts.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/get-compressed-token-accounts.ts
@@ -64,40 +64,6 @@ async function parseEventWithTokenTlvData(
     event: PublicTransactionEvent,
 ): Promise<EventWithParsedTokenTlvData> {
     const pubkeyArray = event.pubkeyArray;
-    const inputHashes = event.inputCompressedAccountHashes;
-    /// TODO: consider different structure
-    // const inputCompressedAccountWithParsedTokenData: ParsedTokenAccount[] =
-    //     event.inputCompressedAccounts.map((compressedAccount, i) => {
-    //         const merkleContext: MerkleContext = {
-    //             merkleTree:
-    //                 pubkeyArray[compressedAccount.merkleTreePubkeyIndex],
-    //             nullifierQueue:
-    //                 pubkeyArray[compressedAccount.nullifierQueuePubkeyIndex],
-    //             hash: inputHashes[i],
-    //             leafIndex: compressedAccount.leafIndex,
-    //         };
-
-    //         if (!compressedAccount.compressedAccount.data)
-    //             throw new Error('No data');
-
-    //         const parsedData = parseTokenLayoutWithIdl(
-    //             compressedAccount.compressedAccount,
-    //         );
-
-    //         if (!parsedData) throw new Error('Invalid token data');
-
-    //         const withMerkleContext = createCompressedAccountWithMerkleContext(
-    //             merkleContext,
-    //             compressedAccount.compressedAccount.owner,
-    //             compressedAccount.compressedAccount.lamports,
-    //             compressedAccount.compressedAccount.data,
-    //             compressedAccount.compressedAccount.address ?? undefined,
-    //         );
-    //         return {
-    //             compressedAccount: withMerkleContext,
-    //             parsed: parsedData,
-    //         };
-    //     });
 
     const outputHashes = event.outputCompressedAccountHashes;
     const outputCompressedAccountsWithParsedTokenData: ParsedTokenAccount[] =
@@ -132,8 +98,7 @@ async function parseEventWithTokenTlvData(
         });
 
     return {
-        // inputCompressedAccounts: inputCompressedAccountWithParsedTokenData,
-        inputCompressedAccountHashes: inputHashes,
+        inputCompressedAccountHashes: event.inputCompressedAccountHashes,
         outputCompressedAccounts: outputCompressedAccountsWithParsedTokenData,
     };
 }

--- a/js/stateless.js/tests/e2e/rpc.test.ts
+++ b/js/stateless.js/tests/e2e/rpc.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, assert, beforeAll, expect } from 'vitest';
-import { Signer } from '@solana/web3.js';
+import {  Signer } from '@solana/web3.js';
 import {
     STATE_MERKLE_TREE_ROLLOVER_FEE,
     STATE_MERKLE_TREE_TIP,
@@ -8,7 +8,10 @@ import {
 import { newAccountWithLamports } from '../../src/utils/test-utils';
 import { Rpc } from '../../src/rpc';
 import { compress, decompress } from '../../src/actions';
-import { bn, CompressedAccountWithMerkleContext } from '../../src/state';
+import {
+    bn,
+    CompressedAccountWithMerkleContext,
+} from '../../src/state';
 import { getTestRpc } from '../../src/test-helpers';
 
 /// TODO: add test case for payer != address

--- a/js/stateless.js/tests/e2e/rpc.test.ts
+++ b/js/stateless.js/tests/e2e/rpc.test.ts
@@ -1,17 +1,16 @@
 import { describe, it, assert, beforeAll, expect } from 'vitest';
-import { PublicKey, Signer } from '@solana/web3.js';
+import {  Signer } from '@solana/web3.js';
 import {
     STATE_MERKLE_TREE_ROLLOVER_FEE,
     STATE_MERKLE_TREE_TIP,
     defaultTestStateTreeAccounts,
 } from '../../src/constants';
 import { newAccountWithLamports } from '../../src/utils/test-utils';
-import { Rpc, createRpc } from '../../src/rpc';
+import { Rpc } from '../../src/rpc';
 import { compress, decompress } from '../../src/actions';
 import {
     bn,
     CompressedAccountWithMerkleContext,
-    encodeBN254toBase58,
 } from '../../src/state';
 import { getTestRpc } from '../../src/test-helpers';
 
@@ -27,42 +26,6 @@ describe('rpc / photon', () => {
     let compressedTestAccount: CompressedAccountWithMerkleContext;
     let refPayer: Signer;
     const refCompressLamports = 1e7;
-    /// 0th leaf for refPayer
-    /// Note: also depends on testKeypair derivation seed.
-    const refHash: number[] = [
-        13, 225, 248, 105, 237, 121, 108, 70, 70, 197, 240, 130, 226, 236, 129,
-        58, 213, 50, 236, 99, 216, 99, 91, 201, 141, 76, 196, 33, 41, 181, 236,
-        187,
-    ];
-    /// 0th leaf merkle proof for refPayer after 2 compressions
-    const refMerkleProof: string[] = [
-        '2389670883532368111579825686474970238671018859817536120264461201496859761111',
-        '14744269619966411208579211824598458697587494354926760081771325075741142829156',
-        '7423237065226347324353380772367382631490014989348495481811164164159255474657',
-        '11286972368698509976183087595462810875513684078608517520839298933882497716792',
-        '3607627140608796879659380071776844901612302623152076817094415224584923813162',
-        '19712377064642672829441595136074946683621277828620209496774504837737984048981',
-        '20775607673010627194014556968476266066927294572720319469184847051418138353016',
-        '3396914609616007258851405644437304192397291162432396347162513310381425243293',
-        '21551820661461729022865262380882070649935529853313286572328683688269863701601',
-        '6573136701248752079028194407151022595060682063033565181951145966236778420039',
-        '12413880268183407374852357075976609371175688755676981206018884971008854919922',
-        '14271763308400718165336499097156975241954733520325982997864342600795471836726',
-        '20066985985293572387227381049700832219069292839614107140851619262827735677018',
-        '9394776414966240069580838672673694685292165040808226440647796406499139370960',
-        '11331146992410411304059858900317123658895005918277453009197229807340014528524',
-        '15819538789928229930262697811477882737253464456578333862691129291651619515538',
-        '19217088683336594659449020493828377907203207941212636669271704950158751593251',
-        '21035245323335827719745544373081896983162834604456827698288649288827293579666',
-        '6939770416153240137322503476966641397417391950902474480970945462551409848591',
-        '10941962436777715901943463195175331263348098796018438960955633645115732864202',
-        '15019797232609675441998260052101280400536945603062888308240081994073687793470',
-        '11702828337982203149177882813338547876343922920234831094975924378932809409969',
-        '11217067736778784455593535811108456786943573747466706329920902520905755780395',
-        '16072238744996205792852194127671441602062027943016727953216607508365787157389',
-        '17681057402012993898104192736393849603097507831571622013521167331642182653248',
-        '21694045479371014653083846597424257852691458318143380497809004364947786214945',
-    ];
 
     beforeAll(async () => {
         rpc = await getTestRpc();
@@ -89,41 +52,6 @@ describe('rpc / photon', () => {
             payer.publicKey,
             merkleTree,
         );
-    });
-
-    /// always run this test first per global test suite
-    it('rpc should return refAccountHash', async () => {
-        const compressedAccounts = await rpc.getCompressedAccountsByOwner(
-            refPayer.publicKey,
-        );
-
-        assert.equal(compressedAccounts.length, 1);
-
-        expect(bn(compressedAccounts[0].hash).eq(bn(refHash))).toBeTruthy();
-
-        const b58viaBN = encodeBN254toBase58(bn(refHash));
-        const b58viaPk = new PublicKey(refHash).toBase58();
-        assert.equal(b58viaBN, b58viaPk);
-
-        const arrFromB58 = new PublicKey(b58viaBN).toBytes();
-
-        assert.equal(arrFromB58.length, refHash.length);
-        assert.equal(
-            arrFromB58.every((v, i) => v === refHash[i]),
-            true,
-        );
-
-        const refCacct = await rpc.getCompressedAccount(bn(refHash));
-        assert.equal(refCacct!.owner.toBase58(), refPayer.publicKey.toBase58());
-        assert.equal(bn(refCacct!.hash).eq(bn(refHash)), true);
-
-        const compressedAccount = compressedAccounts[0];
-        assert.equal(Number(compressedAccount.lamports), refCompressLamports);
-        assert.equal(
-            compressedAccount.owner.toBase58(),
-            refPayer.publicKey.toBase58(),
-        );
-        assert.equal(compressedAccount.data?.data, null);
     });
 
     it('getCompressedAccountsByOwner', async () => {
@@ -155,15 +83,20 @@ describe('rpc / photon', () => {
     });
 
     it('getCompressedAccountProof for refPayer', async () => {
+        const compressedAccounts = await rpc.getCompressedAccountsByOwner(
+            payer.publicKey,
+        );
+        const refHash = compressedAccounts[0].hash;
         const compressedAccountProof = await rpc.getCompressedAccountProof(
             bn(refHash),
         );
         const proof = compressedAccountProof.merkleProof.map(x => x.toString());
 
-        expect(proof).toStrictEqual(refMerkleProof);
-
+        expect(proof.length).toStrictEqual(26);
         expect(compressedAccountProof.hash).toStrictEqual(refHash);
-        expect(compressedAccountProof.leafIndex).toStrictEqual(0);
+        expect(compressedAccountProof.leafIndex).toStrictEqual(
+            compressedAccounts[0].leafIndex,
+        );
         expect(compressedAccountProof.rootIndex).toStrictEqual(2);
 
         await compress(
@@ -173,10 +106,10 @@ describe('rpc / photon', () => {
             payer.publicKey,
             merkleTree,
         );
-        const compressedAccounts = await rpc.getCompressedAccountsByOwner(
+        const compressedAccounts1 = await rpc.getCompressedAccountsByOwner(
             payer.publicKey,
         );
-        expect(compressedAccounts?.length).toStrictEqual(2);
+        expect(compressedAccounts1?.length).toStrictEqual(2);
     });
 
     it('getCompressedAccountProof: get many valid proofs (10)', async () => {
@@ -197,17 +130,25 @@ describe('rpc / photon', () => {
     });
 
     it('getCompressedAccount', async () => {
+        const compressedAccounts = await rpc.getCompressedAccountsByOwner(
+            payer.publicKey,
+        );
+        const refHash = compressedAccounts[0].hash;
         /// getCompressedAccount
         const compressedAccount = await rpc.getCompressedAccount(bn(refHash));
         assert(compressedAccount !== null);
         assert.equal(
             compressedAccount.owner.toBase58(),
-            refPayer.publicKey.toBase58(),
+            payer.publicKey.toBase58(),
         );
         assert.equal(compressedAccount.data, null);
     });
 
     it.skip('getCompressedBalance', async () => {
+        const compressedAccounts = await rpc.getCompressedAccountsByOwner(
+            payer.publicKey,
+        );
+        const refHash = compressedAccounts[0].hash;
         /// getCompressedBalance
         const compressedBalance = await rpc.getCompressedBalance(bn(refHash));
         expect(compressedBalance?.eq(bn(refCompressLamports))).toBeTruthy();

--- a/js/stateless.js/tests/e2e/rpc.test.ts
+++ b/js/stateless.js/tests/e2e/rpc.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, assert, beforeAll, expect } from 'vitest';
-import {  Signer } from '@solana/web3.js';
+import { Signer } from '@solana/web3.js';
 import {
     STATE_MERKLE_TREE_ROLLOVER_FEE,
     STATE_MERKLE_TREE_TIP,
@@ -8,10 +8,7 @@ import {
 import { newAccountWithLamports } from '../../src/utils/test-utils';
 import { Rpc } from '../../src/rpc';
 import { compress, decompress } from '../../src/actions';
-import {
-    bn,
-    CompressedAccountWithMerkleContext,
-} from '../../src/state';
+import { bn, CompressedAccountWithMerkleContext } from '../../src/state';
 import { getTestRpc } from '../../src/test-helpers';
 
 /// TODO: add test case for payer != address

--- a/programs/account-compression/src/instructions/append_leaves.rs
+++ b/programs/account-compression/src/instructions/append_leaves.rs
@@ -211,7 +211,7 @@ fn process_batch<'a, 'c: 'info, 'info>(
     Ok(())
 }
 
-#[heap_neutral]
+// #[heap_neutral]
 #[inline(never)]
 fn emit_event<'a, 'b, 'c: 'info, 'info>(
     ctx: &Context<'a, 'b, 'c, 'info, AppendLeaves<'info>>,

--- a/programs/account-compression/src/instructions/append_leaves.rs
+++ b/programs/account-compression/src/instructions/append_leaves.rs
@@ -127,9 +127,11 @@ fn process_batch<'a, 'c: 'info, 'info>(
                     &merkle_tree,
                 )?;
 
-                let lamports =
-                    merkle_tree.tip + merkle_tree.rollover_fee * leaves_to_process as u64;
-
+                let mut lamports = merkle_tree.rollover_fee * leaves_to_process as u64;
+                if *leaves_start == 0 {
+                    msg!(" adding tip");
+                    lamports += merkle_tree.tip;
+                }
                 // Insert leaves to the Merkle tree.
                 let merkle_tree = merkle_tree.load_merkle_tree_mut()?;
                 let (first_changelog_index, first_sequence_number) = merkle_tree

--- a/programs/account-compression/src/instructions/append_leaves.rs
+++ b/programs/account-compression/src/instructions/append_leaves.rs
@@ -211,7 +211,6 @@ fn process_batch<'a, 'c: 'info, 'info>(
     Ok(())
 }
 
-// #[heap_neutral]
 #[inline(never)]
 fn emit_event<'a, 'b, 'c: 'info, 'info>(
     ctx: &Context<'a, 'b, 'c, 'info, AppendLeaves<'info>>,

--- a/programs/account-compression/src/instructions/append_leaves.rs
+++ b/programs/account-compression/src/instructions/append_leaves.rs
@@ -12,7 +12,7 @@ use crate::{
     RegisteredProgram,
 };
 
-const BATCH_SIZE: usize = 6;
+const BATCH_SIZE: usize = 7;
 
 #[derive(Accounts)]
 pub struct AppendLeaves<'info> {
@@ -72,17 +72,11 @@ pub fn process_append_leaves_to_merkle_trees<'a, 'b, 'c: 'info, 'info>(
     ctx: Context<'a, 'b, 'c, 'info, AppendLeaves<'info>>,
     leaves: &'a [[u8; 32]],
 ) -> Result<()> {
-    #[cfg(target_os = "solana")]
-    light_heap::GLOBAL_ALLOCATOR.log_total_heap("append_leaves: start");
-
     if leaves.len() != ctx.remaining_accounts.len() {
         return err!(crate::errors::AccountCompressionErrorCode::NumberOfLeavesMismatch);
     }
 
     let mut merkle_tree_map = build_merkle_tree_map(leaves, ctx.remaining_accounts);
-
-    #[cfg(target_os = "solana")]
-    light_heap::GLOBAL_ALLOCATOR.log_total_heap("append_leaves: merkle tree map");
 
     let mut leaves_start = 0;
     while !merkle_tree_map.is_empty() {
@@ -101,11 +95,9 @@ fn process_batch<'a, 'c: 'info, 'info>(
 ) -> Result<()> {
     let mut leaves_in_batch = 0;
     let mut changelog_events = Vec::with_capacity(BATCH_SIZE);
-
     // A vector of trees which become fully processed and should be removed
     // from the `merkle_tree_map`.
     let mut processed_merkle_trees = Vec::new();
-
     {
         let mut merkle_tree_map_iter = merkle_tree_map.values();
         let mut merkle_tree_map_pair = merkle_tree_map_iter.next();
@@ -115,23 +107,21 @@ fn process_batch<'a, 'c: 'info, 'info>(
                 cmp::min(leaves.len() - *leaves_start, BATCH_SIZE - leaves_in_batch);
             let leaves_end = *leaves_start + leaves_to_process;
 
-            let lamports = {
+            let rollover_fee;
+            let tip;
+            {
                 let merkle_tree =
                     AccountLoader::<StateMerkleTreeAccount>::try_from(merkle_tree_acc_info)
                         .unwrap();
                 let merkle_tree_pubkey = merkle_tree.key();
                 let mut merkle_tree = merkle_tree.load_mut()?;
-
+                rollover_fee = merkle_tree.rollover_fee;
+                tip = merkle_tree.tip;
                 check_registered_or_signer::<AppendLeaves, StateMerkleTreeAccount>(
                     ctx,
                     &merkle_tree,
                 )?;
 
-                let mut lamports = merkle_tree.rollover_fee * leaves_to_process as u64;
-                if *leaves_start == 0 {
-                    msg!(" adding tip");
-                    lamports += merkle_tree.tip;
-                }
                 // Insert leaves to the Merkle tree.
                 let merkle_tree = merkle_tree.load_merkle_tree_mut()?;
                 let (first_changelog_index, first_sequence_number) = merkle_tree
@@ -186,12 +176,11 @@ fn process_batch<'a, 'c: 'info, 'info>(
                 //     )
                 //     .map_err(ProgramError::from)?;
                 // changelog_events.push(changelog_event);
+            }
 
-                lamports
-            };
-
-            msg!("transferring rollover fee: {}", lamports);
-            if lamports > 0 {
+            let lamports = rollover_fee * leaves.len() as u64 + tip;
+            if lamports > 0 && leaves_end == leaves.len() {
+                msg!("transferring rollover fee: {}", lamports);
                 transfer_lamports_cpi(&ctx.accounts.fee_payer, merkle_tree_acc_info, lamports)?;
             }
 
@@ -235,19 +224,10 @@ fn emit_event<'a, 'b, 'c: 'info, 'info>(
 
     // Calling `try_to_vec` allocates too much memory. Allocate the memory, up
     // to the instruction limit, manually.
-    #[cfg(target_os = "solana")]
-    light_heap::GLOBAL_ALLOCATOR.log_total_heap("before borsh serialization");
     let mut data = Vec::with_capacity(10240);
     changelog_event.serialize(&mut data)?;
-    #[cfg(target_os = "solana")]
-    light_heap::GLOBAL_ALLOCATOR.log_total_heap("after borsh serialization");
 
-    emit_indexer_event(data, &ctx.accounts.log_wrapper, &ctx.accounts.authority)?;
-
-    #[cfg(target_os = "solana")]
-    light_heap::GLOBAL_ALLOCATOR.log_total_heap("after invoke");
-
-    Ok(())
+    emit_indexer_event(data, &ctx.accounts.log_wrapper, &ctx.accounts.authority)
 }
 
 pub fn transfer_lamports<'info>(

--- a/programs/compressed-pda/Cargo.toml
+++ b/programs/compressed-pda/Cargo.toml
@@ -51,3 +51,4 @@ num-bigint = "0.4.4"
 num-traits = "0.2.18"
 lazy_static = "1.4.0"
 light-hash-set = { version = "0.1.0", path = "../../merkle-tree/hash-set", features = ["solana"] }
+rand = "0.8.5"

--- a/programs/compressed-pda/src/append_state.rs
+++ b/programs/compressed-pda/src/append_state.rs
@@ -6,8 +6,6 @@ use crate::{
 };
 use account_compression::StateMerkleTreeAccount;
 use anchor_lang::{prelude::*, solana_program::pubkey::Pubkey};
-#[cfg(target_os = "solana")]
-use light_heap::GLOBAL_ALLOCATOR;
 use light_macros::heap_neutral;
 
 #[heap_neutral]

--- a/programs/compressed-pda/src/append_state.rs
+++ b/programs/compressed-pda/src/append_state.rs
@@ -1,29 +1,43 @@
 use std::collections::HashMap;
 
-use account_compression::StateMerkleTreeAccount;
-use anchor_lang::{prelude::*, solana_program::pubkey::Pubkey};
-use light_macros::heap_neutral;
-
 use crate::{
     instructions::{InstructionDataTransfer, TransferInstruction},
     verify_state::check_program_owner_state_merkle_tree,
 };
+use account_compression::StateMerkleTreeAccount;
+use anchor_lang::{prelude::*, solana_program::pubkey::Pubkey};
+#[cfg(target_os = "solana")]
+use light_heap::GLOBAL_ALLOCATOR;
+use light_macros::heap_neutral;
 
 #[heap_neutral]
-pub fn insert_output_compressed_accounts_into_state_merkle_tree<'a, 'b, 'c: 'info, 'info>(
+pub fn insert_output_compressed_accounts_into_state_merkle_tree<
+    'a,
+    'b,
+    'c: 'info,
+    'info,
+    const ITER_SIZE: usize,
+>(
     inputs: &'a InstructionDataTransfer,
     ctx: &'a Context<'a, 'b, 'c, 'info, TransferInstruction<'info>>,
     output_compressed_account_indices: &'a mut [u32],
     output_compressed_account_hashes: &'a mut [[u8; 32]],
     addresses: &'a mut Vec<Option<[u8; 32]>>,
+    global_iter: &'a mut usize,
 ) -> Result<()> {
-    let mut merkle_tree_indices = HashMap::<Pubkey, usize>::new();
     let mut out_merkle_trees_account_infos = Vec::<AccountInfo>::new();
-    for (j, mt_index) in inputs
-        .output_state_merkle_tree_account_indices
-        .iter()
-        .enumerate()
-    {
+    let mut merkle_tree_indices = HashMap::<Pubkey, usize>::new();
+
+    let initial_index = *global_iter;
+    let end = if *global_iter + ITER_SIZE > inputs.output_state_merkle_tree_account_indices.len() {
+        inputs.output_state_merkle_tree_account_indices.len()
+    } else {
+        *global_iter + ITER_SIZE
+    };
+    for mt_index in inputs.output_state_merkle_tree_account_indices[initial_index..end].iter() {
+        let j = *global_iter;
+
+        *global_iter += 1;
         let index = merkle_tree_indices.get_mut(&ctx.remaining_accounts[*mt_index as usize].key());
         out_merkle_trees_account_infos.push(ctx.remaining_accounts[*mt_index as usize].clone());
         check_program_owner_state_merkle_tree(
@@ -50,7 +64,6 @@ pub fn insert_output_compressed_accounts_into_state_merkle_tree<'a, 'b, 'c: 'inf
         }
         // Address has to be created or a compressed account with this address has to be provided as transaction input.
         if let Some(address) = inputs.output_compressed_accounts[j].address {
-            msg!("addresses {:?}", addresses);
             if let Some(position) = addresses
                 .iter()
                 .filter(|x| x.is_some())
@@ -78,7 +91,7 @@ pub fn insert_output_compressed_accounts_into_state_merkle_tree<'a, 'b, 'c: 'inf
         &ctx.accounts.noop_program,
         &ctx.accounts.system_program,
         out_merkle_trees_account_infos,
-        output_compressed_account_hashes.to_vec(),
+        output_compressed_account_hashes[initial_index..*global_iter].to_vec(),
     )?;
 
     Ok(())

--- a/programs/compressed-pda/src/compressed_account.rs
+++ b/programs/compressed-pda/src/compressed_account.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use anchor_lang::prelude::*;
 use light_hasher::{Hasher, Poseidon};
-use light_utils::hash_to_bn254_field_size_le;
+use light_utils::hash_to_bn254_field_size_be;
 
 #[derive(Debug, PartialEq, Default, Clone, AnchorSerialize, AnchorDeserialize)]
 pub struct CompressedAccountWithMerkleContext {
@@ -85,7 +85,7 @@ impl CompressedAccount {
     pub fn hash(&self, &merkle_tree_pubkey: &Pubkey, leaf_index: &u32) -> Result<[u8; 32]> {
         let capacity = 4 + self.address.is_some() as usize + self.data.is_some() as usize * 2;
         let mut vec: Vec<&[u8]> = Vec::with_capacity(capacity);
-        let truncated_owner = hash_to_bn254_field_size_le(&self.owner.to_bytes())
+        let truncated_owner = hash_to_bn254_field_size_be(&self.owner.to_bytes())
             .unwrap()
             .0;
         vec.push(truncated_owner.as_slice());
@@ -94,7 +94,7 @@ impl CompressedAccount {
         let leaf_index = leaf_index.to_le_bytes();
         vec.push(leaf_index.as_slice());
         let truncated_merkle_tree_pubkey =
-            hash_to_bn254_field_size_le(&merkle_tree_pubkey.to_bytes())
+            hash_to_bn254_field_size_be(&merkle_tree_pubkey.to_bytes())
                 .unwrap()
                 .0;
         vec.push(truncated_merkle_tree_pubkey.as_slice());
@@ -121,7 +121,7 @@ impl CompressedAccount {
 }
 
 pub fn derive_address(merkle_tree_pubkey: &Pubkey, seed: &[u8; 32]) -> Result<[u8; 32]> {
-    let hash = match hash_to_bn254_field_size_le(
+    let hash = match hash_to_bn254_field_size_be(
         [merkle_tree_pubkey.to_bytes(), *seed].concat().as_slice(),
     ) {
         Some(hash) => Ok::<[u8; 32], Error>(hash.0),
@@ -159,12 +159,12 @@ mod tests {
             .hash(&merkle_tree_pubkey, &leaf_index)
             .unwrap();
         let hash_manual = Poseidon::hashv(&[
-            hash_to_bn254_field_size_le(&owner.to_bytes())
+            hash_to_bn254_field_size_be(&owner.to_bytes())
                 .unwrap()
                 .0
                 .as_slice(),
             leaf_index.to_le_bytes().as_slice(),
-            hash_to_bn254_field_size_le(&merkle_tree_pubkey.to_bytes())
+            hash_to_bn254_field_size_be(&merkle_tree_pubkey.to_bytes())
                 .unwrap()
                 .0
                 .as_slice(),
@@ -189,12 +189,12 @@ mod tests {
             .unwrap();
 
         let hash_manual = Poseidon::hashv(&[
-            hash_to_bn254_field_size_le(&owner.to_bytes())
+            hash_to_bn254_field_size_be(&owner.to_bytes())
                 .unwrap()
                 .0
                 .as_slice(),
             leaf_index.to_le_bytes().as_slice(),
-            hash_to_bn254_field_size_le(&merkle_tree_pubkey.to_bytes())
+            hash_to_bn254_field_size_be(&merkle_tree_pubkey.to_bytes())
                 .unwrap()
                 .0
                 .as_slice(),
@@ -216,12 +216,12 @@ mod tests {
             .hash(&merkle_tree_pubkey, &leaf_index)
             .unwrap();
         let hash_manual = Poseidon::hashv(&[
-            hash_to_bn254_field_size_le(&owner.to_bytes())
+            hash_to_bn254_field_size_be(&owner.to_bytes())
                 .unwrap()
                 .0
                 .as_slice(),
             leaf_index.to_le_bytes().as_slice(),
-            hash_to_bn254_field_size_le(&merkle_tree_pubkey.to_bytes())
+            hash_to_bn254_field_size_be(&merkle_tree_pubkey.to_bytes())
                 .unwrap()
                 .0
                 .as_slice(),
@@ -245,12 +245,12 @@ mod tests {
             .hash(&merkle_tree_pubkey, &leaf_index)
             .unwrap();
         let hash_manual = Poseidon::hashv(&[
-            hash_to_bn254_field_size_le(&owner.to_bytes())
+            hash_to_bn254_field_size_be(&owner.to_bytes())
                 .unwrap()
                 .0
                 .as_slice(),
             leaf_index.to_le_bytes().as_slice(),
-            hash_to_bn254_field_size_le(&merkle_tree_pubkey.to_bytes())
+            hash_to_bn254_field_size_be(&merkle_tree_pubkey.to_bytes())
                 .unwrap()
                 .0
                 .as_slice(),

--- a/programs/compressed-pda/src/compressed_cpi.rs
+++ b/programs/compressed-pda/src/compressed_cpi.rs
@@ -46,7 +46,7 @@ impl CpiSignatureAccount {
 pub const CPI_SEED: &[u8] = b"cpi_signature_pda";
 
 /// To spend multiple compressed
-#[derive(Debug, AnchorSerialize, AnchorDeserialize)]
+#[derive(Debug, AnchorSerialize, AnchorDeserialize, PartialEq, Clone)]
 pub struct CompressedCpiContext {
     /// index of the output state Merkle tree that will be used to store cpi signatures
     /// The transaction will fail if this index is not consistent in your transaction.

--- a/programs/compressed-pda/src/event.rs
+++ b/programs/compressed-pda/src/event.rs
@@ -11,7 +11,6 @@ pub struct PublicTransactionEvent {
     pub input_compressed_account_hashes: Vec<[u8; 32]>,
     pub output_compressed_account_hashes: Vec<[u8; 32]>,
     pub output_compressed_accounts: Vec<CompressedAccount>,
-    // index of Merkle tree account in remaining accounts
     pub output_state_merkle_tree_account_indices: Vec<u8>,
     pub output_leaf_indices: Vec<u32>,
     pub relay_fee: Option<u64>,
@@ -44,26 +43,16 @@ impl SizedEvent for PublicTransactionEvent {
 
 impl PublicTransactionEvent {
     pub fn man_serialize<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        // #[cfg(target_os = "solana")]
-        // let pos = light_heap::GLOBAL_ALLOCATOR.get_heap_pos();
-        // input compressed account hashes
         writer.write_all(&(self.input_compressed_account_hashes.len() as u32).to_le_bytes())?;
         for hash in self.input_compressed_account_hashes.iter() {
             writer.write_all(hash)?;
         }
-        // output compressed account hashes
+
         writer.write_all(&(self.output_compressed_account_hashes.len() as u32).to_le_bytes())?;
         for hash in self.output_compressed_account_hashes.iter() {
             writer.write_all(hash)?;
         }
-        // #[cfg(target_os = "solana")]
-        // light_heap::GLOBAL_ALLOCATOR.free_heap(pos);
-        // input compressed accounts
-        // writer.write_all(&(input_compressed_accounts.len() as u32).to_le_bytes())?;
-        // for account in &input_compressed_accounts {}
-        // output compressed accounts
-        #[cfg(target_os = "solana")]
-        light_heap::GLOBAL_ALLOCATOR.log_total_heap("before output compressed accounts");
+
         #[cfg(target_os = "solana")]
         let pos = light_heap::GLOBAL_ALLOCATOR.get_heap_pos();
         writer.write_all(&(self.output_compressed_accounts.len() as u32).to_le_bytes())?;
@@ -73,32 +62,20 @@ impl PublicTransactionEvent {
         }
         #[cfg(target_os = "solana")]
         light_heap::GLOBAL_ALLOCATOR.free_heap(pos);
-        msg!("here1");
-        // #[cfg(target_os = "solana")]
-        // let pos = light_heap::GLOBAL_ALLOCATOR.get_heap_pos();
-        // output state merkle tree account indices
+
         writer.write_all(
             &(self.output_state_merkle_tree_account_indices.len() as u32).to_le_bytes(),
         )?;
-        // #[cfg(target_os = "solana")]
-        // light_heap::GLOBAL_ALLOCATOR.free_heap(pos);
-        // #[cfg(target_os = "solana")]
-        // let pos = light_heap::GLOBAL_ALLOCATOR.get_heap_pos();
+
         for index in self.output_state_merkle_tree_account_indices.iter() {
             writer.write_all(&[*index])?;
         }
-        // #[cfg(target_os = "solana")]
-        // light_heap::GLOBAL_ALLOCATOR.free_heap(pos);
-        // #[cfg(target_os = "solana")]
-        // let pos = light_heap::GLOBAL_ALLOCATOR.get_heap_pos();
-        // output leaf indices
+
         writer.write_all(&(self.output_leaf_indices.len() as u32).to_le_bytes())?;
         for index in self.output_leaf_indices.iter() {
             writer.write_all(&index.to_le_bytes())?;
         }
-        // #[cfg(target_os = "solana")]
-        // light_heap::GLOBAL_ALLOCATOR.free_heap(pos);
-        // relay fee
+
         match self.relay_fee {
             Some(relay_fee) => {
                 writer.write_all(&[1])?;

--- a/programs/compressed-pda/src/event.rs
+++ b/programs/compressed-pda/src/event.rs
@@ -1,21 +1,15 @@
-use std::{mem, str::FromStr};
-
+use crate::{compressed_account::CompressedAccount, InstructionDataTransfer, TransferInstruction};
 use anchor_lang::{
     prelude::*,
     solana_program::{instruction::Instruction, program::invoke},
 };
 use light_macros::heap_neutral;
-
-use crate::{
-    compressed_account::{CompressedAccount, CompressedAccountWithMerkleContext},
-    InstructionDataTransfer, TransferInstruction,
-};
+use std::{io::Write, mem, str::FromStr};
 
 #[derive(Debug, Clone, AnchorSerialize, AnchorDeserialize, Default, PartialEq)]
 pub struct PublicTransactionEvent {
     pub input_compressed_account_hashes: Vec<[u8; 32]>,
     pub output_compressed_account_hashes: Vec<[u8; 32]>,
-    pub input_compressed_accounts: Vec<CompressedAccountWithMerkleContext>,
     pub output_compressed_accounts: Vec<CompressedAccount>,
     // index of Merkle tree account in remaining accounts
     pub output_state_merkle_tree_account_indices: Vec<u8>,
@@ -36,8 +30,6 @@ impl SizedEvent for PublicTransactionEvent {
         mem::size_of::<Self>()
             + self.input_compressed_account_hashes.len() * mem::size_of::<[u8; 32]>()
             + self.output_compressed_account_hashes.len() * mem::size_of::<[u8; 32]>()
-            + self.input_compressed_accounts.len()
-                * mem::size_of::<CompressedAccountWithMerkleContext>()
             + self.output_compressed_accounts.len() * mem::size_of::<CompressedAccount>()
             + self.output_state_merkle_tree_account_indices.len()
             + self.output_leaf_indices.len() * mem::size_of::<u32>()
@@ -50,26 +42,120 @@ impl SizedEvent for PublicTransactionEvent {
     }
 }
 
-#[inline(never)]
-pub fn invoke_indexer_transaction_event<T>(event: &T, noop_program: &AccountInfo) -> Result<()>
-where
-    T: AnchorSerialize + SizedEvent,
-{
-    if noop_program.key()
-        != Pubkey::from_str("noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV").unwrap()
-    {
-        return err!(crate::ErrorCode::InvalidNoopPubkey);
+impl PublicTransactionEvent {
+    pub fn man_serialize<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        // #[cfg(target_os = "solana")]
+        // let pos = light_heap::GLOBAL_ALLOCATOR.get_heap_pos();
+        // input compressed account hashes
+        writer.write_all(&(self.input_compressed_account_hashes.len() as u32).to_le_bytes())?;
+        for hash in self.input_compressed_account_hashes.iter() {
+            writer.write_all(hash)?;
+        }
+        // output compressed account hashes
+        writer.write_all(&(self.output_compressed_account_hashes.len() as u32).to_le_bytes())?;
+        for hash in self.output_compressed_account_hashes.iter() {
+            writer.write_all(hash)?;
+        }
+        // #[cfg(target_os = "solana")]
+        // light_heap::GLOBAL_ALLOCATOR.free_heap(pos);
+        // input compressed accounts
+        // writer.write_all(&(input_compressed_accounts.len() as u32).to_le_bytes())?;
+        // for account in &input_compressed_accounts {}
+        // output compressed accounts
+        #[cfg(target_os = "solana")]
+        light_heap::GLOBAL_ALLOCATOR.log_total_heap("before output compressed accounts");
+        #[cfg(target_os = "solana")]
+        let pos = light_heap::GLOBAL_ALLOCATOR.get_heap_pos();
+        writer.write_all(&(self.output_compressed_accounts.len() as u32).to_le_bytes())?;
+        for i in 0..self.output_compressed_accounts.len() {
+            let account = self.output_compressed_accounts[i].clone();
+            account.serialize(writer)?;
+        }
+        #[cfg(target_os = "solana")]
+        light_heap::GLOBAL_ALLOCATOR.free_heap(pos);
+        msg!("here1");
+        // #[cfg(target_os = "solana")]
+        // let pos = light_heap::GLOBAL_ALLOCATOR.get_heap_pos();
+        // output state merkle tree account indices
+        writer.write_all(
+            &(self.output_state_merkle_tree_account_indices.len() as u32).to_le_bytes(),
+        )?;
+        // #[cfg(target_os = "solana")]
+        // light_heap::GLOBAL_ALLOCATOR.free_heap(pos);
+        // #[cfg(target_os = "solana")]
+        // let pos = light_heap::GLOBAL_ALLOCATOR.get_heap_pos();
+        for index in self.output_state_merkle_tree_account_indices.iter() {
+            writer.write_all(&[*index])?;
+        }
+        // #[cfg(target_os = "solana")]
+        // light_heap::GLOBAL_ALLOCATOR.free_heap(pos);
+        // #[cfg(target_os = "solana")]
+        // let pos = light_heap::GLOBAL_ALLOCATOR.get_heap_pos();
+        // output leaf indices
+        writer.write_all(&(self.output_leaf_indices.len() as u32).to_le_bytes())?;
+        for index in self.output_leaf_indices.iter() {
+            writer.write_all(&index.to_le_bytes())?;
+        }
+        // #[cfg(target_os = "solana")]
+        // light_heap::GLOBAL_ALLOCATOR.free_heap(pos);
+        // relay fee
+        match self.relay_fee {
+            Some(relay_fee) => {
+                writer.write_all(&[1])?;
+                writer.write_all(&relay_fee.to_le_bytes())
+            }
+            None => writer.write_all(&[0]),
+        }?;
+        // is compress
+        writer.write_all(&[self.is_compress as u8])?;
+        // compression lamports
+        match self.compression_lamports {
+            Some(compression_lamports) => {
+                writer.write_all(&[1])?;
+                writer.write_all(&compression_lamports.to_le_bytes())
+            }
+            None => writer.write_all(&[0]),
+        }?;
+        // pubkey array
+        writer.write_all(&(self.pubkey_array.len() as u32).to_le_bytes())?;
+        for pubkey in self.pubkey_array.iter() {
+            writer.write_all(&pubkey.to_bytes())?;
+        }
+        // message
+        match &self.message {
+            Some(message) => {
+                writer.write_all(&[1])?;
+                writer.write_all(&(message.len() as u32).to_le_bytes())?;
+                writer.write_all(message)
+            }
+            None => writer.write_all(&[0]),
+        }?;
+
+        Ok(())
     }
-    let mut data = Vec::with_capacity(event.event_size());
-    event.serialize(&mut data)?;
-    let instruction = Instruction {
-        program_id: noop_program.key(),
-        accounts: vec![],
-        data,
-    };
-    invoke(&instruction, &[noop_program.to_account_info()])?;
-    Ok(())
 }
+
+// #[inline(never)]
+// pub fn invoke_indexer_transaction_event<T>(event: &T, noop_program: &AccountInfo) -> Result<()>
+// where
+//     T: AnchorSerialize + SizedEvent,
+// {
+//     if noop_program.key()
+//         != Pubkey::from_str("noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV").unwrap()
+//     {
+//         return err!(crate::ErrorCode::InvalidNoopPubkey);
+//     }
+//     let mut data = Vec::with_capacity(event.event_size());
+//     // TODO: add compression lamports
+//     event.man_serialize(&mut data)?;
+//     let instruction = Instruction {
+//         program_id: noop_program.key(),
+//         accounts: vec![],
+//         data,
+//     };
+//     invoke(&instruction, &[noop_program.to_account_info()])?;
+//     Ok(())
+// }
 
 #[heap_neutral]
 pub fn emit_state_transition_event<'a, 'b, 'c: 'info, 'info>(
@@ -83,7 +169,6 @@ pub fn emit_state_transition_event<'a, 'b, 'c: 'info, 'info>(
     let event = PublicTransactionEvent {
         input_compressed_account_hashes,
         output_compressed_account_hashes,
-        input_compressed_accounts: inputs.input_compressed_accounts_with_merkle_context,
         output_compressed_accounts: inputs.output_compressed_accounts,
         output_state_merkle_tree_account_indices: inputs.output_state_merkle_tree_account_indices,
         output_leaf_indices,
@@ -93,6 +178,146 @@ pub fn emit_state_transition_event<'a, 'b, 'c: 'info, 'info>(
         message: None,
         is_compress: false,
     };
-    invoke_indexer_transaction_event(&event, &ctx.accounts.noop_program)?;
+
+    if ctx.accounts.noop_program.key()
+        != Pubkey::from_str("noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV").unwrap()
+    {
+        return err!(crate::ErrorCode::InvalidNoopPubkey);
+    }
+    let mut data = Vec::with_capacity(event.event_size());
+    // TODO: add compression lamports
+    event.man_serialize(&mut data)?;
+    let instruction = Instruction {
+        program_id: ctx.accounts.noop_program.key(),
+        accounts: vec![],
+        data,
+    };
+    invoke(&instruction, &[ctx.accounts.noop_program.to_account_info()])?;
     Ok(())
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+    use crate::compressed_account::CompressedAccountData;
+    use rand::Rng;
+
+    #[test]
+    fn test_manual_vs_borsh_serialization() {
+        // Create a sample `PublicTransactionEvent` instance
+        let event = PublicTransactionEvent {
+            input_compressed_account_hashes: vec![[0u8; 32], [1u8; 32]],
+            output_compressed_account_hashes: vec![[2u8; 32], [3u8; 32]],
+            output_compressed_accounts: vec![CompressedAccount {
+                owner: Pubkey::new_unique(),
+                lamports: 100,
+                address: Some([5u8; 32]),
+                data: Some(CompressedAccountData {
+                    discriminator: [6u8; 8],
+                    data: vec![7u8; 32],
+                    data_hash: [8u8; 32],
+                }),
+            }],
+            output_state_merkle_tree_account_indices: vec![1, 2, 3],
+            output_leaf_indices: vec![4, 5, 6],
+            relay_fee: Some(1000),
+            is_compress: true,
+            compression_lamports: Some(5000),
+            pubkey_array: vec![Pubkey::new_unique(), Pubkey::new_unique()],
+            message: Some(vec![8, 9, 10]),
+        };
+
+        // Serialize using Borsh
+        let borsh_serialized = event.try_to_vec().unwrap();
+
+        // Serialize manually
+        let mut manual_serialized = Vec::new();
+        event
+            .man_serialize(
+                &mut manual_serialized,
+                // &event.input_compressed_account_hashes,
+                // &event.output_compressed_account_hashes,
+                // &event.output_compressed_accounts,
+                // &event.output_state_merkle_tree_account_indices,
+                // &event.output_leaf_indices,
+                // &event.relay_fee,
+                // event.is_compress,
+                // &event.compression_lamports,
+                // &event.pubkey_array,
+                // &event.message,
+            )
+            .unwrap();
+
+        // Compare the two byte arrays
+        assert_eq!(
+            borsh_serialized, manual_serialized,
+            "Borsh and manual serialization results should match"
+        );
+    }
+
+    #[test]
+    fn test_serialization_consistency() {
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..1_000_000 {
+            let input_hashes: Vec<[u8; 32]> =
+                (0..rng.gen_range(1..10)).map(|_| rng.gen()).collect();
+            let output_hashes: Vec<[u8; 32]> =
+                (0..rng.gen_range(1..10)).map(|_| rng.gen()).collect();
+            let output_accounts: Vec<CompressedAccount> = (0..rng.gen_range(1..10))
+                .map(|_| CompressedAccount {
+                    owner: Pubkey::new_unique(),
+                    lamports: rng.gen(),
+                    address: Some(rng.gen()),
+                    data: None,
+                })
+                .collect();
+            let merkle_indices: Vec<u8> = (0..rng.gen_range(1..10)).map(|_| rng.gen()).collect();
+            let leaf_indices: Vec<u32> = (0..rng.gen_range(1..10)).map(|_| rng.gen()).collect();
+            let pubkeys: Vec<Pubkey> = (0..rng.gen_range(1..10))
+                .map(|_| Pubkey::new_unique())
+                .collect();
+            let message: Option<Vec<u8>> = if rng.gen() {
+                Some((0..rng.gen_range(1..100)).map(|_| rng.gen()).collect())
+            } else {
+                None
+            };
+
+            let event = PublicTransactionEvent {
+                input_compressed_account_hashes: input_hashes,
+                output_compressed_account_hashes: output_hashes,
+                output_compressed_accounts: output_accounts,
+                output_state_merkle_tree_account_indices: merkle_indices,
+                output_leaf_indices: leaf_indices,
+                relay_fee: if rng.gen() { Some(rng.gen()) } else { None },
+                is_compress: rng.gen(),
+                compression_lamports: if rng.gen() { Some(rng.gen()) } else { None },
+                pubkey_array: pubkeys,
+                message,
+            };
+
+            let borsh_serialized = event.try_to_vec().unwrap();
+            let mut manual_serialized = Vec::new();
+            event
+                .man_serialize(
+                    &mut manual_serialized,
+                    // &event.input_compressed_account_hashes,
+                    // &event.output_compressed_account_hashes,
+                    // &event.output_compressed_accounts,
+                    // &event.output_state_merkle_tree_account_indices,
+                    // &event.output_leaf_indices,
+                    // &event.relay_fee,
+                    // event.is_compress,
+                    // &event.compression_lamports,
+                    // &event.pubkey_array,
+                    // &event.message,
+                )
+                .unwrap();
+
+            assert_eq!(
+                borsh_serialized, manual_serialized,
+                "Borsh and manual serialization results should match"
+            );
+        }
+    }
 }

--- a/programs/compressed-pda/src/event.rs
+++ b/programs/compressed-pda/src/event.rs
@@ -185,21 +185,7 @@ pub mod test {
 
         // Serialize manually
         let mut manual_serialized = Vec::new();
-        event
-            .man_serialize(
-                &mut manual_serialized,
-                // &event.input_compressed_account_hashes,
-                // &event.output_compressed_account_hashes,
-                // &event.output_compressed_accounts,
-                // &event.output_state_merkle_tree_account_indices,
-                // &event.output_leaf_indices,
-                // &event.relay_fee,
-                // event.is_compress,
-                // &event.compression_lamports,
-                // &event.pubkey_array,
-                // &event.message,
-            )
-            .unwrap();
+        event.man_serialize(&mut manual_serialized).unwrap();
 
         // Compare the two byte arrays
         assert_eq!(
@@ -251,21 +237,7 @@ pub mod test {
 
             let borsh_serialized = event.try_to_vec().unwrap();
             let mut manual_serialized = Vec::new();
-            event
-                .man_serialize(
-                    &mut manual_serialized,
-                    // &event.input_compressed_account_hashes,
-                    // &event.output_compressed_account_hashes,
-                    // &event.output_compressed_accounts,
-                    // &event.output_state_merkle_tree_account_indices,
-                    // &event.output_leaf_indices,
-                    // &event.relay_fee,
-                    // event.is_compress,
-                    // &event.compression_lamports,
-                    // &event.pubkey_array,
-                    // &event.message,
-                )
-                .unwrap();
+            event.man_serialize(&mut manual_serialized).unwrap();
 
             assert_eq!(
                 borsh_serialized, manual_serialized,

--- a/programs/compressed-pda/src/event.rs
+++ b/programs/compressed-pda/src/event.rs
@@ -3,7 +3,6 @@ use anchor_lang::{
     prelude::*,
     solana_program::{instruction::Instruction, program::invoke},
 };
-use light_macros::heap_neutral;
 use std::{io::Write, mem, str::FromStr};
 
 #[derive(Debug, Clone, AnchorSerialize, AnchorDeserialize, Default, PartialEq)]
@@ -83,9 +82,9 @@ impl PublicTransactionEvent {
             }
             None => writer.write_all(&[0]),
         }?;
-        // is compress
+
         writer.write_all(&[self.is_compress as u8])?;
-        // compression lamports
+
         match self.compression_lamports {
             Some(compression_lamports) => {
                 writer.write_all(&[1])?;
@@ -93,12 +92,12 @@ impl PublicTransactionEvent {
             }
             None => writer.write_all(&[0]),
         }?;
-        // pubkey array
+
         writer.write_all(&(self.pubkey_array.len() as u32).to_le_bytes())?;
         for pubkey in self.pubkey_array.iter() {
             writer.write_all(&pubkey.to_bytes())?;
         }
-        // message
+
         match &self.message {
             Some(message) => {
                 writer.write_all(&[1])?;
@@ -112,29 +111,6 @@ impl PublicTransactionEvent {
     }
 }
 
-// #[inline(never)]
-// pub fn invoke_indexer_transaction_event<T>(event: &T, noop_program: &AccountInfo) -> Result<()>
-// where
-//     T: AnchorSerialize + SizedEvent,
-// {
-//     if noop_program.key()
-//         != Pubkey::from_str("noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV").unwrap()
-//     {
-//         return err!(crate::ErrorCode::InvalidNoopPubkey);
-//     }
-//     let mut data = Vec::with_capacity(event.event_size());
-//     // TODO: add compression lamports
-//     event.man_serialize(&mut data)?;
-//     let instruction = Instruction {
-//         program_id: noop_program.key(),
-//         accounts: vec![],
-//         data,
-//     };
-//     invoke(&instruction, &[noop_program.to_account_info()])?;
-//     Ok(())
-// }
-
-#[heap_neutral]
 pub fn emit_state_transition_event<'a, 'b, 'c: 'info, 'info>(
     inputs: InstructionDataTransfer,
     ctx: &'a Context<'a, 'b, 'c, 'info, TransferInstruction<'info>>,

--- a/programs/compressed-pda/src/instructions.rs
+++ b/programs/compressed-pda/src/instructions.rs
@@ -132,6 +132,8 @@ pub fn process_execute_compressed_transaction<'a, 'b, 'c: 'info, 'info>(
     if !inputs.output_compressed_accounts.is_empty() {
         let mut i = 0;
         for _ in inputs.output_compressed_accounts.iter().step_by(ITER_SIZE) {
+            // safety buffer prior to heap pos
+            let _buffer = vec![0u8; 8];
             insert_output_compressed_accounts_into_state_merkle_tree::<ITER_SIZE>(
                 &inputs,
                 &ctx,

--- a/programs/compressed-pda/src/instructions.rs
+++ b/programs/compressed-pda/src/instructions.rs
@@ -132,8 +132,6 @@ pub fn process_execute_compressed_transaction<'a, 'b, 'c: 'info, 'info>(
     if !inputs.output_compressed_accounts.is_empty() {
         let mut i = 0;
         for _ in inputs.output_compressed_accounts.iter().step_by(ITER_SIZE) {
-            // safety buffer prior to heap pos
-            let _buffer = vec![0u8; 8];
             insert_output_compressed_accounts_into_state_merkle_tree::<ITER_SIZE>(
                 &inputs,
                 &ctx,

--- a/programs/compressed-pda/src/lib.rs
+++ b/programs/compressed-pda/src/lib.rs
@@ -121,13 +121,12 @@ pub mod light_compressed_pda {
     pub fn execute_compressed_transaction<'a, 'b, 'c: 'info, 'info>(
         ctx: Context<'a, 'b, 'c, 'info, TransferInstruction<'info>>,
         inputs: Vec<u8>,
-        cpi_context: Option<CompressedCpiContext>,
     ) -> Result<()> {
         // TODO: remove manual deserialization
         let inputs: InstructionDataTransfer =
             InstructionDataTransfer::deserialize(&mut inputs.as_slice())?;
         inputs.check_input_lengths()?;
-        process_execute_compressed_transaction(inputs, ctx, cpi_context)
+        process_execute_compressed_transaction(inputs, ctx)
     }
 
     // /// This function can be used to transfer sol and execute any other compressed transaction.

--- a/programs/compressed-pda/src/sdk.rs
+++ b/programs/compressed-pda/src/sdk.rs
@@ -138,16 +138,14 @@ pub fn create_execute_compressed_instruction(
         compression_lamports,
         is_compress,
         signer_seeds: None,
+        cpi_context: None,
     };
 
     let mut inputs = Vec::new();
 
     InstructionDataTransfer::serialize(&inputs_struct, &mut inputs).unwrap();
 
-    let instruction_data = crate::instruction::ExecuteCompressedTransaction {
-        inputs,
-        cpi_context: None,
-    };
+    let instruction_data = crate::instruction::ExecuteCompressedTransaction { inputs };
 
     let compressed_sol_pda = compression_lamports.map(|_| get_compressed_sol_pda());
 

--- a/programs/compressed-pda/src/verify_state.rs
+++ b/programs/compressed-pda/src/verify_state.rs
@@ -258,7 +258,8 @@ pub fn input_compressed_accounts_signer_check(
 /// Only program owned output accounts can hold data.
 /// Every output account that holds data has to be owned by the invoking_program.
 /// For every account that has data, the owner has to be the invoking_program.
-// #[heap_neutral] //TODO: investigate why owned becomes mint when heap_neutral is used
+#[inline(never)]
+#[heap_neutral]
 pub fn output_compressed_accounts_write_access_check(
     inputs: &InstructionDataTransfer,
     invoking_program_id: &Option<UncheckedAccount>,

--- a/programs/compressed-pda/tests/test.rs
+++ b/programs/compressed-pda/tests/test.rs
@@ -1230,40 +1230,45 @@ impl MockIndexer {
 
     /// Checks for every address in an output compressed account whether there is an input-compressed account with the same address
     /// If there is no input account with the same address, the address has been created in the transaction
-    pub fn get_created_addresses_from_events(event: &PublicTransactionEvent) -> Vec<[u8; 32]> {
-        // get all addresses from output compressed accounts
-        let output_compressed_account_addresses: Vec<[u8; 32]> = event
-            .output_compressed_accounts
-            .iter()
-            .map(|x| x.address.unwrap())
-            .collect();
-        // filter out addresses that are in input compressed accounts
-        output_compressed_account_addresses
-            .iter()
-            .filter(|address| {
-                !event.input_compressed_accounts.iter().any(|x| {
-                    x.compressed_account.address.is_some()
-                        && x.compressed_account.address.unwrap() == **address
-                })
-            })
-            .copied()
-            .collect()
-    }
+    // pub fn get_created_addresses_from_events(event: &PublicTransactionEvent) -> Vec<[u8; 32]> {
+    //     // get all addresses from output compressed accounts
+    //     let output_compressed_account_addresses: Vec<[u8; 32]> = event
+    //         .output_compressed_accounts
+    //         .iter()
+    //         .map(|x| x.address.unwrap())
+    //         .collect();
+    //     // filter out addresses that are in input compressed accounts
+    //     output_compressed_account_addresses
+    //         .iter()
+    //         .filter(|address| {
+    //             !event.input_compressed_accounts.iter().any(|x| {
+    //                 x.compressed_account.address.is_some()
+    //                     && x.compressed_account.address.unwrap() == **address
+    //             })
+    //         })
+    //         .copied()
+    //         .collect()
+    // }
 
     pub fn add_event_and_compressed_accounts(
         &mut self,
         event: PublicTransactionEvent,
     ) -> Vec<usize> {
-        for compressed_account in event.input_compressed_accounts.iter() {
+        for hash in event.input_compressed_account_hashes.iter() {
             let index = self
                 .compressed_accounts
                 .iter()
-                .position(|x| x.compressed_account == compressed_account.compressed_account)
+                .position(|x| {
+                    x.compressed_account
+                        .hash(&self.merkle_tree_pubkey, &x.leaf_index)
+                        .unwrap()
+                        == *hash
+                })
                 .expect("compressed_account not found");
+            let compressed_account = self.compressed_accounts.get(index).unwrap().clone();
             self.compressed_accounts.remove(index);
             // TODO: nullify compressed_account in Merkle tree, not implemented yet
-            self.nullified_compressed_accounts
-                .push(compressed_account.clone());
+            self.nullified_compressed_accounts.push(compressed_account);
         }
         let mut indices = Vec::with_capacity(event.output_compressed_accounts.len());
         for (i, compressed_account) in event.output_compressed_accounts.iter().enumerate() {

--- a/programs/compressed-pda/tests/test.rs
+++ b/programs/compressed-pda/tests/test.rs
@@ -1228,28 +1228,6 @@ impl MockIndexer {
         (non_inclusion_proof_inputs_json, address_root_indices)
     }
 
-    /// Checks for every address in an output compressed account whether there is an input-compressed account with the same address
-    /// If there is no input account with the same address, the address has been created in the transaction
-    // pub fn get_created_addresses_from_events(event: &PublicTransactionEvent) -> Vec<[u8; 32]> {
-    //     // get all addresses from output compressed accounts
-    //     let output_compressed_account_addresses: Vec<[u8; 32]> = event
-    //         .output_compressed_accounts
-    //         .iter()
-    //         .map(|x| x.address.unwrap())
-    //         .collect();
-    //     // filter out addresses that are in input compressed accounts
-    //     output_compressed_account_addresses
-    //         .iter()
-    //         .filter(|address| {
-    //             !event.input_compressed_accounts.iter().any(|x| {
-    //                 x.compressed_account.address.is_some()
-    //                     && x.compressed_account.address.unwrap() == **address
-    //             })
-    //         })
-    //         .copied()
-    //         .collect()
-    // }
-
     pub fn add_event_and_compressed_accounts(
         &mut self,
         event: PublicTransactionEvent,

--- a/programs/compressed-token/src/process_mint.rs
+++ b/programs/compressed-token/src/process_mint.rs
@@ -56,12 +56,14 @@ pub fn process_mint_to<'info>(
     {
         let inputs_len =
     // struct
-    mem::size_of::<InstructionDataTransfer>()
+    mem::size_of::<light_compressed_pda::InstructionDataTransfer>()
     // `output_compressed_accounts`
     + mem::size_of::<CompressedAccount>() * amounts.len()
     // `output_state_merkle_tree_account_indices`
-    + amounts.len()+ mem::size_of::<Option::<CompressedCpiContext>>();
+    + amounts.len()+ mem::size_of::<Option::<light_compressed_pda::CompressedCpiContext>>();
         let mut inputs = Vec::<u8>::with_capacity(inputs_len);
+        // safety buffer prior to heap pos
+        let buffer = vec![0u8; 8];
         // # SAFETY: the inputs vector needs to be allocated before this point.
         // All heap memory from this point on is freed prior to the cpi call.
         let pre_compressed_acounts_pos = light_heap::GLOBAL_ALLOCATOR.get_heap_pos();
@@ -171,7 +173,7 @@ pub fn cpi_execute_compressed_transaction_mint_to<'info>(
         }),
     };
 
-    InstructionDataTransfer::serialize(&inputs_struct, inputs)?;
+    light_compressed_pda::InstructionDataTransfer::serialize(&inputs_struct, inputs)?;
 
     light_heap::GLOBAL_ALLOCATOR.free_heap(pre_compressed_acounts_pos);
 

--- a/programs/compressed-token/src/process_transfer.rs
+++ b/programs/compressed-token/src/process_transfer.rs
@@ -12,7 +12,7 @@ use light_compressed_pda::{
     InstructionDataTransfer as LightCompressedPdaInstructionDataTransfer,
 };
 use light_hasher::{errors::HasherError, DataHasher, Hasher, Poseidon};
-use light_utils::hash_to_bn254_field_size_le;
+use light_utils::hash_to_bn254_field_size_be;
 
 /// Process a token transfer instruction
 ///
@@ -418,7 +418,7 @@ impl DataHasher for TokenData {
     fn hash(&self) -> std::result::Result<[u8; 32], HasherError> {
         let delegate = match self.delegate {
             Some(delegate) => {
-                hash_to_bn254_field_size_le(delegate.to_bytes().as_slice())
+                hash_to_bn254_field_size_be(delegate.to_bytes().as_slice())
                     .unwrap()
                     .0
             }
@@ -426,7 +426,7 @@ impl DataHasher for TokenData {
         };
         // let close_authority = match self.close_authority {
         //     Some(close_authority) => {
-        //         hash_to_bn254_field_size_le(close_authority.to_bytes().as_slice())
+        //         hash_to_bn254_field_size_be(close_authority.to_bytes().as_slice())
         //             .unwrap()
         //             .0
         //     }
@@ -440,10 +440,10 @@ impl DataHasher for TokenData {
 
         // TODO: optimize hashing scheme, to not hash rarely used values
         Poseidon::hashv(&[
-            &hash_to_bn254_field_size_le(self.mint.to_bytes().as_slice())
+            &hash_to_bn254_field_size_be(self.mint.to_bytes().as_slice())
                 .unwrap()
                 .0,
-            &hash_to_bn254_field_size_le(self.owner.to_bytes().as_slice())
+            &hash_to_bn254_field_size_be(self.owner.to_bytes().as_slice())
                 .unwrap()
                 .0,
             &self.amount.to_le_bytes(),

--- a/programs/compressed-token/tests/test.rs
+++ b/programs/compressed-token/tests/test.rs
@@ -168,102 +168,92 @@ async fn create_mint_helper(context: &mut ProgramTestContext, payer: &Keypair) -
     mint.pubkey()
 }
 
-async fn test_mint_to<const MINTS: usize>() {
+async fn test_mint_to<const MINTS: usize, const ITER: usize>() {
     let (mut context, env) = setup_test_programs_with_accounts(None).await;
     let payer = context.payer.insecure_clone();
     let payer_pubkey = payer.pubkey();
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
     let nullifier_queue_pubkey = env.nullifier_queue_pubkey;
-    let mock_indexer = MockIndexer::new(
+    let mut mock_indexer = MockIndexer::new(
         merkle_tree_pubkey,
         nullifier_queue_pubkey,
         payer.insecure_clone(),
-    );
-    let recipient_keypair = Keypair::new();
-    let mint = create_mint_helper(&mut context, &payer).await;
-    let amount = 10000u64;
-    let instruction = create_mint_to_instruction(
-        &payer_pubkey,
-        &payer_pubkey,
-        &mint,
-        &merkle_tree_pubkey,
-        vec![amount; MINTS],
-        vec![recipient_keypair.pubkey(); MINTS],
-    );
-    let old_merkle_tree_account =
-        AccountZeroCopy::<StateMerkleTreeAccount>::new(&mut context, env.merkle_tree_pubkey).await;
-    let old_merkle_tree = old_merkle_tree_account
-        .deserialized()
-        .copy_merkle_tree()
-        .unwrap();
-    let event = create_and_send_transaction_with_event(
-        &mut context,
-        &[instruction],
-        &payer_pubkey,
-        &[&payer],
-        Some(TransactionParams {
-            num_new_addresses: 0,
-            num_input_compressed_accounts: 0,
-            num_output_compressed_accounts: MINTS as u8,
-            compress: 0,
-            fee_config: FeeConfig::default(),
-        }),
-    )
-    .await
-    .unwrap()
-    .unwrap();
-
-    let mut mock_indexer = mock_indexer.await;
-    mock_indexer.add_compressed_accounts_with_token_data(event);
-    assert_mint_to::<MINTS>(
-        &mut context,
-        &mock_indexer,
-        &recipient_keypair,
-        mint,
-        amount,
-        &old_merkle_tree,
     )
     .await;
+
+    let recipient_keypair = Keypair::new();
+    let mint = create_mint_helper(&mut context, &payer).await;
+    for i in 0..ITER {
+        let amount = 10000u64;
+        let instruction = create_mint_to_instruction(
+            &payer_pubkey,
+            &payer_pubkey,
+            &mint,
+            &merkle_tree_pubkey,
+            vec![amount; MINTS],
+            vec![recipient_keypair.pubkey(); MINTS],
+        );
+        let old_merkle_tree_account =
+            AccountZeroCopy::<StateMerkleTreeAccount>::new(&mut context, env.merkle_tree_pubkey)
+                .await;
+        let old_merkle_tree = old_merkle_tree_account
+            .deserialized()
+            .copy_merkle_tree()
+            .unwrap();
+        let event = create_and_send_transaction_with_event(
+            &mut context,
+            &[instruction],
+            &payer_pubkey,
+            &[&payer],
+            Some(TransactionParams {
+                num_new_addresses: 0,
+                num_input_compressed_accounts: 0,
+                num_output_compressed_accounts: MINTS as u8,
+                compress: 0,
+                fee_config: FeeConfig::default(),
+            }),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        if i == 0 {
+            mock_indexer.add_compressed_accounts_with_token_data(event);
+            assert_mint_to::<MINTS>(
+                &mut context,
+                &mock_indexer,
+                &recipient_keypair,
+                mint,
+                amount,
+                &old_merkle_tree,
+            )
+            .await;
+        }
+    }
 }
 
 #[tokio::test]
 async fn test_mint_to_1() {
-    test_mint_to::<1>().await
+    test_mint_to::<1, 1>().await
 }
 
 #[tokio::test]
 async fn test_mint_to_5() {
-    test_mint_to::<5>().await
+    test_mint_to::<5, 1>().await
 }
 
 #[tokio::test]
 async fn test_mint_to_10() {
-    test_mint_to::<10>().await
-}
-
-#[tokio::test]
-async fn test_mint_to_15() {
-    test_mint_to::<10>().await
-}
-
-#[tokio::test]
-async fn test_mint_to_19() {
-    test_mint_to::<19>().await
+    test_mint_to::<10, 1>().await
 }
 
 #[tokio::test]
 async fn test_mint_to_20() {
-    test_mint_to::<20>().await
+    test_mint_to::<20, 1>().await
 }
 
 #[tokio::test]
 async fn test_mint_to_25() {
-    test_mint_to::<25>().await
-}
-
-#[tokio::test]
-async fn test_mint_to_30() {
-    test_mint_to::<30>().await
+    test_mint_to::<25, 1000>().await
 }
 
 #[tokio::test]

--- a/programs/compressed-token/tests/test.rs
+++ b/programs/compressed-token/tests/test.rs
@@ -233,28 +233,28 @@ async fn test_mint_to<const MINTS: usize, const ITER: usize>() {
 
 #[tokio::test]
 async fn test_mint_to_1() {
-    test_mint_to::<1, 1>().await
+    test_mint_to::<1, 10>().await
 }
 
-// #[tokio::test]
-// async fn test_mint_to_5() {
-//     test_mint_to::<5, 1>().await
-// }
+#[tokio::test]
+async fn test_mint_to_5() {
+    test_mint_to::<5, 10>().await
+}
 
-// #[tokio::test]
-// async fn test_mint_to_10() {
-//     test_mint_to::<10, 1>().await
-// }
+#[tokio::test]
+async fn test_mint_to_10() {
+    test_mint_to::<10, 10>().await
+}
 
-// #[tokio::test]
-// async fn test_mint_to_20() {
-//     test_mint_to::<20, 1>().await
-// }
+#[tokio::test]
+async fn test_mint_to_20() {
+    test_mint_to::<20, 10>().await
+}
 
-// #[tokio::test]
-// async fn test_mint_to_25() {
-//     test_mint_to::<25, 10>().await
-// }
+#[tokio::test]
+async fn test_mint_to_25() {
+    test_mint_to::<25, 10>().await
+}
 
 #[tokio::test]
 async fn test_transfer() {

--- a/programs/compressed-token/tests/test.rs
+++ b/programs/compressed-token/tests/test.rs
@@ -215,7 +215,7 @@ async fn test_mint_to<const MINTS: usize>() {
 
     let mut mock_indexer = mock_indexer.await;
     mock_indexer.add_compressed_accounts_with_token_data(event);
-    assert_mint_to(
+    assert_mint_to::<MINTS>(
         &mut context,
         &mock_indexer,
         &recipient_keypair,
@@ -313,7 +313,7 @@ async fn test_transfer() {
     .unwrap();
     let mut mock_indexer = mock_indexer.await;
     mock_indexer.add_compressed_accounts_with_token_data(event);
-    assert_mint_to(
+    assert_mint_to::<1>(
         &mut context,
         &mock_indexer,
         &recipient_keypair,
@@ -472,7 +472,7 @@ async fn test_decompression() {
     .unwrap();
     let mut mock_indexer = mock_indexer.await;
     mock_indexer.add_compressed_accounts_with_token_data(event);
-    assert_mint_to(
+    assert_mint_to::<1>(
         &mut context,
         &mock_indexer,
         &recipient_keypair,
@@ -683,7 +683,7 @@ async fn test_invalid_inputs() {
     .unwrap();
     let mut mock_indexer = mock_indexer.await;
     mock_indexer.add_compressed_accounts_with_token_data(event);
-    assert_mint_to(
+    assert_mint_to::<1>(
         &mut context,
         &mock_indexer,
         &recipient_keypair,
@@ -1073,7 +1073,7 @@ pub async fn create_token_account(
     Ok(())
 }
 
-async fn assert_mint_to<'a>(
+async fn assert_mint_to<'a, const MINT: usize>(
     context: &mut ProgramTestContext,
     mock_indexer: &MockIndexer,
     recipient_keypair: &Keypair,
@@ -1104,7 +1104,7 @@ async fn assert_mint_to<'a>(
         mock_indexer.merkle_tree.root(),
         "merkle tree root update failed"
     );
-    assert_eq!(merkle_tree.root_index(), 1);
+    assert_eq!(merkle_tree.root_index(), MINT);
     assert_ne!(
         old_merkle_tree.root().unwrap(),
         merkle_tree.root().unwrap(),
@@ -1120,7 +1120,7 @@ async fn assert_mint_to<'a>(
             .data,
     )
     .unwrap();
-    assert_eq!(mint_account.supply, amount);
+    assert_eq!(mint_account.supply, amount * MINT as u64);
 
     let pool = get_token_pool_pda(&mint);
     let pool_account = spl_token::state::Account::unpack(
@@ -1133,7 +1133,7 @@ async fn assert_mint_to<'a>(
             .data,
     )
     .unwrap();
-    assert_eq!(pool_account.amount, amount);
+    assert_eq!(pool_account.amount, amount * MINT as u64);
 }
 
 async fn assert_transfer<'a>(

--- a/programs/compressed-token/tests/test.rs
+++ b/programs/compressed-token/tests/test.rs
@@ -236,25 +236,25 @@ async fn test_mint_to_1() {
     test_mint_to::<1, 1>().await
 }
 
-#[tokio::test]
-async fn test_mint_to_5() {
-    test_mint_to::<5, 1>().await
-}
+// #[tokio::test]
+// async fn test_mint_to_5() {
+//     test_mint_to::<5, 1>().await
+// }
 
-#[tokio::test]
-async fn test_mint_to_10() {
-    test_mint_to::<10, 1>().await
-}
+// #[tokio::test]
+// async fn test_mint_to_10() {
+//     test_mint_to::<10, 1>().await
+// }
 
-#[tokio::test]
-async fn test_mint_to_20() {
-    test_mint_to::<20, 1>().await
-}
+// #[tokio::test]
+// async fn test_mint_to_20() {
+//     test_mint_to::<20, 1>().await
+// }
 
-#[tokio::test]
-async fn test_mint_to_25() {
-    test_mint_to::<25, 1000>().await
-}
+// #[tokio::test]
+// async fn test_mint_to_25() {
+//     test_mint_to::<25, 10>().await
+// }
 
 #[tokio::test]
 async fn test_transfer() {

--- a/programs/compressed-token/tests/test.rs
+++ b/programs/compressed-token/tests/test.rs
@@ -168,8 +168,7 @@ async fn create_mint_helper(context: &mut ProgramTestContext, payer: &Keypair) -
     mint.pubkey()
 }
 
-#[tokio::test]
-async fn test_mint_to() {
+async fn test_mint_to<const MINTS: usize>() {
     let (mut context, env) = setup_test_programs_with_accounts(None).await;
     let payer = context.payer.insecure_clone();
     let payer_pubkey = payer.pubkey();
@@ -188,8 +187,8 @@ async fn test_mint_to() {
         &payer_pubkey,
         &mint,
         &merkle_tree_pubkey,
-        vec![amount; 1],
-        vec![recipient_keypair.pubkey(); 1],
+        vec![amount; MINTS],
+        vec![recipient_keypair.pubkey(); MINTS],
     );
     let old_merkle_tree_account =
         AccountZeroCopy::<StateMerkleTreeAccount>::new(&mut context, env.merkle_tree_pubkey).await;
@@ -205,7 +204,7 @@ async fn test_mint_to() {
         Some(TransactionParams {
             num_new_addresses: 0,
             num_input_compressed_accounts: 0,
-            num_output_compressed_accounts: 1,
+            num_output_compressed_accounts: MINTS as u8,
             compress: 0,
             fee_config: FeeConfig::default(),
         }),
@@ -225,6 +224,46 @@ async fn test_mint_to() {
         &old_merkle_tree,
     )
     .await;
+}
+
+#[tokio::test]
+async fn test_mint_to_1() {
+    test_mint_to::<1>().await
+}
+
+#[tokio::test]
+async fn test_mint_to_5() {
+    test_mint_to::<5>().await
+}
+
+#[tokio::test]
+async fn test_mint_to_10() {
+    test_mint_to::<10>().await
+}
+
+#[tokio::test]
+async fn test_mint_to_15() {
+    test_mint_to::<10>().await
+}
+
+#[tokio::test]
+async fn test_mint_to_19() {
+    test_mint_to::<19>().await
+}
+
+#[tokio::test]
+async fn test_mint_to_20() {
+    test_mint_to::<20>().await
+}
+
+#[tokio::test]
+async fn test_mint_to_25() {
+    test_mint_to::<25>().await
+}
+
+#[tokio::test]
+async fn test_mint_to_30() {
+    test_mint_to::<30>().await
 }
 
 #[tokio::test]
@@ -1373,21 +1412,26 @@ impl MockIndexer {
         &mut self,
         event: PublicTransactionEvent,
     ) -> Vec<usize> {
-        for compressed_account in event.input_compressed_accounts.iter() {
+        for hash in event.input_compressed_account_hashes.iter() {
             let index = self
                 .compressed_accounts
                 .iter()
-                .position(|x| x.compressed_account == compressed_account.compressed_account)
+                .position(|x| {
+                    x.compressed_account
+                        .hash(&self.merkle_tree_pubkey, &x.leaf_index)
+                        .unwrap()
+                        == *hash
+                })
                 .expect("compressed_account not found");
+            let compressed_account = self.compressed_accounts.get(index).unwrap().clone();
             self.compressed_accounts.remove(index);
             // TODO: nullify compressed_account in Merkle tree, not implemented yet
-            self.nullified_compressed_accounts
-                .push(compressed_account.clone());
-            let index = self
-                .compressed_accounts
+            self.nullified_compressed_accounts.push(compressed_account);
+            let token_account_index = self
+                .token_compressed_accounts
                 .iter()
-                .position(|x| x == compressed_account);
-            if let Some(index) = index {
+                .position(|x| x.index == index);
+            if let Some(index) = token_account_index {
                 let token_compressed_account_element =
                     self.token_compressed_accounts[index].clone();
                 self.token_compressed_accounts.remove(index);

--- a/test-programs/program-owned-account-test/src/create_pda.rs
+++ b/test-programs/program-owned-account-test/src/create_pda.rs
@@ -206,7 +206,7 @@ pub struct RegisteredUser {
 impl light_hasher::DataHasher for RegisteredUser {
     fn hash(&self) -> std::result::Result<[u8; 32], HasherError> {
         let truncated_user_pubkey =
-            light_utils::hash_to_bn254_field_size_le(&self.user_pubkey.to_bytes())
+            light_utils::hash_to_bn254_field_size_be(&self.user_pubkey.to_bytes())
                 .unwrap()
                 .0;
 

--- a/test-programs/program-owned-account-test/src/create_pda.rs
+++ b/test-programs/program-owned-account-test/src/create_pda.rs
@@ -83,6 +83,7 @@ fn cpi_compressed_pda_transfer_as_non_program<'info>(
         compression_lamports: None,
         is_compress: false,
         signer_seeds: None,
+        cpi_context: Some(cpi_context),
     };
 
     let mut inputs = Vec::new();
@@ -108,7 +109,7 @@ fn cpi_compressed_pda_transfer_as_non_program<'info>(
 
     cpi_ctx.remaining_accounts = ctx.remaining_accounts.to_vec();
 
-    light_compressed_pda::cpi::execute_compressed_transaction(cpi_ctx, inputs, Some(cpi_context))?;
+    light_compressed_pda::cpi::execute_compressed_transaction(cpi_ctx, inputs)?;
     Ok(())
 }
 
@@ -134,6 +135,7 @@ fn cpi_compressed_pda_transfer_as_program<'info>(
         compression_lamports: None,
         is_compress: false,
         signer_seeds: Some(seeds.iter().map(|seed| seed.to_vec()).collect()),
+        cpi_context: Some(cpi_context),
     };
     // defining seeds again so that the cpi doesn't fail we want to test the check in the compressed pda program
     let seeds: [&[u8]; 2] = [b"cpi_signer".as_slice(), &[bump]];
@@ -164,7 +166,7 @@ fn cpi_compressed_pda_transfer_as_program<'info>(
 
     cpi_ctx.remaining_accounts = ctx.remaining_accounts.to_vec();
 
-    light_compressed_pda::cpi::execute_compressed_transaction(cpi_ctx, inputs, Some(cpi_context))?;
+    light_compressed_pda::cpi::execute_compressed_transaction(cpi_ctx, inputs)?;
     Ok(())
 }
 

--- a/test-programs/program-owned-account-test/src/invalidate_not_owned_account.rs
+++ b/test-programs/program-owned-account-test/src/invalidate_not_owned_account.rs
@@ -14,6 +14,10 @@ pub fn process_invalidate_not_owned_compressed_account<'info>(
     root_indices: Vec<u16>,
     bump: u8,
 ) -> Result<()> {
+    let cpi_context = CompressedCpiContext {
+        execute: true,
+        cpi_signature_account_index: (ctx.remaining_accounts.len() - 1) as u8,
+    };
     let seeds: [&[u8]; 2] = [b"cpi_signer".as_slice(), &[bump]];
     let inputs_struct = InstructionDataTransfer {
         relay_fee: None,
@@ -26,11 +30,9 @@ pub fn process_invalidate_not_owned_compressed_account<'info>(
         compression_lamports: None,
         is_compress: false,
         signer_seeds: Some(seeds.iter().map(|seed| seed.to_vec()).collect()),
+        cpi_context: Some(cpi_context),
     };
-    let cpi_context = CompressedCpiContext {
-        execute: true,
-        cpi_signature_account_index: (ctx.remaining_accounts.len() - 1) as u8,
-    };
+
     let mut inputs = Vec::new();
     InstructionDataTransfer::serialize(&inputs_struct, &mut inputs).unwrap();
 
@@ -57,7 +59,7 @@ pub fn process_invalidate_not_owned_compressed_account<'info>(
 
     cpi_ctx.remaining_accounts = ctx.remaining_accounts.to_vec();
 
-    light_compressed_pda::cpi::execute_compressed_transaction(cpi_ctx, inputs, Some(cpi_context))?;
+    light_compressed_pda::cpi::execute_compressed_transaction(cpi_ctx, inputs)?;
     Ok(())
 }
 

--- a/test-programs/program-owned-account-test/tests/test.rs
+++ b/test-programs/program-owned-account-test/tests/test.rs
@@ -10,7 +10,7 @@ use light_test_utils::test_indexer::{create_mint_helper, mint_tokens_helper, Tes
 use light_test_utils::{
     assert_custom_error_or_program_error, create_and_send_transaction_with_event,
 };
-use light_utils::hash_to_bn254_field_size_le;
+use light_utils::hash_to_bn254_field_size_be;
 use program_owned_account_test::sdk::{
     create_invalidate_not_owned_account_instruction, create_pda_instruction,
     CreateCompressedPdaInstructionInputs, InvalidateNotOwnedCompressedAccountInstructionInputs,
@@ -423,7 +423,7 @@ pub async fn assert_created_pda(
         1u64.to_le_bytes(),
     );
     let truncated_user_pubkey =
-        hash_to_bn254_field_size_le(&compressed_escrow_pda_data.user_pubkey.to_bytes())
+        hash_to_bn254_field_size_be(&compressed_escrow_pda_data.user_pubkey.to_bytes())
             .unwrap()
             .0;
     assert_eq!(

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -274,6 +274,11 @@ where
             println!("pre_balance: {}", pre_balance);
             println!("post_balance: {}", post_balance);
             println!("expected post_balance: {}", expected_post_balance);
+            println!(
+                "diff post_balance: {}",
+                post_balance as i64 - expected_post_balance
+            );
+            println!("tip: {}", tip);
             return Err(BanksClientError::TransactionError(
                 solana_sdk::transaction::TransactionError::InstructionError(
                     0,

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -267,7 +267,7 @@ where
                 * transaction_params.fee_config.state_merkle_tree_rollover as i64
             - transaction_params.compress
             - 5000
-            - tip;
+            - tip * (i64::from(transaction_params.num_output_compressed_accounts) / 14 + 1);
 
         if post_balance as i64 != expected_post_balance {
             println!("transaction_params: {:?}", transaction_params);


### PR DESCRIPTION
Motivation:
- heap memory constraints the number of pubkeys we can mint to in a single transaction
- this pr enables to mint to up to 25 pubkeys in a single transaction

Changes:
- added manual borsh compatible event serialization
  - borsh serialization takes too much heap memory
  - in manual serialization we can free heap memory during serialization
- removed  inputCompressedAccounts from PublicTransactionEvent
- active heap management:
  - process_mint_to  (compressed-token program)
    - initialize cpi input vector at the beginning, record memory position,  free memory after cpi input vector is written into
  - create_output_compressed_accounts  (compressed-token program)
    - initialize the output_compressed_accounts vector outside of the function
    - at the beginning of every loop init the memory for the token data
    - then record memory position and free memory at the end of the iteration
  - process_execute_compressed_transaction (compressed-pda program)
    - wrap insert_output_compressed_accounts_into_state_merkle_tree into a loop with max 14 compressed accounts at once
      (14 because a lot more blows up the heap, and we batch appends by 7 in the account compression program)
   - append_leaves (account-compression program)
     - fixed fee distribution
     - increased batch size to 7 again so that it fits better with compressed-pda program where I had a batch of 15 before