### PR TITLE
fix: token instruction creation & add onchain check

### DIFF
--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_pda/sdk.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_pda/sdk.rs
@@ -38,6 +38,7 @@ pub fn create_escrow_instruction(
 ) -> Instruction {
     let token_owner_pda = get_token_owner_pda(input_params.signer);
     let timelock_pda = get_timelock_pda(input_params.signer);
+    // TODO: separate the creation of inputs and remaining accounts
     let (remaining_accounts, inputs) = create_inputs_and_remaining_accounts_checked(
         input_params.input_token_data,
         input_params.input_merkle_context,

--- a/programs/compressed-pda/src/invoke/append_state.rs
+++ b/programs/compressed-pda/src/invoke/append_state.rs
@@ -71,8 +71,8 @@ pub fn insert_output_compressed_accounts_into_state_merkle_tree<
     // if the index is higher add the account info to out_merkle_trees_account_infos.
     let initial_index = *global_iter;
     let mut current_index: u8 = 0;
-    let end = if *global_iter + ITER_SIZE > inputs.output_state_merkle_tree_account_indices.len() {
-        inputs.output_state_merkle_tree_account_indices.len()
+    let end = if *global_iter + ITER_SIZE > inputs.output_compressed_accounts.len() {
+        inputs.output_compressed_accounts.len()
     } else {
         *global_iter + ITER_SIZE
     };

--- a/programs/compressed-pda/src/invoke_cpi/processor.rs
+++ b/programs/compressed-pda/src/invoke_cpi/processor.rs
@@ -40,6 +40,7 @@ pub fn process_invoke_cpi<'a, 'b, 'c: 'info + 'b, 'info>(
         compression_lamports: inputs.compression_lamports,
         is_compress: inputs.is_compress,
     };
+    data.check_input_lengths()?;
     bench_sbf_end!("cpda_InstructionDataInvoke");
     process(data, Some(ctx.accounts.invoking_program.key()), ctx)
 }

--- a/programs/compressed-token/src/process_transfer.rs
+++ b/programs/compressed-token/src/process_transfer.rs
@@ -641,7 +641,7 @@ pub mod transfer_sdk {
         }
         let len: usize = remaining_accounts.len();
         let mut output_state_merkle_tree_account_indices: Vec<u8> =
-            vec![0u8; output_compressed_accounts.len()];
+            vec![0u8; output_compressed_account_merkle_tree_pubkeys.len()];
         for (i, mt) in output_compressed_account_merkle_tree_pubkeys
             .iter()
             .enumerate()

--- a/programs/compressed-token/src/process_transfer.rs
+++ b/programs/compressed-token/src/process_transfer.rs
@@ -641,7 +641,7 @@ pub mod transfer_sdk {
         }
         let len: usize = remaining_accounts.len();
         let mut output_state_merkle_tree_account_indices: Vec<u8> =
-            vec![0u8; output_compressed_account_merkle_tree_pubkeys.len()];
+            vec![0u8; output_compressed_accounts.len()];
         for (i, mt) in output_compressed_account_merkle_tree_pubkeys
             .iter()
             .enumerate()

--- a/test-programs/compressed-token-test/Cargo.toml
+++ b/test-programs/compressed-token-test/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "lib"]
-name = "comrpessed_token_test"
+name = "compressed_token_test"
 
 [features]
 no-entrypoint = []


### PR DESCRIPTION
Issue:
- if not all output Merkle tree indices are provided we didn't append all output compressed accounts to a state Merkle tree
- there is a bug in the compressed token transfer instruction method that doesn't create enough output indices

Changes:
- [append_state.rs](https://github.com/Lightprotocol/light-protocol/pull/688/files#diff-659f5e4f0f52ebc162eccbd75ce52338debd996979398f8db1506692ab6e3fea) iterate over compressed output account instead of output indices to make sure that we insert every output account into a Merkle tree
- fixed the bug in compressed token transfer instruction creation