### PR TITLE
fix: hashset double insert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2900,6 +2900,7 @@ dependencies = [
  "ark-bn254",
  "ark-ff",
  "light-bounded-vec",
+ "light-heap",
  "light-utils",
  "memoffset 0.9.0",
  "num-bigint 0.4.4",

--- a/merkle-tree/hash-set/Cargo.toml
+++ b/merkle-tree/hash-set/Cargo.toml
@@ -17,6 +17,8 @@ num-bigint = "0.4"
 num-traits = "0.2"
 solana-program = { version = "1.18.11", optional = true }
 thiserror = "1.0"
+[target.'cfg(target_os = "solana")'.dependencies]
+light-heap = { path = "../../heap", version = "0.1.1" }
 
 [dev-dependencies]
 ark-bn254 = "0.4"

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -16,7 +16,7 @@ pub mod fee;
 
 const CHUNK_SIZE: usize = 32;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum UtilsError {
     #[error("Invalid input size, expected at most {0}")]
     InputTooLarge(usize),


### PR DESCRIPTION
Issue:
- multiple indentical values can be inserted into the hashset:
   1. insert 2 nullifiers into the hashset with overlapping probing indices
      // nullifier_1 has probing indices 1, and 2 -> is inserted in 1
      // nullifier_2 hash probing indices 1 and 3 -> is inserted after nullifier_1 in 3
    2. mark nullifier_1 with sequence 2401
    3. wait until sequence is 2402
    4. insert nullfier_2 again this time in position 1

you can reproduce this by setting the 1 in [this line](https://github.com/Lightprotocol/light-protocol/blob/2f71c66d528c8f3df34a46dff5bc9ac6f02b6289/merkle-tree/hash-set/src/lib.rs#L930) to 2399

Changes:
- added find_element_iter
  - always loops over the first 20 probe indices of a value
  - checks every encountered value for equality throws if yes
- refactored the insert:
  - calls find_element_iter
- fixed by_value_index
  - it returned values with higher sequence number not lower
  - now it returns values with lower sequence number
- adapted the randomized test (left some commented test code with a comment why it shouldn't work)
- for one assert I am not sure why it throws now and whether it shouldn't cc @vadorovsky

Note:
- we should make the iteration count a struct property, because that impacts the zero copy I will leave it hardcoded for now