### PR TITLE
test: nullifier queue failing tests full queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ node_modules
 
 /cli/.crates2.json
 /cli/.crates.toml
+test-programs/rnd-inf-test/**/*.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
  "light-utils",
  "light-verifier",
  "log",
- "memoffset 0.9.0",
+ "memoffset 0.9.1",
  "num-bigint 0.4.4",
  "num-traits",
  "solana-program-test",
@@ -56,12 +56,14 @@ dependencies = [
  "light-compressed-pda",
  "light-compressed-token",
  "light-concurrent-merkle-tree",
+ "light-hash-set",
  "light-hasher",
  "light-indexed-merkle-tree",
  "light-merkle-tree-reference",
  "light-test-utils",
  "light-utils",
  "light-verifier",
+ "memoffset 0.9.1",
  "num-bigint 0.4.4",
  "num-traits",
  "reqwest 0.11.26",
@@ -1467,7 +1469,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.9.0",
+ "memoffset 0.9.1",
  "scopeguard",
 ]
 
@@ -2785,7 +2787,7 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-std",
- "borsh 0.9.3",
+ "borsh 0.10.3",
  "bytemuck",
  "color-eyre",
  "duct",
@@ -2902,7 +2904,7 @@ dependencies = [
  "light-bounded-vec",
  "light-heap",
  "light-utils",
- "memoffset 0.9.0",
+ "memoffset 0.9.1",
  "num-bigint 0.4.4",
  "num-traits",
  "rand 0.8.5",
@@ -3155,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -5390,7 +5392,7 @@ dependencies = [
  "libsecp256k1",
  "light-poseidon",
  "log",
- "memoffset 0.9.0",
+ "memoffset 0.9.1",
  "num-bigint 0.4.4",
  "num-derive 0.4.2",
  "num-traits",

--- a/programs/account-compression/src/instructions/initialize_state_merkle_tree_and_nullifier_queue.rs
+++ b/programs/account-compression/src/instructions/initialize_state_merkle_tree_and_nullifier_queue.rs
@@ -65,7 +65,6 @@ impl default::Default for NullifierQueueConfig {
         }
     }
 }
-
 pub fn process_initialize_state_merkle_tree_and_nullifier_queue(
     ctx: Context<'_, '_, '_, '_, InitializeStateMerkleTreeAndNullifierQueue<'_>>,
     index: u64,

--- a/programs/account-compression/src/instructions/insert_into_nullifier_queue.rs
+++ b/programs/account-compression/src/instructions/insert_into_nullifier_queue.rs
@@ -22,7 +22,7 @@ pub struct InsertIntoNullifierQueues<'info> {
     pub registered_program_pda: Option<Account<'info, RegisteredProgram>>, // nullifiers are sent in remaining accounts. @ErrorCode::InvalidVerifier
     pub system_program: Program<'info, System>,
 }
-
+// TODO: add test that the first two elements of the queue cannot be inserted into the tree and removed from the queue
 /// Inserts every element into the indexed array.
 /// Throws an error if the element already exists.
 /// Expects an indexed queue account as for every index as remaining account.
@@ -97,7 +97,6 @@ pub fn process_insert_into_nullifier_queues<'a, 'b, 'c: 'info, 'info>(
             light_heap::bench_sbf_start!("acp_insert_nf_into_queue");
             for element in queue_bundle.elements.iter() {
                 let element = BigUint::from_bytes_be(element.as_slice());
-                msg!("Inserting element {:?} into nullifier queue", element);
                 indexed_array
                     .insert(&element, sequence_number)
                     .map_err(ProgramError::from)?;

--- a/test-programs/account-compression-test/Cargo.toml
+++ b/test-programs/account-compression-test/Cargo.toml
@@ -35,6 +35,7 @@ light-compressed-token = { path = "../../programs/compressed-token"  , features 
 light-compressed-pda = { path = "../../programs/compressed-pda"  , features = ["cpi"]}
 account-compression = { path = "../../programs/account-compression" , features = ["cpi"] }
 light-hasher = {path = "../../merkle-tree/hasher"}
+light-hash-set = {path = "../../merkle-tree/hash-set"}
 light-concurrent-merkle-tree = {path = "../../merkle-tree/concurrent"}
 light-indexed-merkle-tree = {path = "../../merkle-tree/indexed"}
 light-merkle-tree-reference = {path = "../../merkle-tree/reference"}
@@ -45,3 +46,4 @@ solana-cli-output = "1.18.11"
 serde_json = "1.0.114"
 solana-sdk = "1.18.11"
 thiserror = "1.0"
+memoffset = "0.9.1"

--- a/test-programs/compressed-pda-test/tests/test.rs
+++ b/test-programs/compressed-pda-test/tests/test.rs
@@ -1,5 +1,4 @@
 #![cfg(feature = "test-sbf")]
-
 use light_compressed_pda::{
     errors::CompressedPdaError,
     sdk::{


### PR DESCRIPTION
### Changes:
- add failing test for nullifier queue operations to show that we cannot insert into a full queue.
**Scenario:**
1. try to insert into queue to generate the full error
2. nullify one
3. try to insert again it should still generate the full error
4. advance Merkle tree seq until one before it would work check that it still fails
5. advance Merkle tree seq by one and check that inserting works now
6.try inserting again it should fail with full error