### PR TITLE
fix: Handle conflicting changelogs in concurrent Merkle tree

### DIFF
--- a/merkle-tree/bounded-vec/src/lib.rs
+++ b/merkle-tree/bounded-vec/src/lib.rs
@@ -32,13 +32,10 @@ impl From<BoundedVecError> for solana_program::program_error::ProgramError {
     }
 }
 
-/// `BoundedVec` is a custom vector implementation which:
-///
-/// * Forbids post-initialization reallocations. The size is not known during
-///   compile time (that makes it different from arrays), but can be defined
-///   only once (that makes it different from [`Vec`](std::vec::Vec)).
-/// * Can store only Plain Old Data ([`Pod`](bytemuck::Pod)). It cannot nest
-///   any other dynamically sized types.
+/// `BoundedVec` is a custom vector implementation which forbids
+/// post-initialization reallocations. The size is not known during compile
+/// time (that makes it different from arrays), but can be defined only once
+/// (that makes it different from [`Vec`](std::vec::Vec)).
 pub struct BoundedVec<'a, T>
 where
     T: Clone,
@@ -60,10 +57,7 @@ where
         // layout is guaranteed to be aligned.
         let layout = unsafe { Layout::from_size_align_unchecked(size, align) };
 
-        // SAFETY: As long as the provided `Pod` type is correct, this global
-        // allocator call should be correct too.
-        //
-        // We are handling the null pointer case gracefully.
+        // SAFETY: We are handling the null pointer case gracefully.
         let ptr = unsafe { alloc::alloc(layout) };
         if ptr.is_null() {
             handle_alloc_error(layout);
@@ -346,10 +340,7 @@ where
         // layout is guaranteed to be aligned.
         let layout = unsafe { Layout::from_size_align_unchecked(size, align) };
 
-        // SAFETY: As long as the provided `Pod` type is correct, this global
-        // allocator call should be correct too.
-        //
-        // We are handling the null pointer case gracefully.
+        // SAFETY: We are handling the null pointer case gracefully.
         let ptr = unsafe { alloc::alloc(layout) };
         if ptr.is_null() {
             handle_alloc_error(layout);

--- a/merkle-tree/bounded-vec/src/lib.rs
+++ b/merkle-tree/bounded-vec/src/lib.rs
@@ -32,27 +32,6 @@ impl From<BoundedVecError> for solana_program::program_error::ProgramError {
     }
 }
 
-/// Plain Old Data.
-///
-/// # Safety
-///
-/// This trait should be implemented only for types with size known at compile
-/// time, like primitives or arrays of primitives.
-pub unsafe trait Pod {}
-
-unsafe impl Pod for i8 {}
-unsafe impl Pod for i16 {}
-unsafe impl Pod for i32 {}
-unsafe impl Pod for i64 {}
-unsafe impl Pod for isize {}
-unsafe impl Pod for u8 {}
-unsafe impl Pod for u16 {}
-unsafe impl Pod for u32 {}
-unsafe impl Pod for u64 {}
-unsafe impl Pod for usize {}
-
-unsafe impl<const N: usize> Pod for [u8; N] {}
-
 /// `BoundedVec` is a custom vector implementation which:
 ///
 /// * Forbids post-initialization reallocations. The size is not known during
@@ -62,7 +41,7 @@ unsafe impl<const N: usize> Pod for [u8; N] {}
 ///   any other dynamically sized types.
 pub struct BoundedVec<'a, T>
 where
-    T: Clone + Pod,
+    T: Clone,
 {
     capacity: usize,
     length: usize,
@@ -71,7 +50,7 @@ where
 
 impl<'a, T> BoundedVec<'a, T>
 where
-    T: Clone + Pod,
+    T: Clone,
 {
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
@@ -261,7 +240,7 @@ where
 
 impl<'a, T> Clone for BoundedVec<'a, T>
 where
-    T: Clone + Pod,
+    T: Clone,
 {
     fn clone(&self) -> Self {
         // Create a new buffer with the same capacity as the original
@@ -295,7 +274,7 @@ where
 
 impl<'a, T> fmt::Debug for BoundedVec<'a, T>
 where
-    T: Clone + fmt::Debug + Pod,
+    T: Clone + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", &self.data[..self.length])
@@ -304,7 +283,7 @@ where
 
 impl<'a, T, I: SliceIndex<[T]>> Index<I> for BoundedVec<'a, T>
 where
-    T: Clone + Pod,
+    T: Clone,
     I: SliceIndex<[T]>,
 {
     type Output = I::Output;
@@ -317,7 +296,7 @@ where
 
 impl<'a, T, I> IndexMut<I> for BoundedVec<'a, T>
 where
-    T: Clone + Pod,
+    T: Clone,
     I: SliceIndex<[T]>,
 {
     fn index_mut(&mut self, index: I) -> &mut Self::Output {
@@ -327,7 +306,7 @@ where
 
 impl<'a, T> PartialEq for BoundedVec<'a, T>
 where
-    T: Clone + PartialEq + Pod,
+    T: Clone + PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         self.data[..self.length]
@@ -336,7 +315,7 @@ where
     }
 }
 
-impl<'a, T> Eq for BoundedVec<'a, T> where T: Clone + Eq + Pod {}
+impl<'a, T> Eq for BoundedVec<'a, T> where T: Clone + Eq {}
 
 /// `CyclicBoundedVec` is a wrapper around [`Vec`](std::vec::Vec) which:
 ///
@@ -346,7 +325,7 @@ impl<'a, T> Eq for BoundedVec<'a, T> where T: Clone + Eq + Pod {}
 #[derive(Debug)]
 pub struct CyclicBoundedVec<'a, T>
 where
-    T: Clone + Pod,
+    T: Clone,
 {
     capacity: usize,
     length: usize,
@@ -357,7 +336,7 @@ where
 
 impl<'a, T> CyclicBoundedVec<'a, T>
 where
-    T: Clone + Pod,
+    T: Clone,
 {
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
@@ -534,7 +513,7 @@ where
 
 impl<'a, T, I> Index<I> for CyclicBoundedVec<'a, T>
 where
-    T: Clone + Pod,
+    T: Clone,
     I: SliceIndex<[T]>,
 {
     type Output = I::Output;
@@ -547,7 +526,7 @@ where
 
 impl<'a, T, I> IndexMut<I> for CyclicBoundedVec<'a, T>
 where
-    T: Clone + Pod,
+    T: Clone,
     I: SliceIndex<[T]>,
 {
     fn index_mut(&mut self, index: I) -> &mut Self::Output {
@@ -557,18 +536,18 @@ where
 
 impl<'a, T> PartialEq for CyclicBoundedVec<'a, T>
 where
-    T: Clone + Pod + PartialEq,
+    T: Clone + PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         self.data[..self.length].iter().eq(other.data.iter())
     }
 }
 
-impl<'a, T> Eq for CyclicBoundedVec<'a, T> where T: Clone + Eq + Pod {}
+impl<'a, T> Eq for CyclicBoundedVec<'a, T> where T: Clone + Eq {}
 
 pub struct CyclicBoundedVecIterator<'a, T>
 where
-    T: Clone + Pod,
+    T: Clone,
 {
     vec: &'a CyclicBoundedVec<'a, T>,
     current: usize,
@@ -577,7 +556,7 @@ where
 
 impl<'a, T> Iterator for CyclicBoundedVecIterator<'a, T>
 where
-    T: Clone + Pod,
+    T: Clone,
 {
     type Item = &'a T;
 

--- a/merkle-tree/concurrent/src/changelog.rs
+++ b/merkle-tree/concurrent/src/changelog.rs
@@ -1,4 +1,4 @@
-use light_bounded_vec::{BoundedVec, Pod};
+use light_bounded_vec::BoundedVec;
 
 use crate::errors::ConcurrentMerkleTreeError;
 
@@ -17,8 +17,6 @@ pub type ChangelogEntry22 = ChangelogEntry<22>;
 pub type ChangelogEntry26 = ChangelogEntry<26>;
 pub type ChangelogEntry32 = ChangelogEntry<32>;
 pub type ChangelogEntry40 = ChangelogEntry<40>;
-
-unsafe impl<const HEIGHT: usize> Pod for ChangelogEntry<HEIGHT> {}
 
 impl<const HEIGHT: usize> ChangelogEntry<HEIGHT> {
     pub fn new(root: [u8; 32], path: [[u8; 32]; HEIGHT], index: usize) -> Self {

--- a/merkle-tree/concurrent/src/changelog.rs
+++ b/merkle-tree/concurrent/src/changelog.rs
@@ -9,7 +9,7 @@ pub struct ChangelogEntry<const HEIGHT: usize> {
     pub root: [u8; 32],
     // Path of the changelog.
     pub path: [[u8; 32]; HEIGHT],
-    // Index.
+    // Index of the affected leaf.
     pub index: u64,
 }
 

--- a/merkle-tree/concurrent/src/changelog.rs
+++ b/merkle-tree/concurrent/src/changelog.rs
@@ -65,6 +65,12 @@ impl<const HEIGHT: usize> ChangelogEntry<HEIGHT> {
         if leaf_index != self.index() {
             let intersection_index = self.intersection_index(leaf_index);
             proof[intersection_index] = self.path[intersection_index];
+        } else {
+            // This case means that the leaf we are trying to update was
+            // already updated. Therefore, the right thing to do is to notify
+            // the caller to sync the local Merkle tree and update the leaf,
+            // if necessary.
+            return Err(ConcurrentMerkleTreeError::CannotUpdateLeaf);
         }
 
         Ok(())

--- a/merkle-tree/concurrent/src/lib.rs
+++ b/merkle-tree/concurrent/src/lib.rs
@@ -1,7 +1,7 @@
-use std::{marker::PhantomData, mem, slice};
+use std::{iter::Skip, marker::PhantomData, mem, slice};
 
 use event::{ChangelogEvent, ChangelogEventV1};
-use light_bounded_vec::{BoundedVec, CyclicBoundedVec};
+use light_bounded_vec::{BoundedVec, CyclicBoundedVec, CyclicBoundedVecIterator};
 pub use light_hasher;
 use light_hasher::Hasher;
 pub mod changelog;
@@ -769,7 +769,27 @@ where
         Ok(())
     }
 
-    /// Returns an updated Merkle proof.
+    /// Returns an iterator with changelog entries newer than the requested
+    /// `changelog_index`.
+    pub fn changelog_entries(
+        &self,
+        changelog_index: usize,
+    ) -> Skip<CyclicBoundedVecIterator<'_, ChangelogEntry<HEIGHT>>> {
+        // `CyclicBoundedVec::iter_from` returns an iterator which includes also
+        // the element indicated by the provided index.
+        //
+        // However, we want to iterate only on changelog events **newer** than
+        // the provided one.
+        //
+        // Calling `iter_from(changelog_index + 1)` wouldn't work. If
+        // `changelog_index` points to the newest changelog entry,
+        // `changelog_index + 1` would point to the **oldest** changelog entry.
+        // That would result in iterating over the whole changelog - from the
+        // oldest to the newest element.
+        self.changelog.iter_from(changelog_index).skip(1)
+    }
+
+    /// Updates the given Merkle proof.
     ///
     /// The update is performed by checking whether there are any new changelog
     /// entries and whether they contain changes which affect the current
@@ -792,7 +812,12 @@ where
         leaf_index: usize,
         proof: &mut BoundedVec<[u8; 32]>,
     ) -> Result<(), ConcurrentMerkleTreeError> {
-        for changelog_entry in self.changelog.iter_from(changelog_index) {
+        // Iterate over changelog entries starting from the requested
+        // `changelog_index`.
+        //
+        // Since we are interested only in subsequent, new changelog entries,
+        // skip the first result.
+        for changelog_entry in self.changelog_entries(changelog_index) {
             changelog_entry.update_proof(leaf_index, proof)?;
         }
 

--- a/merkle-tree/concurrent/tests/tests.rs
+++ b/merkle-tree/concurrent/tests/tests.rs
@@ -2856,7 +2856,7 @@ where
             reference_tree.append(&leaf).unwrap();
         } else {
             // Update random leaf.
-            let leaf_index = rng.gen_range(0..reference_tree.leaves().len());
+            let leaf_index = rng.gen_range(1..reference_tree.leaves().len());
             let old_leaf = reference_tree.leaf(leaf_index);
             let new_leaf: [u8; 32] = Fr::rand(&mut rng)
                 .into_bigint()
@@ -2890,6 +2890,14 @@ where
         res,
         Err(ConcurrentMerkleTreeError::InvalidProof(_, _))
     ));
+
+    // Try to update the original `leaf` with an up-to-date proof and changelog
+    // index. Expect a success.
+    let changelog_index = merkle_tree.changelog_index();
+    let mut proof = reference_tree.get_proof_of_leaf(0, false).unwrap();
+    merkle_tree
+        .update(changelog_index, &leaf, &new_leaf, 0, &mut proof)
+        .unwrap();
 }
 
 #[test]

--- a/merkle-tree/concurrent/tests/tests.rs
+++ b/merkle-tree/concurrent/tests/tests.rs
@@ -2,7 +2,7 @@ use std::{cmp, mem};
 
 use ark_bn254::Fr;
 use ark_ff::{BigInteger, PrimeField, UniformRand};
-use light_bounded_vec::BoundedVec;
+use light_bounded_vec::{BoundedVec, CyclicBoundedVec};
 use light_concurrent_merkle_tree::{
     changelog::ChangelogEntry, errors::ConcurrentMerkleTreeError, event::ChangelogEvent,
     ConcurrentMerkleTree,
@@ -1917,27 +1917,43 @@ pub fn test_100_nullify_mt() {
         assert_eq!(onchain_merkle_tree.root(), crank_merkle_tree.root());
 
         let mut rng = rand::thread_rng();
+
+        // Pick random queue indices to nullify.
+        let mut queue_indices = std::collections::HashSet::new();
+        while queue_indices.len() < cmp::min(9, iterations) {
+            let index = rng.gen_range(0..iterations);
+            queue_indices.insert(index);
+        }
+
         let change_log_index = onchain_merkle_tree.changelog_index();
 
-        let mut nullified_leaf_indices = vec![0];
-        for _ in 1..std::cmp::min(9, iterations) {
-            let mut leaf = [0u8; 32];
-            let mut leaf_index = 0;
-            while nullified_leaf_indices.contains(&leaf_index) {
-                let index = rng.gen_range(0..std::cmp::min(9, iterations));
-                leaf = queue.by_value_index(index, None).unwrap().value_bytes();
-                leaf_index = crank_merkle_tree.get_leaf_index(&leaf).unwrap().clone();
-            }
+        let mut nullified_leaf_indices = Vec::with_capacity(queue_indices.len());
 
-            nullified_leaf_indices.push(leaf_index);
-            let mut proof0 = crank_merkle_tree
+        // Nullify the leaves we picked.
+        for queue_index in queue_indices {
+            let leaf_cell = queue
+                .by_value_index(queue_index, Some(onchain_merkle_tree.sequence_number))
+                .unwrap();
+            let leaf_index = crank_merkle_tree
+                .get_leaf_index(&leaf_cell.value_bytes())
+                .unwrap()
+                .clone();
+
+            let mut proof = crank_merkle_tree
                 .get_proof_of_leaf(leaf_index, false)
                 .unwrap();
             onchain_merkle_tree
-                .update(change_log_index, &leaf, &[0u8; 32], leaf_index, &mut proof0)
+                .update(
+                    change_log_index,
+                    &leaf_cell.value_bytes(),
+                    &[0u8; 32],
+                    leaf_index,
+                    &mut proof,
+                )
                 .unwrap();
+
+            nullified_leaf_indices.push(leaf_index);
         }
-        nullified_leaf_indices.remove(0);
         for leaf_index in nullified_leaf_indices {
             crank_merkle_tree.update(&[0; 32], leaf_index).unwrap();
         }
@@ -2206,4 +2222,699 @@ fn test_subtree_updates() {
     assert_eq!(spl_concurrent_mt.get_root(), ref_mt.root());
     assert_eq!(spl_concurrent_mt.get_root(), con_mt.root());
     assert_eq!(ref_mt.root(), con_mt.root());
+}
+
+/// Tests an update of a leaf which was modified by another updates.
+fn update_already_modified_leaf<
+    H,
+    // Number of conflicting updates of the same leaf.
+    const CONFLICTS: usize,
+    // Number of appends of random leaves before submitting the conflicting
+    // updates.
+    const RANDOM_APPENDS_BEFORE_CONFLICTS: usize,
+    // Number of appends of random leaves after every single conflicting
+    // update.
+    const RANDOM_APPENDS_AFTER_EACH_CONFLICT: usize,
+>()
+where
+    H: Hasher,
+{
+    const HEIGHT: usize = 26;
+    const MAX_CHANGELOG: usize = 8;
+    const MAX_ROOTS: usize = 8;
+    const CANOPY: usize = 0;
+
+    let mut merkle_tree =
+        ConcurrentMerkleTree::<H, HEIGHT>::new(HEIGHT, MAX_CHANGELOG, MAX_ROOTS, CANOPY).unwrap();
+    merkle_tree.init().unwrap();
+    let mut reference_tree = light_merkle_tree_reference::MerkleTree::<H>::new(HEIGHT, CANOPY);
+
+    let mut rng = thread_rng();
+
+    // Create tree with a single leaf.
+    let first_leaf: [u8; 32] = Fr::rand(&mut rng)
+        .into_bigint()
+        .to_bytes_be()
+        .try_into()
+        .unwrap();
+    merkle_tree.append(&first_leaf).unwrap();
+    reference_tree.append(&first_leaf).unwrap();
+
+    // Save a proof of the first append.
+    let outdated_changelog_index = merkle_tree.changelog_index();
+    let mut outdated_proof = reference_tree.get_proof_of_leaf(0, false).unwrap().clone();
+
+    let mut old_leaf = first_leaf;
+    for _ in 0..CONFLICTS {
+        // Update leaf. Always use an up-to-date proof.
+        let mut up_to_date_proof = reference_tree.get_proof_of_leaf(0, false).unwrap();
+        let new_leaf = Fr::rand(&mut rng)
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .unwrap();
+        merkle_tree
+            .update(
+                merkle_tree.changelog_index(),
+                &old_leaf,
+                &new_leaf,
+                0,
+                &mut up_to_date_proof,
+            )
+            .unwrap();
+        reference_tree.update(&new_leaf, 0).unwrap();
+
+        old_leaf = new_leaf;
+
+        assert_eq!(merkle_tree.root(), reference_tree.root());
+    }
+
+    // Update leaf. This time, try using an outdated proof.
+    let new_leaf = Fr::rand(&mut rng)
+        .into_bigint()
+        .to_bytes_be()
+        .try_into()
+        .unwrap();
+    let res = merkle_tree.update(
+        outdated_changelog_index,
+        &first_leaf,
+        &new_leaf,
+        0,
+        &mut outdated_proof,
+    );
+    assert!(matches!(
+        res,
+        Err(ConcurrentMerkleTreeError::CannotUpdateLeaf)
+    ));
+}
+
+#[test]
+fn test_update_already_modified_leaf_keccak_1_0_0() {
+    update_already_modified_leaf::<Keccak, 1, 0, 0>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_poseidon_1_0_0() {
+    update_already_modified_leaf::<Poseidon, 1, 0, 0>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_sha256_1_0_0() {
+    update_already_modified_leaf::<Sha256, 1, 0, 0>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_keccak_1_1_1() {
+    update_already_modified_leaf::<Keccak, 1, 1, 1>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_poseidon_1_1_1() {
+    update_already_modified_leaf::<Poseidon, 1, 1, 1>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_sha256_1_1_1() {
+    update_already_modified_leaf::<Sha256, 1, 1, 1>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_keccak_1_2_2() {
+    update_already_modified_leaf::<Keccak, 1, 2, 2>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_poseidon_1_2_2() {
+    update_already_modified_leaf::<Poseidon, 1, 2, 2>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_sha256_1_2_2() {
+    update_already_modified_leaf::<Sha256, 1, 2, 2>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_keccak_2_0_0() {
+    update_already_modified_leaf::<Keccak, 2, 0, 0>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_poseidon_2_0_0() {
+    update_already_modified_leaf::<Poseidon, 2, 0, 0>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_sha256_2_0_0() {
+    update_already_modified_leaf::<Sha256, 2, 0, 0>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_keccak_2_1_1() {
+    update_already_modified_leaf::<Keccak, 2, 1, 1>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_poseidon_2_1_1() {
+    update_already_modified_leaf::<Poseidon, 2, 1, 1>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_sha256_2_1_1() {
+    update_already_modified_leaf::<Sha256, 2, 1, 1>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_keccak_2_2_2() {
+    update_already_modified_leaf::<Keccak, 2, 2, 2>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_poseidon_2_2_2() {
+    update_already_modified_leaf::<Poseidon, 2, 2, 2>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_sha256_2_2_2() {
+    update_already_modified_leaf::<Sha256, 2, 2, 2>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_keccak_4_0_0() {
+    update_already_modified_leaf::<Keccak, 4, 0, 0>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_poseidon_4_0_0() {
+    update_already_modified_leaf::<Poseidon, 4, 0, 0>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_sha256_4_0_0() {
+    update_already_modified_leaf::<Sha256, 4, 0, 0>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_keccak_4_1_1() {
+    update_already_modified_leaf::<Keccak, 4, 1, 1>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_poseidon_4_1_1() {
+    update_already_modified_leaf::<Poseidon, 4, 1, 1>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_sha256_4_1_1() {
+    update_already_modified_leaf::<Sha256, 4, 1, 1>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_keccak_4_4_4() {
+    update_already_modified_leaf::<Keccak, 4, 4, 4>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_poseidon_4_4_4() {
+    update_already_modified_leaf::<Poseidon, 4, 4, 4>()
+}
+
+#[test]
+fn test_update_already_modified_leaf_sha256_4_4_4() {
+    update_already_modified_leaf::<Sha256, 4, 4, 4>()
+}
+
+/// Checks whether the [`changelog_entries`](ConcurrentMerkleTree::changelog_entries)
+/// method returns an iterator with expected entries.
+///
+/// We expect the `changelog_entries` method to return an iterator with entries
+/// newer than the requested index.
+///
+/// # Examples
+///
+/// (In the tree) `current_index`: 1
+/// (Requested) `changelog_index`: 1
+/// Expected iterator: `[]` (empty)
+///
+/// (In the tree) `current_index`: 3
+/// (Requested) `changelog_index`: 1
+/// Expected iterator: `[2, 3]` (1 is skipped)
+///
+/// Changelog capacity: 12
+/// (In the tree) `current_index`: 9
+/// (Requested) `changelog_index`: 3 (lowed than `current_index`, because the
+/// changelog is full and started overwriting values from the head)
+/// Expected iterator: `[10, 11, 12, 13, 14, 15]` (9 is skipped)
+fn changelog_entries<H>()
+where
+    H: Hasher,
+{
+    const HEIGHT: usize = 26;
+    const CHANGELOG: usize = 12;
+    const ROOTS: usize = 16;
+    const CANOPY: usize = 0;
+
+    let mut merkle_tree =
+        ConcurrentMerkleTree::<H, HEIGHT>::new(HEIGHT, CHANGELOG, ROOTS, CANOPY).unwrap();
+    merkle_tree.init().unwrap();
+
+    merkle_tree
+        .append(&[
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1,
+        ])
+        .unwrap();
+
+    let changelog_entries = merkle_tree.changelog_entries(1).collect::<Vec<_>>();
+    assert!(changelog_entries.is_empty());
+
+    merkle_tree
+        .append(&[
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 2,
+        ])
+        .unwrap();
+    merkle_tree
+        .append(&[
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 3,
+        ])
+        .unwrap();
+
+    let changelog_leaves = merkle_tree
+        .changelog_entries(1)
+        .map(|changelog_entry| changelog_entry.path[0])
+        .collect::<Vec<_>>();
+    assert_eq!(
+        changelog_leaves.as_slice(),
+        &[
+            [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 2
+            ],
+            [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 3
+            ]
+        ]
+    );
+
+    for i in 4_u8..16_u8 {
+        merkle_tree
+            .append(&[
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, i,
+            ])
+            .unwrap();
+    }
+
+    let changelog_leaves = merkle_tree
+        .changelog_entries(9)
+        .map(|changelog_entry| changelog_entry.path[0])
+        .collect::<Vec<_>>();
+    assert_eq!(
+        changelog_leaves.as_slice(),
+        &[
+            [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 10
+            ],
+            [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 11
+            ],
+            [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 12
+            ],
+            [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 13
+            ],
+            [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 14
+            ],
+            [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 15
+            ]
+        ]
+    );
+}
+
+#[test]
+fn changelog_entries_keccak() {
+    changelog_entries::<Keccak>()
+}
+
+#[test]
+fn changelog_entries_poseidon() {
+    changelog_entries::<Poseidon>()
+}
+
+#[test]
+fn changelog_entries_sha256() {
+    changelog_entries::<Sha256>()
+}
+
+/// Checks whether the [`changelog_entries`](ConcurrentMerkleTree::changelog_entries)
+/// method returns an iterator with expected entries.
+///
+/// It tests random insertions and updates and checks the consistency of leaves
+/// (`path[0]`) in changelogs.
+fn changelog_entries_random<
+    H,
+    const HEIGHT: usize,
+    const CHANGELOG: usize,
+    const ROOTS: usize,
+    const CANOPY: usize,
+>()
+where
+    H: Hasher,
+{
+    let mut merkle_tree =
+        ConcurrentMerkleTree::<H, HEIGHT>::new(HEIGHT, CHANGELOG, ROOTS, CANOPY).unwrap();
+    merkle_tree.init().unwrap();
+
+    let mut reference_tree = light_merkle_tree_reference::MerkleTree::<H>::new(HEIGHT, CANOPY);
+
+    let mut rng = thread_rng();
+
+    let changelog_entries = merkle_tree.changelog_entries(0).collect::<Vec<_>>();
+    assert!(changelog_entries.is_empty());
+
+    // Requesting changelog entries starting from the current `changelog_index()`
+    // should always return an empty iterator.
+    let changelog_entries = merkle_tree
+        .changelog_entries(merkle_tree.changelog_index())
+        .collect::<Vec<_>>();
+    assert!(changelog_entries.is_empty());
+
+    // Vector of leaves we append and update.
+    let mut leaves = CyclicBoundedVec::with_capacity(CHANGELOG);
+    // Changelog is always initialized with a changelog path consisting of zero
+    // bytes. For consistency, we need to assert the 1st zero byte as the first
+    // expected leaf in the changelog.
+    leaves.push(H::zero_bytes()[0]);
+
+    for _ in 0..1000 {
+        // Append random leaf.
+        let leaf: [u8; 32] = Fr::rand(&mut rng)
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .unwrap();
+        merkle_tree.append(&leaf).unwrap();
+        reference_tree.append(&leaf).unwrap();
+        leaves.push(leaf);
+
+        let changelog_entries = merkle_tree
+            .changelog_entries(merkle_tree.changelog.first_index())
+            .collect::<Vec<_>>();
+        assert_eq!(changelog_entries.len(), leaves.len() - 1);
+
+        for (leaf, changelog_entry) in leaves.iter().skip(1).zip(changelog_entries) {
+            assert_eq!(&changelog_entry.path[0], leaf);
+        }
+
+        // Requesting changelog entries starting from the current `changelog_index()`
+        // should always return an empty iterator.
+        let changelog_entries = merkle_tree
+            .changelog_entries(merkle_tree.changelog_index())
+            .collect::<Vec<_>>();
+        assert!(changelog_entries.is_empty());
+
+        // Update random leaf.
+        let leaf_index = rng.gen_range(0..reference_tree.leaves().len());
+        let old_leaf = reference_tree.leaf(leaf_index);
+        let new_leaf: [u8; 32] = Fr::rand(&mut rng)
+            .into_bigint()
+            .to_bytes_be()
+            .try_into()
+            .unwrap();
+        let mut proof = reference_tree.get_proof_of_leaf(leaf_index, false).unwrap();
+        merkle_tree
+            .update(
+                merkle_tree.changelog_index(),
+                &old_leaf,
+                &new_leaf,
+                leaf_index,
+                &mut proof,
+            )
+            .unwrap();
+        reference_tree.update(&new_leaf, leaf_index).unwrap();
+        leaves.push(new_leaf);
+        println!("Updated leaf {leaf_index} {old_leaf:?} to {new_leaf:?}");
+
+        println!("\n\n\nLEAVES:");
+        for (i, leaf) in leaves.iter().enumerate() {
+            println!("{i}: {leaf:?}");
+        }
+        println!("\n\n\nCHANGELOG:");
+        for (i, changelog_entry) in merkle_tree.changelog.iter().enumerate() {
+            println!("{i}: {:?}", changelog_entry.path[0]);
+        }
+
+        let changelog_entries = merkle_tree
+            .changelog_entries(merkle_tree.changelog.first_index())
+            .collect::<Vec<_>>();
+        assert_eq!(changelog_entries.len(), leaves.len() - 1);
+
+        for (leaf, changelog_entry) in leaves.iter().skip(1).zip(changelog_entries) {
+            assert_eq!(&changelog_entry.path[0], leaf);
+        }
+
+        // Requesting changelog entries starting from the current `changelog_index()`
+        // should always return an empty iterator.
+        let changelog_entries = merkle_tree
+            .changelog_entries(merkle_tree.changelog_index())
+            .collect::<Vec<_>>();
+        assert!(changelog_entries.is_empty());
+    }
+}
+
+#[test]
+fn test_changelog_entries_random_keccak_26_256_256_0() {
+    const HEIGHT: usize = 26;
+    const CHANGELOG: usize = 256;
+    const ROOTS: usize = 256;
+    const CANOPY: usize = 0;
+    changelog_entries_random::<Keccak, HEIGHT, CHANGELOG, ROOTS, CANOPY>()
+}
+
+#[test]
+fn test_changelog_entries_random_poseidon_26_256_256_0() {
+    const HEIGHT: usize = 26;
+    const CHANGELOG: usize = 256;
+    const ROOTS: usize = 256;
+    const CANOPY: usize = 0;
+    changelog_entries_random::<Poseidon, HEIGHT, CHANGELOG, ROOTS, CANOPY>()
+}
+
+#[test]
+fn test_changelog_entries_random_sha256_26_256_256_0() {
+    const HEIGHT: usize = 26;
+    const CHANGELOG: usize = 256;
+    const ROOTS: usize = 256;
+    const CANOPY: usize = 0;
+    changelog_entries_random::<Sha256, HEIGHT, CHANGELOG, ROOTS, CANOPY>()
+}
+
+/// When reading the tests above (`changelog_entries`, `changelog_entries_random`)
+/// you might be still wondering why is skipping the **current** changelog element
+/// necessary.
+///
+/// The explanation is that not skipping the current element might produce leaf
+/// conflicts. Imagine that we insert a leaf and then we try to immediately update
+/// it. Starting the iteration
+///
+/// This test reproduces that case and serves as a proof that skipping is the
+/// right action.
+fn changelog_iteration_without_skipping<
+    H,
+    const HEIGHT: usize,
+    const CHANGELOG: usize,
+    const ROOTS: usize,
+    const CANOPY: usize,
+>()
+where
+    H: Hasher,
+{
+    /// A broken re-implementation of `ConcurrentMerkleTree::update_proof_from_changelog`
+    /// which reproduces the described issue.
+    fn update_proof_from_changelog<H, const HEIGHT: usize>(
+        merkle_tree: &ConcurrentMerkleTree<H, HEIGHT>,
+        changelog_index: usize,
+        leaf_index: usize,
+        proof: &mut BoundedVec<[u8; 32]>,
+    ) -> Result<(), ConcurrentMerkleTreeError>
+    where
+        H: Hasher,
+    {
+        for changelog_entry in merkle_tree.changelog.iter_from(changelog_index) {
+            changelog_entry.update_proof(leaf_index, proof)?;
+        }
+
+        Ok(())
+    }
+
+    let mut merkle_tree =
+        ConcurrentMerkleTree::<H, HEIGHT>::new(HEIGHT, CHANGELOG, ROOTS, CANOPY).unwrap();
+    merkle_tree.init().unwrap();
+
+    let mut reference_tree = light_merkle_tree_reference::MerkleTree::<H>::new(HEIGHT, CANOPY);
+
+    let mut rng = thread_rng();
+
+    let leaf: [u8; 32] = Fr::rand(&mut rng)
+        .into_bigint()
+        .to_bytes_be()
+        .try_into()
+        .unwrap();
+
+    merkle_tree.append(&leaf).unwrap();
+    reference_tree.append(&leaf).unwrap();
+
+    let mut proof = reference_tree.get_proof_of_leaf(0, false).unwrap();
+
+    let res =
+        update_proof_from_changelog(&merkle_tree, merkle_tree.changelog_index(), 0, &mut proof);
+    assert!(matches!(
+        res,
+        Err(ConcurrentMerkleTreeError::CannotUpdateLeaf)
+    ));
+}
+
+#[test]
+fn test_changelog_interation_without_skipping_keccak_26_16_16_0() {
+    const HEIGHT: usize = 26;
+    const CHANGELOG: usize = 16;
+    const ROOTS: usize = 16;
+    const CANOPY: usize = 0;
+    changelog_iteration_without_skipping::<Keccak, HEIGHT, CHANGELOG, ROOTS, CANOPY>()
+}
+
+#[test]
+fn test_changelog_interation_without_skipping_poseidon_26_16_16_0() {
+    const HEIGHT: usize = 26;
+    const CHANGELOG: usize = 16;
+    const ROOTS: usize = 16;
+    const CANOPY: usize = 0;
+    changelog_iteration_without_skipping::<Poseidon, HEIGHT, CHANGELOG, ROOTS, CANOPY>()
+}
+
+#[test]
+fn test_changelog_interation_without_skipping_sha256_26_16_16_0() {
+    const HEIGHT: usize = 26;
+    const CHANGELOG: usize = 16;
+    const ROOTS: usize = 16;
+    const CANOPY: usize = 0;
+    changelog_iteration_without_skipping::<Sha256, HEIGHT, CHANGELOG, ROOTS, CANOPY>()
+}
+
+/// Tests an update with an old `changelog_index` and proof, which refers to the
+/// state before the changelog wrap-around (enough new operations to overwrite
+/// the whole changelog). Such an update should fail,
+fn update_changelog_wrap_around<
+    H,
+    const HEIGHT: usize,
+    const CHANGELOG: usize,
+    const ROOTS: usize,
+    const CANOPY: usize,
+>()
+where
+    H: Hasher,
+{
+    let mut merkle_tree =
+        ConcurrentMerkleTree::<H, HEIGHT>::new(HEIGHT, CHANGELOG, ROOTS, CANOPY).unwrap();
+    merkle_tree.init().unwrap();
+
+    let mut reference_tree = light_merkle_tree_reference::MerkleTree::<H>::new(HEIGHT, CANOPY);
+
+    let mut rng = thread_rng();
+
+    // The leaf which we will want to update with an expired changelog.
+    let leaf: [u8; 32] = Fr::rand(&mut rng)
+        .into_bigint()
+        .to_bytes_be()
+        .try_into()
+        .unwrap();
+    let (changelog_index, _) = merkle_tree.append(&leaf).unwrap();
+    reference_tree.append(&leaf).unwrap();
+    let mut proof = reference_tree.get_proof_of_leaf(0, false).unwrap();
+
+    // Perform enough appends and updates to overfill the changelog
+    for i in 0..CHANGELOG {
+        if i % 2 == 0 {
+            // Append random leaf.
+            let leaf: [u8; 32] = Fr::rand(&mut rng)
+                .into_bigint()
+                .to_bytes_be()
+                .try_into()
+                .unwrap();
+            merkle_tree.append(&leaf).unwrap();
+            reference_tree.append(&leaf).unwrap();
+        } else {
+            // Update random leaf.
+            let leaf_index = rng.gen_range(0..reference_tree.leaves().len());
+            let old_leaf = reference_tree.leaf(leaf_index);
+            let new_leaf: [u8; 32] = Fr::rand(&mut rng)
+                .into_bigint()
+                .to_bytes_be()
+                .try_into()
+                .unwrap();
+            let mut proof = reference_tree.get_proof_of_leaf(leaf_index, false).unwrap();
+            merkle_tree
+                .update(
+                    merkle_tree.changelog_index(),
+                    &old_leaf,
+                    &new_leaf,
+                    leaf_index,
+                    &mut proof,
+                )
+                .unwrap();
+            reference_tree.update(&new_leaf, leaf_index).unwrap();
+        }
+    }
+
+    // Try to update the original `leaf` with an outdated proof and changelog
+    // index. Expect an error.
+    let new_leaf: [u8; 32] = Fr::rand(&mut rng)
+        .into_bigint()
+        .to_bytes_be()
+        .try_into()
+        .unwrap();
+
+    let res = merkle_tree.update(changelog_index, &leaf, &new_leaf, 0, &mut proof);
+    assert!(matches!(
+        res,
+        Err(ConcurrentMerkleTreeError::InvalidProof(_, _))
+    ));
+}
+
+#[test]
+fn test_update_changelog_wrap_around_keccak_26_256_512_0() {
+    const HEIGHT: usize = 26;
+    const CHANGELOG: usize = 256;
+    const ROOTS: usize = 256;
+    const CANOPY: usize = 0;
+    update_changelog_wrap_around::<Keccak, HEIGHT, CHANGELOG, ROOTS, CANOPY>()
+}
+
+#[test]
+fn test_update_changelog_wrap_around_poseidon_26_256_512_0() {
+    const HEIGHT: usize = 26;
+    const CHANGELOG: usize = 256;
+    const ROOTS: usize = 256;
+    const CANOPY: usize = 0;
+    update_changelog_wrap_around::<Poseidon, HEIGHT, CHANGELOG, ROOTS, CANOPY>()
+}
+
+#[test]
+fn test_update_changelog_wrap_around_sha256_26_256_512_0() {
+    const HEIGHT: usize = 26;
+    const CHANGELOG: usize = 256;
+    const ROOTS: usize = 256;
+    const CANOPY: usize = 0;
+    update_changelog_wrap_around::<Sha256, HEIGHT, CHANGELOG, ROOTS, CANOPY>()
 }

--- a/merkle-tree/indexed/src/copy.rs
+++ b/merkle-tree/indexed/src/copy.rs
@@ -1,6 +1,6 @@
 use std::{marker::PhantomData, mem, slice};
 
-use light_bounded_vec::{BoundedVec, CyclicBoundedVec, Pod};
+use light_bounded_vec::{BoundedVec, CyclicBoundedVec};
 use light_concurrent_merkle_tree::{
     changelog::ChangelogEntry, errors::ConcurrentMerkleTreeError, ConcurrentMerkleTree,
 };
@@ -15,15 +15,7 @@ pub struct IndexedMerkleTreeCopy<'a, H, I, const HEIGHT: usize>(
 )
 where
     H: Hasher,
-    I: CheckedAdd
-        + CheckedSub
-        + Copy
-        + Clone
-        + PartialOrd
-        + ToBytes
-        + TryFrom<usize>
-        + Unsigned
-        + Pod,
+    I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
     usize: From<I>;
 
 pub type IndexedMerkleTreeCopy22<'a, H, I> = IndexedMerkleTreeCopy<'a, H, I, 22>;
@@ -34,15 +26,7 @@ pub type IndexedMerkleTreeCopy40<'a, H, I> = IndexedMerkleTreeCopy<'a, H, I, 40>
 impl<'a, H, I, const HEIGHT: usize> IndexedMerkleTreeCopy<'a, H, I, HEIGHT>
 where
     H: Hasher,
-    I: CheckedAdd
-        + CheckedSub
-        + Copy
-        + Clone
-        + PartialOrd
-        + ToBytes
-        + TryFrom<usize>
-        + Unsigned
-        + Pod,
+    I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
     usize: From<I>,
 {
     /// Casts a byte slice into wrapped `IndexedMerkleTree` structure reference,

--- a/merkle-tree/indexed/src/lib.rs
+++ b/merkle-tree/indexed/src/lib.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use array::{IndexedArray, IndexedElement};
-use light_bounded_vec::{BoundedVec, CyclicBoundedVec, Pod};
+use light_bounded_vec::{BoundedVec, CyclicBoundedVec};
 use light_concurrent_merkle_tree::{
     errors::ConcurrentMerkleTreeError, event::UpdatedLeaf, light_hasher::Hasher,
     ConcurrentMerkleTree,
@@ -24,29 +24,20 @@ pub const FIELD_SIZE_SUB_ONE: &str =
 #[derive(Debug, Default, Clone, Copy)]
 pub struct RawIndexedElement<I>
 where
-    I: Clone + Pod,
+    I: Clone,
 {
     pub value: [u8; 32],
     pub next_index: I,
     pub next_value: [u8; 32],
     pub index: I,
 }
-unsafe impl<I> Pod for RawIndexedElement<I> where I: Pod + Clone {}
 
 #[derive(Debug)]
 #[repr(C)]
 pub struct IndexedMerkleTree<'a, H, I, const HEIGHT: usize>
 where
     H: Hasher,
-    I: CheckedAdd
-        + CheckedSub
-        + Copy
-        + Clone
-        + PartialOrd
-        + ToBytes
-        + TryFrom<usize>
-        + Unsigned
-        + Pod,
+    I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
     usize: From<I>,
 {
     pub merkle_tree: ConcurrentMerkleTree<'a, H, HEIGHT>,
@@ -63,15 +54,7 @@ pub type IndexedMerkleTree40<'a, H, I> = IndexedMerkleTree<'a, H, I, 40>;
 impl<'a, H, I, const HEIGHT: usize> IndexedMerkleTree<'a, H, I, HEIGHT>
 where
     H: Hasher,
-    I: CheckedAdd
-        + CheckedSub
-        + Copy
-        + Clone
-        + PartialOrd
-        + ToBytes
-        + TryFrom<usize>
-        + Unsigned
-        + Pod,
+    I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
     usize: From<I>,
 {
     pub fn new(

--- a/merkle-tree/indexed/src/zero_copy.rs
+++ b/merkle-tree/indexed/src/zero_copy.rs
@@ -1,6 +1,6 @@
 use std::mem;
 
-use light_bounded_vec::{BoundedVec, CyclicBoundedVec, Pod};
+use light_bounded_vec::{BoundedVec, CyclicBoundedVec};
 use light_concurrent_merkle_tree::{
     changelog::ChangelogEntry, errors::ConcurrentMerkleTreeError, ConcurrentMerkleTree,
 };
@@ -13,15 +13,7 @@ use crate::{errors::IndexedMerkleTreeError, IndexedMerkleTree, RawIndexedElement
 pub struct IndexedMerkleTreeZeroCopy<'a, H, I, const HEIGHT: usize>
 where
     H: Hasher,
-    I: CheckedAdd
-        + CheckedSub
-        + Copy
-        + Clone
-        + PartialOrd
-        + ToBytes
-        + TryFrom<usize>
-        + Unsigned
-        + Pod,
+    I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
     usize: From<I>,
 {
     pub merkle_tree: &'a IndexedMerkleTree<'a, H, I, HEIGHT>,
@@ -35,15 +27,7 @@ pub type IndexedMerkleTreeZeroCopy40<'a, H, I> = IndexedMerkleTreeZeroCopy<'a, H
 impl<'a, H, I, const HEIGHT: usize> IndexedMerkleTreeZeroCopy<'a, H, I, HEIGHT>
 where
     H: Hasher,
-    I: CheckedAdd
-        + CheckedSub
-        + Copy
-        + Clone
-        + PartialOrd
-        + ToBytes
-        + TryFrom<usize>
-        + Unsigned
-        + Pod,
+    I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
     usize: From<I>,
 {
     /// Casts a byte slice into wrapped `IndexedMerkleTree` structure reference,
@@ -213,15 +197,7 @@ where
 pub struct IndexedMerkleTreeZeroCopyMut<'a, H, I, const HEIGHT: usize>
 where
     H: Hasher,
-    I: CheckedAdd
-        + CheckedSub
-        + Copy
-        + Clone
-        + PartialOrd
-        + ToBytes
-        + TryFrom<usize>
-        + Unsigned
-        + Pod,
+    I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
     usize: From<I>,
 {
     pub merkle_tree: &'a mut IndexedMerkleTree<'a, H, I, HEIGHT>,
@@ -235,15 +211,7 @@ pub type IndexedMerkleTreeZeroCopyMut40<'a, H, I> = IndexedMerkleTreeZeroCopyMut
 impl<'a, H, I, const HEIGHT: usize> IndexedMerkleTreeZeroCopyMut<'a, H, I, HEIGHT>
 where
     H: Hasher,
-    I: CheckedAdd
-        + CheckedSub
-        + Copy
-        + Clone
-        + PartialOrd
-        + ToBytes
-        + TryFrom<usize>
-        + Unsigned
-        + Pod,
+    I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
     usize: From<I>,
 {
     /// Casts a byte slice into wrapped `IndexedMerkleTree` structure mutable

--- a/merkle-tree/reference/src/lib.rs
+++ b/merkle-tree/reference/src/lib.rs
@@ -121,11 +121,11 @@ where
         self.roots.last().cloned().unwrap()
     }
 
-    pub fn get_proof_of_leaf(
+    pub fn get_proof_of_leaf<'a>(
         &self,
         mut index: usize,
         full: bool,
-    ) -> Result<BoundedVec<[u8; 32]>, BoundedVecError> {
+    ) -> Result<BoundedVec<'a, [u8; 32]>, BoundedVecError> {
         let mut proof = BoundedVec::with_capacity(self.height);
         let limit = match full {
             true => self.height,
@@ -157,6 +157,10 @@ where
 
     pub fn get_leaf_index(&self, leaf: &[u8; 32]) -> Option<usize> {
         self.layers[0].iter().position(|node| node == leaf)
+    }
+
+    pub fn leaves(&self) -> &[[u8; 32]] {
+        self.layers[0].as_slice()
     }
 
     pub fn verify(

--- a/merkle-tree/reference/src/lib.rs
+++ b/merkle-tree/reference/src/lib.rs
@@ -121,6 +121,30 @@ where
         self.roots.last().cloned().unwrap()
     }
 
+    pub fn get_path_of_leaf<'a>(
+        &self,
+        mut index: usize,
+        full: bool,
+    ) -> Result<BoundedVec<'a, [u8; 32]>, BoundedVecError> {
+        let mut path = BoundedVec::with_capacity(self.height);
+        let limit = match full {
+            true => self.height,
+            false => self.height - self.canopy_depth,
+        };
+
+        for level in 0..limit {
+            let node = self.layers[level]
+                .get(index)
+                .cloned()
+                .unwrap_or(H::zero_bytes()[level]);
+            path.push(node)?;
+
+            index /= 2;
+        }
+
+        Ok(path)
+    }
+
     pub fn get_proof_of_leaf<'a>(
         &self,
         mut index: usize,

--- a/merkle-tree/reference/tests/tests.rs
+++ b/merkle-tree/reference/tests/tests.rs
@@ -57,6 +57,9 @@ where
     //  /    \
     // L1   Z[0]
     let expected_root = H::hashv(&[&h3, &H::zero_bytes()[3]]).unwrap();
+    // The Merkle path is:
+    // [L1, H1, H2, H3]
+    let expected_path = BoundedVec::from_array(&[leaf1, h1, h2, h3]);
     let expected_proof = BoundedVec::from_array(&[
         H::zero_bytes()[0],
         H::zero_bytes()[1],
@@ -67,6 +70,10 @@ where
     merkle_tree.append(&leaf1).unwrap();
 
     assert_eq!(merkle_tree.root(), expected_root);
+    assert_eq!(
+        merkle_tree.get_path_of_leaf(0, false).unwrap(),
+        expected_path
+    );
     assert_eq!(
         merkle_tree.get_proof_of_leaf(0, false).unwrap(),
         expected_proof
@@ -94,6 +101,9 @@ where
     let h2 = H::hashv(&[&h1, &H::zero_bytes()[1]]).unwrap();
     let h3 = H::hashv(&[&h2, &H::zero_bytes()[2]]).unwrap();
     let expected_root = H::hashv(&[&h3, &H::zero_bytes()[3]]).unwrap();
+    // The Merkle path is:
+    // [L2, H1, H2, H3]
+    let expected_path = BoundedVec::from_array(&[leaf2, h1, h2, h3]);
     let expected_proof = BoundedVec::from_array(&[
         leaf1,
         H::zero_bytes()[1],
@@ -104,6 +114,10 @@ where
     merkle_tree.append(&leaf2).unwrap();
 
     assert_eq!(merkle_tree.root(), expected_root);
+    assert_eq!(
+        merkle_tree.get_path_of_leaf(1, false).unwrap(),
+        expected_path
+    );
     assert_eq!(
         merkle_tree.get_proof_of_leaf(1, false).unwrap(),
         expected_proof
@@ -131,6 +145,9 @@ where
     let h3 = H::hashv(&[&h1, &h2]).unwrap();
     let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
     let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    // The Merkle path is:
+    // [L3, H2, H3, H4]
+    let expected_path = BoundedVec::from_array(&[leaf3, h2, h3, h4]);
     let expected_proof = BoundedVec::from_array(&[
         H::zero_bytes()[0],
         h1,
@@ -141,6 +158,10 @@ where
     merkle_tree.append(&leaf3).unwrap();
 
     assert_eq!(merkle_tree.root(), expected_root);
+    assert_eq!(
+        merkle_tree.get_path_of_leaf(2, false).unwrap(),
+        expected_path
+    );
     assert_eq!(
         merkle_tree.get_proof_of_leaf(2, false).unwrap(),
         expected_proof
@@ -168,12 +189,19 @@ where
     let h3 = H::hashv(&[&h1, &h2]).unwrap();
     let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
     let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    // The Merkle path is:
+    // [L4, H2, H3, H4]
+    let expected_path = BoundedVec::from_array(&[leaf4, h2, h3, h4]);
     let expected_proof =
         BoundedVec::from_array(&[leaf3, h1, H::zero_bytes()[2], H::zero_bytes()[3]]);
 
     merkle_tree.append(&leaf4).unwrap();
 
     assert_eq!(merkle_tree.root(), expected_root);
+    assert_eq!(
+        merkle_tree.get_path_of_leaf(3, false).unwrap(),
+        expected_path
+    );
     assert_eq!(
         merkle_tree.get_proof_of_leaf(3, false).unwrap(),
         expected_proof
@@ -207,10 +235,17 @@ where
     let h3 = H::hashv(&[&h1, &h2]).unwrap();
     let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
     let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    // The Merkle path is:
+    // [L1, H1, H3, H4]
+    let expected_path = BoundedVec::from_array(&[new_leaf1, h1, h3, h4]);
     let expected_proof =
         BoundedVec::from_array(&[leaf2, h2, H::zero_bytes()[2], H::zero_bytes()[3]]);
 
     assert_eq!(merkle_tree.root(), expected_root);
+    assert_eq!(
+        merkle_tree.get_path_of_leaf(0, false).unwrap(),
+        expected_path
+    );
     assert_eq!(
         merkle_tree.get_proof_of_leaf(0, false).unwrap(),
         expected_proof
@@ -240,10 +275,17 @@ where
     let h3 = H::hashv(&[&h1, &h2]).unwrap();
     let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
     let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    // The Merkle path is:
+    // [L2, H1, H3, H4]
+    let expected_path = BoundedVec::from_array(&[new_leaf2, h1, h3, h4]);
     let expected_proof =
         BoundedVec::from_array(&[new_leaf1, h2, H::zero_bytes()[2], H::zero_bytes()[3]]);
 
     assert_eq!(merkle_tree.root(), expected_root);
+    assert_eq!(
+        merkle_tree.get_path_of_leaf(1, false).unwrap(),
+        expected_path
+    );
     assert_eq!(
         merkle_tree.get_proof_of_leaf(1, false).unwrap(),
         expected_proof
@@ -273,10 +315,17 @@ where
     let h3 = H::hashv(&[&h1, &h2]).unwrap();
     let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
     let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    // The Merkle path is:
+    // [L3, H2, H3, H4]
+    let expected_path = BoundedVec::from_array(&[new_leaf3, h2, h3, h4]);
     let expected_proof =
         BoundedVec::from_array(&[leaf4, h1, H::zero_bytes()[2], H::zero_bytes()[3]]);
 
     assert_eq!(merkle_tree.root(), expected_root);
+    assert_eq!(
+        merkle_tree.get_path_of_leaf(2, false).unwrap(),
+        expected_path
+    );
     assert_eq!(
         merkle_tree.get_proof_of_leaf(2, false).unwrap(),
         expected_proof
@@ -306,10 +355,17 @@ where
     let h3 = H::hashv(&[&h1, &h2]).unwrap();
     let h4 = H::hashv(&[&h3, &H::zero_bytes()[2]]).unwrap();
     let expected_root = H::hashv(&[&h4, &H::zero_bytes()[3]]).unwrap();
+    // The Merkle path is:
+    // [L4, H2, H3, H4]
+    let expected_path = BoundedVec::from_array(&[new_leaf4, h2, h3, h4]);
     let expected_proof =
         BoundedVec::from_array(&[new_leaf3, h1, H::zero_bytes()[2], H::zero_bytes()[3]]);
 
     assert_eq!(merkle_tree.root(), expected_root);
+    assert_eq!(
+        merkle_tree.get_path_of_leaf(3, false).unwrap(),
+        expected_path
+    );
     assert_eq!(
         merkle_tree.get_proof_of_leaf(3, false).unwrap(),
         expected_proof


### PR DESCRIPTION
Restore the usage of `ConcurrentMerkleTreeError::CannotUpdateLeaf` error. Throwing an error when any changelog entry that modifies the same leaf we try to update is a right thing to do.

In case of indexed Merkle tree, we can ignore this error. We are already patching the leaf using the indexed changelog.

Other changes:

* Fix `test_100_nullify_mt`:
  * Each Merkle tree update was pointing to old `changelog_index`. And the crank Merkle tree was not being updated after each operation.
* Implement `Clone` in `BoundedVec`, to make cloning of Merkle proofs possible.
* Add more tests:
  * Check whether elements returned in `ConcurrentMerkleTree::changelog_entries`
    are as expected.
  * Test proving that we need to `skip(1)` during Merkle proof update.
  * Test with an update on wrapped-around changelog.
