### PR TITLE
refactor: Use a regular `Vec` inside `BoundedVec`, add more tests

### DIFF
--- a/js/stateless.js/src/idls/account_compression.ts
+++ b/js/stateless.js/src/idls/account_compression.ts
@@ -785,7 +785,7 @@ export type AccountCompression = {
                     {
                         name: 'merkleTreeStruct';
                         type: {
-                            array: ['u8', 320];
+                            array: ['u8', 280];
                         };
                     },
                     {
@@ -893,7 +893,7 @@ export type AccountCompression = {
                         name: 'stateMerkleTreeStruct';
                         docs: ['Merkle tree for the transaction state.'];
                         type: {
-                            array: ['u8', 272];
+                            array: ['u8', 240];
                         };
                     },
                     {
@@ -1045,6 +1045,15 @@ export type AccountCompression = {
                 kind: 'alias';
                 value: {
                     defined: 'NullifierQueueConfig';
+                };
+            };
+        },
+        {
+            name: 'StateMerkleTree';
+            type: {
+                kind: 'alias';
+                value: {
+                    defined: 'ConcurrentMerkleTree26<Poseidon>';
                 };
             };
         },
@@ -1975,7 +1984,7 @@ export const IDL: AccountCompression = {
                     {
                         name: 'merkleTreeStruct',
                         type: {
-                            array: ['u8', 320],
+                            array: ['u8', 280],
                         },
                     },
                     {
@@ -2083,7 +2092,7 @@ export const IDL: AccountCompression = {
                         name: 'stateMerkleTreeStruct',
                         docs: ['Merkle tree for the transaction state.'],
                         type: {
-                            array: ['u8', 272],
+                            array: ['u8', 240],
                         },
                     },
                     {
@@ -2235,6 +2244,15 @@ export const IDL: AccountCompression = {
                 kind: 'alias',
                 value: {
                     defined: 'NullifierQueueConfig',
+                },
+            },
+        },
+        {
+            name: 'StateMerkleTree',
+            type: {
+                kind: 'alias',
+                value: {
+                    defined: 'ConcurrentMerkleTree26<Poseidon>',
                 },
             },
         },

--- a/merkle-tree/concurrent/src/changelog.rs
+++ b/merkle-tree/concurrent/src/changelog.rs
@@ -1,4 +1,4 @@
-use light_bounded_vec::{BoundedVec, Pod};
+use light_bounded_vec::BoundedVec;
 
 use crate::errors::ConcurrentMerkleTreeError;
 
@@ -17,8 +17,6 @@ pub type ChangelogEntry22 = ChangelogEntry<22>;
 pub type ChangelogEntry26 = ChangelogEntry<26>;
 pub type ChangelogEntry32 = ChangelogEntry<32>;
 pub type ChangelogEntry40 = ChangelogEntry<40>;
-
-unsafe impl<const HEIGHT: usize> Pod for ChangelogEntry<HEIGHT> {}
 
 impl<const HEIGHT: usize> ChangelogEntry<HEIGHT> {
     pub fn new(root: [u8; 32], path: [[u8; 32]; HEIGHT], index: usize) -> Self {

--- a/merkle-tree/concurrent/src/lib.rs
+++ b/merkle-tree/concurrent/src/lib.rs
@@ -32,7 +32,7 @@ use crate::{
 // const generic here is that removing it would require keeping a `BoundecVec`
 // inside `CyclicBoundedVec`. Casting byte slices to such nested vector is not
 // a trivial task, but we might eventually do it at some point.
-pub struct ConcurrentMerkleTree<'a, H, const HEIGHT: usize>
+pub struct ConcurrentMerkleTree<H, const HEIGHT: usize>
 where
     H: Hasher,
 {
@@ -53,23 +53,23 @@ where
     pub rightmost_leaf: [u8; 32],
 
     /// Hashes of subtrees.
-    pub filled_subtrees: BoundedVec<'a, [u8; 32]>,
+    pub filled_subtrees: BoundedVec<[u8; 32]>,
     /// History of Merkle proofs.
-    pub changelog: CyclicBoundedVec<'a, ChangelogEntry<HEIGHT>>,
+    pub changelog: CyclicBoundedVec<ChangelogEntry<HEIGHT>>,
     /// History of roots.
-    pub roots: CyclicBoundedVec<'a, [u8; 32]>,
+    pub roots: CyclicBoundedVec<[u8; 32]>,
     /// Cached upper nodes.
-    pub canopy: BoundedVec<'a, [u8; 32]>,
+    pub canopy: BoundedVec<[u8; 32]>,
 
     pub _hasher: PhantomData<H>,
 }
 
-pub type ConcurrentMerkleTree22<'a, H> = ConcurrentMerkleTree<'a, H, 22>;
-pub type ConcurrentMerkleTree26<'a, H> = ConcurrentMerkleTree<'a, H, 26>;
-pub type ConcurrentMerkleTree32<'a, H> = ConcurrentMerkleTree<'a, H, 32>;
-pub type ConcurrentMerkleTree40<'a, H> = ConcurrentMerkleTree<'a, H, 40>;
+pub type ConcurrentMerkleTree22<H> = ConcurrentMerkleTree<H, 22>;
+pub type ConcurrentMerkleTree26<H> = ConcurrentMerkleTree<H, 26>;
+pub type ConcurrentMerkleTree32<H> = ConcurrentMerkleTree<H, 32>;
+pub type ConcurrentMerkleTree40<H> = ConcurrentMerkleTree<H, 40>;
 
-impl<'a, H, const HEIGHT: usize> ConcurrentMerkleTree<'a, H, HEIGHT>
+impl<'a, H, const HEIGHT: usize> ConcurrentMerkleTree<H, HEIGHT>
 where
     H: Hasher,
 {

--- a/merkle-tree/concurrent/tests/tests.rs
+++ b/merkle-tree/concurrent/tests/tests.rs
@@ -1117,7 +1117,7 @@ where
     }
 
     let merkle_tree = unsafe {
-        ConcurrentMerkleTree::<H, HEIGHT>::from_bytes(
+        ConcurrentMerkleTree::<H, HEIGHT>::copy_from_bytes(
             bytes_struct.as_slice(),
             bytes_filled_subtrees.as_slice(),
             bytes_changelog.as_slice(),

--- a/merkle-tree/indexed/src/copy.rs
+++ b/merkle-tree/indexed/src/copy.rs
@@ -1,6 +1,6 @@
 use std::{marker::PhantomData, mem, slice};
 
-use light_bounded_vec::{BoundedVec, CyclicBoundedVec, Pod};
+use light_bounded_vec::{BoundedVec, CyclicBoundedVec};
 use light_concurrent_merkle_tree::{
     changelog::ChangelogEntry, errors::ConcurrentMerkleTreeError, ConcurrentMerkleTree,
 };
@@ -10,39 +10,21 @@ use num_traits::{CheckedAdd, CheckedSub, ToBytes, Unsigned};
 use crate::{errors::IndexedMerkleTreeError, IndexedMerkleTree, RawIndexedElement};
 
 #[derive(Debug)]
-pub struct IndexedMerkleTreeCopy<'a, H, I, const HEIGHT: usize>(
-    pub IndexedMerkleTree<'a, H, I, HEIGHT>,
-)
+pub struct IndexedMerkleTreeCopy<H, I, const HEIGHT: usize>(pub IndexedMerkleTree<H, I, HEIGHT>)
 where
     H: Hasher,
-    I: CheckedAdd
-        + CheckedSub
-        + Copy
-        + Clone
-        + PartialOrd
-        + ToBytes
-        + TryFrom<usize>
-        + Unsigned
-        + Pod,
+    I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
     usize: From<I>;
 
-pub type IndexedMerkleTreeCopy22<'a, H, I> = IndexedMerkleTreeCopy<'a, H, I, 22>;
-pub type IndexedMerkleTreeCopy26<'a, H, I> = IndexedMerkleTreeCopy<'a, H, I, 26>;
-pub type IndexedMerkleTreeCopy32<'a, H, I> = IndexedMerkleTreeCopy<'a, H, I, 32>;
-pub type IndexedMerkleTreeCopy40<'a, H, I> = IndexedMerkleTreeCopy<'a, H, I, 40>;
+pub type IndexedMerkleTreeCopy22<H, I> = IndexedMerkleTreeCopy<H, I, 22>;
+pub type IndexedMerkleTreeCopy26<H, I> = IndexedMerkleTreeCopy<H, I, 26>;
+pub type IndexedMerkleTreeCopy32<H, I> = IndexedMerkleTreeCopy<H, I, 32>;
+pub type IndexedMerkleTreeCopy40<H, I> = IndexedMerkleTreeCopy<H, I, 40>;
 
-impl<'a, H, I, const HEIGHT: usize> IndexedMerkleTreeCopy<'a, H, I, HEIGHT>
+impl<H, I, const HEIGHT: usize> IndexedMerkleTreeCopy<H, I, HEIGHT>
 where
     H: Hasher,
-    I: CheckedAdd
-        + CheckedSub
-        + Copy
-        + Clone
-        + PartialOrd
-        + ToBytes
-        + TryFrom<usize>
-        + Unsigned
-        + Pod,
+    I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
     usize: From<I>,
 {
     /// Casts a byte slice into wrapped `IndexedMerkleTree` structure reference,
@@ -66,9 +48,9 @@ where
         bytes_changelog: &[u8],
         bytes_roots: &[u8],
         bytes_canopy: &[u8],
-        bytes_indexed_changelog: &'a [u8],
+        bytes_indexed_changelog: &[u8],
     ) -> Result<Self, IndexedMerkleTreeError> {
-        let expected_bytes_struct_size = mem::size_of::<IndexedMerkleTree<'a, H, I, HEIGHT>>();
+        let expected_bytes_struct_size = mem::size_of::<IndexedMerkleTree<H, I, HEIGHT>>();
         if bytes_struct.len() != expected_bytes_struct_size {
             return Err(IndexedMerkleTreeError::ConcurrentMerkleTree(
                 ConcurrentMerkleTreeError::StructBufferSize(
@@ -77,7 +59,7 @@ where
                 ),
             ));
         }
-        let struct_ref: *mut IndexedMerkleTree<'a, H, I, HEIGHT> = bytes_struct.as_ptr() as _;
+        let struct_ref: *mut IndexedMerkleTree<H, I, HEIGHT> = bytes_struct.as_ptr() as _;
 
         let mut merkle_tree = unsafe {
             ConcurrentMerkleTree {

--- a/merkle-tree/indexed/src/lib.rs
+++ b/merkle-tree/indexed/src/lib.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use array::{IndexedArray, IndexedElement};
-use light_bounded_vec::{BoundedVec, CyclicBoundedVec, Pod};
+use light_bounded_vec::{BoundedVec, CyclicBoundedVec};
 use light_concurrent_merkle_tree::{
     errors::ConcurrentMerkleTreeError, light_hasher::Hasher, ConcurrentMerkleTree,
 };
@@ -23,54 +23,37 @@ pub const FIELD_SIZE_SUB_ONE: &str =
 #[derive(Debug, Default, Clone, Copy)]
 pub struct RawIndexedElement<I>
 where
-    I: Clone + Pod,
+    I: Clone,
 {
     pub value: [u8; 32],
     pub next_index: I,
     pub next_value: [u8; 32],
     pub index: I,
 }
-unsafe impl<I> Pod for RawIndexedElement<I> where I: Pod + Clone {}
 
 #[derive(Debug)]
 #[repr(C)]
-pub struct IndexedMerkleTree<'a, H, I, const HEIGHT: usize>
+pub struct IndexedMerkleTree<H, I, const HEIGHT: usize>
 where
     H: Hasher,
-    I: CheckedAdd
-        + CheckedSub
-        + Copy
-        + Clone
-        + PartialOrd
-        + ToBytes
-        + TryFrom<usize>
-        + Unsigned
-        + Pod,
+    I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
     usize: From<I>,
 {
-    pub merkle_tree: ConcurrentMerkleTree<'a, H, HEIGHT>,
-    pub changelog: CyclicBoundedVec<'a, RawIndexedElement<I>>,
+    pub merkle_tree: ConcurrentMerkleTree<H, HEIGHT>,
+    pub changelog: CyclicBoundedVec<RawIndexedElement<I>>,
 
     _index: PhantomData<I>,
 }
 
-pub type IndexedMerkleTree22<'a, H, I> = IndexedMerkleTree<'a, H, I, 22>;
-pub type IndexedMerkleTree26<'a, H, I> = IndexedMerkleTree<'a, H, I, 26>;
-pub type IndexedMerkleTree32<'a, H, I> = IndexedMerkleTree<'a, H, I, 32>;
-pub type IndexedMerkleTree40<'a, H, I> = IndexedMerkleTree<'a, H, I, 40>;
+pub type IndexedMerkleTree22<H, I> = IndexedMerkleTree<H, I, 22>;
+pub type IndexedMerkleTree26<H, I> = IndexedMerkleTree<H, I, 26>;
+pub type IndexedMerkleTree32<H, I> = IndexedMerkleTree<H, I, 32>;
+pub type IndexedMerkleTree40<H, I> = IndexedMerkleTree<H, I, 40>;
 
-impl<'a, H, I, const HEIGHT: usize> IndexedMerkleTree<'a, H, I, HEIGHT>
+impl<H, I, const HEIGHT: usize> IndexedMerkleTree<H, I, HEIGHT>
 where
     H: Hasher,
-    I: CheckedAdd
-        + CheckedSub
-        + Copy
-        + Clone
-        + PartialOrd
-        + ToBytes
-        + TryFrom<usize>
-        + Unsigned
-        + Pod,
+    I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
     usize: From<I>,
 {
     pub fn new(

--- a/merkle-tree/indexed/src/reference.rs
+++ b/merkle-tree/indexed/src/reference.rs
@@ -172,12 +172,12 @@ where
 /// We prove non-inclusion by:
 /// 1. Showing that value is greater than leaf_lower_range_value and less than leaf_higher_range_value
 /// 2. Showing that the leaf_hash H(leaf_lower_range_value, leaf_next_index, leaf_higher_value) is included in the root (Merkle tree)
-pub struct NonInclusionProof<'a> {
+pub struct NonInclusionProof {
     pub root: [u8; 32],
     pub value: [u8; 32],
     pub leaf_lower_range_value: [u8; 32],
     pub leaf_higher_range_value: [u8; 32],
     pub leaf_index: usize,
     pub next_index: usize,
-    pub merkle_proof: BoundedVec<'a, [u8; 32]>,
+    pub merkle_proof: BoundedVec<[u8; 32]>,
 }

--- a/merkle-tree/indexed/src/zero_copy.rs
+++ b/merkle-tree/indexed/src/zero_copy.rs
@@ -1,6 +1,6 @@
 use std::mem;
 
-use light_bounded_vec::{BoundedVec, CyclicBoundedVec, Pod};
+use light_bounded_vec::{BoundedVec, CyclicBoundedVec};
 use light_concurrent_merkle_tree::{
     changelog::ChangelogEntry, errors::ConcurrentMerkleTreeError, ConcurrentMerkleTree,
 };
@@ -13,18 +13,10 @@ use crate::{errors::IndexedMerkleTreeError, IndexedMerkleTree, RawIndexedElement
 pub struct IndexedMerkleTreeZeroCopy<'a, H, I, const HEIGHT: usize>
 where
     H: Hasher,
-    I: CheckedAdd
-        + CheckedSub
-        + Copy
-        + Clone
-        + PartialOrd
-        + ToBytes
-        + TryFrom<usize>
-        + Unsigned
-        + Pod,
+    I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
     usize: From<I>,
 {
-    pub merkle_tree: &'a IndexedMerkleTree<'a, H, I, HEIGHT>,
+    pub merkle_tree: &'a IndexedMerkleTree<H, I, HEIGHT>,
 }
 
 pub type IndexedMerkleTreeZeroCopy22<'a, H, I> = IndexedMerkleTreeZeroCopy<'a, H, I, 22>;
@@ -35,15 +27,7 @@ pub type IndexedMerkleTreeZeroCopy40<'a, H, I> = IndexedMerkleTreeZeroCopy<'a, H
 impl<'a, H, I, const HEIGHT: usize> IndexedMerkleTreeZeroCopy<'a, H, I, HEIGHT>
 where
     H: Hasher,
-    I: CheckedAdd
-        + CheckedSub
-        + Copy
-        + Clone
-        + PartialOrd
-        + ToBytes
-        + TryFrom<usize>
-        + Unsigned
-        + Pod,
+    I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
     usize: From<I>,
 {
     /// Casts a byte slice into wrapped `IndexedMerkleTree` structure reference,
@@ -64,7 +48,7 @@ where
     pub unsafe fn struct_from_bytes_zero_copy(
         bytes_struct: &'a [u8],
     ) -> Result<Self, IndexedMerkleTreeError> {
-        let expected_bytes_struct_size = mem::size_of::<IndexedMerkleTree<'a, H, I, HEIGHT>>();
+        let expected_bytes_struct_size = mem::size_of::<IndexedMerkleTree<H, I, HEIGHT>>();
         if bytes_struct.len() != expected_bytes_struct_size {
             return Err(IndexedMerkleTreeError::ConcurrentMerkleTree(
                 ConcurrentMerkleTreeError::StructBufferSize(
@@ -73,7 +57,7 @@ where
                 ),
             ));
         }
-        let tree: *const IndexedMerkleTree<'a, H, I, HEIGHT> = bytes_struct.as_ptr() as _;
+        let tree: *const IndexedMerkleTree<H, I, HEIGHT> = bytes_struct.as_ptr() as _;
 
         Ok(Self {
             merkle_tree: &*tree,
@@ -163,16 +147,15 @@ where
                 ),
             ));
         }
-        tree.merkle_tree.merkle_tree.roots =
-            ConcurrentMerkleTree::<'a, H, HEIGHT>::roots_from_bytes(
-                bytes_roots,
-                tree.merkle_tree.merkle_tree.roots.len(),
-                tree.merkle_tree.merkle_tree.roots.capacity(),
-                tree.merkle_tree.merkle_tree.roots.first_index(),
-                tree.merkle_tree.merkle_tree.roots.last_index(),
-            )?;
+        tree.merkle_tree.merkle_tree.roots = ConcurrentMerkleTree::<H, HEIGHT>::roots_from_bytes(
+            bytes_roots,
+            tree.merkle_tree.merkle_tree.roots.len(),
+            tree.merkle_tree.merkle_tree.roots.capacity(),
+            tree.merkle_tree.merkle_tree.roots.first_index(),
+            tree.merkle_tree.merkle_tree.roots.last_index(),
+        )?;
 
-        let canopy_size = ConcurrentMerkleTree::<'a, H, HEIGHT>::canopy_size(
+        let canopy_size = ConcurrentMerkleTree::<H, HEIGHT>::canopy_size(
             tree.merkle_tree.merkle_tree.canopy_depth,
         );
         let expected_canopy_size = mem::size_of::<[u8; 32]>() * canopy_size;
@@ -213,18 +196,10 @@ where
 pub struct IndexedMerkleTreeZeroCopyMut<'a, H, I, const HEIGHT: usize>
 where
     H: Hasher,
-    I: CheckedAdd
-        + CheckedSub
-        + Copy
-        + Clone
-        + PartialOrd
-        + ToBytes
-        + TryFrom<usize>
-        + Unsigned
-        + Pod,
+    I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
     usize: From<I>,
 {
-    pub merkle_tree: &'a mut IndexedMerkleTree<'a, H, I, HEIGHT>,
+    pub merkle_tree: &'a mut IndexedMerkleTree<H, I, HEIGHT>,
 }
 
 pub type IndexedMerkleTreeZeroCopyMut22<'a, H, I> = IndexedMerkleTreeZeroCopyMut<'a, H, I, 22>;
@@ -235,15 +210,7 @@ pub type IndexedMerkleTreeZeroCopyMut40<'a, H, I> = IndexedMerkleTreeZeroCopyMut
 impl<'a, H, I, const HEIGHT: usize> IndexedMerkleTreeZeroCopyMut<'a, H, I, HEIGHT>
 where
     H: Hasher,
-    I: CheckedAdd
-        + CheckedSub
-        + Copy
-        + Clone
-        + PartialOrd
-        + ToBytes
-        + TryFrom<usize>
-        + Unsigned
-        + Pod,
+    I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
     usize: From<I>,
 {
     /// Casts a byte slice into wrapped `IndexedMerkleTree` structure mutable
@@ -264,7 +231,7 @@ where
     pub unsafe fn struct_from_bytes_zero_copy_mut(
         bytes_struct: &'a [u8],
     ) -> Result<Self, IndexedMerkleTreeError> {
-        let expected_bytes_struct_size = mem::size_of::<IndexedMerkleTree<'a, H, I, HEIGHT>>();
+        let expected_bytes_struct_size = mem::size_of::<IndexedMerkleTree<H, I, HEIGHT>>();
         if bytes_struct.len() != expected_bytes_struct_size {
             return Err(IndexedMerkleTreeError::ConcurrentMerkleTree(
                 ConcurrentMerkleTreeError::StructBufferSize(
@@ -273,7 +240,7 @@ where
                 ),
             ));
         }
-        let tree: *mut IndexedMerkleTree<'a, H, I, HEIGHT> = bytes_struct.as_ptr() as _;
+        let tree: *mut IndexedMerkleTree<H, I, HEIGHT> = bytes_struct.as_ptr() as _;
 
         Ok(Self {
             merkle_tree: &mut *tree,
@@ -449,7 +416,7 @@ where
             tree.merkle_tree.merkle_tree.roots.capacity(),
             tree.merkle_tree.merkle_tree.roots.first_index(),
             tree.merkle_tree.merkle_tree.roots.last_index(),
-            ConcurrentMerkleTree::<'a, H, HEIGHT>::canopy_size(
+            ConcurrentMerkleTree::<H, HEIGHT>::canopy_size(
                 tree.merkle_tree.merkle_tree.canopy_depth,
             ),
             bytes_indexed_changelog,
@@ -471,7 +438,7 @@ mod test {
 
     #[test]
     fn test_from_bytes_zero_copy_init() {
-        let mut bytes_struct = [0u8; 320];
+        let mut bytes_struct = [0u8; 280];
         let mut bytes_filled_subtrees = [0u8; 832];
         let mut bytes_changelog = [0u8; 1220800];
         let mut bytes_roots = [0u8; 76800];

--- a/programs/account-compression/src/state/address.rs
+++ b/programs/account-compression/src/state/address.rs
@@ -116,7 +116,7 @@ pub struct AddressMerkleTreeAccount {
     pub owner: Pubkey,
     /// Delegate of the Merkle tree. This will be used for program owned Merkle trees.
     pub delegate: Pubkey,
-    pub merkle_tree_struct: [u8; 320],
+    pub merkle_tree_struct: [u8; 280],
     pub merkle_tree_filled_subtrees: [u8; 832],
     pub merkle_tree_changelog: [u8; 1220800],
     pub merkle_tree_roots: [u8; 76800],

--- a/programs/account-compression/src/state/public_state_merkle_tree.rs
+++ b/programs/account-compression/src/state/public_state_merkle_tree.rs
@@ -4,7 +4,7 @@ use light_bounded_vec::CyclicBoundedVec;
 use light_concurrent_merkle_tree::ConcurrentMerkleTree26;
 use light_hasher::Poseidon;
 
-pub type StateMerkleTree<'a> = ConcurrentMerkleTree26<'a, Poseidon>;
+pub type StateMerkleTree = ConcurrentMerkleTree26<Poseidon>;
 
 /// Concurrent state Merkle tree used for public compressed transactions.
 #[account(zero_copy)]
@@ -33,7 +33,7 @@ pub struct StateMerkleTreeAccount {
     pub associated_queue: Pubkey,
 
     /// Merkle tree for the transaction state.
-    pub state_merkle_tree_struct: [u8; 272],
+    pub state_merkle_tree_struct: [u8; 240],
     pub state_merkle_tree_filled_subtrees: [u8; 832],
     pub state_merkle_tree_changelog: [u8; 1220800],
     pub state_merkle_tree_roots: [u8; 76800],
@@ -156,7 +156,7 @@ mod test {
             owner: Pubkey::new_from_array([2u8; 32]),
             delegate: Pubkey::new_from_array([3u8; 32]),
             associated_queue: Pubkey::new_from_array([4u8; 32]),
-            state_merkle_tree_struct: [0u8; 272],
+            state_merkle_tree_struct: [0u8; 240],
             state_merkle_tree_filled_subtrees: [0u8; 832],
             state_merkle_tree_changelog: [0u8; 1220800],
             state_merkle_tree_roots: [0u8; 76800],
@@ -176,7 +176,7 @@ mod test {
         }
         let root = merkle_tree.root().unwrap();
 
-        let merkle_tree_2 = account.load_merkle_tree().unwrap();
+        let merkle_tree_2 = account.copy_merkle_tree().unwrap();
         assert_eq!(root, merkle_tree_2.root().unwrap())
     }
 }

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -156,9 +156,9 @@ async fn update_merkle_tree(
 
         let address_merkle_tree = &address_merkle_tree
             .deserialized()
-            .load_merkle_tree()
+            .copy_merkle_tree()
             .unwrap();
-        let changelog_index = address_merkle_tree.merkle_tree.changelog_index();
+        let changelog_index = address_merkle_tree.0.changelog_index();
         changelog_index
     };
 
@@ -224,12 +224,10 @@ async fn relayer_update(
             AccountZeroCopy::<AddressMerkleTreeAccount>::new(context, address_merkle_tree_pubkey)
                 .await;
         let mut address_merkle_tree_deserialized = address_merkle_tree.deserialized().clone();
-        let address_merkle_tree = address_merkle_tree_deserialized
-            .load_merkle_tree_mut()
-            .unwrap();
+        let address_merkle_tree = address_merkle_tree_deserialized.copy_merkle_tree().unwrap();
         assert_eq!(
             relayer_merkle_tree.root(),
-            address_merkle_tree.merkle_tree.root().unwrap()
+            address_merkle_tree.0.root().unwrap()
         );
         let address_queue = unsafe {
             get_hash_set::<u16, AddressQueueAccount>(context, address_queue_pubkey).await
@@ -261,16 +259,16 @@ async fn relayer_update(
         for i in 0..16 {
             bounded_vec.push(array[i]).unwrap();
         }
-        address_merkle_tree
-            .merkle_tree
-            .update(
-                address_merkle_tree.merkle_tree.changelog_index(),
-                address_bundle.new_element.clone(),
-                old_low_address.clone(),
-                old_low_address_next_value.clone(),
-                &mut bounded_vec,
-            )
-            .unwrap();
+        // address_merkle_tree
+        //     .merkle_tree
+        //     .update(
+        //         address_merkle_tree.merkle_tree.changelog_index(),
+        //         address_bundle.new_element.clone(),
+        //         old_low_address.clone(),
+        //         old_low_address_next_value.clone(),
+        //         &mut bounded_vec,
+        //     )
+        //     .unwrap();
 
         // Update on-chain tree.
         let update_successful = match update_merkle_tree(
@@ -365,7 +363,7 @@ async fn test_address_queue() {
     .await;
     let address_merkle_tree = &address_merkle_tree
         .deserialized()
-        .load_merkle_tree()
+        .copy_merkle_tree()
         .unwrap();
 
     let address_queue = unsafe {
@@ -374,19 +372,13 @@ async fn test_address_queue() {
 
     assert_eq!(
         address_queue
-            .contains(
-                &address1,
-                address_merkle_tree.merkle_tree.merkle_tree.sequence_number
-            )
+            .contains(&address1, address_merkle_tree.0.merkle_tree.sequence_number)
             .unwrap(),
         true
     );
     assert_eq!(
         address_queue
-            .contains(
-                &address2,
-                address_merkle_tree.merkle_tree.merkle_tree.sequence_number
-            )
+            .contains(&address2, address_merkle_tree.0.merkle_tree.sequence_number)
             .unwrap(),
         true
     );


### PR DESCRIPTION
* There is no need to use manual allocations in `BoundedVec`. Instead, we can just embed a regular `Vec`, make it private and make sure that the methods we expose never reallocate it.
* Add more test cases covering all error variants.