### PR TITLE
ci: Fix the release jobs

### DIFF
--- a/.github/workflows/prover-release.yml
+++ b/.github/workflows/prover-release.yml
@@ -2,7 +2,7 @@ name: Release prover binaries
 on:
   push:
     tags:
-      - '*'
+      - 'light-prover*'
 
 jobs:
   create_release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  auto-tag:
+  release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -20,13 +20,13 @@ jobs:
           version: 8
           run_install: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
+      - name: Setup and build
+        uses: ./.github/actions/setup-and-build
 
       - name: Install cargo-workspaces
-        run: cargo install cargo-workspaces
+        run: |
+          source ./scripts/devenv.sh
+          cargo install cargo-release cargo-workspaces
 
       - name: Extract project
         id: extract-project
@@ -116,6 +116,8 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
           PACKAGE: ${{ steps.extract-project.outputs.package }}
         run: |
+          source ./scripts/devenv.sh
+
           anchor build
           cp -r ./target/deploy/*.so .
           cargo release publish \
@@ -129,6 +131,8 @@ jobs:
           PACKAGE: ${{ steps.extract-project.outputs.package }}
           PACKAGE_SNAKE_CASE: ${{ steps.extract-project.outputs.package-snake-case }}
         run: |
+          source ./scripts/devenv.sh
+
           # Check whether we are building an on-chain program.
           if [[ $(anchor keys list | grep "$PACKAGE_SNAKE_CASE") -eq 0 ]]; then
             anchor build -p "$PACKAGE_SNAKE_CASE"
@@ -147,9 +151,9 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
           PACKAGE: ${{ steps.extract-project.outputs.package }}
         run: |
-            SUBDIR=$(grep "$PACKAGE" pnpm-workspace.yaml | awk -F '"' '{gsub("/\\*\\*", "", $2); print $2}')
-            cd "$SUBDIR"
-            pnpm publish --access public --no-git-checks
+          SUBDIR=$(grep "$PACKAGE" pnpm-workspace.yaml | awk -F '"' '{gsub("/\\*\\*", "", $2); print $2}')
+          cd "$SUBDIR"
+          pnpm publish --access public --no-git-checks
 
       - name: GitHub release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
* Run `prover-release.yml` only for `light-prover*` tags, not for all tags. Doing so for all tags results in prover binaries attached to unrelated releases.
* Activate devenv to make sure that Anchor and all other dependencies are there.