### PR TITLE
refactor: test indexer

### DIFF
--- a/.github/workflows/light-system-programs-tests.yml
+++ b/.github/workflows/light-system-programs-tests.yml
@@ -4,6 +4,7 @@ on:
       - main
     paths:
       - "programs/**"
+      - "test-programs/**"
       - "circuit-lib/verifier/**"
       - "merkle-tree/**"
       - ".github/workflows/light-system-programs-tests.yml"
@@ -12,6 +13,7 @@ on:
       - main
     paths:
       - "programs/**"
+      - "test-programs/**"
       - "circuit-lib/verifier/**"
       - "merkle-tree/**"
       - ".github/workflows/light-system-programs-tests.yml"

--- a/examples/token-escrow/programs/token-escrow/Cargo.toml
+++ b/examples/token-escrow/programs/token-escrow/Cargo.toml
@@ -32,7 +32,7 @@ solana-sdk = "1.18.11"
 
 [dev-dependencies]
 solana-program-test = "1.18.11"
-light-test-utils = { version = "0.1.1", path = "../../../../test-utils", default-features= true, features = ["test_indexer", "light_program"] }
+light-test-utils = { version = "0.1.1", path = "../../../../test-utils"}
 reqwest = "0.12"
 tokio = "1.36.0"
 light-circuitlib-rs = { path = "../../../../circuit-lib/circuitlib-rs", version = "0.1.1" }

--- a/programs/account-compression/src/instructions/initialize_state_merkle_tree_and_nullifier_queue.rs
+++ b/programs/account-compression/src/instructions/initialize_state_merkle_tree_and_nullifier_queue.rs
@@ -88,7 +88,6 @@ pub fn process_initialize_state_merkle_tree_and_nullifier_queue(
     if nullifier_queue_config != NullifierQueueConfig::default() {
         unimplemented!("Only default nullifier queue config supported.");
     }
-    msg!("state Merkle tree init delegate {:?}", delegate);
 
     process_initialize_state_merkle_tree(
         &ctx.accounts.merkle_tree,

--- a/programs/account-compression/src/instructions/initialize_state_merkle_tree_and_nullifier_queue.rs
+++ b/programs/account-compression/src/instructions/initialize_state_merkle_tree_and_nullifier_queue.rs
@@ -88,6 +88,7 @@ pub fn process_initialize_state_merkle_tree_and_nullifier_queue(
     if nullifier_queue_config != NullifierQueueConfig::default() {
         unimplemented!("Only default nullifier queue config supported.");
     }
+    msg!("state Merkle tree init delegate {:?}", delegate);
 
     process_initialize_state_merkle_tree(
         &ctx.accounts.merkle_tree,

--- a/test-programs/account-compression-test/Cargo.toml
+++ b/test-programs/account-compression-test/Cargo.toml
@@ -22,7 +22,7 @@ default = ["custom-heap"]
 
 [dev-dependencies]
 solana-program-test = "1.18.11"
-light-test-utils = { version = "0.1.1", path = "../../test-utils", default-features= true, features = ["test_indexer"] }
+light-test-utils = { version = "0.1.1", path = "../../test-utils" }
 reqwest = "0.11.26"
 tokio = "1.36.0"
 light-circuitlib-rs = {path = "../../circuit-lib/circuitlib-rs"}

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -390,7 +390,6 @@ async fn test_address_queue() {
             .unwrap(),
         true
     );
-    println!("Address queue insert successful");
     relayer_update(
         &mut context,
         address_queue_keypair.pubkey(),

--- a/test-programs/account-compression-test/tests/merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/merkle_tree_tests.rs
@@ -183,7 +183,6 @@ async fn test_nullifier_queue_security() {
         replacement_start_value,
         nullifier_queue.hash_set.capacity_values as usize,
     );
-    println!("replacement_value {}", replacement_value);
     // CHECK: 5
     let element: [u8; 32] =
         bigint_to_be_bytes_array(&replacement_value.to_biguint().unwrap()).unwrap();
@@ -311,7 +310,6 @@ pub async fn set_state_merkle_tree_sequence(
     sequence_number: u64,
     lamports: u64,
 ) {
-    println!("advance to sequence number {}", sequence_number);
     // is in range 9 - 10 in concurrent mt
     // offset for sequence number
     // let offset_start = 6 * 8 + 8 + 4 * 32 + 8 * 9;

--- a/test-programs/compressed-pda-test/Cargo.toml
+++ b/test-programs/compressed-pda-test/Cargo.toml
@@ -22,7 +22,7 @@ default = ["custom-heap"]
 
 [dev-dependencies]
 solana-program-test = "1.18.11"
-light-test-utils = { version = "0.1.1", path = "../../test-utils", default-features= true, features = ["test_indexer"] }
+light-test-utils = { version = "0.1.1", path = "../../test-utils" }
 reqwest = "0.11.26"
 tokio = "1.36.0"
 light-circuitlib-rs = {path = "../../circuit-lib/circuitlib-rs"}

--- a/test-programs/compressed-pda-test/tests/test.rs
+++ b/test-programs/compressed-pda-test/tests/test.rs
@@ -11,22 +11,24 @@ use light_compressed_pda::{
     },
     NewAddressParams,
 };
+use solana_sdk::transaction::TransactionError;
+
 use light_hasher::Poseidon;
 use light_test_utils::{
     assert_custom_error_or_program_error, create_and_send_transaction,
     create_and_send_transaction_with_event,
-    system_program::{assert_created_compressed_accounts, create_addresses_test},
+    system_program::{
+        assert_created_compressed_accounts, compress_sol_test, create_addresses_test,
+        decompress_sol_test, transfer_compressed_sol_test,
+    },
     test_env::setup_test_programs_with_accounts,
     test_indexer::TestIndexer,
     FeeConfig, TransactionParams,
 };
 use solana_cli_output::CliAccount;
-use solana_program_test::{BanksClientError, ProgramTestContext};
+use solana_program_test::BanksClientError;
 use solana_sdk::{
-    instruction::InstructionError,
-    pubkey::Pubkey,
-    signer::Signer,
-    transaction::{Transaction, TransactionError},
+    instruction::InstructionError, pubkey::Pubkey, signer::Signer, transaction::Transaction,
 };
 use tokio::fs::write as async_write;
 
@@ -176,6 +178,10 @@ async fn invoke_test() {
                     &compressed_account_with_context.merkle_context.leaf_index,
                 )
                 .unwrap()]),
+            Some(&[compressed_account_with_context
+                .merkle_context
+                .merkle_tree_pubkey]),
+            None,
             None,
             &mut context,
         )
@@ -300,7 +306,6 @@ async fn test_with_address() {
 
     let payer_pubkey = payer.pubkey();
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
-    let nullifier_queue_pubkey = env.nullifier_queue_pubkey;
 
     let address_seed = [1u8; 32];
     let derived_address = derive_address(&env.address_merkle_tree_pubkey, &address_seed).unwrap();
@@ -339,90 +344,109 @@ async fn test_with_address() {
     .await
     .unwrap();
     assert_custom_error_or_program_error(res, CompressedPdaError::InvalidAddress.into()).unwrap();
-
-    let event = create_addresses_test(
+    println!("creating address -------------------------");
+    create_addresses_test(
         &mut context,
         &mut test_indexer,
-        &env.address_merkle_tree_pubkey,
-        &env.address_merkle_tree_queue_pubkey,
-        &env.merkle_tree_pubkey,
-        &env.nullifier_queue_pubkey,
+        &[env.address_merkle_tree_pubkey],
+        &[env.address_merkle_tree_queue_pubkey],
+        vec![env.merkle_tree_pubkey],
         &[address_seed],
         &Vec::new(),
-        true,
-    )
-    .await
-    .unwrap()
-    .unwrap();
-    test_indexer.add_event_and_compressed_accounts(event);
-    assert_eq!(test_indexer.compressed_accounts.len(), 1);
-    assert_eq!(
-        test_indexer.compressed_accounts[0]
-            .compressed_account
-            .address
-            .unwrap(),
-        derived_address
-    );
-
-    let compressed_account_with_context = test_indexer.compressed_accounts[0].clone();
-    let proof_rpc_res = test_indexer
-        .create_proof_for_compressed_accounts(
-            Some(&[compressed_account_with_context
-                .compressed_account
-                .hash::<Poseidon>(
-                    &merkle_tree_pubkey,
-                    &compressed_account_with_context.merkle_context.leaf_index,
-                )
-                .unwrap()]),
-            None,
-            &mut context,
-        )
-        .await;
-    let input_compressed_accounts = vec![compressed_account_with_context.compressed_account];
-    let recipient_pubkey = Pubkey::new_unique();
-    let output_compressed_accounts = vec![CompressedAccount {
-        lamports: 0,
-        owner: recipient_pubkey,
-        data: None,
-        address: Some(derived_address),
-    }];
-    let instruction = create_invoke_instruction(
-        &payer_pubkey,
-        &payer_pubkey,
-        &input_compressed_accounts,
-        &output_compressed_accounts,
-        &[MerkleContext {
-            merkle_tree_pubkey,
-            leaf_index: 0,
-            nullifier_queue_pubkey,
-        }],
-        &[merkle_tree_pubkey],
-        &proof_rpc_res.root_indices,
-        &Vec::new(),
-        Some(proof_rpc_res.proof.clone()),
-        None,
         false,
         None,
-    );
-    println!("Transaction with zkp -------------------------");
-    let event = create_and_send_transaction_with_event(
-        &mut context,
-        &[instruction],
-        &payer_pubkey,
-        &[&payer],
-        Some(TransactionParams {
-            num_input_compressed_accounts: 1,
-            num_output_compressed_accounts: 1,
-            num_new_addresses: 0,
-            compress: 0,
-            fee_config: FeeConfig::default(),
-        }),
     )
     .await
-    .unwrap()
     .unwrap();
+    // test_indexer.add_event_and_compressed_accounts(event);
+    // assert_eq!(test_indexer.compressed_accounts.len(), 1);
+    // assert_eq!(
+    //     test_indexer.compressed_accounts[0]
+    //         .compressed_account
+    //         .address
+    //         .unwrap(),
+    //     derived_address
+    // );
+    // transfer with address
+    println!("transfer with address-------------------------");
 
-    test_indexer.add_event_and_compressed_accounts(event);
+    let compressed_account_with_context = test_indexer.compressed_accounts[0].clone();
+    let recipient_pubkey = Pubkey::new_unique();
+    transfer_compressed_sol_test(
+        &mut context,
+        &mut test_indexer,
+        &payer,
+        &[compressed_account_with_context.clone()],
+        &[recipient_pubkey],
+        &[compressed_account_with_context
+            .merkle_context
+            .merkle_tree_pubkey],
+        None,
+    )
+    .await
+    .unwrap();
+    // let proof_rpc_res = test_indexer
+    //     .create_proof_for_compressed_accounts(
+    //         Some(&[compressed_account_with_context
+    //             .compressed_account
+    //             .hash::<Poseidon>(
+    //                 &merkle_tree_pubkey,
+    //                 &compressed_account_with_context.merkle_context.leaf_index,
+    //             )
+    //             .unwrap()]),
+    //         Some(&[compressed_account_with_context
+    //             .merkle_context
+    //             .merkle_tree_pubkey]),
+    //         None,
+    //         None,
+    //         &mut context,
+    //     )
+    //     .await;
+    // let input_compressed_accounts = vec![compressed_account_with_context.compressed_account];
+    // let recipient_pubkey = Pubkey::new_unique();
+    // let output_compressed_accounts = vec![CompressedAccount {
+    //     lamports: 0,
+    //     owner: recipient_pubkey,
+    //     data: None,
+    //     address: Some(derived_address),
+    // }];
+    // let instruction = create_invoke_instruction(
+    //     &payer_pubkey,
+    //     &payer_pubkey,
+    //     &input_compressed_accounts,
+    //     &output_compressed_accounts,
+    //     &[MerkleContext {
+    //         merkle_tree_pubkey,
+    //         leaf_index: 0,
+    //         nullifier_queue_pubkey,
+    //     }],
+    //     &[merkle_tree_pubkey],
+    //     &proof_rpc_res.root_indices,
+    //     &Vec::new(),
+    //     Some(proof_rpc_res.proof.clone()),
+    //     None,
+    //     false,
+    //     None,
+    // );
+    // println!("Transaction with zkp -------------------------");
+    // let event = create_and_send_transaction_with_event(
+    //     &mut context,
+    //     &[instruction],
+    //     &payer_pubkey,
+    //     &[&payer],
+    //     Some(TransactionParams {
+    //         num_input_compressed_accounts: 1,
+    //         num_output_compressed_accounts: 1,
+    //         num_new_addresses: 0,
+    //         compress: 0,
+    //         fee_config: FeeConfig::default(),
+    //     }),
+    // )
+    // .await
+    // .unwrap()
+    // .unwrap();
+
+    // test_indexer.add_event_and_compressed_accounts(event);
     assert_eq!(test_indexer.compressed_accounts.len(), 1);
     assert_eq!(
         test_indexer.compressed_accounts[0]
@@ -441,13 +465,19 @@ async fn test_with_address() {
     let event = create_addresses_test(
         &mut context,
         &mut test_indexer,
-        &env.address_merkle_tree_pubkey,
-        &env.address_merkle_tree_queue_pubkey,
-        &env.merkle_tree_pubkey,
-        &env.nullifier_queue_pubkey,
+        &[
+            env.address_merkle_tree_pubkey,
+            env.address_merkle_tree_pubkey,
+        ],
+        &[
+            env.address_merkle_tree_queue_pubkey,
+            env.address_merkle_tree_queue_pubkey,
+        ],
+        vec![env.merkle_tree_pubkey, env.merkle_tree_pubkey],
         &[address_seed_2, address_seed_2],
         &Vec::new(),
-        true,
+        false,
+        None,
     )
     .await;
     // Should fail to insert the same address twice in the same tx
@@ -462,38 +492,42 @@ async fn test_with_address() {
     println!("test 2in -------------------------");
 
     let address_seed_3 = [3u8; 32];
-    let event = create_addresses_test(
+    create_addresses_test(
         &mut context,
         &mut test_indexer,
-        &env.address_merkle_tree_pubkey,
-        &env.address_merkle_tree_queue_pubkey,
-        &env.merkle_tree_pubkey,
-        &env.nullifier_queue_pubkey,
+        &[
+            env.address_merkle_tree_pubkey,
+            env.address_merkle_tree_pubkey,
+        ],
+        &[
+            env.address_merkle_tree_queue_pubkey,
+            env.address_merkle_tree_queue_pubkey,
+        ],
+        vec![env.merkle_tree_pubkey, env.merkle_tree_pubkey],
         &[address_seed_2, address_seed_3],
         &Vec::new(),
-        true,
+        false,
+        None,
     )
     .await
-    .unwrap()
     .unwrap();
-    test_indexer.add_event_and_compressed_accounts(event);
 
-    // spend one input compressed accounts and create one new address
-    println!("test combined -------------------------");
-
+    // Test combination
+    // (num_input_compressed_accounts, num_new_addresses)
     let test_inputs = vec![
         (1, 1),
         (1, 2),
         (2, 1),
         (2, 2),
         (3, 1),
-        // (3, 2), TODO: enable once heap optimization is done
-        // (4, 1),
-        // (4, 2),
+        (3, 2),
+        (4, 1),
+        (4, 2),
     ];
     for (n_input_compressed_accounts, n_new_addresses) in test_inputs {
-        let compressed_input_accounts =
-            test_indexer.compressed_accounts[1..n_input_compressed_accounts].to_vec();
+        let compressed_input_accounts = test_indexer
+            .get_compressed_accounts_by_owner(&payer_pubkey)[0..n_input_compressed_accounts]
+            .to_vec();
         let mut address_vec = Vec::new();
         // creates multiple seeds by taking the number of input accounts and zeroing out the jth byte
         for j in 0..n_new_addresses {
@@ -502,16 +536,16 @@ async fn test_with_address() {
             address_vec.push(address_seed);
         }
 
-        let event = create_addresses_test(
+        create_addresses_test(
             &mut context,
             &mut test_indexer,
-            &env.address_merkle_tree_pubkey,
-            &env.address_merkle_tree_queue_pubkey,
-            &env.merkle_tree_pubkey,
-            &env.nullifier_queue_pubkey,
+            &vec![env.address_merkle_tree_pubkey; n_new_addresses],
+            &vec![env.address_merkle_tree_queue_pubkey; n_new_addresses],
+            vec![env.merkle_tree_pubkey; n_new_addresses],
             &address_vec,
             &compressed_input_accounts,
-            false, // TODO: enable once heap optimization is done
+            true,
+            None,
         )
         .await
         .unwrap();
@@ -527,163 +561,232 @@ async fn test_with_compression() {
 
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
     let nullifier_queue_pubkey = env.nullifier_queue_pubkey;
-    let address_merkle_tree_pubkey = env.address_merkle_tree_pubkey;
-    let test_indexer = TestIndexer::new(
-        merkle_tree_pubkey,
-        nullifier_queue_pubkey,
-        address_merkle_tree_pubkey,
-        payer.insecure_clone(),
+    let mut test_indexer = TestIndexer::init_from_env(
+        &payer,
+        &env,
         true,
         false,
         "../../circuit-lib/circuitlib-rs/scripts/prover.sh",
-    );
+    )
+    .await;
     let compress_amount = 1_000_000;
-    let output_compressed_accounts = vec![CompressedAccount {
-        lamports: compress_amount,
-        owner: payer_pubkey,
-        data: None,
-        address: None, // this should not be sent, only derived on-chain
-    }];
-
-    let instruction = create_invoke_instruction(
-        &payer_pubkey,
-        &payer_pubkey,
-        &Vec::new(),
-        &output_compressed_accounts,
-        &Vec::new(),
-        &[merkle_tree_pubkey],
-        &Vec::new(),
-        &Vec::new(),
-        None,
-        Some(compress_amount),
-        false,
-        None,
-    );
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&payer_pubkey),
-        &[&payer],
-        context.get_new_latest_blockhash().await.unwrap(),
-    );
-    let res = solana_program_test::BanksClient::process_transaction_with_metadata(
-        &mut context.banks_client,
-        transaction,
-    )
-    .await
-    .unwrap();
-    // should fail because of insufficient input funds
-    assert_custom_error_or_program_error(res, CompressedPdaError::ComputeOutputSumFailed.into())
-        .unwrap();
-    let instruction = create_invoke_instruction(
-        &payer_pubkey,
-        &payer_pubkey,
-        &Vec::new(),
-        &output_compressed_accounts,
-        &Vec::new(),
-        &[merkle_tree_pubkey],
-        &Vec::new(),
-        &Vec::new(),
-        None,
-        None,
-        true,
-        None,
-    );
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&payer_pubkey),
-        &[&payer],
-        context.get_new_latest_blockhash().await.unwrap(),
-    );
-    let res = solana_program_test::BanksClient::process_transaction_with_metadata(
-        &mut context.banks_client,
-        transaction,
-    )
-    .await
-    .unwrap();
-    // should fail because of insufficient decompress amount funds
-    assert_custom_error_or_program_error(res, CompressedPdaError::ComputeOutputSumFailed.into())
-        .unwrap();
-
-    let instruction = create_invoke_instruction(
-        &payer_pubkey,
-        &payer_pubkey,
-        &Vec::new(),
-        &output_compressed_accounts,
-        &Vec::new(),
-        &[merkle_tree_pubkey],
-        &Vec::new(),
-        &Vec::new(),
-        None,
-        Some(compress_amount),
-        true,
-        None,
-    );
-    let sender_pre_balance = context
-        .banks_client
-        .get_account(payer_pubkey)
-        .await
-        .unwrap()
-        .unwrap()
-        .lamports;
-    let event = create_and_send_transaction_with_event(
+    let error = compress_sol_test(
         &mut context,
-        &[instruction],
+        &mut test_indexer,
+        &payer,
+        &Vec::new(),
+        false,
+        compress_amount,
         &payer_pubkey,
-        &[&payer],
-        Some(TransactionParams {
-            num_input_compressed_accounts: 0,
-            num_output_compressed_accounts: 1,
-            num_new_addresses: 0,
-            compress: compress_amount as i64,
-            fee_config: FeeConfig::default(),
-        }),
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        error.unwrap_err().to_string(),
+        BanksClientError::TransactionError(
+            solana_sdk::transaction::TransactionError::InstructionError(
+                0,
+                solana_sdk::instruction::InstructionError::Custom(
+                    CompressedPdaError::ComputeOutputSumFailed.into()
+                )
+            )
+        )
+        .to_string()
+    );
+    // let instruction = create_invoke_instruction(
+    //     &payer_pubkey,
+    //     &payer_pubkey,
+    //     &Vec::new(),
+    //     &output_compressed_accounts,
+    //     &Vec::new(),
+    //     &[merkle_tree_pubkey],
+    //     &Vec::new(),
+    //     &Vec::new(),
+    //     None,
+    //     Some(compress_amount),
+    //     false,
+    //     None,
+    // );
+
+    // let transaction = Transaction::new_signed_with_payer(
+    //     &[instruction],
+    //     Some(&payer_pubkey),
+    //     &[&payer],
+    //     context.get_new_latest_blockhash().await.unwrap(),
+    // );
+    // let res = solana_program_test::BanksClient::process_transaction_with_metadata(
+    //     &mut context.banks_client,
+    //     transaction,
+    // )
+    // .await
+    // .unwrap();
+    // should fail because of insufficient input funds
+    // assert_custom_error_or_program_error(error, CompressedPdaError::ComputeOutputSumFailed.into())
+    // .unwrap();
+    let error = compress_sol_test(
+        &mut context,
+        &mut test_indexer,
+        &payer,
+        &Vec::new(),
+        false,
+        compress_amount,
+        &payer_pubkey,
+        None,
+    )
+    .await;
+    // let instruction = create_invoke_instruction(
+    //     &payer_pubkey,
+    //     &payer_pubkey,
+    //     &Vec::new(),
+    //     &output_compressed_accounts,
+    //     &Vec::new(),
+    //     &[merkle_tree_pubkey],
+    //     &Vec::new(),
+    //     &Vec::new(),
+    //     None,
+    //     None,
+    //     true,
+    //     None,
+    // );
+
+    // let transaction = Transaction::new_signed_with_payer(
+    //     &[instruction],
+    //     Some(&payer_pubkey),
+    //     &[&payer],
+    //     context.get_new_latest_blockhash().await.unwrap(),
+    // );
+    // let res = solana_program_test::BanksClient::process_transaction_with_metadata(
+    //     &mut context.banks_client,
+    //     transaction,
+    // )
+    // .await
+    // .unwrap();
+    // // should fail because of insufficient decompress amount funds
+    // assert_custom_error_or_program_error(res, CompressedPdaError::ComputeOutputSumFailed.into())
+    //     .unwrap();
+    assert_eq!(
+        error.unwrap_err().to_string(),
+        BanksClientError::TransactionError(
+            solana_sdk::transaction::TransactionError::InstructionError(
+                0,
+                solana_sdk::instruction::InstructionError::Custom(
+                    CompressedPdaError::ComputeOutputSumFailed.into()
+                )
+            )
+        )
+        .to_string()
+    );
+    compress_sol_test(
+        &mut context,
+        &mut test_indexer,
+        &payer,
+        &Vec::new(),
+        false,
+        compress_amount,
+        &payer_pubkey,
+        None,
     )
     .await
-    .unwrap()
     .unwrap();
+    // let instruction = create_invoke_instruction(
+    //     &payer_pubkey,
+    //     &payer_pubkey,
+    //     &Vec::new(),
+    //     &output_compressed_accounts,
+    //     &Vec::new(),
+    //     &[merkle_tree_pubkey],
+    //     &Vec::new(),
+    //     &Vec::new(),
+    //     None,
+    //     Some(compress_amount),
+    //     true,
+    //     None,
+    // );
+    // let sender_pre_balance = context
+    //     .banks_client
+    //     .get_account(payer_pubkey)
+    //     .await
+    //     .unwrap()
+    //     .unwrap()
+    //     .lamports;
+    // let event = create_and_send_transaction_with_event(
+    //     &mut context,
+    //     &[instruction],
+    //     &payer_pubkey,
+    //     &[&payer],
+    //     Some(TransactionParams {
+    //         num_input_compressed_accounts: 0,
+    //         num_output_compressed_accounts: 1,
+    //         num_new_addresses: 0,
+    //         compress: compress_amount as i64,
+    //         fee_config: FeeConfig::default(),
+    //     }),
+    // )
+    // .await
+    // .unwrap()
+    // .unwrap();
 
-    let compressed_sol_pda_balance = context
-        .banks_client
-        .get_account(get_compressed_sol_pda())
-        .await
-        .unwrap()
-        .unwrap()
-        .lamports;
+    // let compressed_sol_pda_balance = context
+    //     .banks_client
+    //     .get_account(get_compressed_sol_pda())
+    //     .await
+    //     .unwrap()
+    //     .unwrap()
+    //     .lamports;
 
-    assert_eq!(
-        compressed_sol_pda_balance, compress_amount,
-        "balance of compressed sol pda insufficient, compress sol failed"
-    );
+    // assert_eq!(
+    //     compressed_sol_pda_balance, compress_amount,
+    //     "balance of compressed sol pda insufficient, compress sol failed"
+    // );
 
-    // Wait until now to reduce startup lag by prover server
-    let mut test_indexer = test_indexer.await;
-    test_indexer.add_event_and_compressed_accounts(event);
-    assert_eq!(test_indexer.compressed_accounts.len(), 1);
-    assert_eq!(
-        test_indexer.compressed_accounts[0]
-            .compressed_account
-            .address,
-        None
-    );
-    let sender_post_balance = context
-        .banks_client
-        .get_account(payer_pubkey)
-        .await
-        .unwrap()
-        .unwrap()
-        .lamports;
-    let network_fee = 5000;
-    let state_merkle_tree_rollover_fee = 150;
-    assert_eq!(
-        sender_pre_balance,
-        sender_post_balance + compress_amount + network_fee + state_merkle_tree_rollover_fee,
-        "sender balance incorrect, compress sol failed diff {}",
-        sender_pre_balance
-            - (sender_pre_balance - compress_amount - network_fee - state_merkle_tree_rollover_fee)
-    );
-    let compressed_account_with_context = test_indexer.compressed_accounts[0].clone();
+    // test_indexer.add_event_and_compressed_accounts(event);
+    // assert_eq!(test_indexer.compressed_accounts.len(), 1);
+    // assert_eq!(
+    //     test_indexer.compressed_accounts[0]
+    //         .compressed_account
+    //         .address,
+    //     None
+    // );
+    // let sender_post_balance = context
+    //     .banks_client
+    //     .get_account(payer_pubkey)
+    //     .await
+    //     .unwrap()
+    //     .unwrap()
+    //     .lamports;
+    // let network_fee = 5000;
+    // let state_merkle_tree_rollover_fee = 150;
+    // assert_eq!(
+    //     sender_pre_balance,
+    //     sender_post_balance + compress_amount + network_fee + state_merkle_tree_rollover_fee,
+    //     "sender balance incorrect, compress sol failed diff {}",
+    //     sender_pre_balance
+    //         - (sender_pre_balance - compress_amount - network_fee - state_merkle_tree_rollover_fee)
+    // );
+    let compressed_account_with_context = test_indexer.compressed_accounts.last().unwrap().clone();
+    // let recipient = Pubkey::new_unique();
+    // let error = compress_sol_test(
+    //     &mut context,
+    //     &mut test_indexer,
+    //     &payer,
+    //     &vec![compressed_account_with_context],
+    //     false,
+    //     compress_amount,
+    //     &recipient,
+    //     None,
+    // )
+    // .await;
+    // assert_eq!(
+    //     error.unwrap_err().to_string(),
+    //     BanksClientError::TransactionError(InstructionError(
+    //         0,
+    //         solana_sdk::instruction::InstructionError::Custom(
+    //             CompressedPdaError::SumCheckFailed.into()
+    //         )
+    //     ))
+    //     .to_string()
+    // );
     let proof_rpc_res = test_indexer
         .create_proof_for_compressed_accounts(
             Some(&[compressed_account_with_context
@@ -693,11 +796,16 @@ async fn test_with_compression() {
                     &compressed_account_with_context.merkle_context.leaf_index,
                 )
                 .unwrap()]),
+            Some(&[compressed_account_with_context
+                .merkle_context
+                .merkle_tree_pubkey]),
+            None,
             None,
             &mut context,
         )
         .await;
-    let input_compressed_accounts = vec![compressed_account_with_context.compressed_account];
+    let input_compressed_accounts =
+        vec![compressed_account_with_context.clone().compressed_account];
     let recipient_pubkey = Pubkey::new_unique();
     let output_compressed_accounts = vec![CompressedAccount {
         lamports: 0,
@@ -741,67 +849,81 @@ async fn test_with_compression() {
     // should fail because of insufficient output funds
     assert_custom_error_or_program_error(res, CompressedPdaError::SumCheckFailed.into()).unwrap();
 
-    let instruction = create_invoke_instruction(
-        &payer_pubkey,
-        &payer_pubkey,
-        &input_compressed_accounts,
-        &output_compressed_accounts,
-        &[MerkleContext {
-            merkle_tree_pubkey,
-            leaf_index: 0,
-            nullifier_queue_pubkey,
-        }],
-        &[merkle_tree_pubkey],
-        &proof_rpc_res.root_indices,
-        &Vec::new(),
-        Some(proof_rpc_res.proof.clone()),
-        Some(compress_amount),
-        false,
-        Some(recipient),
-    );
-    println!("Transaction with zkp -------------------------");
-
-    let event = create_and_send_transaction_with_event(
+    let compressed_account_with_context =
+        test_indexer.get_compressed_accounts_by_owner(&payer_pubkey)[0].clone();
+    decompress_sol_test(
         &mut context,
-        &[instruction],
-        &payer_pubkey,
-        &[&payer],
-        Some(TransactionParams {
-            num_input_compressed_accounts: 1,
-            num_output_compressed_accounts: 1,
-            num_new_addresses: 0,
-            compress: 0, // we are decompressing to a new account not the payer
-            fee_config: FeeConfig::default(),
-        }),
+        &mut test_indexer,
+        &payer,
+        &vec![compressed_account_with_context],
+        &recipient_pubkey,
+        compress_amount,
+        &env.merkle_tree_pubkey,
+        None,
     )
     .await
-    .unwrap()
     .unwrap();
-    let recipient_balance = context
-        .banks_client
-        .get_account(recipient)
-        .await
-        .unwrap()
-        .unwrap()
-        .lamports;
-    assert_eq!(
-        recipient_balance, compress_amount,
-        "recipient balance incorrect, decompress sol failed"
-    );
-    test_indexer.add_event_and_compressed_accounts(event);
-    assert_eq!(test_indexer.compressed_accounts.len(), 1);
-    assert_eq!(
-        test_indexer.compressed_accounts[0]
-            .compressed_account
-            .address,
-        None
-    );
-    assert_eq!(
-        test_indexer.compressed_accounts[0].compressed_account.owner,
-        recipient_pubkey
-    );
-}
+    // let instruction = create_invoke_instruction(
+    //     &payer_pubkey,
+    //     &payer_pubkey,
+    //     &input_compressed_accounts,
+    //     &output_compressed_accounts,
+    //     &[MerkleContext {
+    //         merkle_tree_pubkey,
+    //         leaf_index: 0,
+    //         nullifier_queue_pubkey,
+    //     }],
+    //     &[merkle_tree_pubkey],
+    //     &proof_rpc_res.root_indices,
+    //     &Vec::new(),
+    //     Some(proof_rpc_res.proof.clone()),
+    //     Some(compress_amount),
+    //     false,
+    //     Some(recipient),
+    // );
+    // println!("Transaction with zkp -------------------------");
 
+    // let event = create_and_send_transaction_with_event(
+    //     &mut context,
+    //     &[instruction],
+    //     &payer_pubkey,
+    //     &[&payer],
+    //     Some(TransactionParams {
+    //         num_input_compressed_accounts: 1,
+    //         num_output_compressed_accounts: 1,
+    //         num_new_addresses: 0,
+    //         compress: 0, // we are decompressing to a new account not the payer
+    //         fee_config: FeeConfig::default(),
+    //     }),
+    // )
+    // .await
+    // .unwrap()
+    // .unwrap();
+    // let recipient_balance = context
+    //     .banks_client
+    //     .get_account(recipient)
+    //     .await
+    //     .unwrap()
+    //     .unwrap()
+    //     .lamports;
+    // assert_eq!(
+    //     recipient_balance, compress_amount,
+    //     "recipient balance incorrect, decompress sol failed"
+    // );
+    // test_indexer.add_event_and_compressed_accounts(event);
+    // assert_eq!(test_indexer.compressed_accounts.len(), 1);
+    // assert_eq!(
+    //     test_indexer.compressed_accounts[0]
+    //         .compressed_account
+    //         .address,
+    //     None
+    // );
+    // assert_eq!(
+    //     test_indexer.compressed_accounts[0].compressed_account.owner,
+    //     recipient_pubkey
+    // );
+}
+/*
 #[ignore = "this is a helper function to regenerate accounts"]
 #[tokio::test]
 async fn regenerate_accounts() {
@@ -843,3 +965,4 @@ async fn regenerate_accounts() {
         async_write(file_path.clone(), json_data).await.unwrap();
     }
 }
+*/

--- a/test-programs/compressed-pda-test/tests/test.rs
+++ b/test-programs/compressed-pda-test/tests/test.rs
@@ -14,8 +14,11 @@ use light_compressed_pda::{
 use light_hasher::Poseidon;
 use light_test_utils::{
     assert_custom_error_or_program_error, create_and_send_transaction,
-    create_and_send_transaction_with_event, test_env::setup_test_programs_with_accounts,
-    test_indexer::TestIndexer, FeeConfig, TransactionParams,
+    create_and_send_transaction_with_event,
+    system_program::{assert_created_compressed_accounts, create_addresses_test},
+    test_env::setup_test_programs_with_accounts,
+    test_indexer::TestIndexer,
+    FeeConfig, TransactionParams,
 };
 use solana_cli_output::CliAccount;
 use solana_program_test::{BanksClientError, ProgramTestContext};
@@ -58,14 +61,14 @@ async fn invoke_test() {
         data: None,
         address: None,
     }];
-
+    let output_merkle_tree_pubkeys = vec![merkle_tree_pubkey];
     let instruction = create_invoke_instruction(
         &payer_pubkey,
         &payer_pubkey,
         &Vec::new(),
         &output_compressed_accounts,
         &Vec::new(),
-        &[merkle_tree_pubkey],
+        output_merkle_tree_pubkeys.as_slice(),
         &Vec::new(),
         &Vec::new(),
         None,
@@ -90,9 +93,14 @@ async fn invoke_test() {
     .await
     .unwrap()
     .unwrap();
-    test_indexer.add_event_and_compressed_accounts(event);
+    let (created_compressed_accounts, _) = test_indexer.add_event_and_compressed_accounts(event);
+    assert_created_compressed_accounts(
+        output_compressed_accounts.as_slice(),
+        output_merkle_tree_pubkeys.as_slice(),
+        created_compressed_accounts.as_slice(),
+        false,
+    );
 
-    assert_eq!(test_indexer.compressed_accounts.len(), 1);
     let input_compressed_accounts = vec![CompressedAccount {
         lamports: 0,
         owner: payer_pubkey,
@@ -332,7 +340,7 @@ async fn test_with_address() {
     .unwrap();
     assert_custom_error_or_program_error(res, CompressedPdaError::InvalidAddress.into()).unwrap();
 
-    let event = create_addresses(
+    let event = create_addresses_test(
         &mut context,
         &mut test_indexer,
         &env.address_merkle_tree_pubkey,
@@ -430,7 +438,7 @@ async fn test_with_address() {
 
     let address_seed_2 = [2u8; 32];
 
-    let event = create_addresses(
+    let event = create_addresses_test(
         &mut context,
         &mut test_indexer,
         &env.address_merkle_tree_pubkey,
@@ -454,7 +462,7 @@ async fn test_with_address() {
     println!("test 2in -------------------------");
 
     let address_seed_3 = [3u8; 32];
-    let event = create_addresses(
+    let event = create_addresses_test(
         &mut context,
         &mut test_indexer,
         &env.address_merkle_tree_pubkey,
@@ -494,7 +502,7 @@ async fn test_with_address() {
             address_vec.push(address_seed);
         }
 
-        let event = create_addresses(
+        let event = create_addresses_test(
             &mut context,
             &mut test_indexer,
             &env.address_merkle_tree_pubkey,
@@ -506,149 +514,8 @@ async fn test_with_address() {
             false, // TODO: enable once heap optimization is done
         )
         .await
-        .unwrap()
         .unwrap();
-        test_indexer.add_event_and_compressed_accounts(event);
-        // there exists a compressed account with the address x
-        for address_seed in address_vec.iter() {
-            assert!(test_indexer
-                .compressed_accounts
-                .iter()
-                .any(|x| x.compressed_account.address
-                    == Some(
-                        derive_address(&env.address_merkle_tree_pubkey, address_seed).unwrap()
-                    )));
-        }
-        // input compressed accounts are spent
-        for compressed_account in compressed_input_accounts.iter() {
-            assert!(test_indexer
-                .nullified_compressed_accounts
-                .iter()
-                .any(|x| x.compressed_account == compressed_account.compressed_account));
-        }
-        // TODO: assert that output compressed accounts with addresses of input accounts are created once enabled
     }
-}
-
-#[allow(clippy::too_many_arguments)]
-pub async fn create_addresses(
-    context: &mut ProgramTestContext,
-    test_indexer: &mut TestIndexer,
-    address_merkle_tree_pubkey: &Pubkey,
-    address_merkle_tree_queue_pubkey: &Pubkey,
-    merkle_tree_pubkey: &Pubkey,
-    nullifier_queue_pubkey: &Pubkey,
-    address_seeds: &[[u8; 32]],
-    input_compressed_accounts: &[CompressedAccountWithMerkleContext],
-    create_out_compressed_accounts_for_input_compressed_accounts: bool,
-) -> Result<Option<PublicTransactionEvent>, BanksClientError> {
-    let mut derived_addresses = Vec::new();
-    for address_seed in address_seeds.iter() {
-        let derived_address = derive_address(address_merkle_tree_pubkey, address_seed).unwrap();
-        derived_addresses.push(derived_address);
-    }
-    let mut compressed_account_hashes = Vec::new();
-
-    let compressed_account_input_hashes = if input_compressed_accounts.is_empty() {
-        None
-    } else {
-        for compressed_account in input_compressed_accounts.iter() {
-            compressed_account_hashes.push(
-                compressed_account
-                    .compressed_account
-                    .hash::<Poseidon>(
-                        merkle_tree_pubkey,
-                        &compressed_account.merkle_context.leaf_index,
-                    )
-                    .unwrap(),
-            );
-        }
-        Some(compressed_account_hashes.as_slice())
-    };
-    let proof_rpc_res = test_indexer
-        .create_proof_for_compressed_accounts(
-            compressed_account_input_hashes,
-            Some(derived_addresses.as_slice()),
-            context,
-        )
-        .await;
-    let mut address_params = Vec::new();
-
-    for (i, seed) in address_seeds.iter().enumerate() {
-        let new_address_params = NewAddressParams {
-            address_queue_pubkey: *address_merkle_tree_queue_pubkey,
-            address_merkle_tree_pubkey: *address_merkle_tree_pubkey,
-            seed: *seed,
-            address_merkle_tree_root_index: proof_rpc_res.address_root_indices[i],
-        };
-        address_params.push(new_address_params);
-    }
-
-    let mut output_compressed_accounts = Vec::new();
-    for address_param in address_params.iter() {
-        output_compressed_accounts.push(CompressedAccount {
-            lamports: 0,
-            owner: context.payer.pubkey(),
-            data: None,
-            address: Some(derive_address(address_merkle_tree_pubkey, &address_param.seed).unwrap()),
-        });
-    }
-
-    if create_out_compressed_accounts_for_input_compressed_accounts {
-        for compressed_account in input_compressed_accounts.iter() {
-            output_compressed_accounts.push(CompressedAccount {
-                lamports: 0,
-                owner: context.payer.pubkey(),
-                data: None,
-                address: compressed_account.compressed_account.address,
-            });
-        }
-    }
-
-    // create two new addresses with the same see should fail
-    let instruction = create_invoke_instruction(
-        &context.payer.pubkey(),
-        &context.payer.pubkey().clone(),
-        input_compressed_accounts
-            .iter()
-            .map(|x| x.compressed_account.clone())
-            .collect::<Vec<CompressedAccount>>()
-            .as_slice(),
-        &output_compressed_accounts,
-        input_compressed_accounts
-            .iter()
-            .map(|x| MerkleContext {
-                merkle_tree_pubkey: *merkle_tree_pubkey,
-                leaf_index: x.merkle_context.leaf_index,
-                nullifier_queue_pubkey: *nullifier_queue_pubkey,
-            })
-            .collect::<Vec<MerkleContext>>()
-            .as_slice(),
-        &vec![*merkle_tree_pubkey; output_compressed_accounts.len()],
-        &proof_rpc_res.root_indices,
-        &address_params,
-        Some(proof_rpc_res.proof.clone()),
-        None,
-        false,
-        None,
-    );
-
-    let event = create_and_send_transaction_with_event::<PublicTransactionEvent>(
-        context,
-        &[instruction],
-        &context.payer.pubkey(),
-        &[&context.payer.insecure_clone()],
-        Some(TransactionParams {
-            num_input_compressed_accounts: input_compressed_accounts.len() as u8,
-            num_output_compressed_accounts: output_compressed_accounts.len() as u8,
-            num_new_addresses: address_params.len() as u8,
-            compress: 0,
-            fee_config: FeeConfig::default(),
-        }),
-    )
-    .await;
-
-    event
 }
 
 #[tokio::test]

--- a/test-programs/compressed-token-test/Cargo.toml
+++ b/test-programs/compressed-token-test/Cargo.toml
@@ -33,7 +33,7 @@ solana-sdk = "1.18.11"
 
 [dev-dependencies]
 solana-program-test = "1.18.11"
-light-test-utils = { version = "0.1.1", path = "../../test-utils", default-features= true, features = ["test_indexer"] }
+light-test-utils = { version = "0.1.1", path = "../../test-utils" }
 reqwest = "0.11.26"
 tokio = "1.36.0"
 light-circuitlib-rs = {path = "../../circuit-lib/circuitlib-rs"}

--- a/test-programs/compressed-token-test/tests/test.rs
+++ b/test-programs/compressed-token-test/tests/test.rs
@@ -1,174 +1,43 @@
 #![cfg(feature = "test-sbf")]
-
-use account_compression::{
-    initialize_nullifier_queue::NullifierQueueAccount, StateMerkleTreeAccount,
-};
+use anchor_lang::AnchorDeserialize;
 use anchor_lang::AnchorSerialize;
-use anchor_lang::{solana_program::program_pack::Pack, AnchorDeserialize};
 use light_circuitlib_rs::gnark::helpers::kill_gnark_server;
 use light_compressed_pda::{
     invoke::processor::CompressedProof,
     sdk::compressed_account::{CompressedAccountWithMerkleContext, MerkleContext},
 };
 use light_compressed_token::{
-    get_cpi_authority_pda, get_token_authority_pda, get_token_pool_pda,
-    mint_sdk::{create_initialize_mint_instruction, create_mint_to_instruction},
-    token_data::TokenData,
-    transfer_sdk, ErrorCode, TokenTransferOutputData,
+    token_data::TokenData, transfer_sdk, ErrorCode, TokenTransferOutputData,
 };
-use light_concurrent_merkle_tree::ConcurrentMerkleTree26;
 use light_hasher::Poseidon;
+use light_test_utils::spl::{
+    compress_test, compressed_transfer_test, create_mint_helper, create_token_account,
+    decompress_test, mint_tokens_helper,
+};
 use light_test_utils::{
-    airdrop_lamports, assert_custom_error_or_program_error, create_account_instruction,
-    create_and_send_transaction, create_and_send_transaction_with_event, get_hash_set,
-    test_env::setup_test_programs_with_accounts,
-    test_indexer::{TestIndexer, TokenDataWithContext},
-    AccountZeroCopy, FeeConfig, TransactionParams,
+    airdrop_lamports, assert_custom_error_or_program_error,
+    test_env::setup_test_programs_with_accounts, test_indexer::TestIndexer,
 };
 use light_verifier::VerifierError;
-use num_bigint::BigUint;
-use num_traits::ops::bytes::FromBytes;
 use solana_program_test::{
     BanksClientError, BanksTransactionResultWithMetadata, ProgramTestContext,
 };
-use solana_sdk::{
-    instruction::Instruction, pubkey::Pubkey, signature::Keypair, signer::Signer,
-    transaction::Transaction,
-};
-use spl_token::instruction::initialize_mint;
-
-pub fn create_initialize_mint_instructions(
-    payer: &Pubkey,
-    authority: &Pubkey,
-    rent: u64,
-    decimals: u8,
-    mint_keypair: &Keypair,
-) -> ([Instruction; 4], Pubkey) {
-    let account_create_ix = create_account_instruction(
-        payer,
-        anchor_spl::token::Mint::LEN,
-        rent,
-        &anchor_spl::token::ID,
-        Some(mint_keypair),
-    );
-
-    let mint_pubkey = mint_keypair.pubkey();
-    let mint_authority = get_token_authority_pda(authority, &mint_pubkey).0;
-    let create_mint_instruction = initialize_mint(
-        &anchor_spl::token::ID,
-        &mint_keypair.pubkey(),
-        &mint_authority,
-        None,
-        decimals,
-    )
-    .unwrap();
-    let transfer_ix =
-        anchor_lang::solana_program::system_instruction::transfer(payer, &mint_pubkey, rent);
-
-    let instruction = create_initialize_mint_instruction(payer, authority, &mint_pubkey);
-    let pool_pubkey = get_token_pool_pda(&mint_pubkey);
-    (
-        [
-            account_create_ix,
-            create_mint_instruction,
-            transfer_ix,
-            instruction,
-        ],
-        pool_pubkey,
-    )
-}
-
-async fn assert_create_mint(
-    context: &mut ProgramTestContext,
-    authority: &Pubkey,
-    mint: &Pubkey,
-    pool: &Pubkey,
-) {
-    let mint_account: spl_token::state::Mint = spl_token::state::Mint::unpack(
-        &context
-            .banks_client
-            .get_account(*mint)
-            .await
-            .unwrap()
-            .unwrap()
-            .data,
-    )
-    .unwrap();
-    let mint_authority = get_token_authority_pda(authority, mint).0;
-    assert_eq!(mint_account.supply, 0);
-    assert_eq!(mint_account.decimals, 2);
-    assert_eq!(mint_account.mint_authority.unwrap(), mint_authority);
-    assert_eq!(mint_account.freeze_authority, None.into());
-    assert!(mint_account.is_initialized);
-    let mint_account: spl_token::state::Account = spl_token::state::Account::unpack(
-        &context
-            .banks_client
-            .get_account(*pool)
-            .await
-            .unwrap()
-            .unwrap()
-            .data,
-    )
-    .unwrap();
-
-    assert_eq!(mint_account.amount, 0);
-    assert_eq!(mint_account.delegate, None.into());
-    assert_eq!(mint_account.mint, *mint);
-    assert_eq!(mint_account.owner, get_cpi_authority_pda().0);
-}
+use solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::Signer, transaction::Transaction};
 
 #[tokio::test]
 async fn test_create_mint() {
     let (mut context, _) = setup_test_programs_with_accounts(None).await;
     let payer = context.payer.insecure_clone();
-    let payer_pubkey = payer.pubkey();
-    let rent = context
-        .banks_client
-        .get_rent()
-        .await
-        .unwrap()
-        .minimum_balance(anchor_spl::token::Mint::LEN);
-    let mint = Keypair::new();
-    let (instructions, pool) =
-        create_initialize_mint_instructions(&payer_pubkey, &payer_pubkey, rent, 2, &mint);
-
-    create_and_send_transaction(&mut context, &instructions, &payer_pubkey, &[&payer, &mint])
-        .await
-        .unwrap();
-    assert_create_mint(&mut context, &payer_pubkey, &mint.pubkey(), &pool).await;
-}
-
-async fn create_mint_helper(context: &mut ProgramTestContext, payer: &Keypair) -> Pubkey {
-    let payer_pubkey = payer.pubkey();
-    let rent = context
-        .banks_client
-        .get_rent()
-        .await
-        .unwrap()
-        .minimum_balance(anchor_spl::token::Mint::LEN);
-    let mint = Keypair::new();
-
-    let (instructions, pool) =
-        create_initialize_mint_instructions(&payer_pubkey, &payer_pubkey, rent, 2, &mint);
-
-    create_and_send_transaction(context, &instructions, &payer_pubkey, &[&payer, &mint])
-        .await
-        .unwrap();
-    assert_create_mint(context, &payer_pubkey, &mint.pubkey(), &pool).await;
-    mint.pubkey()
+    create_mint_helper(&mut context, &payer).await;
 }
 
 async fn test_mint_to<const MINTS: usize, const ITER: usize>() {
     let (mut context, env) = setup_test_programs_with_accounts(None).await;
     let payer = context.payer.insecure_clone();
-    let payer_pubkey = payer.pubkey();
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
-    let nullifier_queue_pubkey = env.nullifier_queue_pubkey;
-    let mut test_indexer = TestIndexer::new(
-        merkle_tree_pubkey,
-        nullifier_queue_pubkey,
-        env.address_merkle_tree_pubkey,
-        payer.insecure_clone(),
+    let mut test_indexer = TestIndexer::init_from_env(
+        &payer,
+        &env,
         true,
         false,
         "../../circuit-lib/circuitlib-rs/scripts/prover.sh",
@@ -177,53 +46,18 @@ async fn test_mint_to<const MINTS: usize, const ITER: usize>() {
 
     let recipient_keypair = Keypair::new();
     let mint = create_mint_helper(&mut context, &payer).await;
-    for i in 0..ITER {
+    for _ in 0..ITER {
         let amount = 10000u64;
-        let instruction = create_mint_to_instruction(
-            &payer_pubkey,
-            &payer_pubkey,
-            &mint,
+        mint_tokens_helper(
+            &mut context,
+            &mut test_indexer,
             &merkle_tree_pubkey,
+            &payer,
+            &mint,
             vec![amount; MINTS],
             vec![recipient_keypair.pubkey(); MINTS],
-        );
-        let old_merkle_tree_account =
-            AccountZeroCopy::<StateMerkleTreeAccount>::new(&mut context, env.merkle_tree_pubkey)
-                .await;
-        let old_merkle_tree = old_merkle_tree_account
-            .deserialized()
-            .copy_merkle_tree()
-            .unwrap();
-        let event = create_and_send_transaction_with_event(
-            &mut context,
-            &[instruction],
-            &payer_pubkey,
-            &[&payer],
-            Some(TransactionParams {
-                num_new_addresses: 0,
-                num_input_compressed_accounts: 0,
-                num_output_compressed_accounts: MINTS as u8,
-                compress: 0,
-                fee_config: FeeConfig::default(),
-            }),
         )
-        .await
-        .unwrap()
-        .unwrap();
-
-        if i == 0 {
-            test_indexer.add_compressed_accounts_with_token_data(event);
-            assert_mint_to(
-                MINTS,
-                &mut context,
-                &test_indexer,
-                &recipient_keypair,
-                mint,
-                amount,
-                &old_merkle_tree,
-            )
-            .await;
-        }
+        .await;
     }
     kill_gnark_server();
 }
@@ -266,7 +100,7 @@ async fn test_transfers() {
                 "\n\ninput num: {}, output num: {}\n\n",
                 input_num, output_num
             );
-            test_transfer(input_num, output_num, 10_000).await
+            perform_transfer_test(input_num, output_num, 10_000).await
         }
     }
 }
@@ -283,7 +117,7 @@ async fn test_1_transfer() {
                 "\n\ninput num: {}, output num: {}\n\n",
                 input_num, output_num
             );
-            test_transfer(input_num, output_num, 10_000).await
+            perform_transfer_test(input_num, output_num, 10_000).await
         }
     }
 }
@@ -301,7 +135,7 @@ async fn test_2_transfer() {
                 "\n\ninput num: {}, output num: {}\n\n",
                 input_num, output_num
             );
-            test_transfer(input_num, output_num, 10_000).await
+            perform_transfer_test(input_num, output_num, 10_000).await
         }
     }
 }
@@ -319,380 +153,120 @@ async fn test_8_transfer() {
                 "\n\ninput num: {}, output num: {}\n\n",
                 input_num, output_num
             );
-            test_transfer(input_num, output_num, 10_000).await
+            perform_transfer_test(input_num, output_num, 10_000).await
         }
     }
 }
+
 /// Creates inputs compressed accounts with amount tokens each
 /// Transfers all tokens from inputs compressed accounts evenly distributed to outputs compressed accounts
-async fn test_transfer(inputs: usize, outputs: usize, amount: u64) {
+async fn perform_transfer_test(inputs: usize, outputs: usize, amount: u64) {
     let (mut context, env) = setup_test_programs_with_accounts(None).await;
     let payer = context.payer.insecure_clone();
-    let payer_pubkey = payer.pubkey();
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
-    let nullifier_queue_pubkey = env.nullifier_queue_pubkey;
-    let test_indexer = TestIndexer::new(
-        merkle_tree_pubkey,
-        nullifier_queue_pubkey,
-        env.address_merkle_tree_pubkey,
-        payer.insecure_clone(),
+    let mut test_indexer = TestIndexer::init_from_env(
+        &payer,
+        &env,
         true,
         false,
         "../../circuit-lib/circuitlib-rs/scripts/prover.sh",
-    );
-    let recipient_keypair = Keypair::new();
-    let mint = create_mint_helper(&mut context, &payer).await;
-    let instruction = create_mint_to_instruction(
-        &payer_pubkey,
-        &payer_pubkey,
-        &mint,
-        &merkle_tree_pubkey,
-        vec![amount; inputs],
-        vec![recipient_keypair.pubkey(); inputs],
-    );
-    let old_merkle_tree_account =
-        AccountZeroCopy::<StateMerkleTreeAccount>::new(&mut context, env.merkle_tree_pubkey).await;
-    let old_merkle_tree = old_merkle_tree_account
-        .deserialized()
-        .copy_merkle_tree()
-        .unwrap();
-    let event = create_and_send_transaction_with_event(
-        &mut context,
-        &[instruction],
-        &payer_pubkey,
-        &[&payer],
-        Some(TransactionParams {
-            num_new_addresses: 0,
-            num_input_compressed_accounts: 0,
-            num_output_compressed_accounts: inputs as u8,
-            compress: 0,
-            fee_config: FeeConfig::default(),
-        }),
-    )
-    .await
-    .unwrap()
-    .unwrap();
-    let mut test_indexer = test_indexer.await;
-    test_indexer.add_compressed_accounts_with_token_data(event);
-    assert_mint_to(
-        inputs,
-        &mut context,
-        &test_indexer,
-        &recipient_keypair,
-        mint,
-        amount,
-        &old_merkle_tree,
     )
     .await;
-
-    let mut input_merkle_tree_context = Vec::new();
-    let mut input_compressed_account_token_data = Vec::new();
-    let mut input_compressed_account_hashes = Vec::new();
-    for i in 0..inputs {
-        let token_data: TokenDataWithContext = test_indexer.token_compressed_accounts[i].clone();
-        let leaf_index = token_data
-            .compressed_account
-            .merkle_context
-            .leaf_index
-            .clone();
-        input_compressed_account_token_data.push(token_data.token_data);
-        input_compressed_account_hashes.push(
-            token_data
-                .compressed_account
-                .compressed_account
-                .hash::<Poseidon>(&merkle_tree_pubkey, &leaf_index)
-                .unwrap(),
-        );
-        input_merkle_tree_context.push(MerkleContext {
-            merkle_tree_pubkey,
-            nullifier_queue_pubkey,
-            leaf_index,
-        });
+    let mint = create_mint_helper(&mut context, &payer).await;
+    let sender = Keypair::new();
+    mint_tokens_helper(
+        &mut context,
+        &mut test_indexer,
+        &merkle_tree_pubkey,
+        &payer,
+        &mint,
+        vec![amount; inputs],
+        vec![sender.pubkey(); inputs],
+    )
+    .await;
+    let mut recipients = Vec::new();
+    for _ in 0..outputs {
+        recipients.push(Pubkey::new_unique());
     }
-
+    let input_compressed_accounts =
+        test_indexer.get_compressed_token_accounts_by_owner(&sender.pubkey());
     let equal_amount = (amount * inputs as u64) / outputs as u64;
     let rest_amount = (amount * inputs as u64) % outputs as u64;
-    let mut output_compressed_accounts = Vec::new();
-
-    let change_out_compressed_account = TokenTransferOutputData {
-        amount: equal_amount + rest_amount,
-        owner: recipient_keypair.pubkey(),
-        lamports: None,
-    };
-    output_compressed_accounts.push(change_out_compressed_account);
-    for _ in 1..outputs {
-        let transfer_recipient_keypair = Keypair::new();
-        let transfer_recipient_out_compressed_account = TokenTransferOutputData {
-            amount: equal_amount,
-            owner: transfer_recipient_keypair.pubkey(),
-            lamports: None,
-        };
-        output_compressed_accounts.push(transfer_recipient_out_compressed_account);
-    }
-    let proof_rpc_result = test_indexer
-        .create_proof_for_compressed_accounts(
-            Some(&input_compressed_account_hashes),
-            None,
-            &mut context,
-        )
-        .await;
-
-    let instruction = transfer_sdk::create_transfer_instruction(
-        &payer_pubkey,
-        &recipient_keypair.pubkey(), // authority
-        &input_merkle_tree_context,
-        &vec![merkle_tree_pubkey; outputs], // output_compressed_account_merkle_tree_pubkeys
-        &output_compressed_accounts,        // output_compressed_accounts
-        &proof_rpc_result.root_indices,
-        &Some(proof_rpc_result.proof),
-        input_compressed_account_token_data.as_slice(), // input_token_data
-        mint,
-        None,  // owner_if_delegate_is_signer
-        false, // is_compress
-        None,  // compression_amount
-        None,  // token_pool_pda
-        None,  // decompress_token_account
-    )
-    .unwrap();
-
-    let old_merkle_tree_account =
-        AccountZeroCopy::<StateMerkleTreeAccount>::new(&mut context, env.merkle_tree_pubkey).await;
-    let old_merkle_tree = old_merkle_tree_account
-        .deserialized()
-        .copy_merkle_tree()
-        .unwrap();
-    let event = create_and_send_transaction_with_event(
+    let mut output_amounts = vec![equal_amount; outputs - 1];
+    output_amounts.push(equal_amount + rest_amount);
+    compressed_transfer_test(
+        &payer,
         &mut context,
-        &[instruction],
-        &payer_pubkey,
-        &[&payer, &recipient_keypair],
-        Some(TransactionParams {
-            num_new_addresses: 0,
-            num_input_compressed_accounts: input_compressed_account_hashes.len() as u8,
-            num_output_compressed_accounts: output_compressed_accounts.len() as u8,
-            compress: 5000, // for second signer
-            fee_config: FeeConfig::default(),
-        }),
-    )
-    .await
-    .unwrap()
-    .unwrap();
-
-    test_indexer.add_compressed_accounts_with_token_data(event);
-
-    assert_transfer(
-        &mut context,
-        &test_indexer,
-        &output_compressed_accounts,
-        &old_merkle_tree,
-        &input_compressed_account_hashes,
+        &mut test_indexer,
+        &mint,
+        &sender,
+        &recipients,
+        &output_amounts,
+        input_compressed_accounts.as_slice(),
+        &vec![env.merkle_tree_pubkey; outputs],
+        None,
     )
     .await;
-    kill_gnark_server();
-
-    // TODO: fix nullify function
-    // test_indexer.nullify_compressed_accounts(&mut context).await;
 }
 
 #[tokio::test]
 async fn test_decompression() {
     let (mut context, env) = setup_test_programs_with_accounts(None).await;
     let payer = context.payer.insecure_clone();
-    let payer_pubkey = payer.pubkey();
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
-    let nullifier_queue_pubkey = env.nullifier_queue_pubkey;
-    let test_indexer = TestIndexer::new(
-        merkle_tree_pubkey,
-        nullifier_queue_pubkey,
-        env.address_merkle_tree_pubkey,
-        payer.insecure_clone(),
+    let mut test_indexer = TestIndexer::init_from_env(
+        &payer,
+        &env,
         true,
         false,
         "../../circuit-lib/circuitlib-rs/scripts/prover.sh",
-    );
-    let recipient_keypair = Keypair::new();
-    airdrop_lamports(&mut context, &recipient_keypair.pubkey(), 1_000_000_000)
+    )
+    .await;
+    let sender = Keypair::new();
+    airdrop_lamports(&mut context, &sender.pubkey(), 1_000_000_000)
         .await
         .unwrap();
     let mint = create_mint_helper(&mut context, &payer).await;
     let amount = 10000u64;
-    let instruction = create_mint_to_instruction(
-        &payer_pubkey,
-        &payer_pubkey,
-        &mint,
+    mint_tokens_helper(
+        &mut context,
+        &mut test_indexer,
         &merkle_tree_pubkey,
+        &payer,
+        &mint,
         vec![amount],
-        vec![recipient_keypair.pubkey()],
-    );
-    let old_merkle_tree_account =
-        AccountZeroCopy::<StateMerkleTreeAccount>::new(&mut context, env.merkle_tree_pubkey).await;
-    let old_merkle_tree = old_merkle_tree_account
-        .deserialized()
-        .copy_merkle_tree()
-        .unwrap();
-    let event = create_and_send_transaction_with_event(
-        &mut context,
-        &[instruction],
-        &payer_pubkey,
-        &[&payer],
-        Some(TransactionParams {
-            num_new_addresses: 0,
-            num_input_compressed_accounts: 0,
-            num_output_compressed_accounts: 1,
-            compress: 0,
-            fee_config: FeeConfig::default(),
-        }),
-    )
-    .await
-    .unwrap()
-    .unwrap();
-    let mut test_indexer = test_indexer.await;
-    test_indexer.add_compressed_accounts_with_token_data(event);
-    assert_mint_to(
-        1,
-        &mut context,
-        &test_indexer,
-        &recipient_keypair,
-        mint,
-        amount,
-        &old_merkle_tree,
+        vec![sender.pubkey()],
     )
     .await;
-    let recipient_token_account_keypair = Keypair::new();
-
-    create_token_account(
+    let token_account_keypair = Keypair::new();
+    create_token_account(&mut context, &mint, &token_account_keypair, &sender)
+        .await
+        .unwrap();
+    let input_compressed_account =
+        test_indexer.get_compressed_token_accounts_by_owner(&sender.pubkey());
+    decompress_test(
+        &sender,
         &mut context,
-        &mint,
-        &recipient_token_account_keypair,
-        &recipient_keypair,
-    )
-    .await
-    .unwrap();
-
-    let input_compressed_account_token_data = test_indexer.token_compressed_accounts[0].token_data;
-    let input_compressed_accounts = vec![test_indexer.token_compressed_accounts[0]
-        .compressed_account
-        .clone()];
-
-    let change_out_compressed_account = TokenTransferOutputData {
-        amount: input_compressed_account_token_data.amount - 1000,
-        owner: recipient_keypair.pubkey(),
-        lamports: None,
-    };
-
-    let proof_rpc_result = test_indexer
-        .create_proof_for_compressed_accounts(
-            Some(&[input_compressed_accounts[0]
-                .compressed_account
-                .hash::<Poseidon>(
-                    &merkle_tree_pubkey,
-                    &input_compressed_accounts[0].merkle_context.leaf_index,
-                )
-                .unwrap()]),
-            None,
-            &mut context,
-        )
-        .await;
-
-    let instruction = transfer_sdk::create_transfer_instruction(
-        &payer_pubkey,
-        &recipient_keypair.pubkey(), // authority
-        &[MerkleContext {
-            merkle_tree_pubkey,
-            nullifier_queue_pubkey,
-            leaf_index: input_compressed_accounts[0].merkle_context.leaf_index,
-        }], // input_compressed_account_merkle_context
-        &[merkle_tree_pubkey],       // output_compressed_account_merkle_tree_pubkeys
-        &[change_out_compressed_account], // output_compressed_accounts
-        &proof_rpc_result.root_indices, // root_indices
-        &Some(proof_rpc_result.proof),
-        [input_compressed_account_token_data].as_slice(), // input_token_data
-        mint,                                             // mint
-        None,                                             // owner_if_delegate_is_signer
-        false,                                            // is_compress
-        Some(1000u64),                                    // compression_amount
-        Some(get_token_pool_pda(&mint)),                  // token_pool_pda
-        Some(recipient_token_account_keypair.pubkey()),   // decompress_token_account
-    )
-    .unwrap();
-
-    let event = create_and_send_transaction_with_event(
-        &mut context,
-        &[instruction],
-        &payer_pubkey,
-        &[&payer, &recipient_keypair],
-        Some(TransactionParams {
-            num_new_addresses: 0,
-            num_input_compressed_accounts: 1,
-            num_output_compressed_accounts: 1,
-            compress: 5000, // for second signer
-            fee_config: FeeConfig::default(),
-        }),
-    )
-    .await
-    .unwrap()
-    .unwrap();
-
-    test_indexer.add_compressed_accounts_with_token_data(event);
-
-    let compress_out_compressed_account = TokenTransferOutputData {
-        amount: 1000,
-        owner: recipient_keypair.pubkey(),
-        lamports: None,
-    };
-    let approve_instruction = spl_token::instruction::approve(
-        &anchor_spl::token::ID,
-        &recipient_token_account_keypair.pubkey(),
-        &get_cpi_authority_pda().0,
-        &recipient_keypair.pubkey(),
-        &[&recipient_keypair.pubkey()],
+        &mut test_indexer,
+        input_compressed_account,
         amount,
+        &merkle_tree_pubkey,
+        &token_account_keypair.pubkey(),
+        None,
     )
-    .unwrap();
-    // Compression
-    let instruction = transfer_sdk::create_transfer_instruction(
-        &payer_pubkey,
-        &recipient_keypair.pubkey(),        // authority
-        &[],                                // input_compressed_account_merkle_tree_pubkeys
-        &[merkle_tree_pubkey],              // output_compressed_account_merkle_tree_pubkeys
-        &[compress_out_compressed_account], // output_compressed_accounts
-        &Vec::new(),                        // root_indices
-        &None,
-        &Vec::new(),                                    // input_token_data
-        mint,                                           // mint
-        None,                                           // owner_if_delegate_is_signer
-        true,                                           // is_compress
-        Some(1000u64),                                  // compression_amount
-        Some(get_token_pool_pda(&mint)),                // token_pool_pda
-        Some(recipient_token_account_keypair.pubkey()), // decompress_token_account
-    )
-    .unwrap();
+    .await;
 
-    let event = create_and_send_transaction_with_event(
+    compress_test(
+        &sender,
         &mut context,
-        &[approve_instruction, instruction],
-        &payer_pubkey,
-        &[&payer, &recipient_keypair],
-        Some(TransactionParams {
-            num_new_addresses: 0,
-            num_input_compressed_accounts: 0,
-            num_output_compressed_accounts: 1,
-            compress: 5000, // for second signer
-            fee_config: FeeConfig::default(),
-        }),
+        &mut test_indexer,
+        amount,
+        &mint,
+        &merkle_tree_pubkey,
+        &token_account_keypair.pubkey(),
+        None,
     )
-    .await
-    .unwrap()
-    .unwrap();
-    test_indexer.add_compressed_accounts_with_token_data(event);
-    assert!(test_indexer
-        .token_compressed_accounts
-        .iter()
-        .any(|x| x.token_data.amount == 1000));
-    assert!(test_indexer
-        .token_compressed_accounts
-        .iter()
-        .any(|x| x.token_data.owner == recipient_keypair.pubkey()));
+    .await;
     kill_gnark_server();
 }
 
@@ -712,64 +286,30 @@ async fn test_decompression() {
 async fn test_invalid_inputs() {
     let (mut context, env) = setup_test_programs_with_accounts(None).await;
     let payer = context.payer.insecure_clone();
-    let payer_pubkey = payer.pubkey();
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
     let nullifier_queue_pubkey = env.nullifier_queue_pubkey;
-    let test_indexer = TestIndexer::new(
-        merkle_tree_pubkey,
-        nullifier_queue_pubkey,
-        env.address_merkle_tree_pubkey,
-        payer.insecure_clone(),
+    let mut test_indexer = TestIndexer::init_from_env(
+        &payer,
+        &env,
         true,
         false,
         "../../circuit-lib/circuitlib-rs/scripts/prover.sh",
-    );
+    )
+    .await;
     let recipient_keypair = Keypair::new();
     airdrop_lamports(&mut context, &recipient_keypair.pubkey(), 1_000_000_000)
         .await
         .unwrap();
     let mint = create_mint_helper(&mut context, &payer).await;
     let amount = 10000u64;
-    let instruction = create_mint_to_instruction(
-        &payer_pubkey,
-        &payer_pubkey,
-        &mint,
+    mint_tokens_helper(
+        &mut context,
+        &mut test_indexer,
         &merkle_tree_pubkey,
+        &payer,
+        &mint,
         vec![amount],
         vec![recipient_keypair.pubkey()],
-    );
-    let old_merkle_tree_account =
-        AccountZeroCopy::<StateMerkleTreeAccount>::new(&mut context, env.merkle_tree_pubkey).await;
-    let old_merkle_tree = old_merkle_tree_account
-        .deserialized()
-        .copy_merkle_tree()
-        .unwrap();
-    let event = create_and_send_transaction_with_event(
-        &mut context,
-        &[instruction],
-        &payer_pubkey,
-        &[&payer],
-        Some(TransactionParams {
-            num_new_addresses: 0,
-            num_input_compressed_accounts: 0,
-            num_output_compressed_accounts: 1,
-            compress: 0,
-            fee_config: FeeConfig::default(),
-        }),
-    )
-    .await
-    .unwrap()
-    .unwrap();
-    let mut test_indexer = test_indexer.await;
-    test_indexer.add_compressed_accounts_with_token_data(event);
-    assert_mint_to(
-        1,
-        &mut context,
-        &test_indexer,
-        &recipient_keypair,
-        mint,
-        amount,
-        &old_merkle_tree,
     )
     .await;
     let transfer_recipient_keypair = Keypair::new();
@@ -786,6 +326,10 @@ async fn test_invalid_inputs() {
                     &input_compressed_accounts[0].merkle_context.leaf_index,
                 )
                 .unwrap()]),
+            Some(&[input_compressed_accounts[0]
+                .merkle_context
+                .merkle_tree_pubkey]),
+            None,
             None,
             &mut context,
         )
@@ -801,7 +345,7 @@ async fn test_invalid_inputs() {
         lamports: None,
     };
     // invalid token data amount (+ 1)
-    let res = create_transfer_out_utxo_test(
+    let res = perform_transfer_failing_test(
         &mut context,
         change_out_compressed_account_0,
         transfer_recipient_out_compressed_account_0,
@@ -821,7 +365,7 @@ async fn test_invalid_inputs() {
         lamports: None,
     };
     // invalid token data amount (- 1)
-    let res = create_transfer_out_utxo_test(
+    let res = perform_transfer_failing_test(
         &mut context,
         change_out_compressed_account_0,
         transfer_recipient_out_compressed_account_0,
@@ -843,7 +387,7 @@ async fn test_invalid_inputs() {
         lamports: None,
     };
     // invalid token data zero out amount
-    let res = create_transfer_out_utxo_test(
+    let res = perform_transfer_failing_test(
         &mut context,
         zero_amount,
         zero_amount,
@@ -864,7 +408,7 @@ async fn test_invalid_inputs() {
         lamports: None,
     };
     // invalid double token data  amount
-    let res = create_transfer_out_utxo_test(
+    let res = perform_transfer_failing_test(
         &mut context,
         double_amount,
         double_amount,
@@ -887,7 +431,7 @@ async fn test_invalid_inputs() {
     };
 
     // invalid_lamports_amount
-    let res = create_transfer_out_utxo_test(
+    let res = perform_transfer_failing_test(
         &mut context,
         change_out_compressed_account_0,
         invalid_lamports_amount,
@@ -934,7 +478,7 @@ async fn test_invalid_inputs() {
         lamports: None,
     };
 
-    let res = create_transfer_out_utxo_test(
+    let res = perform_transfer_failing_test(
         &mut context,
         change_out_compressed_account_0,
         transfer_recipient_out_compressed_account_0,
@@ -964,7 +508,7 @@ async fn test_invalid_inputs() {
         .as_mut()
         .unwrap()
         .data = vec;
-    let res = create_transfer_out_utxo_test(
+    let res = perform_transfer_failing_test(
         &mut context,
         change_out_compressed_account_0,
         transfer_recipient_out_compressed_account_0,
@@ -982,7 +526,7 @@ async fn test_invalid_inputs() {
     let input_compressed_accounts = vec![test_indexer.token_compressed_accounts[0]
         .compressed_account
         .clone()];
-    let res = create_transfer_out_utxo_test(
+    let res = perform_transfer_failing_test(
         &mut context,
         change_out_compressed_account_0,
         transfer_recipient_out_compressed_account_0,
@@ -1011,7 +555,7 @@ async fn test_invalid_inputs() {
         .as_mut()
         .unwrap()
         .data = vec;
-    let res = create_transfer_out_utxo_test(
+    let res = perform_transfer_failing_test(
         &mut context,
         change_out_compressed_account_0,
         transfer_recipient_out_compressed_account_0,
@@ -1042,7 +586,7 @@ async fn test_invalid_inputs() {
         .as_mut()
         .unwrap()
         .data = vec;
-    let res = create_transfer_out_utxo_test(
+    let res = perform_transfer_failing_test(
         &mut context,
         change_out_compressed_account_0,
         transfer_recipient_out_compressed_account_0,
@@ -1060,7 +604,7 @@ async fn test_invalid_inputs() {
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn create_transfer_out_utxo_test(
+async fn perform_transfer_failing_test(
     context: &mut ProgramTestContext,
     change_token_transfer_output: TokenTransferOutputData,
     transfer_recipient_token_transfer_output: TokenTransferOutputData,
@@ -1118,511 +662,3 @@ async fn create_transfer_out_utxo_test(
     )
     .await
 }
-
-pub async fn create_token_account(
-    context: &mut ProgramTestContext,
-    mint: &Pubkey,
-    account_keypair: &Keypair,
-    owner: &Keypair,
-) -> Result<(), BanksClientError> {
-    let rent = context
-        .banks_client
-        .get_rent()
-        .await
-        .unwrap()
-        .minimum_balance(anchor_spl::token::TokenAccount::LEN);
-    let account_create_ix = create_account_instruction(
-        &owner.pubkey(),
-        anchor_spl::token::TokenAccount::LEN,
-        rent,
-        &anchor_spl::token::ID,
-        Some(account_keypair),
-    );
-    let instruction = spl_token::instruction::initialize_account(
-        &spl_token::ID,
-        &account_keypair.pubkey(),
-        mint,
-        &owner.pubkey(),
-    )
-    .unwrap();
-    create_and_send_transaction(
-        context,
-        &[account_create_ix, instruction],
-        &owner.pubkey(),
-        &[account_keypair, owner],
-    )
-    .await
-    .unwrap();
-    Ok(())
-}
-
-async fn assert_mint_to<'a>(
-    num_mint_to: usize,
-    context: &mut ProgramTestContext,
-    test_indexer: &'a TestIndexer,
-    recipient_keypair: &Keypair,
-    mint: Pubkey,
-    amount: u64,
-    old_merkle_tree: &ConcurrentMerkleTree26<'a, Poseidon>,
-) {
-    let token_compressed_account_data = test_indexer.token_compressed_accounts[0].token_data;
-    assert_eq!(token_compressed_account_data.amount, amount);
-    assert_eq!(
-        token_compressed_account_data.owner,
-        recipient_keypair.pubkey()
-    );
-    assert_eq!(token_compressed_account_data.mint, mint);
-    assert_eq!(token_compressed_account_data.delegate, None);
-    assert_eq!(token_compressed_account_data.is_native, None);
-    assert_eq!(token_compressed_account_data.delegated_amount, 0);
-
-    let merkle_tree_account =
-        AccountZeroCopy::<StateMerkleTreeAccount>::new(context, test_indexer.merkle_tree_pubkey)
-            .await;
-    let merkle_tree = merkle_tree_account
-        .deserialized()
-        .copy_merkle_tree()
-        .unwrap();
-    assert_eq!(
-        merkle_tree.root().unwrap(),
-        test_indexer.merkle_tree.root(),
-        "merkle tree root update failed"
-    );
-    assert_eq!(merkle_tree.root_index(), num_mint_to);
-    assert_ne!(
-        old_merkle_tree.root().unwrap(),
-        merkle_tree.root().unwrap(),
-        "merkle tree root update failed"
-    );
-    let mint_account: spl_token::state::Mint = spl_token::state::Mint::unpack(
-        &context
-            .banks_client
-            .get_account(mint)
-            .await
-            .unwrap()
-            .unwrap()
-            .data,
-    )
-    .unwrap();
-    assert_eq!(mint_account.supply, amount * num_mint_to as u64);
-
-    let pool = get_token_pool_pda(&mint);
-    let pool_account = spl_token::state::Account::unpack(
-        &context
-            .banks_client
-            .get_account(pool)
-            .await
-            .unwrap()
-            .unwrap()
-            .data,
-    )
-    .unwrap();
-    assert_eq!(pool_account.amount, amount * num_mint_to as u64);
-}
-
-async fn assert_transfer<'a>(
-    context: &mut ProgramTestContext,
-    test_indexer: &TestIndexer,
-    out_compressed_accounts: &[TokenTransferOutputData],
-    old_merkle_tree: &ConcurrentMerkleTree26<'a, Poseidon>,
-    input_compressed_account_hashes: &[[u8; 32]],
-) {
-    let merkle_tree_account =
-        AccountZeroCopy::<StateMerkleTreeAccount>::new(context, test_indexer.merkle_tree_pubkey)
-            .await;
-    let merkle_tree = merkle_tree_account
-        .deserialized()
-        .copy_merkle_tree()
-        .unwrap();
-    assert_eq!(
-        merkle_tree.root_index(),
-        old_merkle_tree.root_index() + out_compressed_accounts.len()
-    );
-
-    assert_eq!(
-        merkle_tree.root().unwrap(),
-        test_indexer.merkle_tree.root(),
-        "merkle tree root update failed"
-    );
-    assert_ne!(
-        old_merkle_tree.root().unwrap(),
-        merkle_tree.root().unwrap(),
-        "merkle tree root update failed"
-    );
-    assert_eq!(
-        merkle_tree.next_index(),
-        old_merkle_tree.next_index() + out_compressed_accounts.len()
-    );
-    let next_index_old_mt = old_merkle_tree.next_index();
-    for (i, out_compressed_account) in out_compressed_accounts.iter().enumerate() {
-        let pos = test_indexer
-            .token_compressed_accounts
-            .iter()
-            .position(|x| {
-                x.token_data.owner == out_compressed_account.owner
-                    && x.token_data.amount == out_compressed_account.amount
-            })
-            .expect("transfer recipient compressed account not found in mock indexer");
-        let transfer_recipient_token_compressed_account =
-            test_indexer.token_compressed_accounts[pos].clone();
-        assert_eq!(
-            transfer_recipient_token_compressed_account
-                .token_data
-                .amount,
-            out_compressed_account.amount
-        );
-        assert_eq!(
-            transfer_recipient_token_compressed_account.token_data.owner,
-            out_compressed_account.owner
-        );
-        assert_eq!(
-            transfer_recipient_token_compressed_account
-                .token_data
-                .delegate,
-            None
-        );
-        assert_eq!(
-            transfer_recipient_token_compressed_account
-                .token_data
-                .is_native,
-            None
-        );
-        assert_eq!(
-            transfer_recipient_token_compressed_account
-                .token_data
-                .delegated_amount,
-            0
-        );
-
-        let transfer_recipient_compressed_account = transfer_recipient_token_compressed_account
-            .compressed_account
-            .clone();
-        assert_eq!(
-            transfer_recipient_compressed_account
-                .compressed_account
-                .lamports,
-            0
-        );
-        assert!(transfer_recipient_compressed_account
-            .compressed_account
-            .data
-            .is_some());
-        let mut data = Vec::new();
-        transfer_recipient_token_compressed_account
-            .token_data
-            .serialize(&mut data)
-            .unwrap();
-        assert_eq!(
-            transfer_recipient_compressed_account
-                .compressed_account
-                .data
-                .as_ref()
-                .unwrap()
-                .data,
-            data
-        );
-        assert_eq!(
-            transfer_recipient_compressed_account
-                .compressed_account
-                .owner,
-            light_compressed_token::ID
-        );
-        assert_eq!(
-            transfer_recipient_compressed_account
-                .merkle_context
-                .leaf_index as usize,
-            next_index_old_mt + i
-        );
-    }
-    let nullifier_queue = unsafe {
-        get_hash_set::<u16, NullifierQueueAccount>(context, test_indexer.nullifier_queue_pubkey)
-            .await
-    };
-    for hash in input_compressed_account_hashes.iter() {
-        assert!(nullifier_queue
-            .contains(&BigUint::from_be_bytes(hash), 0)
-            .unwrap());
-    }
-}
-
-// #[derive(Debug)]
-// pub struct TestIndexer {
-//     pub merkle_tree_pubkey: Pubkey,
-//     pub nullifier_queue_pubkey: Pubkey,
-//     pub payer: Keypair,
-//     pub compressed_accounts: Vec<PackedCompressedAccountWithMerkleContext>,
-//     pub nullified_compressed_accounts: Vec<PackedCompressedAccountWithMerkleContext>,
-//     pub token_compressed_accounts: Vec<TokenDataWithContext>,
-//     pub token_nullified_compressed_accounts: Vec<TokenDataWithContext>,
-//     pub events: Vec<PublicTransactionEvent>,
-//     pub merkle_tree: light_merkle_tree_reference::MerkleTree<Poseidon>,
-// }
-
-// #[derive(Debug, Clone)]
-// pub struct TokenDataWithContext {
-//     pub token_data: TokenData,
-//     pub compressed_account: PackedCompressedAccountWithMerkleContext,
-// }
-
-// impl TestIndexer {
-//     async fn new(
-//         merkle_tree_pubkey: Pubkey,
-//         nullifier_queue_pubkey: Pubkey,
-//         payer: Keypair,
-//     ) -> Self {
-//         spawn_gnark_server(
-//             "../../circuit-lib/circuitlib-rs/scripts/prover.sh",
-//             true,
-//             &[ProofType::Inclusion],
-//         )
-//         .await;
-//         let merkle_tree = light_merkle_tree_reference::MerkleTree::<Poseidon>::new(
-//             STATE_MERKLE_TREE_HEIGHT as usize,
-//             STATE_MERKLE_TREE_CANOPY_DEPTH as usize,
-//         );
-
-//         Self {
-//             merkle_tree_pubkey,
-//             nullifier_queue_pubkey,
-//             payer,
-//             compressed_accounts: vec![],
-//             nullified_compressed_accounts: vec![],
-//             events: vec![],
-//             token_compressed_accounts: vec![],
-//             token_nullified_compressed_accounts: vec![],
-//             merkle_tree,
-//         }
-//     }
-
-//     pub async fn create_proof_for_compressed_accounts(
-//         &mut self,
-//         compressed_accounts: &[[u8; 32]],
-//         context: &mut ProgramTestContext,
-//     ) -> (Vec<u16>, CompressedProof) {
-//         let client = Client::new();
-
-//         let mut inclusion_proofs = Vec::<InclusionMerkleProofInputs>::new();
-//         for compressed_account in compressed_accounts.iter() {
-//             let leaf_index = self.merkle_tree.get_leaf_index(compressed_account).unwrap();
-//             let proof = self
-//                 .merkle_tree
-//                 .get_proof_of_leaf(leaf_index, true)
-//                 .unwrap();
-//             inclusion_proofs.push(InclusionMerkleProofInputs {
-//                 root: BigInt::from_be_bytes(self.merkle_tree.root().as_slice()),
-//                 leaf: BigInt::from_be_bytes(compressed_account),
-//                 path_index: BigInt::from_be_bytes(leaf_index.to_be_bytes().as_slice()), // leaf_index as u32,
-//                 path_elements: proof.iter().map(|x| BigInt::from_be_bytes(x)).collect(),
-//             });
-//         }
-//         let inclusion_proof_inputs = InclusionProofInputs(inclusion_proofs.as_slice());
-//         let json_payload =
-//             BatchInclusionJsonStruct::from_inclusion_proof_inputs(&inclusion_proof_inputs)
-//                 .to_string();
-
-//         let response_result = client
-//             .post(&format!("{}{}", SERVER_ADDRESS, PROVE_PATH))
-//             .header("Content-Type", "text/plain; charset=utf-8")
-//             .body(json_payload)
-//             .send()
-//             .await
-//             .expect("Failed to execute request.");
-//         assert!(response_result.status().is_success());
-//         let body = response_result.text().await.unwrap();
-//         let proof_json = deserialize_gnark_proof_json(&body).unwrap();
-//         let (proof_a, proof_b, proof_c) = proof_from_json_struct(proof_json);
-//         let (proof_a, proof_b, proof_c) = compress_proof(&proof_a, &proof_b, &proof_c);
-
-//         let merkle_tree_account =
-//             AccountZeroCopy::<StateMerkleTreeAccount>::new(context, self.merkle_tree_pubkey).await;
-//         let merkle_tree = merkle_tree_account
-//             .deserialized()
-//             .copy_merkle_tree()
-//             .unwrap();
-//         assert_eq!(
-//             self.merkle_tree.root(),
-//             merkle_tree.root().unwrap(),
-//             "Local Merkle tree root is not equal to latest on-chain root"
-//         );
-
-//         let root_indices: Vec<u16> =
-//             vec![merkle_tree.current_root_index as u16; compressed_accounts.len()];
-//         (
-//             root_indices,
-//             CompressedProof {
-//                 a: proof_a,
-//                 b: proof_b,
-//                 c: proof_c,
-//             },
-//         )
-//     }
-
-//     /// deserializes an event
-//     /// adds the output_compressed_accounts to the compressed_accounts
-//     /// removes the input_compressed_accounts from the compressed_accounts
-//     /// adds the input_compressed_accounts to the nullified_compressed_accounts
-//     pub fn add_lamport_compressed_accounts(&mut self, event_bytes: Vec<u8>) {
-//         let event_bytes = event_bytes.clone();
-//         let event = PublicTransactionEvent::deserialize(&mut event_bytes.as_slice()).unwrap();
-//         self.add_event_and_compressed_accounts(event);
-//     }
-
-//     pub fn add_event_and_compressed_accounts(&mut self, event: PublicTransactionEvent) {
-//         for hash in event.input_compressed_account_hashes.iter() {
-//             let index = self.compressed_accounts.iter().position(|x| {
-//                 x.compressed_account
-//                     .hash::<Poseidon>(&self.merkle_tree_pubkey, &x.merkle_context.leaf_index)
-//                     .unwrap()
-//                     == *hash
-//             });
-//             if let Some(index) = index {
-//                 self.compressed_accounts.remove(index);
-//                 continue;
-//             };
-//             if index.is_none() {
-//                 let index = self
-//                     .token_compressed_accounts
-//                     .iter()
-//                     .position(|x| {
-//                         x.compressed_account
-//                             .compressed_account
-//                             .hash::<Poseidon>(
-//                                 &self.merkle_tree_pubkey,
-//                                 &x.compressed_account.merkle_context.leaf_index,
-//                             )
-//                             .unwrap()
-//                             == *hash
-//                     })
-//                     .expect("input compressed account not found");
-//                 self.token_compressed_accounts.remove(index);
-//             }
-//         }
-
-//         for (i, compressed_account) in event.output_compressed_accounts.iter().enumerate() {
-//             let data = compressed_account.data.as_ref().unwrap();
-//             match TokenData::deserialize(&mut data.data.as_slice()) {
-//                 Ok(token_data) => {
-//                     self.token_compressed_accounts.push(TokenDataWithContext {
-//                         token_data,
-//                         compressed_account: PackedCompressedAccountWithMerkleContext {
-//                             compressed_account: compressed_account.clone(),
-//                             merkle_context: PackedMerkleContext {
-//                                 leaf_index: event.output_leaf_indices[i],
-//                                 merkle_tree_pubkey_index: 0,
-//                                 nullifier_queue_pubkey_index: 0,
-//                             },
-//                         },
-//                     });
-//                 }
-//                 Err(_) => {
-//                     self.compressed_accounts
-//                         .push(PackedCompressedAccountWithMerkleContext {
-//                             compressed_account: compressed_account.clone(),
-//                             merkle_context: PackedMerkleContext {
-//                                 leaf_index: event.output_leaf_indices[i],
-//                                 merkle_tree_pubkey_index: 0,
-//                                 nullifier_queue_pubkey_index: 0,
-//                             },
-//                         });
-//                 }
-//             };
-//             self.merkle_tree
-//                 .append(
-//                     &compressed_account
-//                         .hash::<Poseidon>(&self.merkle_tree_pubkey, &event.output_leaf_indices[i])
-//                         .unwrap(),
-//                 )
-//                 .expect("insert failed");
-//         }
-
-//         self.events.push(event);
-//     }
-
-//     /// deserializes an event
-//     /// adds the output_compressed_accounts to the compressed_accounts
-//     /// removes the input_compressed_accounts from the compressed_accounts
-//     /// adds the input_compressed_accounts to the nullified_compressed_accounts
-//     /// deserializes token data from the output_compressed_accounts
-//     /// adds the token_compressed_accounts to the token_compressed_accounts
-//     pub fn add_compressed_accounts_with_token_data(&mut self, event: PublicTransactionEvent) {
-//         self.add_event_and_compressed_accounts(event);
-//     }
-
-//     /// Check compressed_accounts in the queue array which are not nullified yet
-//     /// Iterate over these compressed_accounts and nullify them
-//     pub async fn nullify_compressed_accounts(&mut self, context: &mut ProgramTestContext) {
-//         let nullifier_queue = unsafe {
-//             get_hash_set::<u16, NullifierQueueAccount>(context, self.nullifier_queue_pubkey).await
-//         };
-//         let merkle_tree_account =
-//             AccountZeroCopy::<StateMerkleTreeAccount>::new(context, self.merkle_tree_pubkey).await;
-//         let merkle_tree = merkle_tree_account
-//             .deserialized()
-//             .copy_merkle_tree()
-//             .unwrap();
-//         let change_log_index = merkle_tree.current_changelog_index as u64;
-
-//         let mut compressed_account_to_nullify = Vec::new();
-
-//         for (i, element) in nullifier_queue.iter() {
-//             if element.sequence_number().is_none() {
-//                 compressed_account_to_nullify.push((i, element.value_bytes()));
-//             }
-//         }
-
-//         for (index_in_nullifier_queue, compressed_account) in compressed_account_to_nullify.iter() {
-//             let leaf_index = self.merkle_tree.get_leaf_index(compressed_account).unwrap();
-//             let proof: Vec<[u8; 32]> = self
-//                 .merkle_tree
-//                 .get_proof_of_leaf(leaf_index, false)
-//                 .unwrap()
-//                 .to_array::<16>()
-//                 .unwrap()
-//                 .to_vec();
-
-//             let instructions = [
-//                 account_compression::nullify_leaves::sdk_nullify::create_nullify_instruction(
-//                     vec![change_log_index].as_slice(),
-//                     vec![(*index_in_nullifier_queue) as u16].as_slice(),
-//                     vec![0u64].as_slice(),
-//                     vec![proof].as_slice(),
-//                     &context.payer.pubkey(),
-//                     &self.merkle_tree_pubkey,
-//                     &self.nullifier_queue_pubkey,
-//                 ),
-//             ];
-
-//             create_and_send_transaction(
-//                 context,
-//                 &instructions,
-//                 &self.payer.pubkey(),
-//                 &[&self.payer],
-//             )
-//             .await
-//             .unwrap();
-
-//             let nullifier_queue = unsafe {
-//                 get_hash_set::<u16, NullifierQueueAccount>(context, self.nullifier_queue_pubkey)
-//                     .await
-//             };
-//             let array_element = nullifier_queue
-//                 .by_value_index(*index_in_nullifier_queue, Some(merkle_tree.sequence_number))
-//                 .unwrap();
-//             assert_eq!(&array_element.value_bytes(), compressed_account);
-//             let merkle_tree_account =
-//                 AccountZeroCopy::<StateMerkleTreeAccount>::new(context, self.merkle_tree_pubkey)
-//                     .await;
-//             assert_eq!(
-//                 array_element.sequence_number(),
-//                 Some(
-//                     merkle_tree_account
-//                         .deserialized()
-//                         .load_merkle_tree()
-//                         .unwrap()
-//                         .sequence_number
-//                         + account_compression::utils::constants::STATE_MERKLE_TREE_ROOTS as usize
-//                 )
-//             );
-//         }
-//     }
-// }

--- a/test-programs/program-owned-account-test/Cargo.toml
+++ b/test-programs/program-owned-account-test/Cargo.toml
@@ -33,7 +33,7 @@ solana-sdk = "1.18.11"
 
 [dev-dependencies]
 solana-program-test = "1.18.11"
-light-test-utils = { version = "0.1.1", path = "../../test-utils", default-features= true, features = ["test_indexer"] }
+light-test-utils = { version = "0.1.1", path = "../../test-utils" }
 reqwest = "0.11.26"
 tokio = "1.36.0"
 light-circuitlib-rs = { path = "../../circuit-lib/circuitlib-rs", version = "0.1.1" }

--- a/test-programs/registry-test/Cargo.toml
+++ b/test-programs/registry-test/Cargo.toml
@@ -22,7 +22,7 @@ default = ["custom-heap"]
 
 [dev-dependencies]
 solana-program-test = "1.18.11"
-light-test-utils = { version = "0.1.1", path = "../../test-utils", default-features= true, features = ["test_indexer"] }
+light-test-utils = { version = "0.1.1", path = "../../test-utils" }
 reqwest = "0.11.26"
 tokio = "1.36.0"
 light-circuitlib-rs = {path = "../../circuit-lib/circuitlib-rs"}

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -7,10 +7,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
-light_program = ["light-registry", "account-compression"]
-account_compression = ["account-compression"]
-test_indexer = ["account-compression", "light_program", "light-registry", "light-compressed-pda", "light-compressed-token"]
-default = ["light_program", "account_compression"]
+default = []
 
 [dependencies]
 anchor-lang = "0.29.0"
@@ -23,10 +20,10 @@ solana-program-test = "1.18.11"
 solana-sdk = "1.18.11"
 thiserror = "1.0"
 light-macros = { path = "../macros/light", version = "0.3.2" }
-account-compression = { path = "../programs/account-compression", version = "0.3.2", features = ["cpi"], optional = true }
-light-compressed-token = { path = "../programs/compressed-token", version = "0.3.1", features = ["cpi"],  optional= true }
-light-compressed-pda = { path = "../programs/compressed-pda", version = "0.3.1", features = ["cpi"],  optional= true}
-light-registry = { path = "../programs/registry", version = "0.3.1", features = ["cpi"],  optional= true }
+account-compression = { path = "../programs/account-compression", version = "0.3.2", features = ["cpi"] }
+light-compressed-token = { path = "../programs/compressed-token", version = "0.3.1", features = ["cpi"] }
+light-compressed-pda = { path = "../programs/compressed-pda", version = "0.3.1", features = ["cpi"]}
+light-registry = { path = "../programs/registry", version = "0.3.1", features = ["cpi"] }
 spl-token = { version="3.5.0", features = ["no-entrypoint"] }
 tokio = "1.36"
 light-circuitlib-rs = { path = "../circuit-lib/circuitlib-rs", version = "0.1.1" }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -15,8 +15,8 @@ use solana_sdk::{
     signer::Signer,
     transaction::Transaction,
 };
-
 pub mod spl;
+pub mod system_program;
 pub mod test_env;
 #[cfg(feature = "test_indexer")]
 pub mod test_indexer;

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,5 +1,3 @@
-use std::{fmt, marker::PhantomData, mem, pin::Pin};
-
 use anchor_lang::{
     solana_program::{pubkey::Pubkey, system_instruction},
     AnchorDeserialize,
@@ -15,10 +13,10 @@ use solana_sdk::{
     signer::Signer,
     transaction::Transaction,
 };
+use std::{fmt, marker::PhantomData, mem, pin::Pin};
 pub mod spl;
 pub mod system_program;
 pub mod test_env;
-#[cfg(feature = "test_indexer")]
 pub mod test_indexer;
 
 #[derive(Debug, Clone)]
@@ -119,13 +117,13 @@ pub async fn airdrop_lamports(
     // Create a transfer instruction
     let transfer_instruction =
         system_instruction::transfer(&banks_client.payer.pubkey(), destination_pubkey, lamports);
-
+    let latest_blockhash = banks_client.get_new_latest_blockhash().await.unwrap();
     // Create and sign a transaction
     let transaction = Transaction::new_signed_with_payer(
         &[transfer_instruction],
         Some(&banks_client.payer.pubkey()),
         &vec![&banks_client.payer],
-        banks_client.last_blockhash,
+        latest_blockhash,
     );
 
     // Send the transaction

--- a/test-utils/src/spl.rs
+++ b/test-utils/src/spl.rs
@@ -1,12 +1,108 @@
-use solana_program_test::ProgramTestContext;
+use crate::{
+    create_account_instruction, create_and_send_transaction,
+    create_and_send_transaction_with_event, get_hash_set,
+    test_env::COMPRESSED_TOKEN_PROGRAM_PROGRAM_ID,
+    test_indexer::{StateMerkleTreeAccounts, TestIndexer, TokenDataWithContext},
+    AccountZeroCopy, TransactionParams,
+};
+use account_compression::{
+    initialize_nullifier_queue::NullifierQueueAccount, StateMerkleTreeAccount,
+};
+use light_compressed_pda::sdk::{compressed_account::MerkleContext, event::PublicTransactionEvent};
+use light_compressed_token::{
+    get_cpi_authority_pda, get_token_authority_pda, get_token_pool_pda,
+    mint_sdk::{create_initialize_mint_instruction, create_mint_to_instruction},
+    transfer_sdk::create_transfer_instruction,
+    TokenTransferOutputData,
+};
+use light_hasher::Poseidon;
+use num_bigint::BigUint;
+use num_traits::FromBytes;
+use solana_program_test::{BanksClientError, ProgramTestContext};
 use solana_sdk::{
+    instruction::Instruction,
     program_pack::Pack,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
 };
+use spl_token::instruction::initialize_mint;
 use spl_token::state::Mint;
+// TODO: replace with borsh serialize
+use anchor_lang::AnchorSerialize;
 
-use crate::{create_and_send_transaction, test_env::COMPRESSED_TOKEN_PROGRAM_PROGRAM_ID};
+pub async fn mint_tokens_helper(
+    context: &mut ProgramTestContext,
+    test_indexer: &mut TestIndexer,
+    merkle_tree_pubkey: &Pubkey,
+    mint_authority: &Keypair,
+    mint: &Pubkey,
+    amounts: Vec<u64>,
+    recipients: Vec<Pubkey>,
+) {
+    let payer_pubkey = mint_authority.pubkey();
+    let instruction = create_mint_to_instruction(
+        &payer_pubkey,
+        &payer_pubkey,
+        mint,
+        merkle_tree_pubkey,
+        amounts.clone(),
+        recipients.clone(),
+    );
+    let snapshots = get_merkle_tree_snapshots(
+        context,
+        test_indexer,
+        &vec![*merkle_tree_pubkey; amounts.len()],
+    )
+    .await;
+    let previous_mint_supply = spl_token::state::Mint::unpack(
+        &context
+            .banks_client
+            .get_account(*mint)
+            .await
+            .unwrap()
+            .unwrap()
+            .data,
+    )
+    .unwrap()
+    .supply;
+
+    let pool: Pubkey = get_token_pool_pda(mint);
+    let previous_pool_amount = spl_token::state::Account::unpack(
+        &context
+            .banks_client
+            .get_account(pool)
+            .await
+            .unwrap()
+            .unwrap()
+            .data,
+    )
+    .unwrap()
+    .amount;
+    let event = create_and_send_transaction_with_event::<PublicTransactionEvent>(
+        context,
+        &[instruction],
+        &payer_pubkey,
+        &[mint_authority],
+        None,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    let (_, created_token_accounts) = test_indexer.add_event_and_compressed_accounts(event);
+
+    assert_mint_to(
+        context,
+        test_indexer,
+        &recipients,
+        *mint,
+        amounts.as_slice(),
+        &snapshots,
+        &created_token_accounts,
+        previous_mint_supply,
+        previous_pool_amount,
+    )
+    .await;
+}
 
 pub async fn create_mint(
     context: &mut ProgramTestContext,
@@ -50,4 +146,775 @@ pub async fn create_mint(
     .await
     .unwrap();
     mint_pubkey
+}
+pub async fn create_mint_helper(context: &mut ProgramTestContext, payer: &Keypair) -> Pubkey {
+    let payer_pubkey = payer.pubkey();
+    let rent = context
+        .banks_client
+        .get_rent()
+        .await
+        .unwrap()
+        .minimum_balance(anchor_spl::token::Mint::LEN);
+    let mint = Keypair::new();
+
+    let (instructions, pool) =
+        create_initialize_mint_instructions(&payer_pubkey, &payer_pubkey, rent, 2, &mint);
+
+    create_and_send_transaction(context, &instructions, &payer_pubkey, &[payer, &mint])
+        .await
+        .unwrap();
+    assert_create_mint(context, &payer_pubkey, &mint.pubkey(), &pool).await;
+    mint.pubkey()
+}
+pub fn create_initialize_mint_instructions(
+    payer: &Pubkey,
+    authority: &Pubkey,
+    rent: u64,
+    decimals: u8,
+    mint_keypair: &Keypair,
+) -> ([Instruction; 4], Pubkey) {
+    let account_create_ix = create_account_instruction(
+        payer,
+        anchor_spl::token::Mint::LEN,
+        rent,
+        &anchor_spl::token::ID,
+        Some(mint_keypair),
+    );
+
+    let mint_pubkey = mint_keypair.pubkey();
+    let mint_authority = get_token_authority_pda(authority, &mint_pubkey).0;
+    let create_mint_instruction = initialize_mint(
+        &anchor_spl::token::ID,
+        &mint_keypair.pubkey(),
+        &mint_authority,
+        None,
+        decimals,
+    )
+    .unwrap();
+    let transfer_ix =
+        anchor_lang::solana_program::system_instruction::transfer(payer, &mint_pubkey, rent);
+
+    let instruction = create_initialize_mint_instruction(payer, authority, &mint_pubkey);
+    let pool_pubkey = get_token_pool_pda(&mint_pubkey);
+    (
+        [
+            account_create_ix,
+            create_mint_instruction,
+            transfer_ix,
+            instruction,
+        ],
+        pool_pubkey,
+    )
+}
+
+pub async fn assert_create_mint(
+    context: &mut ProgramTestContext,
+    authority: &Pubkey,
+    mint: &Pubkey,
+    pool: &Pubkey,
+) {
+    let mint_account: spl_token::state::Mint = spl_token::state::Mint::unpack(
+        &context
+            .banks_client
+            .get_account(*mint)
+            .await
+            .unwrap()
+            .unwrap()
+            .data,
+    )
+    .unwrap();
+    let mint_authority = get_token_authority_pda(authority, mint).0;
+    assert_eq!(mint_account.supply, 0);
+    assert_eq!(mint_account.decimals, 2);
+    assert_eq!(mint_account.mint_authority.unwrap(), mint_authority);
+    assert_eq!(mint_account.freeze_authority, None.into());
+    assert!(mint_account.is_initialized);
+    let mint_account: spl_token::state::Account = spl_token::state::Account::unpack(
+        &context
+            .banks_client
+            .get_account(*pool)
+            .await
+            .unwrap()
+            .unwrap()
+            .data,
+    )
+    .unwrap();
+
+    assert_eq!(mint_account.amount, 0);
+    assert_eq!(mint_account.delegate, None.into());
+    assert_eq!(mint_account.mint, *mint);
+    assert_eq!(mint_account.owner, get_cpi_authority_pda().0);
+}
+
+#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
+pub struct MerkleTreeTestSnapShot {
+    pub accounts: StateMerkleTreeAccounts,
+    pub root: [u8; 32],
+    pub next_index: usize,
+    pub num_added_accounts: usize,
+}
+
+pub async fn assert_merkle_tree_after_tx(
+    context: &mut ProgramTestContext,
+    snapshots: &[MerkleTreeTestSnapShot],
+    test_indexer: &mut TestIndexer,
+) {
+    let mut deduped_snapshots = snapshots.to_vec();
+    deduped_snapshots.sort();
+    deduped_snapshots.dedup();
+    for (i, snapshot) in deduped_snapshots.iter().enumerate() {
+        let merkle_tree_account =
+            AccountZeroCopy::<StateMerkleTreeAccount>::new(context, snapshot.accounts.merkle_tree)
+                .await;
+        let merkle_tree = merkle_tree_account
+            .deserialized()
+            .copy_merkle_tree()
+            .unwrap();
+        if merkle_tree.root().unwrap() == snapshot.root {
+            println!("deduped_snapshots: {:?}", deduped_snapshots);
+            println!("i: {:?}", i);
+            panic!("merkle tree root update failed");
+        }
+        assert_eq!(
+            merkle_tree.next_index(),
+            snapshot.next_index + snapshot.num_added_accounts
+        );
+        let test_indexer_merkle_tree = test_indexer
+            .state_merkle_trees
+            .iter_mut()
+            .find(|x| x.accounts.merkle_tree == snapshot.accounts.merkle_tree)
+            .expect("merkle tree not found in test indexer");
+
+        if merkle_tree.root().unwrap() != test_indexer_merkle_tree.merkle_tree.root() {
+            println!("Merkle tree pubkey {:?}", snapshot.accounts.merkle_tree);
+            for (i, leaf) in test_indexer_merkle_tree.merkle_tree.layers[0]
+                .iter()
+                .enumerate()
+            {
+                println!("test_indexer_merkle_tree index {} leaf: {:?}", i, leaf);
+            }
+            let merkle_tree_roots = merkle_tree_account.deserialized().load_roots().unwrap();
+            for i in 0..16 {
+                println!("root {} {:?}", i, merkle_tree_roots.get(i));
+            }
+            for i in 0..5 {
+                test_indexer_merkle_tree
+                    .merkle_tree
+                    .update(&[0u8; 32], 15 - i)
+                    .unwrap();
+                println!(
+                    "roll back root {} {:?}",
+                    15 - i,
+                    test_indexer_merkle_tree.merkle_tree.root()
+                );
+            }
+
+            panic!("merkle tree root update failed");
+        }
+    }
+}
+
+pub async fn assert_transfer(
+    context: &mut ProgramTestContext,
+    test_indexer: &mut TestIndexer,
+    out_compressed_accounts: &[TokenTransferOutputData],
+    input_compressed_account_hashes: &[[u8; 32]],
+    output_merkle_tree_test_snapshots: &[MerkleTreeTestSnapShot],
+    input_merkle_tree_test_snapshots: &[MerkleTreeTestSnapShot],
+) {
+    assert_merkle_tree_after_tx(context, output_merkle_tree_test_snapshots, test_indexer).await;
+    let mut tree = Pubkey::default();
+    let mut index = 0;
+    for (i, out_compressed_account) in out_compressed_accounts.iter().enumerate() {
+        if output_merkle_tree_test_snapshots[i].accounts.merkle_tree != tree {
+            tree = output_merkle_tree_test_snapshots[i].accounts.merkle_tree;
+            index = 0;
+        } else {
+            index += 1;
+        }
+        let pos = test_indexer
+            .token_compressed_accounts
+            .iter()
+            .position(|x| {
+                x.token_data.owner == out_compressed_account.owner
+                    && x.token_data.amount == out_compressed_account.amount
+            })
+            .expect("transfer recipient compressed account not found in mock indexer");
+        let transfer_recipient_token_compressed_account =
+            test_indexer.token_compressed_accounts[pos].clone();
+        assert_eq!(
+            transfer_recipient_token_compressed_account
+                .token_data
+                .amount,
+            out_compressed_account.amount
+        );
+        assert_eq!(
+            transfer_recipient_token_compressed_account.token_data.owner,
+            out_compressed_account.owner
+        );
+        assert_eq!(
+            transfer_recipient_token_compressed_account
+                .token_data
+                .delegate,
+            None
+        );
+        assert_eq!(
+            transfer_recipient_token_compressed_account
+                .token_data
+                .is_native,
+            None
+        );
+        assert_eq!(
+            transfer_recipient_token_compressed_account
+                .token_data
+                .delegated_amount,
+            0
+        );
+
+        let transfer_recipient_compressed_account = transfer_recipient_token_compressed_account
+            .compressed_account
+            .clone();
+        assert_eq!(
+            transfer_recipient_compressed_account
+                .compressed_account
+                .lamports,
+            0
+        );
+        assert!(transfer_recipient_compressed_account
+            .compressed_account
+            .data
+            .is_some());
+        let mut data = Vec::new();
+        transfer_recipient_token_compressed_account
+            .token_data
+            .serialize(&mut data)
+            .unwrap();
+        assert_eq!(
+            transfer_recipient_compressed_account
+                .compressed_account
+                .data
+                .as_ref()
+                .unwrap()
+                .data,
+            data
+        );
+        assert_eq!(
+            transfer_recipient_compressed_account
+                .compressed_account
+                .owner,
+            light_compressed_token::ID
+        );
+
+        if !test_indexer.token_compressed_accounts.iter().any(|x| {
+            x.compressed_account.merkle_context.leaf_index as usize
+                == output_merkle_tree_test_snapshots[i].next_index + index
+        }) {
+            println!(
+                "token_compressed_accounts {:?}",
+                test_indexer.token_compressed_accounts
+            );
+            println!("snapshot {:?}", output_merkle_tree_test_snapshots[i]);
+            println!("index {:?}", index);
+            panic!("transfer recipient compressed account not found in mock indexer");
+        };
+    }
+    assert_nullifiers_exist_in_hash_sets(
+        context,
+        input_merkle_tree_test_snapshots,
+        input_compressed_account_hashes,
+    )
+    .await;
+}
+
+pub async fn assert_nullifiers_exist_in_hash_sets(
+    context: &mut ProgramTestContext,
+    snapshots: &[MerkleTreeTestSnapShot],
+    input_compressed_account_hashes: &[[u8; 32]],
+) {
+    for (i, hash) in input_compressed_account_hashes.iter().enumerate() {
+        let nullifier_queue = unsafe {
+            get_hash_set::<u16, NullifierQueueAccount>(
+                context,
+                snapshots[i].accounts.nullifier_queue,
+            )
+            .await
+        };
+        assert!(nullifier_queue
+            .contains(&BigUint::from_be_bytes(hash.as_slice()), 0)
+            .unwrap());
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn assert_mint_to<'a>(
+    context: &mut ProgramTestContext,
+    test_indexer: &'a mut TestIndexer,
+    recipients: &[Pubkey],
+    mint: Pubkey,
+    amounts: &[u64],
+    snapshots: &[MerkleTreeTestSnapShot],
+    created_token_accounts: &[TokenDataWithContext],
+    previous_mint_supply: u64,
+    previous_sol_pool_amount: u64,
+) {
+    let mut created_token_accounts = created_token_accounts.to_vec();
+    for (recipient, amount) in recipients.iter().zip(amounts) {
+        let pos = created_token_accounts
+            .iter()
+            .position(|x| {
+                x.token_data.owner == *recipient
+                    && x.token_data.amount == *amount
+                    && x.token_data.mint == mint
+                    && x.token_data.delegate.is_none()
+                    && x.token_data.is_native.is_none()
+                    && x.token_data.delegated_amount == 0
+            })
+            .expect("Mint to failed to create expected compressed token account.");
+        created_token_accounts.remove(pos);
+    }
+    assert_merkle_tree_after_tx(context, snapshots, test_indexer).await;
+    let mint_account: spl_token::state::Mint = spl_token::state::Mint::unpack(
+        &context
+            .banks_client
+            .get_account(mint)
+            .await
+            .unwrap()
+            .unwrap()
+            .data,
+    )
+    .unwrap();
+    let sum_amounts = amounts.iter().sum::<u64>();
+    assert_eq!(mint_account.supply, previous_mint_supply + sum_amounts);
+
+    let pool = get_token_pool_pda(&mint);
+    let pool_account = spl_token::state::Account::unpack(
+        &context
+            .banks_client
+            .get_account(pool)
+            .await
+            .unwrap()
+            .unwrap()
+            .data,
+    )
+    .unwrap();
+    assert_eq!(pool_account.amount, previous_sol_pool_amount + sum_amounts);
+}
+
+/// Creates an spl token account and initializes it with the given mint and owner.
+/// This function is useful to create token accounts for spl compression and decompression tests.
+pub async fn create_token_account(
+    context: &mut ProgramTestContext,
+    mint: &Pubkey,
+    account_keypair: &Keypair,
+    owner: &Keypair,
+) -> Result<(), BanksClientError> {
+    let rent = context
+        .banks_client
+        .get_rent()
+        .await
+        .unwrap()
+        .minimum_balance(anchor_spl::token::TokenAccount::LEN);
+    let account_create_ix = create_account_instruction(
+        &owner.pubkey(),
+        anchor_spl::token::TokenAccount::LEN,
+        rent,
+        &anchor_spl::token::ID,
+        Some(account_keypair),
+    );
+    let instruction = spl_token::instruction::initialize_account(
+        &spl_token::ID,
+        &account_keypair.pubkey(),
+        mint,
+        &owner.pubkey(),
+    )
+    .unwrap();
+    create_and_send_transaction(
+        context,
+        &[account_create_ix, instruction],
+        &owner.pubkey(),
+        &[account_keypair, owner],
+    )
+    .await
+    .unwrap();
+    Ok(())
+}
+
+pub async fn get_merkle_tree_snapshots(
+    context: &mut ProgramTestContext,
+    test_indexer: &TestIndexer,
+    pubkeys: &[Pubkey],
+) -> Vec<MerkleTreeTestSnapShot> {
+    let mut snapshots = Vec::new();
+    for pubkey in pubkeys.iter() {
+        let merkle_tree_account =
+            AccountZeroCopy::<StateMerkleTreeAccount>::new(context, *pubkey).await;
+        let merkle_tree = merkle_tree_account
+            .deserialized()
+            .copy_merkle_tree()
+            .unwrap();
+        let accounts = test_indexer
+            .state_merkle_trees
+            .iter()
+            .find(|x| x.accounts.merkle_tree == *pubkey)
+            .expect("merkle tree not found in test indexer");
+        snapshots.push(MerkleTreeTestSnapShot {
+            accounts: accounts.accounts,
+            root: merkle_tree.root().unwrap(),
+            next_index: merkle_tree.next_index(),
+            num_added_accounts: pubkeys.iter().filter(|x| **x == *pubkey).count(),
+        });
+    }
+    snapshots
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn compressed_transfer_test(
+    payer: &Keypair,
+    context: &mut ProgramTestContext,
+    test_indexer: &mut TestIndexer,
+    mint: &Pubkey,
+    from: &Keypair,
+    recipients: &[Pubkey],
+    amounts: &[u64],
+    input_compressed_accounts: &[TokenDataWithContext],
+    output_merkle_tree_pubkeys: &[Pubkey],
+    transaction_params: Option<TransactionParams>,
+) {
+    if recipients.len() != amounts.len() && amounts.len() != output_merkle_tree_pubkeys.len() {
+        panic!("recipients, amounts, and output_merkle_tree_pubkeys must have the same length");
+    }
+    let mut input_merkle_tree_context = Vec::new();
+    let mut input_compressed_account_token_data = Vec::new();
+    let mut input_compressed_account_hashes = Vec::new();
+    let mut sum_input_amounts = 0;
+    for account in input_compressed_accounts {
+        let leaf_index = account.compressed_account.merkle_context.leaf_index;
+        input_compressed_account_token_data.push(account.token_data);
+        input_compressed_account_hashes.push(
+            account
+                .compressed_account
+                .compressed_account
+                .hash::<Poseidon>(
+                    &account.compressed_account.merkle_context.merkle_tree_pubkey,
+                    &leaf_index,
+                )
+                .unwrap(),
+        );
+        sum_input_amounts += account.token_data.amount;
+        input_merkle_tree_context.push(MerkleContext {
+            merkle_tree_pubkey: account.compressed_account.merkle_context.merkle_tree_pubkey,
+            nullifier_queue_pubkey: account
+                .compressed_account
+                .merkle_context
+                .nullifier_queue_pubkey,
+            leaf_index,
+        });
+    }
+    let mut output_compressed_accounts = Vec::new();
+    for (recipient, amount) in recipients.iter().zip(amounts) {
+        let account = TokenTransferOutputData {
+            amount: *amount,
+            owner: *recipient,
+            lamports: None,
+        };
+        sum_input_amounts -= amount;
+        output_compressed_accounts.push(account);
+    }
+    // add change compressed account if tokens are left
+    if sum_input_amounts > 0 {
+        let account = TokenTransferOutputData {
+            amount: sum_input_amounts,
+            owner: from.pubkey(),
+            lamports: None,
+        };
+        output_compressed_accounts.push(account);
+    }
+    let input_merkle_tree_pubkeys: Vec<Pubkey> = input_merkle_tree_context
+        .iter()
+        .map(|x| x.merkle_tree_pubkey)
+        .collect();
+
+    let proof_rpc_result = test_indexer
+        .create_proof_for_compressed_accounts(
+            Some(&input_compressed_account_hashes),
+            Some(&input_merkle_tree_pubkeys),
+            None,
+            None,
+            context,
+        )
+        .await;
+
+    let instruction = light_compressed_token::transfer_sdk::create_transfer_instruction(
+        &payer.pubkey(),
+        &from.pubkey(), // authority
+        &input_merkle_tree_context,
+        output_merkle_tree_pubkeys, // output_compressed_account_merkle_tree_pubkeys
+        &output_compressed_accounts, // output_compressed_accounts
+        &proof_rpc_result.root_indices,
+        &Some(proof_rpc_result.proof),
+        input_compressed_account_token_data.as_slice(), // input_token_data
+        *mint,
+        None,  // owner_if_delegate_is_signer
+        false, // is_compress
+        None,  // compression_amount
+        None,  // token_pool_pda
+        None,  // decompress_token_account
+    )
+    .unwrap();
+
+    let snapshots =
+        get_merkle_tree_snapshots(context, test_indexer, output_merkle_tree_pubkeys).await;
+    let input_snapshots =
+        get_merkle_tree_snapshots(context, test_indexer, &input_merkle_tree_pubkeys).await;
+    let event = create_and_send_transaction_with_event(
+        context,
+        &[instruction],
+        &payer.pubkey(),
+        &[payer, from],
+        transaction_params,
+        // Some(TransactionParams {
+        //     num_new_addresses: 0,
+        //     num_input_compressed_accounts: input_compressed_account_hashes.len() as u8,
+        //     num_output_compressed_accounts: output_compressed_accounts.len() as u8,
+        //     compress: 5000, // for second signer
+        //     fee_config: crate::FeeConfig::default(),
+        // }),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    test_indexer.add_compressed_accounts_with_token_data(event);
+    assert_transfer(
+        context,
+        test_indexer,
+        &output_compressed_accounts,
+        &input_compressed_account_hashes,
+        &snapshots,
+        &input_snapshots,
+    )
+    .await;
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn decompress_test(
+    payer: &Keypair,
+    context: &mut ProgramTestContext,
+    test_indexer: &mut TestIndexer,
+    input_compressed_accounts: Vec<TokenDataWithContext>,
+    amount: u64,
+    output_merkle_tree_pubkey: &Pubkey,
+    recipient_token_account: &Pubkey,
+    transaction_params: Option<TransactionParams>,
+) {
+    let max_amount: u64 = input_compressed_accounts
+        .iter()
+        .map(|x| x.token_data.amount)
+        .sum();
+    let change_out_compressed_account = TokenTransferOutputData {
+        amount: max_amount - amount,
+        owner: payer.pubkey(),
+        lamports: None,
+    };
+    let input_compressed_account_hashes = input_compressed_accounts
+        .iter()
+        .map(|x| {
+            x.compressed_account
+                .compressed_account
+                .hash::<Poseidon>(
+                    &x.compressed_account.merkle_context.merkle_tree_pubkey,
+                    &x.compressed_account.merkle_context.leaf_index,
+                )
+                .unwrap()
+        })
+        .collect::<Vec<_>>();
+    let input_merkle_tree_pubkeys = input_compressed_accounts
+        .iter()
+        .map(|x| x.compressed_account.merkle_context.merkle_tree_pubkey)
+        .collect::<Vec<_>>();
+
+    let proof_rpc_result = test_indexer
+        .create_proof_for_compressed_accounts(
+            Some(&input_compressed_account_hashes),
+            Some(&input_merkle_tree_pubkeys),
+            None,
+            None,
+            context,
+        )
+        .await;
+    let mint = input_compressed_accounts[0].token_data.mint;
+    let output_merkle_tree_pubkeys = vec![*output_merkle_tree_pubkey];
+    let instruction = create_transfer_instruction(
+        &context.payer.pubkey(),
+        &payer.pubkey(), // authority
+        &input_compressed_accounts
+            .iter()
+            .map(|x| x.compressed_account.merkle_context)
+            .collect::<Vec<_>>(), // input_compressed_account_merkle_tree_pubkeys
+        &output_merkle_tree_pubkeys, // output_cmerkle_contextmerkle_tree_pubkeys
+        &[change_out_compressed_account], // output_compressed_accounts
+        &proof_rpc_result.root_indices, // root_indices
+        &Some(proof_rpc_result.proof),
+        input_compressed_accounts
+            .iter()
+            .map(|x| x.token_data)
+            .collect::<Vec<_>>()
+            .as_slice(), // input_token_data
+        mint,                            // mint
+        None,                            // owner_if_delegate_is_signer
+        false,                           // is_compress
+        Some(amount),                    // compression_amount
+        Some(get_token_pool_pda(&mint)), // token_pool_pda
+        Some(*recipient_token_account),  // decompress_token_account
+    )
+    .unwrap();
+    let output_merkle_tree_test_snapshots =
+        get_merkle_tree_snapshots(context, test_indexer, &output_merkle_tree_pubkeys).await;
+    let input_merkle_tree_test_snapshots =
+        get_merkle_tree_snapshots(context, test_indexer, &input_merkle_tree_pubkeys).await;
+    let recipient_token_account_data_pre = spl_token::state::Account::unpack(
+        &context
+            .banks_client
+            .get_account(*recipient_token_account)
+            .await
+            .unwrap()
+            .unwrap()
+            .data,
+    )
+    .unwrap();
+    let context_payer = context.payer.insecure_clone();
+    let event = create_and_send_transaction_with_event(
+        context,
+        &[instruction],
+        &payer.pubkey(),
+        &[&context_payer, payer],
+        transaction_params,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    test_indexer.add_compressed_accounts_with_token_data(event);
+
+    assert_transfer(
+        context,
+        test_indexer,
+        &[change_out_compressed_account],
+        input_compressed_account_hashes.as_slice(),
+        &output_merkle_tree_test_snapshots,
+        &input_merkle_tree_test_snapshots,
+    )
+    .await;
+
+    let recipient_token_account_data = spl_token::state::Account::unpack(
+        &context
+            .banks_client
+            .get_account(*recipient_token_account)
+            .await
+            .unwrap()
+            .unwrap()
+            .data,
+    )
+    .unwrap();
+    assert_eq!(
+        recipient_token_account_data.amount,
+        recipient_token_account_data_pre.amount + amount
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn compress_test(
+    payer: &Keypair,
+    context: &mut ProgramTestContext,
+    test_indexer: &mut TestIndexer,
+    amount: u64,
+    mint: &Pubkey,
+    output_merkle_tree_pubkey: &Pubkey,
+    sender_token_account: &Pubkey,
+    transaction_params: Option<TransactionParams>,
+) {
+    let output_compressed_account = TokenTransferOutputData {
+        amount,
+        owner: payer.pubkey(),
+        lamports: None,
+    };
+    let approve_instruction = spl_token::instruction::approve(
+        &anchor_spl::token::ID,
+        sender_token_account,
+        &get_cpi_authority_pda().0,
+        &payer.pubkey(),
+        &[&payer.pubkey()],
+        amount,
+    )
+    .unwrap();
+
+    let output_merkle_tree_pubkeys = vec![*output_merkle_tree_pubkey];
+    let instruction = create_transfer_instruction(
+        &context.payer.pubkey(),
+        &payer.pubkey(),              // authority
+        &Vec::new(),                  // input_compressed_account_merkle_tree_pubkeys
+        &output_merkle_tree_pubkeys,  // output_cmerkle_contextmerkle_tree_pubkeys
+        &[output_compressed_account], // output_compressed_accounts
+        &Vec::new(),                  // root_indices
+        &None,
+        &Vec::new(),                    // input_token_data
+        *mint,                          // mint
+        None,                           // owner_if_delegate_is_signer
+        true,                           // is_compress
+        Some(amount),                   // compression_amount
+        Some(get_token_pool_pda(mint)), // token_pool_pda
+        Some(*sender_token_account),    // decompress_token_account
+    )
+    .unwrap();
+    let output_merkle_tree_test_snapshots =
+        get_merkle_tree_snapshots(context, test_indexer, &output_merkle_tree_pubkeys).await;
+    let input_merkle_tree_test_snapshots = Vec::new();
+    let recipient_token_account_data_pre = spl_token::state::Account::unpack(
+        &context
+            .banks_client
+            .get_account(*sender_token_account)
+            .await
+            .unwrap()
+            .unwrap()
+            .data,
+    )
+    .unwrap();
+    let context_payer = context.payer.insecure_clone();
+    let event = create_and_send_transaction_with_event(
+        context,
+        &[approve_instruction, instruction],
+        &payer.pubkey(),
+        &[&context_payer, payer],
+        transaction_params,
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    test_indexer.add_compressed_accounts_with_token_data(event);
+
+    assert_transfer(
+        context,
+        test_indexer,
+        &[output_compressed_account],
+        Vec::new().as_slice(),
+        &output_merkle_tree_test_snapshots,
+        &input_merkle_tree_test_snapshots,
+    )
+    .await;
+
+    let recipient_token_account_data = spl_token::state::Account::unpack(
+        &context
+            .banks_client
+            .get_account(*sender_token_account)
+            .await
+            .unwrap()
+            .unwrap()
+            .data,
+    )
+    .unwrap();
+    assert_eq!(
+        recipient_token_account_data.amount,
+        recipient_token_account_data_pre.amount - amount
+    );
 }

--- a/test-utils/src/system_program.rs
+++ b/test-utils/src/system_program.rs
@@ -1,0 +1,637 @@
+use light_compressed_pda::{
+    sdk::{
+        address::derive_address,
+        compressed_account::{
+            CompressedAccount, CompressedAccountWithMerkleContext, MerkleContext,
+        },
+        event::PublicTransactionEvent,
+        invoke::{create_invoke_instruction, get_compressed_sol_pda},
+    },
+    NewAddressParams,
+};
+use light_hasher::Poseidon;
+use solana_program_test::{BanksClientError, ProgramTestContext};
+use solana_sdk::{
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+};
+
+use crate::{create_and_send_transaction_with_event, test_indexer::TestIndexer, TransactionParams};
+
+#[allow(clippy::too_many_arguments)]
+pub async fn create_addresses_test(
+    context: &mut ProgramTestContext,
+    test_indexer: &mut TestIndexer,
+    address_merkle_tree_pubkeys: &[Pubkey],
+    address_merkle_tree_queue_pubkeys: &[Pubkey],
+    output_merkle_tree_pubkeys: &[Pubkey],
+    address_seeds: &[[u8; 32]],
+    input_compressed_accounts: &[CompressedAccountWithMerkleContext],
+    create_out_compressed_accounts_for_input_compressed_accounts: bool,
+    transaction_params: Option<TransactionParams>,
+) -> Result<(), BanksClientError> {
+    let mut derived_addresses = Vec::new();
+    for (i, address_seed) in address_seeds.iter().enumerate() {
+        let derived_address =
+            derive_address(&address_merkle_tree_pubkeys[i], address_seed).unwrap();
+        derived_addresses.push(derived_address);
+    }
+    let mut compressed_account_hashes = Vec::new();
+
+    let compressed_account_input_hashes = if input_compressed_accounts.is_empty() {
+        None
+    } else {
+        for compressed_account in input_compressed_accounts.iter() {
+            compressed_account_hashes.push(
+                compressed_account
+                    .compressed_account
+                    .hash::<Poseidon>(
+                        &compressed_account.merkle_context.merkle_tree_pubkey,
+                        &compressed_account.merkle_context.leaf_index,
+                    )
+                    .unwrap(),
+            );
+        }
+        Some(compressed_account_hashes.as_slice())
+    };
+    let state_input_merkle_trees = input_compressed_accounts
+        .iter()
+        .map(|x| x.merkle_context.merkle_tree_pubkey)
+        .collect::<Vec<Pubkey>>();
+    let state_input_merkle_trees = if state_input_merkle_trees.is_empty() {
+        None
+    } else {
+        Some(state_input_merkle_trees.as_slice())
+    };
+    let proof_rpc_res = test_indexer
+        .create_proof_for_compressed_accounts(
+            compressed_account_input_hashes,
+            state_input_merkle_trees,
+            Some(derived_addresses.as_slice()),
+            Some(address_merkle_tree_pubkeys),
+            context,
+        )
+        .await;
+    let mut address_params = Vec::new();
+
+    for (i, seed) in address_seeds.iter().enumerate() {
+        let new_address_params = NewAddressParams {
+            address_queue_pubkey: address_merkle_tree_queue_pubkeys[i],
+            address_merkle_tree_pubkey: address_merkle_tree_pubkeys[i],
+            seed: *seed,
+            address_merkle_tree_root_index: proof_rpc_res.address_root_indices[i],
+        };
+        address_params.push(new_address_params);
+    }
+
+    let mut output_compressed_accounts = Vec::new();
+    for (i, address_param) in address_params.iter().enumerate() {
+        output_compressed_accounts.push(CompressedAccount {
+            lamports: 0,
+            owner: context.payer.pubkey(),
+            data: None,
+            address: Some(
+                derive_address(&address_merkle_tree_pubkeys[i], &address_param.seed).unwrap(),
+            ),
+        });
+    }
+
+    if create_out_compressed_accounts_for_input_compressed_accounts {
+        for compressed_account in input_compressed_accounts.iter() {
+            output_compressed_accounts.push(CompressedAccount {
+                lamports: 0,
+                owner: context.payer.pubkey(),
+                data: None,
+                address: compressed_account.compressed_account.address,
+            });
+        }
+    }
+
+    let instruction = create_invoke_instruction(
+        &context.payer.pubkey(),
+        &context.payer.pubkey().clone(),
+        input_compressed_accounts
+            .iter()
+            .map(|x| x.compressed_account.clone())
+            .collect::<Vec<CompressedAccount>>()
+            .as_slice(),
+        &output_compressed_accounts,
+        input_compressed_accounts
+            .iter()
+            .map(|x| x.merkle_context.clone())
+            .collect::<Vec<MerkleContext>>()
+            .as_slice(),
+        &output_merkle_tree_pubkeys,
+        &proof_rpc_res.root_indices,
+        &address_params,
+        Some(proof_rpc_res.proof.clone()),
+        None,
+        false,
+        None,
+    );
+
+    let event = create_and_send_transaction_with_event::<PublicTransactionEvent>(
+        context,
+        &[instruction],
+        &context.payer.pubkey(),
+        &[&context.payer.insecure_clone()],
+        transaction_params,
+    )
+    .await;
+
+    let (created_out_compressed_accounts, _) =
+        test_indexer.add_event_and_compressed_accounts(event?.unwrap());
+    assert_created_compressed_accounts(
+        &output_compressed_accounts.as_slice(),
+        output_merkle_tree_pubkeys,
+        created_out_compressed_accounts.as_slice(),
+        false,
+    );
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn compress_sol_test(
+    context: &mut ProgramTestContext,
+    test_indexer: &mut TestIndexer,
+    authority: &Keypair,
+    input_compressed_accounts: &[CompressedAccountWithMerkleContext],
+    create_out_compressed_accounts_for_input_compressed_accounts: bool,
+    compress_amount: u64,
+    output_merkle_tree_pubkey: &Pubkey,
+    transaction_params: Option<TransactionParams>,
+) -> Result<(), BanksClientError> {
+    let mut compressed_account_hashes = Vec::new();
+
+    let compressed_account_input_hashes = if input_compressed_accounts.is_empty() {
+        None
+    } else {
+        for compressed_account in input_compressed_accounts.iter() {
+            compressed_account_hashes.push(
+                compressed_account
+                    .compressed_account
+                    .hash::<Poseidon>(
+                        &compressed_account.merkle_context.merkle_tree_pubkey,
+                        &compressed_account.merkle_context.leaf_index,
+                    )
+                    .unwrap(),
+            );
+        }
+        Some(compressed_account_hashes.as_slice())
+    };
+    let state_input_merkle_trees = input_compressed_accounts
+        .iter()
+        .map(|x| x.merkle_context.merkle_tree_pubkey)
+        .collect::<Vec<Pubkey>>();
+    let state_input_merkle_trees = if state_input_merkle_trees.is_empty() {
+        None
+    } else {
+        Some(state_input_merkle_trees.as_slice())
+    };
+    let mut root_indices = Vec::new();
+    let mut proof = None;
+    if !input_compressed_accounts.is_empty() {
+        let proof_rpc_res = test_indexer
+            .create_proof_for_compressed_accounts(
+                compressed_account_input_hashes,
+                state_input_merkle_trees,
+                None,
+                None,
+                context,
+            )
+            .await;
+        root_indices = proof_rpc_res.root_indices;
+        proof = Some(proof_rpc_res.proof);
+    }
+
+    let input_lamports = if input_compressed_accounts.is_empty() {
+        0
+    } else {
+        input_compressed_accounts
+            .iter()
+            .map(|x| x.compressed_account.lamports)
+            .sum::<u64>()
+    };
+    let mut output_compressed_accounts = Vec::new();
+    output_compressed_accounts.push(CompressedAccount {
+        lamports: input_lamports + compress_amount,
+        owner: authority.pubkey(),
+        data: None,
+        address: None,
+    });
+    let mut output_merkle_tree_pubkeys = vec![*output_merkle_tree_pubkey];
+    if create_out_compressed_accounts_for_input_compressed_accounts {
+        for compressed_account in input_compressed_accounts.iter() {
+            output_compressed_accounts.push(CompressedAccount {
+                lamports: 0,
+                owner: authority.pubkey(),
+                data: None,
+                address: compressed_account.compressed_account.address,
+            });
+            output_merkle_tree_pubkeys
+                .push(compressed_account.merkle_context.merkle_tree_pubkey.clone());
+        }
+    }
+    println!("input_compressed_accounts: {:?}", input_compressed_accounts);
+
+    let instruction = create_invoke_instruction(
+        &authority.pubkey(),
+        &authority.pubkey().clone(),
+        input_compressed_accounts
+            .iter()
+            .map(|x| x.compressed_account.clone())
+            .collect::<Vec<CompressedAccount>>()
+            .as_slice(),
+        &output_compressed_accounts,
+        input_compressed_accounts
+            .iter()
+            .map(|x| x.merkle_context.clone())
+            .collect::<Vec<MerkleContext>>()
+            .as_slice(),
+        output_merkle_tree_pubkeys.as_slice(),
+        &root_indices,
+        &Vec::new(),
+        proof,
+        Some(compress_amount),
+        true,
+        Some(get_compressed_sol_pda()),
+    );
+    // TODO: assert sender balance after fee refactor
+    // let sender_pre_balance = context
+    //     .banks_client
+    //     .get_account(authority.pubkey())
+    //     .await
+    //     .unwrap()
+    //     .unwrap()
+    //     .lamports;
+    let compressed_sol_pda_balance_pre = match context
+        .banks_client
+        .get_account(get_compressed_sol_pda())
+        .await
+        .unwrap()
+    {
+        Some(account) => account.lamports,
+        None => 0,
+    };
+
+    let event = create_and_send_transaction_with_event::<PublicTransactionEvent>(
+        context,
+        &[instruction],
+        &authority.pubkey(),
+        &[&authority],
+        transaction_params,
+    )
+    .await;
+
+    let (created_compressed_accounts, _) =
+        test_indexer.add_event_and_compressed_accounts(event?.unwrap());
+    let compressed_sol_pda_balance = context
+        .banks_client
+        .get_account(get_compressed_sol_pda())
+        .await
+        .unwrap()
+        .unwrap()
+        .lamports;
+
+    assert_eq!(
+        compressed_sol_pda_balance,
+        compressed_sol_pda_balance_pre + compress_amount,
+        "balance of compressed sol pda insufficient, compress sol failed"
+    );
+    assert_created_compressed_accounts(
+        &output_compressed_accounts.as_slice(),
+        output_merkle_tree_pubkeys.as_slice(),
+        created_compressed_accounts.as_slice(),
+        false,
+    );
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn decompress_sol_test(
+    context: &mut ProgramTestContext,
+    test_indexer: &mut TestIndexer,
+    authority: &Keypair,
+    input_compressed_accounts: &[CompressedAccountWithMerkleContext],
+    recipient: &Pubkey,
+    decompress_amount: u64,
+    output_merkle_tree_pubkey: &Pubkey,
+    transaction_params: Option<TransactionParams>,
+) -> Result<(), BanksClientError> {
+    let mut compressed_account_hashes = Vec::new();
+
+    let compressed_account_input_hashes = if input_compressed_accounts.is_empty() {
+        panic!("input_compressed_accounts is empty for decompress_sol_test");
+    } else {
+        for compressed_account in input_compressed_accounts.iter() {
+            compressed_account_hashes.push(
+                compressed_account
+                    .compressed_account
+                    .hash::<Poseidon>(
+                        &compressed_account.merkle_context.merkle_tree_pubkey,
+                        &compressed_account.merkle_context.leaf_index,
+                    )
+                    .unwrap(),
+            );
+        }
+        Some(compressed_account_hashes.as_slice())
+    };
+    let state_input_merkle_trees = input_compressed_accounts
+        .iter()
+        .map(|x| x.merkle_context.merkle_tree_pubkey)
+        .collect::<Vec<Pubkey>>();
+    let state_input_merkle_trees = if state_input_merkle_trees.is_empty() {
+        None
+    } else {
+        Some(state_input_merkle_trees.as_slice())
+    };
+    let mut root_indices = Vec::new();
+    let mut proof = None;
+    if !input_compressed_accounts.is_empty() {
+        let proof_rpc_res = test_indexer
+            .create_proof_for_compressed_accounts(
+                compressed_account_input_hashes,
+                state_input_merkle_trees,
+                None,
+                None,
+                context,
+            )
+            .await;
+        root_indices = proof_rpc_res.root_indices;
+        proof = Some(proof_rpc_res.proof);
+    }
+
+    let input_lamports = input_compressed_accounts
+        .iter()
+        .map(|x| x.compressed_account.lamports)
+        .sum::<u64>();
+
+    let mut output_compressed_accounts = Vec::new();
+    output_compressed_accounts.push(CompressedAccount {
+        lamports: input_lamports - decompress_amount,
+        owner: context.payer.pubkey(),
+        data: None,
+        address: None,
+    });
+    let output_merkle_tree_pubkeys = vec![*output_merkle_tree_pubkey];
+
+    let instruction = create_invoke_instruction(
+        &context.payer.pubkey(),
+        &authority.pubkey().clone(),
+        input_compressed_accounts
+            .iter()
+            .map(|x| x.compressed_account.clone())
+            .collect::<Vec<CompressedAccount>>()
+            .as_slice(),
+        &output_compressed_accounts,
+        input_compressed_accounts
+            .iter()
+            .map(|x| x.merkle_context.clone())
+            .collect::<Vec<MerkleContext>>()
+            .as_slice(),
+        output_merkle_tree_pubkeys.as_slice(),
+        &root_indices,
+        &Vec::new(),
+        proof,
+        Some(decompress_amount),
+        false,
+        Some(*recipient),
+    );
+    // TODO: assert sender balance after fee refactor
+    let recipient_balance_pre = context
+        .banks_client
+        .get_account(*recipient)
+        .await
+        .unwrap()
+        .unwrap()
+        .lamports;
+    let compressed_sol_pda_balance_pre = match context
+        .banks_client
+        .get_account(get_compressed_sol_pda())
+        .await
+        .unwrap()
+    {
+        Some(account) => account.lamports,
+        None => 0,
+    };
+
+    let event = create_and_send_transaction_with_event::<PublicTransactionEvent>(
+        context,
+        &[instruction],
+        &context.payer.pubkey(),
+        &[&context.payer.insecure_clone(), authority],
+        transaction_params,
+    )
+    .await;
+
+    let (created_compressed_accounts, _) =
+        test_indexer.add_event_and_compressed_accounts(event?.unwrap());
+    let compressed_sol_pda_balance = context
+        .banks_client
+        .get_account(get_compressed_sol_pda())
+        .await
+        .unwrap()
+        .unwrap()
+        .lamports;
+
+    assert_eq!(
+        compressed_sol_pda_balance,
+        compressed_sol_pda_balance_pre - decompress_amount,
+        "balance of compressed sol pda incorrect, decompress sol failed"
+    );
+
+    let recipient_balance = context
+        .banks_client
+        .get_account(*recipient)
+        .await
+        .unwrap()
+        .unwrap()
+        .lamports;
+
+    assert_eq!(
+        recipient_balance,
+        recipient_balance_pre + decompress_amount,
+        "balance of recipient insufficient, decompress sol failed"
+    );
+
+    assert_created_compressed_accounts(
+        &output_compressed_accounts.as_slice(),
+        output_merkle_tree_pubkeys.as_slice(),
+        created_compressed_accounts.as_slice(),
+        false,
+    );
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn transfer_compressed_sol_test(
+    context: &mut ProgramTestContext,
+    test_indexer: &mut TestIndexer,
+    authority: &Keypair,
+    input_compressed_accounts: &[CompressedAccountWithMerkleContext],
+    output_merkle_tree_pubkeys: &[Pubkey],
+    transaction_params: Option<TransactionParams>,
+) -> Result<(), BanksClientError> {
+    let mut compressed_account_hashes = Vec::new();
+
+    let compressed_account_input_hashes = if input_compressed_accounts.is_empty() {
+        panic!("input_compressed_accounts is empty for transfer_compressed_sol_test");
+    } else {
+        for compressed_account in input_compressed_accounts.iter() {
+            compressed_account_hashes.push(
+                compressed_account
+                    .compressed_account
+                    .hash::<Poseidon>(
+                        &compressed_account.merkle_context.merkle_tree_pubkey,
+                        &compressed_account.merkle_context.leaf_index,
+                    )
+                    .unwrap(),
+            );
+        }
+        Some(compressed_account_hashes.as_slice())
+    };
+    let state_input_merkle_trees = input_compressed_accounts
+        .iter()
+        .map(|x| x.merkle_context.merkle_tree_pubkey)
+        .collect::<Vec<Pubkey>>();
+    let state_input_merkle_trees = if state_input_merkle_trees.is_empty() {
+        None
+    } else {
+        Some(state_input_merkle_trees.as_slice())
+    };
+    let proof_rpc_res = test_indexer
+        .create_proof_for_compressed_accounts(
+            compressed_account_input_hashes,
+            state_input_merkle_trees,
+            None,
+            None,
+            context,
+        )
+        .await;
+    let input_addresses = input_compressed_accounts
+        .iter()
+        .map(|x| x.compressed_account.address)
+        .collect::<Vec<_>>();
+    let input_lamports = input_compressed_accounts
+        .iter()
+        .map(|x| x.compressed_account.lamports)
+        .sum::<u64>();
+    let mut output_compressed_accounts = Vec::new();
+    let mut output_merkle_tree_pubkeys = output_merkle_tree_pubkeys.to_vec();
+    output_merkle_tree_pubkeys.sort();
+    for (i, _) in output_merkle_tree_pubkeys.iter().enumerate() {
+        let address = if i < input_addresses.len() {
+            input_addresses[i]
+        } else {
+            None
+        };
+        let mut lamports = input_lamports / output_merkle_tree_pubkeys.len() as u64;
+        if i == 0 {
+            lamports += input_lamports % output_merkle_tree_pubkeys.len() as u64;
+        }
+
+        output_compressed_accounts.push(CompressedAccount {
+            lamports,
+            owner: authority.pubkey(),
+            data: None,
+            address,
+        });
+    }
+    println!("input_compressed_accounts: {:?}", input_compressed_accounts);
+    println!(
+        "output_compressed_accounts: {:?}",
+        output_compressed_accounts
+    );
+    let instruction = create_invoke_instruction(
+        &context.payer.pubkey(),
+        &authority.pubkey().clone(),
+        input_compressed_accounts
+            .iter()
+            .map(|x| x.compressed_account.clone())
+            .collect::<Vec<CompressedAccount>>()
+            .as_slice(),
+        &output_compressed_accounts,
+        input_compressed_accounts
+            .iter()
+            .map(|x| x.merkle_context.clone())
+            .collect::<Vec<MerkleContext>>()
+            .as_slice(),
+        &output_merkle_tree_pubkeys,
+        &proof_rpc_res.root_indices,
+        &Vec::new(),
+        Some(proof_rpc_res.proof.clone()),
+        None,
+        false,
+        None,
+    );
+
+    let event = create_and_send_transaction_with_event::<PublicTransactionEvent>(
+        context,
+        &[instruction],
+        &context.payer.pubkey(),
+        &[&context.payer.insecure_clone(), authority],
+        transaction_params,
+    )
+    .await;
+
+    let (created_out_compressed_accounts, _) =
+        test_indexer.add_event_and_compressed_accounts(event?.unwrap());
+
+    assert_created_compressed_accounts(
+        &output_compressed_accounts.as_slice(),
+        output_merkle_tree_pubkeys.as_slice(),
+        created_out_compressed_accounts.as_slice(),
+        true,
+    );
+    Ok(())
+}
+
+pub fn assert_created_compressed_accounts(
+    output_compressed_accounts: &[CompressedAccount],
+    output_merkle_tree_pubkeys: &[Pubkey],
+    created_out_compressed_accounts: &[CompressedAccountWithMerkleContext],
+    sorted: bool,
+) {
+    if !sorted {
+        for (i, output_account) in created_out_compressed_accounts.iter().enumerate() {
+            assert_eq!(
+                output_account.compressed_account.lamports, output_compressed_accounts[i].lamports,
+                "lamports mismatch"
+            );
+            assert_eq!(
+                output_account.compressed_account.owner, output_compressed_accounts[i].owner,
+                "owner mismatch"
+            );
+            assert_eq!(
+                output_account.compressed_account.data, output_compressed_accounts[i].data,
+                "data mismatch"
+            );
+            assert_eq!(
+                output_account.compressed_account.address, output_compressed_accounts[i].address,
+                "address mismatch"
+            );
+            assert_eq!(
+                output_account.merkle_context.merkle_tree_pubkey, output_merkle_tree_pubkeys[i],
+                "merkle tree pubkey mismatch"
+            );
+        }
+    } else {
+        for (_, output_account) in created_out_compressed_accounts.iter().enumerate() {
+            assert!(output_compressed_accounts
+                .iter()
+                .any(|x| x.lamports == output_account.compressed_account.lamports),);
+            assert!(output_compressed_accounts
+                .iter()
+                .any(|x| x.owner == output_account.compressed_account.owner),);
+            assert!(output_compressed_accounts
+                .iter()
+                .any(|x| x.data == output_account.compressed_account.data),);
+            assert!(output_compressed_accounts
+                .iter()
+                .any(|x| x.address == output_account.compressed_account.address),);
+            assert!(output_merkle_tree_pubkeys
+                .iter()
+                .any(|x| *x == output_account.merkle_context.merkle_tree_pubkey),);
+        }
+    }
+}

--- a/test-utils/src/test_env.rs
+++ b/test-utils/src/test_env.rs
@@ -1,15 +1,14 @@
-#[cfg(feature = "light_program")]
 use crate::{create_and_send_transaction, get_account};
-#[cfg(feature = "light_program")]
+
 use account_compression::{
     sdk::create_initialize_merkle_tree_instruction, GroupAuthority, RegisteredProgram,
 };
-#[cfg(feature = "test_indexer")]
+
 use anchor_lang::ToAccountMetas;
-#[cfg(feature = "test_indexer")]
+
 use anchor_lang::{system_program, InstructionData};
 use light_macros::pubkey;
-#[cfg(feature = "light_program")]
+
 use light_registry::sdk::{
     create_initialize_governance_authority_instruction,
     create_initialize_group_authority_instruction, create_register_program_instruction,
@@ -17,10 +16,10 @@ use light_registry::sdk::{
 };
 
 use solana_program_test::{ProgramTest, ProgramTestContext};
-#[cfg(feature = "light_program")]
+
 use solana_sdk::transaction::Transaction;
 use solana_sdk::{pubkey::Pubkey, signature::Keypair};
-#[cfg(feature = "light_program")]
+
 use solana_sdk::{signature::Signer, system_instruction};
 
 pub const LIGHT_ID: Pubkey = pubkey!("5WzvRtu7LABotw1SUEpguJiKU27LRGsiCnF5FH6VV7yP");
@@ -122,7 +121,7 @@ pub const SIGNATURE_CPI_TEST_KEYPAIR: [u8; 64] = [
 /// 6. creates and initializes group authority
 /// 7. registers the light_compressed_pda program with the group authority
 /// 8. initializes Merkle tree owned by
-#[cfg(feature = "light_program")]
+
 pub async fn setup_test_programs_with_accounts(
     additional_programs: Option<Vec<(String, Pubkey)>>,
 ) -> (ProgramTestContext, EnvAccounts) {
@@ -214,7 +213,7 @@ pub async fn setup_test_programs_with_accounts(
     )
     .await;
     let cpi_signature_keypair = Keypair::from_bytes(&SIGNATURE_CPI_TEST_KEYPAIR).unwrap();
-    #[cfg(feature = "test_indexer")]
+
     init_cpi_signature_account(&mut context, &merkle_tree_pubkey, &cpi_signature_keypair).await;
     (
         context,
@@ -232,7 +231,6 @@ pub async fn setup_test_programs_with_accounts(
     )
 }
 
-#[cfg(feature = "light_program")]
 pub async fn create_state_merkle_tree_and_queue_account(
     payer: &Keypair,
     context: &mut ProgramTestContext,
@@ -292,7 +290,7 @@ pub async fn create_state_merkle_tree_and_queue_account(
         ],
         Some(&payer.pubkey()),
         &vec![payer, merkle_tree_keypair, nullifier_queue_keypair],
-        context.last_blockhash,
+        context.get_new_latest_blockhash().await.unwrap(),
     );
     context
         .banks_client
@@ -301,7 +299,6 @@ pub async fn create_state_merkle_tree_and_queue_account(
         .unwrap();
 }
 
-#[cfg(feature = "light_program")]
 pub async fn create_address_merkle_tree_and_queue_account(
     payer: &Keypair,
     context: &mut ProgramTestContext,
@@ -370,7 +367,6 @@ pub async fn create_address_merkle_tree_and_queue_account(
         .unwrap();
 }
 
-#[cfg(feature = "test_indexer")]
 pub async fn init_cpi_signature_account(
     context: &mut ProgramTestContext,
     merkle_tree_pubkey: &Pubkey,
@@ -410,7 +406,7 @@ pub async fn init_cpi_signature_account(
         context,
         &[account_create_ix, instruction],
         &payer.pubkey(),
-        &[&payer, &cpi_account_keypair],
+        &[&payer, cpi_account_keypair],
     )
     .await
     .unwrap();

--- a/test-utils/src/test_indexer.rs
+++ b/test-utils/src/test_indexer.rs
@@ -1,49 +1,52 @@
 #![cfg(feature = "test_indexer")]
-use crate::{
-    create_account_instruction, create_and_send_transaction,
-    create_and_send_transaction_with_event, get_hash_set, test_env::EnvAccounts, AccountZeroCopy,
-};
-use account_compression::{
-    utils::constants::{STATE_MERKLE_TREE_CANOPY_DEPTH, STATE_MERKLE_TREE_HEIGHT},
-    AddressMerkleTreeAccount, StateMerkleTreeAccount,
-};
-use anchor_lang::AnchorDeserialize;
-use light_circuitlib_rs::gnark::helpers::spawn_gnark_server;
-use light_circuitlib_rs::gnark::inclusion_json_formatter::BatchInclusionJsonStruct;
-use light_circuitlib_rs::gnark::non_inclusion_json_formatter::BatchNonInclusionJsonStruct;
-use light_circuitlib_rs::{
-    gnark::{
-        combined_json_formatter::CombinedJsonStruct,
-        constants::{PROVE_PATH, SERVER_ADDRESS},
-        helpers::ProofType,
-        proof_helpers::{compress_proof, deserialize_gnark_proof_json, proof_from_json_struct},
+use {
+    crate::{
+        create_account_instruction, create_and_send_transaction, get_hash_set,
+        test_env::EnvAccounts, AccountZeroCopy,
     },
-    inclusion::merkle_inclusion_proof_inputs::{InclusionMerkleProofInputs, InclusionProofInputs},
-    non_inclusion::merkle_non_inclusion_proof_inputs::{
-        get_non_inclusion_proof_inputs, NonInclusionProofInputs,
+    account_compression::{
+        utils::constants::{STATE_MERKLE_TREE_CANOPY_DEPTH, STATE_MERKLE_TREE_HEIGHT},
+        AddressMerkleTreeAccount, StateMerkleTreeAccount,
     },
+    anchor_lang::AnchorDeserialize,
+    light_circuitlib_rs::{
+        gnark::{
+            combined_json_formatter::CombinedJsonStruct,
+            constants::{PROVE_PATH, SERVER_ADDRESS},
+            helpers::{spawn_gnark_server, ProofType},
+            inclusion_json_formatter::BatchInclusionJsonStruct,
+            non_inclusion_json_formatter::BatchNonInclusionJsonStruct,
+            proof_helpers::{compress_proof, deserialize_gnark_proof_json, proof_from_json_struct},
+        },
+        inclusion::merkle_inclusion_proof_inputs::{
+            InclusionMerkleProofInputs, InclusionProofInputs,
+        },
+        non_inclusion::merkle_non_inclusion_proof_inputs::{
+            get_non_inclusion_proof_inputs, NonInclusionProofInputs,
+        },
+    },
+    light_compressed_pda::{
+        invoke::processor::CompressedProof,
+        sdk::{
+            compressed_account::{CompressedAccountWithMerkleContext, MerkleContext},
+            event::PublicTransactionEvent,
+        },
+    },
+    light_compressed_token::{
+        constants::TOKEN_COMPRESSED_ACCOUNT_DISCRIMINATOR, get_token_authority_pda,
+        get_token_pool_pda, mint_sdk::create_initialize_mint_instruction, token_data::TokenData,
+    },
+    light_hasher::Poseidon,
+    light_indexed_merkle_tree::{array::IndexedArray, reference::IndexedMerkleTree},
+    light_merkle_tree_reference::MerkleTree,
+    num_bigint::{BigInt, BigUint},
+    num_traits::{ops::bytes::FromBytes, Num},
+    reqwest::Client,
+    solana_program_test::ProgramTestContext,
+    solana_sdk::{instruction::Instruction, pubkey::Pubkey, signature::Keypair, signer::Signer},
+    spl_token::instruction::initialize_mint,
+    std::{thread, time::Duration},
 };
-use light_compressed_pda::{
-    invoke::processor::CompressedProof, sdk::compressed_account::CompressedAccountWithMerkleContext,
-};
-use light_compressed_pda::{
-    sdk::compressed_account::MerkleContext, sdk::event::PublicTransactionEvent,
-};
-use light_compressed_token::{
-    constants::TOKEN_COMPRESSED_ACCOUNT_DISCRIMINATOR,
-    get_token_authority_pda, get_token_pool_pda,
-    mint_sdk::{create_initialize_mint_instruction, create_mint_to_instruction},
-    token_data::TokenData,
-};
-use light_hasher::Poseidon;
-use light_indexed_merkle_tree::array::IndexedArray;
-use num_bigint::{BigInt, BigUint};
-use num_traits::ops::bytes::FromBytes;
-use num_traits::Num;
-use reqwest::Client;
-use solana_program_test::ProgramTestContext;
-use solana_sdk::{instruction::Instruction, pubkey::Pubkey, signature::Keypair, signer::Signer};
-use spl_token::instruction::initialize_mint;
 
 #[derive(Debug)]
 pub struct ProofRpcResult {
@@ -52,21 +55,33 @@ pub struct ProofRpcResult {
     pub address_root_indices: Vec<u16>,
 }
 
+#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
+pub struct StateMerkleTreeAccounts {
+    pub merkle_tree: Pubkey,
+    pub nullifier_queue: Pubkey,
+    pub cpi_context: Pubkey,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct AddressMerkleTreeAccounts {
+    pub merkle_tree: Pubkey,
+    pub queue: Pubkey,
+}
+
 #[derive(Debug)]
 pub struct TestIndexer {
-    pub address_merkle_tree_pubkey: Pubkey,
-    pub merkle_tree_pubkey: Pubkey,
-    pub nullifier_queue_pubkey: Pubkey,
+    pub state_merkle_trees: Vec<(StateMerkleTreeAccounts, MerkleTree<Poseidon>)>,
+    pub address_merkle_trees: Vec<(
+        AddressMerkleTreeAccounts,
+        IndexedMerkleTree<Poseidon, usize>,
+        IndexedArray<Poseidon, usize, 1000>,
+    )>,
     pub payer: Keypair,
     pub compressed_accounts: Vec<CompressedAccountWithMerkleContext>,
     pub nullified_compressed_accounts: Vec<CompressedAccountWithMerkleContext>,
     pub token_compressed_accounts: Vec<TokenDataWithContext>,
     pub token_nullified_compressed_accounts: Vec<TokenDataWithContext>,
     pub events: Vec<PublicTransactionEvent>,
-    pub merkle_tree: light_merkle_tree_reference::MerkleTree<Poseidon>,
-    pub address_merkle_tree:
-        light_indexed_merkle_tree::reference::IndexedMerkleTree<Poseidon, usize>,
-    pub indexing_array: IndexedArray<Poseidon, usize, 1000>,
     pub path: String,
     pub proof_types: Vec<ProofType>,
 }
@@ -85,9 +100,15 @@ impl TestIndexer {
         gnark_bin_path: &str,
     ) -> Self {
         Self::new(
-            env.merkle_tree_pubkey,
-            env.nullifier_queue_pubkey,
-            env.address_merkle_tree_pubkey,
+            vec![StateMerkleTreeAccounts {
+                merkle_tree: env.merkle_tree_pubkey,
+                nullifier_queue: env.nullifier_queue_pubkey,
+                cpi_context: env.cpi_signature_account_pubkey,
+            }],
+            vec![AddressMerkleTreeAccounts {
+                merkle_tree: env.merkle_tree_pubkey,
+                queue: env.address_merkle_tree_queue_pubkey,
+            }],
             payer.insecure_clone(),
             inclusion,
             non_inclusion,
@@ -96,9 +117,8 @@ impl TestIndexer {
         .await
     }
     pub async fn new(
-        merkle_tree_pubkey: Pubkey,
-        nullifier_queue_pubkey: Pubkey,
-        address_merkle_tree_pubkey: Pubkey,
+        state_merkle_tree_accounts: Vec<StateMerkleTreeAccounts>,
+        address_merkle_tree_accounts: Vec<AddressMerkleTreeAccounts>,
         payer: Keypair,
         inclusion: bool,
         non_inclusion: bool,
@@ -118,38 +138,42 @@ impl TestIndexer {
         // correct path so that the examples can be run:
         // "../../../../circuit-lib/circuitlib-rs/scripts/prover.sh",
         spawn_gnark_server(gnark_bin_path, true, vec_proof_types.as_slice()).await;
-
-        let merkle_tree = light_merkle_tree_reference::MerkleTree::<Poseidon>::new(
-            STATE_MERKLE_TREE_HEIGHT as usize,
-            STATE_MERKLE_TREE_CANOPY_DEPTH as usize,
-        );
-
-        let mut address_merkle_tree = light_indexed_merkle_tree::reference::IndexedMerkleTree::new(
-            STATE_MERKLE_TREE_HEIGHT as usize,
-            STATE_MERKLE_TREE_CANOPY_DEPTH as usize,
-        )
-        .unwrap();
-        let mut indexed_array = IndexedArray::<Poseidon, usize, 1000>::default();
-
+        let mut state_merkle_trees = Vec::new();
+        for state_merkle_tree_account in state_merkle_tree_accounts.iter() {
+            let merkle_tree = MerkleTree::<Poseidon>::new(
+                STATE_MERKLE_TREE_HEIGHT as usize,
+                STATE_MERKLE_TREE_CANOPY_DEPTH as usize,
+            );
+            state_merkle_trees.push((state_merkle_tree_account.clone(), merkle_tree));
+        }
         let init_value = BigUint::from_str_radix(
             &"21888242871839275222246405745257275088548364400416034343698204186575808495616",
             10,
         )
         .unwrap();
-        address_merkle_tree
-            .append(&init_value, &mut indexed_array)
+        let mut address_merkle_trees = Vec::new();
+        for i in 0..address_merkle_tree_accounts.len() {
+            let mut merkle_tree = IndexedMerkleTree::<Poseidon, usize>::new(
+                STATE_MERKLE_TREE_HEIGHT as usize,
+                STATE_MERKLE_TREE_CANOPY_DEPTH as usize,
+            )
             .unwrap();
+            let mut indexed_array = IndexedArray::<Poseidon, usize, 1000>::default();
+
+            merkle_tree.append(&init_value, &mut indexed_array).unwrap();
+            address_merkle_trees.push((
+                address_merkle_tree_accounts[i].clone(),
+                merkle_tree,
+                indexed_array,
+            ));
+        }
         Self {
-            merkle_tree_pubkey,
-            nullifier_queue_pubkey,
-            address_merkle_tree_pubkey,
+            state_merkle_trees,
+            address_merkle_trees,
             payer,
             compressed_accounts: vec![],
             nullified_compressed_accounts: vec![],
             events: vec![],
-            merkle_tree,
-            address_merkle_tree,
-            indexing_array: indexed_array,
             token_compressed_accounts: vec![],
             token_nullified_compressed_accounts: vec![],
             path: String::from(gnark_bin_path),
@@ -224,29 +248,59 @@ impl TestIndexer {
     pub async fn create_proof_for_compressed_accounts(
         &mut self,
         compressed_accounts: Option<&[[u8; 32]]>,
+        state_merkle_tree_pubkeys: Option<&[Pubkey]>,
         new_addresses: Option<&[[u8; 32]]>,
+        address_merkle_tree_pubkeys: Option<&[Pubkey]>,
         context: &mut ProgramTestContext,
     ) -> ProofRpcResult {
-        println!("compressed_accounts {:?}", compressed_accounts);
-        println!("new_addresses {:?}", new_addresses);
-        println!("self.merkle_tree.root() {:?}", self.merkle_tree.root());
+        if compressed_accounts.is_some()
+            && !vec![1usize, 2usize, 3usize, 4usize, 8usize]
+                .contains(&compressed_accounts.unwrap().len())
+        {
+            panic!("compressed_accounts must be of length 1, 2, 3, 4 or 8")
+        }
+        if new_addresses.is_some() && !vec![1usize, 2usize].contains(&new_addresses.unwrap().len())
+        {
+            panic!("new_addresses must be of length 1, 2")
+        }
         let client = Client::new();
         let (root_indices, address_root_indices, json_payload) =
             match (compressed_accounts, new_addresses) {
                 (Some(accounts), None) => {
-                    let (payload, indices) = self.process_inclusion_proofs(accounts, context).await;
+                    let (payload, indices) = self
+                        .process_inclusion_proofs(
+                            state_merkle_tree_pubkeys.unwrap(),
+                            accounts,
+                            context,
+                        )
+                        .await;
                     (indices, Vec::new(), payload.to_string())
                 }
                 (None, Some(addresses)) => {
-                    let (payload, indices) =
-                        self.process_non_inclusion_proofs(addresses, context).await;
+                    let (payload, indices) = self
+                        .process_non_inclusion_proofs(
+                            address_merkle_tree_pubkeys.unwrap(),
+                            addresses,
+                            context,
+                        )
+                        .await;
                     (Vec::<u16>::new(), indices, payload.to_string())
                 }
                 (Some(accounts), Some(addresses)) => {
-                    let (inclusion_payload, inclusion_indices) =
-                        self.process_inclusion_proofs(accounts, context).await;
-                    let (non_inclusion_payload, non_inclusion_indices) =
-                        self.process_non_inclusion_proofs(addresses, context).await;
+                    let (inclusion_payload, inclusion_indices) = self
+                        .process_inclusion_proofs(
+                            state_merkle_tree_pubkeys.unwrap(),
+                            accounts,
+                            context,
+                        )
+                        .await;
+                    let (non_inclusion_payload, non_inclusion_indices) = self
+                        .process_non_inclusion_proofs(
+                            address_merkle_tree_pubkeys.unwrap(),
+                            addresses,
+                            context,
+                        )
+                        .await;
 
                     let combined_payload = CombinedJsonStruct {
                         inclusion: inclusion_payload.inputs,
@@ -264,6 +318,7 @@ impl TestIndexer {
         while retries > 0 {
             if retries < 3 {
                 spawn_gnark_server(self.path.as_str(), true, self.proof_types.as_slice()).await;
+                thread::sleep(Duration::from_secs(5));
             }
             let response_result = client
                 .post(&format!("{}{}", SERVER_ADDRESS, PROVE_PATH))
@@ -272,6 +327,7 @@ impl TestIndexer {
                 .send()
                 .await
                 .expect("Failed to execute request.");
+            println!("response_result {:?}", response_result);
             if response_result.status().is_success() {
                 let body = response_result.text().await.unwrap();
                 let proof_json = deserialize_gnark_proof_json(&body).unwrap();
@@ -287,6 +343,8 @@ impl TestIndexer {
                     },
                 };
             }
+            println!("json_payload {:?}", json_payload);
+            thread::sleep(Duration::from_secs(1));
             retries -= 1;
         }
         panic!("Failed to get proof from server");
@@ -294,23 +352,59 @@ impl TestIndexer {
 
     async fn process_inclusion_proofs(
         &self,
+        merkle_tree_pubkeys: &[Pubkey],
         accounts: &[[u8; 32]],
         context: &mut ProgramTestContext,
     ) -> (BatchInclusionJsonStruct, Vec<u16>) {
         let mut inclusion_proofs = Vec::new();
+        let mut root_indices = Vec::new();
 
-        for account in accounts.iter() {
-            let leaf_index = self.merkle_tree.get_leaf_index(account).unwrap();
-            let proof = self
-                .merkle_tree
-                .get_proof_of_leaf(leaf_index, true)
-                .unwrap();
+        for (i, account) in accounts.iter().enumerate() {
+            let merkle_tree = &self
+                .state_merkle_trees
+                .iter()
+                .find(|x| x.0.merkle_tree == merkle_tree_pubkeys[i])
+                .unwrap()
+                .1;
+            let leaf_index = merkle_tree.get_leaf_index(account).unwrap();
+            let proof = merkle_tree.get_proof_of_leaf(leaf_index, true).unwrap();
             inclusion_proofs.push(InclusionMerkleProofInputs {
-                root: BigInt::from_be_bytes(self.merkle_tree.root().as_slice()),
+                root: BigInt::from_be_bytes(merkle_tree.root().as_slice()),
                 leaf: BigInt::from_be_bytes(account),
                 path_index: BigInt::from_be_bytes(leaf_index.to_be_bytes().as_slice()),
                 path_elements: proof.iter().map(|x| BigInt::from_be_bytes(x)).collect(),
             });
+            let merkle_tree_account =
+                AccountZeroCopy::<StateMerkleTreeAccount>::new(context, merkle_tree_pubkeys[i])
+                    .await;
+            let fetched_merkle_tree_account = merkle_tree_account.deserialized();
+            let fetched_merkle_tree = fetched_merkle_tree_account.copy_merkle_tree().unwrap();
+            assert_eq!(
+                merkle_tree.root(),
+                fetched_merkle_tree.root().unwrap(),
+                "Merkle tree root mismatch"
+            );
+            root_indices.push(fetched_merkle_tree.current_root_index as u16);
+            println!("root_indices {:?}", root_indices);
+            println!(
+                "fetched_merkle_tree changelog_index {:?}",
+                fetched_merkle_tree.changelog_index()
+            );
+            println!(
+                "fetched_merkle_tree current_root_index {:?}",
+                fetched_merkle_tree.current_root_index
+            );
+            let nullifier_queue = unsafe {
+                get_hash_set::<
+                    u16,
+                    account_compression::initialize_nullifier_queue::NullifierQueueAccount,
+                >(context, fetched_merkle_tree_account.associated_queue)
+                .await
+            };
+            println!(
+                "nullifier_queue_account {:?}",
+                nullifier_queue.next_value_index
+            );
         }
 
         let inclusion_proof_inputs = InclusionProofInputs(inclusion_proofs.as_slice());
@@ -320,37 +414,39 @@ impl TestIndexer {
         // let inclusion_proof_inputs_json =
         //     InclusionJsonStruct::from_inclusion_proof_inputs(&batch_inclusion_proof_inputs);
 
-        let merkle_tree_account =
-            AccountZeroCopy::<StateMerkleTreeAccount>::new(context, self.merkle_tree_pubkey).await;
-        let merkle_tree = merkle_tree_account
-            .deserialized()
-            .copy_merkle_tree()
-            .unwrap();
-        assert_eq!(
-            self.merkle_tree.root(),
-            merkle_tree.root().unwrap(),
-            "Merkle tree root mismatch"
-        );
-
-        let root_indices = vec![merkle_tree.current_root_index as u16; accounts.len()];
+        // let root_indices = vec![merkle_tree.current_root_index as u16; accounts.len()];
 
         (batch_inclusion_proof_inputs, root_indices)
     }
 
     async fn process_non_inclusion_proofs(
         &self,
+        address_merkle_tree_pubkeys: &[Pubkey],
         addresses: &[[u8; 32]],
         context: &mut ProgramTestContext,
     ) -> (BatchNonInclusionJsonStruct, Vec<u16>) {
         let mut non_inclusion_proofs = Vec::new();
-
-        for address in addresses.iter() {
-            let proof_inputs = get_non_inclusion_proof_inputs(
-                address,
-                &self.address_merkle_tree,
-                &self.indexing_array,
-            );
+        let mut address_root_indices = Vec::new();
+        for (i, address) in addresses.iter().enumerate() {
+            let (_, address_merkle_tree, indexing_array) = &self
+                .address_merkle_trees
+                .iter()
+                .find(|x| x.0.merkle_tree == address_merkle_tree_pubkeys[0])
+                .unwrap();
+            let proof_inputs =
+                get_non_inclusion_proof_inputs(address, address_merkle_tree, indexing_array);
             non_inclusion_proofs.push(proof_inputs);
+            let merkle_tree_account = AccountZeroCopy::<AddressMerkleTreeAccount>::new(
+                context,
+                address_merkle_tree_pubkeys[i],
+            )
+            .await;
+            let fetched_address_merkle_tree = merkle_tree_account
+                .deserialized()
+                .copy_merkle_tree()
+                .unwrap();
+            address_root_indices
+                .push(fetched_address_merkle_tree.0.merkle_tree.current_root_index as u16);
         }
 
         let non_inclusion_proof_inputs = NonInclusionProofInputs(non_inclusion_proofs.as_slice());
@@ -358,18 +454,6 @@ impl TestIndexer {
             BatchNonInclusionJsonStruct::from_non_inclusion_proof_inputs(
                 &non_inclusion_proof_inputs,
             );
-        let merkle_tree_account = AccountZeroCopy::<AddressMerkleTreeAccount>::new(
-            context,
-            self.address_merkle_tree_pubkey,
-        )
-        .await;
-        let address_merkle_tree = merkle_tree_account
-            .deserialized()
-            .copy_merkle_tree()
-            .unwrap();
-        let address_root_indices =
-            vec![address_merkle_tree.0.merkle_tree.current_root_index as u16; addresses.len()];
-
         (batch_non_inclusion_proof_inputs, address_root_indices)
     }
 
@@ -383,11 +467,20 @@ impl TestIndexer {
         self.add_event_and_compressed_accounts(event);
     }
 
-    pub fn add_event_and_compressed_accounts(&mut self, event: PublicTransactionEvent) {
+    pub fn add_event_and_compressed_accounts(
+        &mut self,
+        event: PublicTransactionEvent,
+    ) -> (
+        Vec<CompressedAccountWithMerkleContext>,
+        Vec<TokenDataWithContext>,
+    ) {
         for hash in event.input_compressed_account_hashes.iter() {
             let index = self.compressed_accounts.iter().position(|x| {
                 x.compressed_account
-                    .hash::<Poseidon>(&self.merkle_tree_pubkey, &x.merkle_context.leaf_index)
+                    .hash::<Poseidon>(
+                        &x.merkle_context.merkle_tree_pubkey,
+                        &x.merkle_context.leaf_index,
+                    )
                     .unwrap()
                     == *hash
             });
@@ -405,7 +498,7 @@ impl TestIndexer {
                         x.compressed_account
                             .compressed_account
                             .hash::<Poseidon>(
-                                &self.merkle_tree_pubkey,
+                                &x.compressed_account.merkle_context.merkle_tree_pubkey,
                                 &x.compressed_account.merkle_context.leaf_index,
                             )
                             .unwrap()
@@ -417,10 +510,25 @@ impl TestIndexer {
                 self.token_compressed_accounts.remove(index);
             }
         }
+        println!("add_event_and_compressed_accounts: event {:?}", event);
 
+        let mut compressed_accounts = Vec::new();
+        let mut token_compressed_accounts = Vec::new();
         for (i, compressed_account) in event.output_compressed_accounts.iter().enumerate() {
+            let nullifier_queue_pubkey = self
+                .state_merkle_trees
+                .iter()
+                .find(|x| {
+                    x.0.merkle_tree
+                        == event.pubkey_array
+                            [event.output_state_merkle_tree_account_indices[i] as usize]
+                })
+                .unwrap()
+                .0
+                .nullifier_queue;
             // if data is some, try to deserialize token data, if it fails, add to compressed_accounts
             // if data is none add to compressed_accounts
+            // new accounts are inserted in front so that the newest accounts are found first
             match compressed_account.data.as_ref() {
                 Some(data) => {
                     if compressed_account.owner == light_compressed_token::ID
@@ -428,7 +536,7 @@ impl TestIndexer {
                     {
                         match TokenData::deserialize(&mut data.data.as_slice()) {
                             Ok(token_data) => {
-                                self.token_compressed_accounts.push(TokenDataWithContext {
+                                let token_account = TokenDataWithContext {
                                     token_data,
                                     compressed_account: CompressedAccountWithMerkleContext {
                                         compressed_account: compressed_account.clone(),
@@ -437,50 +545,68 @@ impl TestIndexer {
                                             merkle_tree_pubkey: event.pubkey_array[event
                                                 .output_state_merkle_tree_account_indices[i]
                                                 as usize],
-                                            nullifier_queue_pubkey: Pubkey::default(),
+                                            nullifier_queue_pubkey,
                                         },
                                     },
-                                });
+                                };
+                                token_compressed_accounts.push(token_account.clone());
+                                self.token_compressed_accounts.insert(0, token_account);
                             }
                             Err(_) => {}
                         }
                     } else {
-                        self.compressed_accounts
-                            .push(CompressedAccountWithMerkleContext {
-                                compressed_account: compressed_account.clone(),
-                                merkle_context: MerkleContext {
-                                    leaf_index: event.output_leaf_indices[i],
-                                    merkle_tree_pubkey: event.pubkey_array[event
-                                        .output_state_merkle_tree_account_indices[i]
-                                        as usize],
-                                    nullifier_queue_pubkey: Pubkey::default(),
-                                },
-                            });
+                        let compressed_account = CompressedAccountWithMerkleContext {
+                            compressed_account: compressed_account.clone(),
+                            merkle_context: MerkleContext {
+                                leaf_index: event.output_leaf_indices[i],
+                                merkle_tree_pubkey: event.pubkey_array
+                                    [event.output_state_merkle_tree_account_indices[i] as usize],
+                                nullifier_queue_pubkey,
+                            },
+                        };
+                        compressed_accounts.push(compressed_account.clone());
+                        self.compressed_accounts.insert(0, compressed_account);
                     }
                 }
-                None => self
-                    .compressed_accounts
-                    .push(CompressedAccountWithMerkleContext {
+                None => {
+                    let compressed_account = CompressedAccountWithMerkleContext {
                         compressed_account: compressed_account.clone(),
                         merkle_context: MerkleContext {
                             leaf_index: event.output_leaf_indices[i],
                             merkle_tree_pubkey: event.pubkey_array
                                 [event.output_state_merkle_tree_account_indices[i] as usize],
-                            nullifier_queue_pubkey: Pubkey::default(),
+                            nullifier_queue_pubkey,
                         },
-                    }),
+                    };
+                    compressed_accounts.push(compressed_account.clone());
+                    self.compressed_accounts.insert(0, compressed_account);
+                }
             };
-
-            self.merkle_tree
+            let merkle_tree = &mut self
+                .state_merkle_trees
+                .iter_mut()
+                .find(|x| {
+                    x.0.merkle_tree
+                        == event.pubkey_array
+                            [event.output_state_merkle_tree_account_indices[i] as usize]
+                })
+                .unwrap()
+                .1;
+            merkle_tree
                 .append(
                     &compressed_account
-                        .hash::<Poseidon>(&self.merkle_tree_pubkey, &event.output_leaf_indices[i])
+                        .hash::<Poseidon>(
+                            &event.pubkey_array
+                                [event.output_state_merkle_tree_account_indices[i] as usize],
+                            &event.output_leaf_indices[i],
+                        )
                         .unwrap(),
                 )
                 .expect("insert failed");
         }
 
         self.events.push(event);
+        (compressed_accounts, token_compressed_accounts)
     }
 
     /// deserializes an event
@@ -493,89 +619,49 @@ impl TestIndexer {
         self.add_event_and_compressed_accounts(event);
     }
 
-    /// Check compressed_accounts in the queue array which are not nullified yet
-    /// Iterate over these compressed_accounts and nullify them
-    pub async fn nullify_compressed_accounts(&mut self, context: &mut ProgramTestContext) {
-        let nullifier_queue = unsafe {
-            get_hash_set::<
-                u16,
-                account_compression::initialize_nullifier_queue::NullifierQueueAccount,
-            >(context, self.nullifier_queue_pubkey)
-            .await
-        };
-        let merkle_tree_account =
-            AccountZeroCopy::<StateMerkleTreeAccount>::new(context, self.merkle_tree_pubkey).await;
-        let merkle_tree = merkle_tree_account
-            .deserialized()
-            .copy_merkle_tree()
-            .unwrap();
-        let change_log_index = merkle_tree.current_changelog_index as u64;
+    /// returns compressed_accounts with the owner pubkey
+    /// does not return token accounts.
+    pub fn get_compressed_accounts_by_owner(
+        &self,
+        owner: &Pubkey,
+    ) -> Vec<CompressedAccountWithMerkleContext> {
+        self.compressed_accounts
+            .iter()
+            .filter(|x| x.compressed_account.owner == *owner)
+            .cloned()
+            .collect()
+    }
 
-        let mut compressed_account_to_nullify = Vec::new();
+    pub fn get_compressed_token_accounts_by_owner(
+        &self,
+        owner: &Pubkey,
+    ) -> Vec<TokenDataWithContext> {
+        self.token_compressed_accounts
+            .iter()
+            .filter(|x| x.token_data.owner == *owner)
+            .cloned()
+            .collect()
+    }
 
-        for (i, element) in nullifier_queue.iter() {
-            if element.sequence_number().is_none() {
-                compressed_account_to_nullify.push((i, element.value_bytes()));
-            }
-        }
+    /// returns the compressed sol balance of the owner pubkey
+    pub fn get_compressed_balance(&self, owner: &Pubkey) -> u64 {
+        self.compressed_accounts
+            .iter()
+            .filter(|x| x.compressed_account.owner == *owner)
+            .map(|x| x.compressed_account.lamports)
+            .sum()
+    }
 
-        for (index_in_nullifier_queue, compressed_account) in compressed_account_to_nullify.iter() {
-            let leaf_index = self.merkle_tree.get_leaf_index(compressed_account).unwrap();
-            let proof: Vec<[u8; 32]> = self
-                .merkle_tree
-                .get_proof_of_leaf(leaf_index, false)
-                .unwrap()
-                .to_array::<16>()
-                .unwrap()
-                .to_vec();
-
-            let instructions = [
-                account_compression::nullify_leaves::sdk_nullify::create_nullify_instruction(
-                    vec![change_log_index].as_slice(),
-                    vec![(*index_in_nullifier_queue) as u16].as_slice(),
-                    vec![0u64].as_slice(),
-                    vec![proof].as_slice(),
-                    &context.payer.pubkey(),
-                    &self.merkle_tree_pubkey,
-                    &self.nullifier_queue_pubkey,
-                ),
-            ];
-
-            create_and_send_transaction(
-                context,
-                &instructions,
-                &self.payer.pubkey(),
-                &[&self.payer],
-            )
-            .await
-            .unwrap();
-
-            let nullifier_queue = unsafe {
-                get_hash_set::<
-                    u16,
-                    account_compression::initialize_nullifier_queue::NullifierQueueAccount,
-                >(context, self.nullifier_queue_pubkey)
-                .await
-            };
-            let array_element = nullifier_queue
-                .by_value_index(*index_in_nullifier_queue, Some(merkle_tree.sequence_number))
-                .unwrap();
-            assert_eq!(&array_element.value_bytes(), compressed_account);
-            let merkle_tree_account =
-                AccountZeroCopy::<StateMerkleTreeAccount>::new(context, self.merkle_tree_pubkey)
-                    .await;
-            assert_eq!(
-                array_element.sequence_number(),
-                Some(
-                    merkle_tree_account
-                        .deserialized()
-                        .load_merkle_tree()
-                        .unwrap()
-                        .sequence_number
-                        + account_compression::utils::constants::STATE_MERKLE_TREE_ROOTS as usize
-                )
-            );
-        }
+    /// returns the compressed token balance of the owner pubkey for a token by mint
+    pub fn get_compressed_token_balance(&self, owner: &Pubkey, mint: &Pubkey) -> u64 {
+        self.token_compressed_accounts
+            .iter()
+            .filter(|x| {
+                x.compressed_account.compressed_account.owner == *owner
+                    && x.token_data.mint == *mint
+            })
+            .map(|x| x.token_data.amount)
+            .sum()
     }
 }
 
@@ -638,35 +724,4 @@ pub async fn create_mint_helper(context: &mut ProgramTestContext, payer: &Keypai
         .unwrap();
 
     mint.pubkey()
-}
-
-pub async fn mint_tokens_helper(
-    context: &mut ProgramTestContext,
-    test_indexer: &mut TestIndexer,
-    merkle_tree_pubkey: &Pubkey,
-    mint_authority: &Keypair,
-    mint: &Pubkey,
-    amounts: Vec<u64>,
-    recipients: Vec<Pubkey>,
-) {
-    let payer_pubkey = mint_authority.pubkey();
-    let instruction = create_mint_to_instruction(
-        &payer_pubkey,
-        &payer_pubkey,
-        mint,
-        merkle_tree_pubkey,
-        amounts,
-        recipients,
-    );
-    let event = create_and_send_transaction_with_event::<PublicTransactionEvent>(
-        context,
-        &[instruction],
-        &payer_pubkey,
-        &[&mint_authority],
-        None,
-    )
-    .await
-    .unwrap()
-    .unwrap();
-    test_indexer.add_compressed_accounts_with_token_data(event);
 }

--- a/test-utils/src/test_indexer.rs
+++ b/test-utils/src/test_indexer.rs
@@ -106,7 +106,7 @@ impl TestIndexer {
                 cpi_context: env.cpi_signature_account_pubkey,
             }],
             vec![AddressMerkleTreeAccounts {
-                merkle_tree: env.merkle_tree_pubkey,
+                merkle_tree: env.address_merkle_tree_pubkey,
                 queue: env.address_merkle_tree_queue_pubkey,
             }],
             payer.insecure_clone(),
@@ -431,7 +431,10 @@ impl TestIndexer {
             let (_, address_merkle_tree, indexing_array) = &self
                 .address_merkle_trees
                 .iter()
-                .find(|x| x.0.merkle_tree == address_merkle_tree_pubkeys[0])
+                .find(|x| {
+                    println!("x.0.merkle_tree {:?}", x.0.merkle_tree);
+                    return x.0.merkle_tree == address_merkle_tree_pubkeys[0];
+                })
                 .unwrap();
             let proof_inputs =
                 get_non_inclusion_proof_inputs(address, address_merkle_tree, indexing_array);


### PR DESCRIPTION
This is a preparation pr for randomized e2e rust tests.

Changes:
- refactor test indexer:
  - works with multiple state and adress Merkle trees
- refactor tests
 - to work with new test indexer
 - pool test functions in test-utils crate