### PR TITLE
build: Treat test-programs as pnpm project

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - "tsconfig/**"
   - "programs/**"
+  - "test-programs/**"
   - "prover.js/**"
   - "circuit-lib/**"
   - "hasher.rs/**"

--- a/programs/package.json
+++ b/programs/package.json
@@ -1,13 +1,8 @@
 {
   "name": "@lightprotocol/programs",
   "version": "0.3.0",
-  "license": "GPL-3.0",
+  "license": "Apache-2.0",
   "scripts": {
     "build": "anchor build",
-    "test": "pnpm test-account-compression && pnpm test-compressed-pda && pnpm test-compressed-token && pnpm test-registry",
-    "test-account-compression": "cargo test-sbf -p account-compression-test",
-    "test-compressed-pda": "cargo test-sbf -p compressed-pda-test -- --test-threads=1",
-    "test-compressed-token": "cargo test-sbf -p compressed-token-test -- --test-threads=1",
-    "test-registry": "cargo test-sbf -p registry-test"
   }
 }

--- a/test-programs/package.json
+++ b/test-programs/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@lightprotocol/test-programs",
+  "version": "0.3.0",
+  "license": "Apache-2.0",
+  "scripts": {
+    "build": "anchor build",
+    "test": "pnpm test-account-compression && pnpm test-compressed-pda && pnpm test-compressed-token && pnpm test-program-owned-account && pnpm test-registry",
+    "test-account-compression": "cargo test-sbf -p account-compression-test",
+    "test-compressed-pda": "cargo test-sbf -p compressed-pda-test -- --test-threads=1",
+    "test-compressed-token": "cargo test-sbf -p compressed-token-test -- --test-threads=1",
+    "test-program-owned-account": "cargo test-sbf -p program-owned-account-test",
+    "test-registry": "cargo test-sbf -p registry-test"
+  }
+}


### PR DESCRIPTION
This way, they are included in `npx nx run-many --target=test`, which is a standard way of running tests locally.