### PR TITLE
perf: cpda program switch to native cpi

### DIFF
--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/sdk.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/sdk.rs
@@ -1,7 +1,6 @@
 #![cfg(not(target_os = "solana"))]
 
 use crate::escrow_with_compressed_pda::escrow::PackedInputCompressedPda;
-use account_compression::NOOP_PROGRAM_ID;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use light_compressed_pda::{
     invoke::processor::CompressedProof,
@@ -93,7 +92,7 @@ pub fn create_escrow_instruction(
 
     let accounts = crate::accounts::EscrowCompressedTokensWithCompressedPda {
         signer: *input_params.signer,
-        noop_program: NOOP_PROGRAM_ID,
+        noop_program: Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
         compressed_token_program: light_compressed_token::ID,
         compressed_pda_program: light_compressed_pda::ID,
         account_compression_program: account_compression::ID,
@@ -210,7 +209,7 @@ pub fn create_withdrawal_instruction(
 
     let accounts = crate::accounts::EscrowCompressedTokensWithCompressedPda {
         signer: *input_params.signer,
-        noop_program: NOOP_PROGRAM_ID,
+        noop_program: Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
         compressed_token_program: light_compressed_token::ID,
         compressed_pda_program: light_compressed_pda::ID,
         account_compression_program: account_compression::ID,

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_pda/sdk.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_pda/sdk.rs
@@ -1,6 +1,5 @@
 #![cfg(not(target_os = "solana"))]
 
-use account_compression::NOOP_PROGRAM_ID;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use light_compressed_pda::{
     invoke::processor::CompressedProof, sdk::compressed_account::MerkleContext,
@@ -75,7 +74,7 @@ pub fn create_escrow_instruction(
         light_compressed_pda::utils::get_cpi_authority_pda(&light_compressed_pda::ID);
     let accounts = crate::accounts::EscrowCompressedTokensWithPda {
         signer: *input_params.signer,
-        noop_program: NOOP_PROGRAM_ID,
+        noop_program: Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
         compressed_token_program: light_compressed_token::ID,
         compressed_pda_program: light_compressed_pda::ID,
         account_compression_program: account_compression::ID,
@@ -140,7 +139,7 @@ pub fn create_withdrawal_escrow_instruction(
     let accounts = crate::accounts::EscrowCompressedTokensWithPda {
         signer: *input_params.signer,
         token_owner_pda: token_owner_pda.0,
-        noop_program: NOOP_PROGRAM_ID,
+        noop_program: Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
         compressed_token_program: light_compressed_token::ID,
         compressed_pda_program: light_compressed_pda::ID,
         account_compression_program: account_compression::ID,

--- a/js/stateless.js/src/idls/account_compression.ts
+++ b/js/stateless.js/src/idls/account_compression.ts
@@ -83,6 +83,13 @@ export type AccountCompression = {
             value: '2400';
         },
         {
+            name: 'NOOP_PUBKEY';
+            type: {
+                array: ['u8', 32];
+            };
+            value: '[11 , 188 , 15 , 192 , 187 , 71 , 202 , 47 , 116 , 196 , 17 , 46 , 148 , 171 , 19 , 207 , 163 , 198 , 52 , 229 , 220 , 23 , 234 , 203 , 3 , 205 , 26 , 35 , 205 , 126 , 120 , 124 ,]';
+        },
+        {
             name: 'PROGRAM_ID';
             type: 'string';
             value: '"5QPEJ5zDsVou9FQS3KCauKswM3VwBEBu4dpL9xTqkWwN"';
@@ -462,7 +469,7 @@ export type AccountCompression = {
                     name: 'leaves';
                     type: {
                         vec: {
-                            array: ['u8', 32];
+                            defined: '(u8,[u8;32])';
                         };
                     };
                 },
@@ -1266,6 +1273,13 @@ export const IDL: AccountCompression = {
             value: '2400',
         },
         {
+            name: 'NOOP_PUBKEY',
+            type: {
+                array: ['u8', 32],
+            },
+            value: '[11 , 188 , 15 , 192 , 187 , 71 , 202 , 47 , 116 , 196 , 17 , 46 , 148 , 171 , 19 , 207 , 163 , 198 , 52 , 229 , 220 , 23 , 234 , 203 , 3 , 205 , 26 , 35 , 205 , 126 , 120 , 124 ,]',
+        },
+        {
             name: 'PROGRAM_ID',
             type: 'string',
             value: '"5QPEJ5zDsVou9FQS3KCauKswM3VwBEBu4dpL9xTqkWwN"',
@@ -1645,7 +1659,7 @@ export const IDL: AccountCompression = {
                     name: 'leaves',
                     type: {
                         vec: {
-                            array: ['u8', 32],
+                            defined: '(u8,[u8;32])',
                         },
                     },
                 },

--- a/js/stateless.js/src/idls/light_compressed_pda.ts
+++ b/js/stateless.js/src/idls/light_compressed_pda.ts
@@ -826,6 +826,11 @@ export type LightCompressedPda = {
             name: 'ProofIsNone';
             msg: 'ProofIsNone';
         },
+        {
+            code: 6034;
+            name: 'InvalidMerkleTreeIndex';
+            msg: 'InvalidMerkleTreeIndex';
+        },
     ];
 };
 
@@ -1658,6 +1663,11 @@ export const IDL: LightCompressedPda = {
             code: 6033,
             name: 'ProofIsNone',
             msg: 'ProofIsNone',
+        },
+        {
+            code: 6034,
+            name: 'InvalidMerkleTreeIndex',
+            msg: 'InvalidMerkleTreeIndex',
         },
     ],
 };

--- a/programs/account-compression/src/instructions/append_leaves.rs
+++ b/programs/account-compression/src/instructions/append_leaves.rs
@@ -1,4 +1,4 @@
-use std::{cmp, collections::BTreeMap};
+use std::cmp;
 
 use anchor_lang::{prelude::*, solana_program::pubkey::Pubkey};
 use light_concurrent_merkle_tree::event::{ChangelogEvent, ChangelogEventV1, Changelogs, PathNode};
@@ -46,23 +46,6 @@ impl<'info> GroupAccounts<'info> for AppendLeaves<'info> {
     }
 }
 
-fn build_merkle_tree_map<'a, 'c: 'info, 'info>(
-    leaves: &'a [[u8; 32]],
-    remaining_accounts: &'c [AccountInfo<'info>],
-) -> BTreeMap<Pubkey, (&'c AccountInfo<'info>, Vec<&'a [u8; 32]>)> {
-    let mut merkle_tree_map = BTreeMap::new();
-
-    for (i, merkle_tree) in remaining_accounts.iter().enumerate() {
-        merkle_tree_map
-            .entry(merkle_tree.key())
-            .or_insert_with(|| (merkle_tree, Vec::new()))
-            .1
-            .push(&leaves[i]);
-    }
-
-    merkle_tree_map
-}
-
 /// for every leaf one Merkle tree account has to be passed as remaining account
 /// for every leaf could be inserted into a different Merkle tree account
 /// 1. deduplicate Merkle trees and identify into which tree to insert what leaf
@@ -70,19 +53,24 @@ fn build_merkle_tree_map<'a, 'c: 'info, 'info>(
 #[heap_neutral]
 pub fn process_append_leaves_to_merkle_trees<'a, 'b, 'c: 'info, 'info>(
     ctx: Context<'a, 'b, 'c, 'info, AppendLeaves<'info>>,
-    leaves: &'a [[u8; 32]],
+    leaves: &'a [(u8, [u8; 32])],
 ) -> Result<()> {
-    if leaves.len() != ctx.remaining_accounts.len() {
-        return err!(crate::errors::AccountCompressionErrorCode::NumberOfLeavesMismatch);
+    let mut fee_vec = Vec::<(u8, u64)>::with_capacity(leaves.len());
+    for i in 0..((leaves.len() / BATCH_SIZE) + 1) {
+        let leaves_start = i * BATCH_SIZE;
+        let leaves_to_process = cmp::min(leaves.len().saturating_sub(i * BATCH_SIZE), BATCH_SIZE);
+        let leaves_end = leaves_start + leaves_to_process;
+        process_batch(&ctx, &leaves[i * BATCH_SIZE..leaves_end], &mut fee_vec)?;
     }
 
-    let mut merkle_tree_map = build_merkle_tree_map(leaves, ctx.remaining_accounts);
-
-    let mut leaves_start = 0;
-    while !merkle_tree_map.is_empty() {
-        process_batch(&ctx, &mut leaves_start, &mut merkle_tree_map)?;
+    for (index, lamports) in fee_vec {
+        msg!("rollover fee lamports: {:?}", lamports);
+        transfer_lamports_cpi(
+            &ctx.accounts.fee_payer,
+            &ctx.remaining_accounts[index as usize].to_account_info(),
+            lamports,
+        )?;
     }
-
     Ok(())
 }
 
@@ -90,80 +78,98 @@ pub fn process_append_leaves_to_merkle_trees<'a, 'b, 'c: 'info, 'info>(
 #[inline(never)]
 fn process_batch<'a, 'c: 'info, 'info>(
     ctx: &Context<'a, '_, 'c, 'info, AppendLeaves<'info>>,
-    leaves_start: &mut usize,
-    merkle_tree_map: &mut BTreeMap<Pubkey, (&'c AccountInfo<'info>, Vec<&'a [u8; 32]>)>,
+    leaves: &'a [(u8, [u8; 32])],
+    fee_vec: &mut Vec<(u8, u64)>,
 ) -> Result<()> {
     let mut leaves_in_batch = 0;
+    let mut batch = Vec::with_capacity(BATCH_SIZE);
     let mut changelog_events = Vec::with_capacity(BATCH_SIZE);
-    // A vector of trees which become fully processed and should be removed
-    // from the `merkle_tree_map`.
-    let mut processed_merkle_trees = Vec::new();
+
     {
-        let mut merkle_tree_map_iter = merkle_tree_map.values();
-        let mut merkle_tree_map_pair = merkle_tree_map_iter.next();
+        // init with first Merkle tree account
+        // iterate over all leaves
+        // if leaf belongs to current Merkle tree account insert into batch
+        // if leaf does not belong to current Merkle tree account
+        // append batch to Merkle tree
+        // insert rollover fee into vector
+        // reset batch
+        // get next Merkle tree account
+        // append leaf of different Merkle tree account to batch
+        let mut current_mt_index = leaves[0].0 as usize;
+        let mut merkle_tree_acc_info = &ctx.remaining_accounts[current_mt_index];
+        let merkle_tree_account =
+            AccountLoader::<StateMerkleTreeAccount>::try_from(merkle_tree_acc_info).unwrap();
+        let mut merkle_tree_pubkey = merkle_tree_acc_info.key();
 
-        while let Some((merkle_tree_acc_info, leaves)) = merkle_tree_map_pair {
-            let leaves_to_process =
-                cmp::min(leaves.len() - *leaves_start, BATCH_SIZE - leaves_in_batch);
-            let leaves_end = *leaves_start + leaves_to_process;
+        for leaf in leaves.iter() {
+            if leaf.0 as usize == current_mt_index {
+                batch.push(&leaf.1);
+                leaves_in_batch += 1;
+            }
 
-            let rollover_fee;
-            let tip;
-            {
-                let merkle_tree =
-                    AccountLoader::<StateMerkleTreeAccount>::try_from(merkle_tree_acc_info)
-                        .unwrap();
-                let merkle_tree_pubkey = merkle_tree.key();
-                let mut merkle_tree = merkle_tree.load_mut()?;
-                rollover_fee = merkle_tree.rollover_fee;
-                tip = merkle_tree.tip;
-                check_registered_or_signer::<AppendLeaves, StateMerkleTreeAccount>(
-                    ctx,
-                    &merkle_tree,
-                )?;
-
+            if leaf.0 as usize != current_mt_index || leaves_in_batch == leaves.len() {
                 // Insert leaves to the Merkle tree.
-                let merkle_tree = merkle_tree.load_merkle_tree_mut()?;
-                let (first_changelog_index, first_sequence_number) = merkle_tree
-                    .append_batch(&leaves[*leaves_start..leaves_end])
-                    .map_err(ProgramError::from)?;
-
-                let mut paths = Vec::with_capacity(leaves_to_process);
-
-                // NOTE: It's tricky to factor our this code to a separate function
-                // without increasing the heap usage.
-                // If you feel brave enough to refactor it, don't break the test
-                // which appends 60 leaves!
-                for changelog_index in
-                    first_changelog_index..first_changelog_index + leaves_to_process
                 {
-                    let changelog_index = changelog_index % merkle_tree.changelog_capacity;
-                    let mut path = Vec::with_capacity(merkle_tree.height);
+                    let mut merkle_tree_account = merkle_tree_account.load_mut()?;
+                    let index = fee_vec.iter().position(|x| x.0 == current_mt_index as u8);
+                    match index {
+                        Some(i) => {
+                            fee_vec[i].1 +=
+                                merkle_tree_account.rollover_fee * leaves_in_batch as u64;
+                        }
+                        None => {
+                            fee_vec.push((
+                                current_mt_index as u8,
+                                merkle_tree_account.rollover_fee * leaves_in_batch as u64
+                                    + merkle_tree_account.tip,
+                            ));
+                        }
+                    }
+                    check_registered_or_signer::<AppendLeaves, StateMerkleTreeAccount>(
+                        ctx,
+                        &merkle_tree_account,
+                    )?;
+                    let merkle_tree = merkle_tree_account.load_merkle_tree_mut()?;
+                    let (first_changelog_index, first_sequence_number) = merkle_tree
+                        .append_batch(&batch)
+                        .map_err(ProgramError::from)?;
+                    let mut paths = Vec::with_capacity(leaves_in_batch);
 
-                    for (level, node) in merkle_tree.changelog[changelog_index]
-                        .path
-                        .iter()
-                        .enumerate()
+                    // NOTE: It's tricky to factor our this code to a separate function
+                    // without increasing the heap usage.
+                    // If you feel brave enough to refactor it, don't break the test
+                    // which appends 60 leaves!
+                    for changelog_index in
+                        first_changelog_index..first_changelog_index + leaves_in_batch
                     {
-                        let level = u32::try_from(level)
-                            .map_err(|_| AccountCompressionErrorCode::IntegerOverflow)?;
-                        let index = (1 << (merkle_tree.height as u32 - level))
-                            + (merkle_tree.changelog[changelog_index].index as u32 >> level);
-                        path.push(PathNode {
-                            node: node.to_owned(),
-                            index,
-                        });
+                        let changelog_index = changelog_index % merkle_tree.changelog_capacity;
+                        let mut path = Vec::with_capacity(merkle_tree.height);
+
+                        for (level, node) in merkle_tree.changelog[changelog_index]
+                            .path
+                            .iter()
+                            .enumerate()
+                        {
+                            let level = u32::try_from(level)
+                                .map_err(|_| AccountCompressionErrorCode::IntegerOverflow)?;
+                            let index = (1 << (merkle_tree.height as u32 - level))
+                                + (merkle_tree.changelog[changelog_index].index as u32 >> level);
+                            path.push(PathNode {
+                                node: node.to_owned(),
+                                index,
+                            });
+                        }
+
+                        paths.push(path);
                     }
 
-                    paths.push(path);
-                }
-
-                changelog_events.push(ChangelogEvent::V1(ChangelogEventV1 {
-                    id: merkle_tree_pubkey.to_bytes(),
-                    paths,
-                    seq: first_sequence_number as u64,
-                    index: merkle_tree.changelog[first_changelog_index].index as u32,
-                }));
+                    changelog_events.push(ChangelogEvent::V1(ChangelogEventV1 {
+                        id: merkle_tree_pubkey.to_bytes(),
+                        paths,
+                        seq: first_sequence_number as u64,
+                        index: merkle_tree.changelog[first_changelog_index].index as u32,
+                    }));
+                };
                 // NOTE: Making this to work would be the part of the potential
                 // refactor mentioned above.
                 //
@@ -176,38 +182,21 @@ fn process_batch<'a, 'c: 'info, 'info>(
                 //     )
                 //     .map_err(ProgramError::from)?;
                 // changelog_events.push(changelog_event);
-            }
-
-            let lamports = rollover_fee * leaves.len() as u64 + tip;
-            if lamports > 0 && leaves_end == leaves.len() {
-                msg!("transferring rollover fee: {}", lamports);
-                transfer_lamports_cpi(&ctx.accounts.fee_payer, merkle_tree_acc_info, lamports)?;
-            }
-
-            leaves_in_batch += leaves_to_process;
-            *leaves_start += leaves_to_process;
-
-            if *leaves_start == leaves.len() {
-                // We processed all the leaves from the current Merkle tree.
-                // Move to the next one.
-                *leaves_start = 0;
-                merkle_tree_map_pair = merkle_tree_map_iter.next();
-                processed_merkle_trees.push(merkle_tree_acc_info.key().to_owned());
-            }
-
-            if leaves_in_batch == BATCH_SIZE {
-                // We reached the batch limit.
-                break;
+                current_mt_index = leaf.0 as usize;
+                merkle_tree_acc_info = &ctx.remaining_accounts[current_mt_index];
+                merkle_tree_pubkey = merkle_tree_acc_info.key();
+                batch = Vec::with_capacity(BATCH_SIZE);
+                batch.push(&leaf.1);
+                leaves_in_batch += 1;
+                if leaves_in_batch == BATCH_SIZE {
+                    // We reached the batch limit.
+                    break;
+                }
             }
         }
+
+        emit_event(ctx, changelog_events)?;
     }
-
-    emit_event(ctx, changelog_events)?;
-
-    for processed_merkle_tree in processed_merkle_trees {
-        merkle_tree_map.remove(&processed_merkle_tree);
-    }
-
     Ok(())
 }
 

--- a/programs/account-compression/src/instructions/append_leaves.rs
+++ b/programs/account-compression/src/instructions/append_leaves.rs
@@ -56,7 +56,8 @@ pub fn process_append_leaves_to_merkle_trees<'a, 'b, 'c: 'info, 'info>(
     leaves: &'a [(u8, [u8; 32])],
 ) -> Result<()> {
     let mut fee_vec = Vec::<(u8, u64)>::with_capacity(leaves.len());
-    for i in 0..((leaves.len() / BATCH_SIZE) + 1) {
+    for i in 0..(leaves.len().div_ceil(BATCH_SIZE)) {
+        msg!("append batch i {:?}", i);
         let leaves_start = i * BATCH_SIZE;
         let leaves_to_process = cmp::min(leaves.len().saturating_sub(i * BATCH_SIZE), BATCH_SIZE);
         let leaves_end = leaves_start + leaves_to_process;

--- a/programs/account-compression/src/instructions/insert_into_nullifier_queue.rs
+++ b/programs/account-compression/src/instructions/insert_into_nullifier_queue.rs
@@ -97,6 +97,7 @@ pub fn process_insert_into_nullifier_queues<'a, 'b, 'c: 'info, 'info>(
             light_heap::bench_sbf_start!("acp: insert nf into queue");
             for element in queue_bundle.elements.iter() {
                 let element = BigUint::from_bytes_be(element.as_slice());
+                msg!("Inserting element {:?} into nullifier queue", element);
                 indexed_array
                     .insert(&element, sequence_number)
                     .map_err(ProgramError::from)?;

--- a/programs/account-compression/src/instructions/nullify_leaves.rs
+++ b/programs/account-compression/src/instructions/nullify_leaves.rs
@@ -172,6 +172,8 @@ pub mod sdk_nullify {
     use anchor_lang::{InstructionData, ToAccountMetas};
     use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
 
+    use crate::utils::constants::NOOP_PUBKEY;
+
     pub fn create_nullify_instruction(
         change_log_indices: &[u64],
         leaves_queue_indices: &[u16],
@@ -191,7 +193,7 @@ pub mod sdk_nullify {
         let accounts = crate::accounts::NullifyLeaves {
             authority: *payer,
             registered_program_pda: None,
-            log_wrapper: crate::state::change_log_event::NOOP_PROGRAM_ID,
+            log_wrapper: Pubkey::new_from_array(NOOP_PUBKEY),
             merkle_tree: *merkle_tree_pubkey,
             nullifier_queue: *nullifier_queue_pubkey,
         };

--- a/programs/account-compression/src/lib.rs
+++ b/programs/account-compression/src/lib.rs
@@ -136,7 +136,7 @@ pub mod account_compression {
 
     pub fn append_leaves_to_merkle_trees<'a, 'b, 'c: 'info, 'info>(
         ctx: Context<'a, 'b, 'c, 'info, AppendLeaves<'info>>,
-        leaves: Vec<[u8; 32]>,
+        leaves: Vec<(u8, [u8; 32])>,
     ) -> Result<()> {
         process_append_leaves_to_merkle_trees(ctx, &leaves)
     }

--- a/programs/account-compression/src/sdk.rs
+++ b/programs/account-compression/src/sdk.rs
@@ -41,7 +41,7 @@ pub fn create_initialize_merkle_tree_instruction(
 }
 
 pub fn create_insert_leaves_instruction(
-    leaves: Vec<[u8; 32]>,
+    leaves: Vec<(u8, [u8; 32])>,
     fee_payer: Pubkey,
     authority: Pubkey,
     merkle_tree_pubkeys: Vec<Pubkey>,

--- a/programs/account-compression/src/sdk.rs
+++ b/programs/account-compression/src/sdk.rs
@@ -52,7 +52,7 @@ pub fn create_insert_leaves_instruction(
         fee_payer,
         authority,
         registered_program_pda: None,
-        log_wrapper: crate::state::change_log_event::NOOP_PROGRAM_ID,
+        log_wrapper: Pubkey::new_from_array(crate::utils::constants::NOOP_PUBKEY),
         system_program: system_program::ID,
     };
     let merkle_tree_account_metas = merkle_tree_pubkeys

--- a/programs/account-compression/src/state/change_log_event.rs
+++ b/programs/account-compression/src/state/change_log_event.rs
@@ -2,11 +2,8 @@ use anchor_lang::{
     prelude::*,
     solana_program::{instruction::Instruction, program::invoke},
 };
-use light_macros::pubkey;
 
-use crate::errors::AccountCompressionErrorCode;
-
-pub const NOOP_PROGRAM_ID: Pubkey = pubkey!("noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV");
+use crate::{errors::AccountCompressionErrorCode, utils::constants::NOOP_PUBKEY};
 
 #[inline(never)]
 pub fn emit_indexer_event<'info>(
@@ -14,7 +11,7 @@ pub fn emit_indexer_event<'info>(
     noop_program: &AccountInfo<'info>,
     signer: &AccountInfo<'info>,
 ) -> Result<()> {
-    if noop_program.key() != NOOP_PROGRAM_ID {
+    if noop_program.key() != Pubkey::new_from_array(NOOP_PUBKEY) {
         return err!(AccountCompressionErrorCode::InvalidNoopPubkey);
     }
     let instruction = Instruction {

--- a/programs/account-compression/src/utils/constants.rs
+++ b/programs/account-compression/src/utils/constants.rs
@@ -37,3 +37,9 @@ pub const ADDRESS_QUEUE_INDICES: u16 = 6857;
 pub const ADDRESS_QUEUE_VALUES: u16 = 4800;
 #[constant]
 pub const ADDRESS_QUEUE_SEQUENCE_THRESHOLD: u64 = 2400;
+// noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV
+#[constant]
+pub const NOOP_PUBKEY: [u8; 32] = [
+    11, 188, 15, 192, 187, 71, 202, 47, 116, 196, 17, 46, 148, 171, 19, 207, 163, 198, 52, 229,
+    220, 23, 234, 203, 3, 205, 26, 35, 205, 126, 120, 124,
+];

--- a/programs/account-compression/tests/merkle_tree_tests.rs
+++ b/programs/account-compression/tests/merkle_tree_tests.rs
@@ -44,7 +44,7 @@ async fn test_init_and_rollover_state_merkle_tree() {
     program_test.add_program("account_compression", ID, None);
     program_test.add_program(
         "spl_noop",
-        account_compression::state::change_log_event::NOOP_PROGRAM_ID,
+        Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
         None,
     );
     let merkle_tree_keypair = Keypair::new();
@@ -582,7 +582,7 @@ async fn test_init_and_insert_leaves_into_merkle_tree() {
     program_test.add_program("account_compression", ID, None);
     program_test.add_program(
         "spl_noop",
-        account_compression::state::change_log_event::NOOP_PROGRAM_ID,
+        Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
         None,
     );
 
@@ -717,7 +717,7 @@ pub async fn fail_2_append_leaves_with_invalid_inputs(
         fee_payer: context.payer.pubkey(),
         authority: context.payer.pubkey(),
         registered_program_pda: None,
-        log_wrapper: account_compression::state::change_log_event::NOOP_PROGRAM_ID,
+        log_wrapper: Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
         system_program: system_program::ID,
     };
 
@@ -826,7 +826,7 @@ pub async fn fail_4_append_leaves_with_invalid_authority(
         fee_payer: context.payer.pubkey(),
         authority: invalid_autority.pubkey(),
         registered_program_pda: None,
-        log_wrapper: account_compression::state::change_log_event::NOOP_PROGRAM_ID,
+        log_wrapper: Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
         system_program: system_program::ID,
     };
 
@@ -863,7 +863,7 @@ async fn test_nullify_leaves() {
     program_test.add_program("account_compression", ID, None);
     program_test.add_program(
         "spl_noop",
-        account_compression::state::change_log_event::NOOP_PROGRAM_ID,
+        Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
         None,
     );
     let merkle_tree_keypair = Keypair::new();
@@ -1101,7 +1101,7 @@ async fn test_init_and_insert_into_nullifier_queue() {
     program_test.add_program("account_compression", ID, None);
     program_test.add_program(
         "spl_noop",
-        account_compression::state::change_log_event::NOOP_PROGRAM_ID,
+        Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
         None,
     );
     let merkle_tree_keypair = Keypair::new();

--- a/programs/compressed-pda/src/errors.rs
+++ b/programs/compressed-pda/src/errors.rs
@@ -70,4 +70,6 @@ pub enum CompressedPdaError {
     InvalidMerkleTreeOwner,
     #[msg("ProofIsNone")]
     ProofIsNone,
+    #[msg("InvalidMerkleTreeIndex")]
+    InvalidMerkleTreeIndex,
 }

--- a/programs/compressed-pda/src/invoke/append_state.rs
+++ b/programs/compressed-pda/src/invoke/append_state.rs
@@ -69,7 +69,7 @@ pub fn insert_output_compressed_accounts_into_state_merkle_tree<
     // -> Merkle tree index can only be equal or higher than the previous one.
     // if the index is higher add the account info to out_merkle_trees_account_infos.
     let initial_index = *global_iter;
-    let mut current_index = 0;
+    let mut current_index: u8 = 0;
     let end = if *global_iter + ITER_SIZE > inputs.output_state_merkle_tree_account_indices.len() {
         inputs.output_state_merkle_tree_account_indices.len()
     } else {
@@ -85,10 +85,10 @@ pub fn insert_output_compressed_accounts_into_state_merkle_tree<
     instruction_data.extend_from_slice(&(num_leaves as u32).to_le_bytes());
     if inputs.output_state_merkle_tree_account_indices[initial_index] == 0 {
         let account_info = ctx.remaining_accounts
-            [inputs.output_state_merkle_tree_account_indices[initial_index] as usize]
+            [inputs.output_state_merkle_tree_account_indices[current_index as usize] as usize]
             .to_account_info();
         mt_next_index = check_program_owner_state_merkle_tree(
-            &ctx.remaining_accounts[initial_index],
+            &ctx.remaining_accounts[current_index as usize],
             invoking_program,
         )?;
         accounts.push(AccountMeta {

--- a/programs/compressed-pda/src/invoke/emit_event.rs
+++ b/programs/compressed-pda/src/invoke/emit_event.rs
@@ -1,5 +1,4 @@
-use std::str::FromStr;
-
+use account_compression::utils::constants::NOOP_PUBKEY;
 use anchor_lang::{
     prelude::*,
     solana_program::{instruction::Instruction, program::invoke},
@@ -35,9 +34,7 @@ pub fn emit_state_transition_event<'a, 'b, 'c: 'info, 'info, A: InvokeAccounts<'
         is_compress: false,
     };
 
-    if ctx.accounts.get_noop_program().key()
-        != Pubkey::from_str("noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV").unwrap()
-    {
+    if ctx.accounts.get_noop_program().key() != Pubkey::new_from_array(NOOP_PUBKEY) {
         return err!(CompressedPdaError::InvalidNoopPubkey);
     }
     let mut data = Vec::with_capacity(event.event_size());

--- a/programs/compressed-pda/src/invoke_cpi/verify_signer.rs
+++ b/programs/compressed-pda/src/invoke_cpi/verify_signer.rs
@@ -135,10 +135,11 @@ pub fn output_compressed_accounts_write_access_check(
 pub fn check_program_owner_state_merkle_tree<'a, 'b: 'a>(
     merkle_tree_acc_info: &'b AccountInfo<'a>,
     invoking_program: &Option<Pubkey>,
-) -> Result<()> {
+) -> Result<u32> {
     let merkle_tree =
         AccountLoader::<StateMerkleTreeAccount>::try_from(merkle_tree_acc_info).unwrap();
     let merkle_tree_unpacked = merkle_tree.load()?;
+    let next_index = merkle_tree_unpacked.load_next_index()?.try_into().unwrap();
     // TODO: rename delegate to program_owner
     if merkle_tree_unpacked.delegate != Pubkey::default() {
         if let Some(invoking_program) = invoking_program {
@@ -148,12 +149,12 @@ pub fn check_program_owner_state_merkle_tree<'a, 'b: 'a>(
                     invoking_program,
                     merkle_tree_unpacked.delegate
                 );
-                return Ok(());
+                return Ok(next_index);
             }
         }
         return Err(CompressedPdaError::InvalidMerkleTreeOwner.into());
     }
-    Ok(())
+    Ok(next_index)
 }
 
 pub fn check_program_owner_address_merkle_tree<'a, 'b: 'a>(

--- a/programs/compressed-pda/src/sdk/invoke.rs
+++ b/programs/compressed-pda/src/sdk/invoke.rs
@@ -155,7 +155,7 @@ pub fn create_invoke_instruction(
         fee_payer: *fee_payer,
         authority: *payer,
         registered_program_pda: get_registered_program_pda(&crate::ID),
-        noop_program: account_compression::state::change_log_event::NOOP_PROGRAM_ID,
+        noop_program: Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
         account_compression_program: account_compression::ID,
         account_compression_authority: get_cpi_authority_pda(&crate::ID),
         compressed_sol_pda,
@@ -216,7 +216,7 @@ pub fn create_invoke_instruction(
 //     let accounts = crate::accounts::InvokeInstruction {
 //         signer: *payer,
 //         registered_program_pda: get_registered_program_pda(&crate::ID),
-//         noop_program: account_compression::state::change_log_event::NOOP_PROGRAM_ID,
+//         noop_program: Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
 //         account_compression_program: account_compression::ID,
 //         account_compression_authority: get_cpi_authority_pda(&crate::ID),
 //         cpi_context_account: None,

--- a/programs/compressed-pda/src/sdk/invoke.rs
+++ b/programs/compressed-pda/src/sdk/invoke.rs
@@ -154,7 +154,6 @@ pub fn create_invoke_instruction(
     let accounts = crate::accounts::InvokeInstruction {
         fee_payer: *fee_payer,
         authority: *payer,
-        // authority_pda: get_cpi_authority_pda(&crate::ID),
         registered_program_pda: get_registered_program_pda(&crate::ID),
         noop_program: account_compression::state::change_log_event::NOOP_PROGRAM_ID,
         account_compression_program: account_compression::ID,

--- a/programs/compressed-token/src/process_mint.rs
+++ b/programs/compressed-token/src/process_mint.rs
@@ -296,7 +296,6 @@ pub fn get_token_pool_pda(mint: &Pubkey) -> Pubkey {
 
 #[cfg(not(target_os = "solana"))]
 pub mod mint_sdk {
-    use account_compression::NOOP_PROGRAM_ID;
     use anchor_lang::{system_program, InstructionData, ToAccountMetas};
     use anchor_spl;
     use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
@@ -356,7 +355,9 @@ pub mod mint_sdk {
             registered_program_pda: light_compressed_pda::utils::get_registered_program_pda(
                 &light_compressed_pda::ID,
             ),
-            noop_program: NOOP_PROGRAM_ID,
+            noop_program: Pubkey::new_from_array(
+                account_compression::utils::constants::NOOP_PUBKEY,
+            ),
             account_compression_authority: light_compressed_pda::utils::get_cpi_authority_pda(
                 &light_compressed_pda::ID,
             ),

--- a/programs/compressed-token/src/process_transfer.rs
+++ b/programs/compressed-token/src/process_transfer.rs
@@ -471,7 +471,6 @@ pub fn get_cpi_authority_pda() -> (Pubkey, u8) {
 pub mod transfer_sdk {
     use std::collections::HashMap;
 
-    use account_compression::NOOP_PROGRAM_ID;
     use anchor_lang::{AnchorSerialize, Id, InstructionData, ToAccountMetas};
     use anchor_spl::token::Token;
     use light_compressed_pda::{
@@ -538,7 +537,9 @@ pub mod transfer_sdk {
             registered_program_pda: light_compressed_pda::utils::get_registered_program_pda(
                 &light_compressed_pda::ID,
             ),
-            noop_program: NOOP_PROGRAM_ID,
+            noop_program: Pubkey::new_from_array(
+                account_compression::utils::constants::NOOP_PUBKEY,
+            ),
             account_compression_authority: light_compressed_pda::utils::get_cpi_authority_pda(
                 &light_compressed_pda::ID,
             ),

--- a/test-programs/program-owned-account-test/src/sdk.rs
+++ b/test-programs/program-owned-account-test/src/sdk.rs
@@ -2,7 +2,6 @@
 
 use std::collections::HashMap;
 
-use account_compression::NOOP_PROGRAM_ID;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use light_compressed_pda::{
     invoke::processor::CompressedProof, sdk::address::pack_new_address_params,
@@ -57,7 +56,7 @@ pub fn create_pda_instruction(input_params: CreateCompressedPdaInstructionInputs
 
     let accounts = crate::accounts::CreateCompressedPda {
         signer: *input_params.signer,
-        noop_program: NOOP_PROGRAM_ID,
+        noop_program: Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
         compressed_pda_program: light_compressed_pda::ID,
         account_compression_program: account_compression::ID,
         registered_program_pda,
@@ -111,7 +110,7 @@ pub fn create_invalidate_not_owned_account_instruction(
 
     let accounts = crate::accounts::InvalidateNotOwnedCompressedAccount {
         signer: *input_params.signer,
-        noop_program: NOOP_PROGRAM_ID,
+        noop_program: Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
         compressed_pda_program: light_compressed_pda::ID,
         account_compression_program: account_compression::ID,
         registered_program_pda,


### PR DESCRIPTION
Changes:
- removed NOOP from str calls
- removed HashMap in append_state.rs
  - this forced me to refactor append_leaves as well
  - switched append state to rust native cpi
- switched nullify state to rust native cpi
  - didn't refactor the hashmap on the nullifier queue side here because it didn't seem worth it
  - but can get back to that in case that we still have time pre audit
-  hardcoded bumpseed for native cpis