### PR TITLE
fix: edge cases in rust sdks

### DIFF
--- a/programs/compressed-pda/src/sdk/address.rs
+++ b/programs/compressed-pda/src/sdk/address.rs
@@ -28,12 +28,13 @@ pub fn pack_new_address_params(
             address_queue_account_index: 0,       // will be assigned later
         })
         .collect::<Vec<NewAddressParamsPacked>>();
-    let len: usize = remaining_accounts.len();
+    let mut next_index: usize = remaining_accounts.len();
     for (i, params) in new_address_params.iter().enumerate() {
         match remaining_accounts.get(&params.address_merkle_tree_pubkey) {
             Some(_) => {}
             None => {
-                remaining_accounts.insert(params.address_merkle_tree_pubkey, i + len);
+                remaining_accounts.insert(params.address_merkle_tree_pubkey, next_index);
+                next_index += 1;
             }
         };
         new_address_params_packed[i].address_merkle_tree_account_index = *remaining_accounts
@@ -42,12 +43,12 @@ pub fn pack_new_address_params(
             as u8;
     }
 
-    let len: usize = remaining_accounts.len();
     for (i, params) in new_address_params.iter().enumerate() {
         match remaining_accounts.get(&params.address_queue_pubkey) {
             Some(_) => {}
             None => {
-                remaining_accounts.insert(params.address_queue_pubkey, i + len);
+                remaining_accounts.insert(params.address_queue_pubkey, next_index);
+                next_index += 1;
             }
         };
         new_address_params_packed[i].address_queue_account_index = *remaining_accounts

--- a/programs/compressed-pda/src/sdk/compressed_account.rs
+++ b/programs/compressed-pda/src/sdk/compressed_account.rs
@@ -42,24 +42,25 @@ pub fn pack_merkle_context(
             nullifier_queue_pubkey_index: 0, // will be assigned later
         })
         .collect::<Vec<PackedMerkleContext>>();
-    let len: usize = remaining_accounts.len();
+    let mut index: usize = remaining_accounts.len();
     for (i, params) in merkle_context.iter().enumerate() {
         match remaining_accounts.get(&params.merkle_tree_pubkey) {
             Some(_) => {}
             None => {
-                remaining_accounts.insert(params.merkle_tree_pubkey, i + len);
+                remaining_accounts.insert(params.merkle_tree_pubkey, index);
+                index += 1;
             }
         };
         merkle_context_packed[i].merkle_tree_pubkey_index =
             *remaining_accounts.get(&params.merkle_tree_pubkey).unwrap() as u8;
     }
 
-    let len: usize = remaining_accounts.len();
     for (i, params) in merkle_context.iter().enumerate() {
         match remaining_accounts.get(&params.nullifier_queue_pubkey) {
             Some(_) => {}
             None => {
-                remaining_accounts.insert(params.nullifier_queue_pubkey, i + len);
+                remaining_accounts.insert(params.nullifier_queue_pubkey, index);
+                index += 1;
             }
         };
         merkle_context_packed[i].nullifier_queue_pubkey_index = *remaining_accounts


### PR DESCRIPTION
Issue:
- indices in rust pack functions did not work for multiple input trees

Changes:
- fix the offset and unify index assignment to a single variable
- removed some outdated commented code