### PR TITLE
refactor: token transfer test

### DIFF
--- a/programs/account-compression/src/instructions/insert_into_nullifier_queue.rs
+++ b/programs/account-compression/src/instructions/insert_into_nullifier_queue.rs
@@ -63,10 +63,6 @@ pub fn process_insert_into_nullifier_queues<'a, 'b, 'c: 'info, 'info>(
     }
 
     for queue_bundle in queue_map.values() {
-        msg!(
-            "Inserting into indexed array {:?}",
-            queue_bundle.queue.key()
-        );
         let lamports: u64;
 
         let indexed_array = AccountLoader::<NullifierQueueAccount>::try_from(queue_bundle.queue)?;
@@ -96,7 +92,6 @@ pub fn process_insert_into_nullifier_queues<'a, 'b, 'c: 'info, 'info>(
                 unsafe { nullifier_queue_from_bytes_zero_copy_mut(&mut indexed_array).unwrap() };
 
             for element in queue_bundle.elements.iter() {
-                msg!("Inserting element {:?}", element);
                 let element = BigUint::from_bytes_be(element.as_slice());
                 indexed_array
                     .insert(&element, sequence_number)

--- a/programs/compressed-pda/src/nullify_state.rs
+++ b/programs/compressed-pda/src/nullify_state.rs
@@ -80,6 +80,5 @@ pub fn insert_nullifiers_cpi<'a, 'b>(
         .remaining_accounts
         .extend(nullifier_queue_account_infos);
     cpi_ctx.remaining_accounts.extend(merkle_tree_account_infos);
-    msg!("inserting nullifiers {:?}", nullifiers);
     account_compression::cpi::insert_into_nullifier_queues(cpi_ctx, nullifiers)
 }


### PR DESCRIPTION
Changes:
- refactored transfer test to test:
  - 1 in 1..11 outputs
  - 2 in 1..11 outputs
  - 3 in 1..11 outputs
  - 4 in 1..11 outputs
  - 8 in 1..8 outputs
- removed onchain prints