### PR TITLE
refactor: Rollover fee computing and assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7579,6 +7579,7 @@ dependencies = [
  "light-utils",
  "quote",
  "sha2 0.10.8",
+ "solana-program",
  "tabled",
 ]
 

--- a/programs/account-compression/src/processor/initialize_concurrent_merkle_tree.rs
+++ b/programs/account-compression/src/processor/initialize_concurrent_merkle_tree.rs
@@ -1,9 +1,7 @@
 use anchor_lang::prelude::*;
+use light_utils::fee::compute_rollover_fee;
 
-use crate::{
-    errors::AccountCompressionErrorCode, initialize_address_merkle_tree::compute_rollover_fee,
-    state::StateMerkleTreeAccount,
-};
+use crate::{errors::AccountCompressionErrorCode, state::StateMerkleTreeAccount};
 
 #[derive(Accounts)]
 pub struct InitializeStateMerkleTree<'info> {
@@ -38,10 +36,9 @@ pub fn process_initialize_state_merkle_tree(
     merkle_tree.delegate = delegate.unwrap_or_default();
     merkle_tree.associated_queue = associated_queue;
     merkle_tree.tip = tip;
-    let total_number_of_leaves = 2u64.pow(*height);
     merkle_tree.rollover_fee = match rollover_threshold {
         Some(rollover_threshold) => {
-            compute_rollover_fee(rollover_threshold, total_number_of_leaves, rent)?
+            compute_rollover_fee(rollover_threshold, *height, rent).map_err(ProgramError::from)?
         }
         None => 0,
     };

--- a/programs/account-compression/src/processor/initialize_nullifier_queue.rs
+++ b/programs/account-compression/src/processor/initialize_nullifier_queue.rs
@@ -3,8 +3,8 @@ use std::{cell::RefMut, mem};
 use aligned_sized::aligned_sized;
 use anchor_lang::{prelude::*, solana_program::pubkey::Pubkey};
 use light_hash_set::{zero_copy::HashSetZeroCopy, HashSet};
+use light_utils::fee::compute_rollover_fee;
 
-use crate::initialize_address_merkle_tree::compute_rollover_fee;
 use crate::InsertIntoNullifierQueues;
 use crate::{
     utils::check_registered_or_signer::{GroupAccess, GroupAccounts},
@@ -34,9 +34,9 @@ pub fn process_initialize_nullifier_queue<'a, 'b, 'c: 'info, 'info>(
         nullifier_queue_account.rolledover_slot = u64::MAX;
         nullifier_queue_account.tip = tip;
         let queue_rent = nullifier_queue_account_info.lamports();
-        let total_number_of_leaves = 2u64.pow(height);
         let rollover_fee = if let Some(rollover_threshold) = rollover_threshold {
-            compute_rollover_fee(rollover_threshold, total_number_of_leaves, queue_rent)?
+            compute_rollover_fee(rollover_threshold, height, queue_rent)
+                .map_err(ProgramError::from)?
         } else {
             0
         };

--- a/utils/src/fee.rs
+++ b/utils/src/fee.rs
@@ -1,0 +1,35 @@
+use crate::UtilsError;
+
+pub fn compute_rollover_fee(
+    rollover_threshold: u64,
+    tree_height: u32,
+    rent: u64,
+) -> Result<u64, UtilsError> {
+    let number_of_transactions = 1 << tree_height;
+    if rollover_threshold > 100 {
+        return Err(UtilsError::InvalidRolloverThreshold);
+    }
+    // rent / (total_number_of_leaves * (rollover_threshold / 100))
+    // (with ceil division)
+    Ok((rent * 100).div_ceil(number_of_transactions * rollover_threshold))
+}
+
+#[test]
+fn test_compute_rollover_fee() {
+    let rollover_threshold = 100;
+    let tree_height = 26;
+    let rent = 1392890880;
+    let total_number_of_leaves = 1 << tree_height;
+
+    let fee = compute_rollover_fee(rollover_threshold, tree_height, rent).unwrap();
+    // assert_ne!(fee, 0u64);
+    assert!((fee + 1) * (total_number_of_leaves * 100 / rollover_threshold) > rent);
+
+    let rollover_threshold = 50;
+    let fee = compute_rollover_fee(rollover_threshold, tree_height, rent).unwrap();
+    assert!((fee + 1) * (total_number_of_leaves * 100 / rollover_threshold) > rent);
+    let rollover_threshold: u64 = 95;
+
+    let fee = compute_rollover_fee(rollover_threshold, tree_height, rent).unwrap();
+    assert!((fee + 1) * (total_number_of_leaves * 100 / rollover_threshold) > rent);
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -5,12 +5,15 @@ use std::{
     thread::spawn,
 };
 
+use ark_ff::PrimeField;
 use num_bigint::BigUint;
+
+use solana_program::keccak::hashv;
 use thiserror::Error;
 
 pub mod bigint;
-use ark_ff::PrimeField;
-use solana_program::keccak::hashv;
+pub mod fee;
+
 const CHUNK_SIZE: usize = 32;
 
 #[derive(Debug, Error)]
@@ -21,6 +24,8 @@ pub enum UtilsError {
     InvalidChunkSize,
     #[error("Invalid seeds")]
     InvalidSeeds,
+    #[error("Invalid rollover thresold")]
+    InvalidRolloverThreshold,
 }
 
 // NOTE(vadorovsky): Unfortunately, we need to do it by hand. `num_derive::ToPrimitive`
@@ -31,6 +36,7 @@ impl From<UtilsError> for u32 {
             UtilsError::InputTooLarge(_) => 9001,
             UtilsError::InvalidChunkSize => 9002,
             UtilsError::InvalidSeeds => 9003,
+            UtilsError::InvalidRolloverThreshold => 9004,
         }
     }
 }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,4 +16,5 @@ light-indexed-merkle-tree = { path = "../merkle-tree/indexed", version = "0.1.0"
 light-utils = { path = "../utils", version = "0.1.0" }
 quote = "1.0"
 sha2 = "0.10"
+solana-program = "1.18.11"
 tabled = "0.15"

--- a/xtask/src/fee.rs
+++ b/xtask/src/fee.rs
@@ -1,0 +1,67 @@
+use std::mem;
+
+use account_compression::{
+    initialize_nullifier_queue::NullifierQueueAccount,
+    utils::constants::{
+        ADDRESS_MERKLE_TREE_HEIGHT, ADDRESS_QUEUE_INDICES, ADDRESS_QUEUE_VALUES,
+        STATE_MERKLE_TREE_HEIGHT, STATE_NULLIFIER_QUEUE_INDICES, STATE_NULLIFIER_QUEUE_VALUES,
+    },
+    AddressMerkleTreeAccount, AddressQueueAccount, StateMerkleTreeAccount, StateMerkleTreeConfig,
+};
+use light_utils::fee::compute_rollover_fee;
+use solana_program::rent::Rent;
+use tabled::{Table, Tabled};
+
+#[derive(Tabled)]
+struct AccountFee {
+    account: String,
+    fee: u64,
+}
+
+pub fn fees() -> anyhow::Result<()> {
+    let rent = Rent::default();
+
+    let state_merkle_tree_config = StateMerkleTreeConfig::default();
+
+    let fees = vec![
+        AccountFee {
+            account: "State Merkle tree (rollover)".to_owned(),
+            fee: compute_rollover_fee(
+                state_merkle_tree_config.rollover_threshold.unwrap(),
+                STATE_MERKLE_TREE_HEIGHT as u32,
+                rent.minimum_balance(8 + mem::size_of::<StateMerkleTreeAccount>()),
+            )?,
+        },
+        AccountFee {
+            account: "Nullifier queue (rollover)".to_owned(),
+            fee: compute_rollover_fee(
+                state_merkle_tree_config.rollover_threshold.unwrap(),
+                STATE_MERKLE_TREE_HEIGHT as u32,
+                rent.minimum_balance(NullifierQueueAccount::size(
+                    STATE_NULLIFIER_QUEUE_INDICES as usize,
+                    STATE_NULLIFIER_QUEUE_VALUES as usize,
+                )?),
+            )?,
+        },
+        AccountFee {
+            account: "Address queue (rollover)".to_owned(),
+            fee: compute_rollover_fee(
+                state_merkle_tree_config.rollover_threshold.unwrap(),
+                ADDRESS_MERKLE_TREE_HEIGHT as u32,
+                rent.minimum_balance(8 + mem::size_of::<AddressMerkleTreeAccount>()),
+            )? + compute_rollover_fee(
+                state_merkle_tree_config.rollover_threshold.unwrap(),
+                ADDRESS_MERKLE_TREE_HEIGHT as u32,
+                rent.minimum_balance(AddressQueueAccount::size(
+                    ADDRESS_QUEUE_INDICES.into(),
+                    ADDRESS_QUEUE_VALUES.into(),
+                )?),
+            )?,
+        },
+    ];
+
+    let table = Table::new(fees);
+    println!("{table}");
+
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, ValueEnum};
 
 mod bench;
 mod create_vkeyrs_from_gnark_key;
+mod fee;
 mod type_sizes;
 mod zero_bytes;
 mod zero_indexed_leaf;
@@ -32,6 +33,8 @@ enum Command {
     GenerateVkeyRs(create_vkeyrs_from_gnark_key::Options),
     /// Generates cu and heap memory usage report from a log.txt file
     Bench(bench::Options),
+    /// Prints fees for different accounts.
+    Fee,
 }
 
 fn main() -> Result<(), anyhow::Error> {
@@ -47,5 +50,6 @@ fn main() -> Result<(), anyhow::Error> {
             create_vkeyrs_from_gnark_key::create_vkeyrs_from_gnark_key(opts)
         }
         Command::Bench(opts) => bench::bench(opts),
+        Command::Fee => fee::fees(),
     }
 }


### PR DESCRIPTION
* Move `compute_rollover_fee` to `light-utils` crate, so it can be imported anywhere without cyclic dependencies.
* Take `height` instead of `number_of_leaves` as an argument. The pattern for number of leaves is always the same (`1 << height`), so doing it inside `compute_rollover_fee` makes sense.
* Add `cargo xtask fee` subcommand instead of unit test. Calculate the rent for different accounts on demand instead of hard coding.
* Avoid hard coding fees and rent in unit tests.