### PR TITLE
chore: all releases in one ci

### DIFF
--- a/.github/workflows/release-pr-rust.yml
+++ b/.github/workflows/release-pr-rust.yml
@@ -9,22 +9,23 @@ on:
         options:
           - all
           - aligned-sized
-          - light-bounded-vec
-          - light-circuitlib-rs
-          - light-concurrent-merkle-tree
-          - light-hash-set
-          - light-hasher
-          - light-indexed-merkle-tree
-          - light-macros
-          - light-merkle-tree-event
-          - light-merkle-tree-reference
-          - light-registry
-          - light-test-utils
+          - light-heap
           - light-utils
-          - light-wasm-hasher
+          - light-bounded-vec
+          - light-hasher
+          - light-macros
+          - light-hash-set
+          - light-merkle-tree-reference
+          - light-concurrent-merkle-tree
+          - light-indexed-merkle-tree
+          - light-circuitlib-rs
+          - light-verifier
           - account-compression
+          - light-registry
           - light-system-program
           - light-compressed-token
+          - light-test-utils
+          - light-wasm-hasher
       version:
         description: Version to release
         required: true
@@ -71,11 +72,8 @@ jobs:
       - name: Bump all crate versions
         if: inputs.crate == 'all'
         run: |
-          for PACKAGE in $(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] .name'); do
-            cargo release --package "$PACKAGE" --execute --no-confirm "${{ inputs.version }}"
-            echo "Waiting for 60 seconds to avoid rate limiting..."
-            sleep 60  # Wait for 60 seconds before processing the next crate
-          done
+          cargo release version --execute --no-confirm \
+            "${{ inputs.version }}"
 
       - name: Bump crate version
         if: inputs.crate != 'all'

--- a/.github/workflows/release-pr-rust.yml
+++ b/.github/workflows/release-pr-rust.yml
@@ -68,10 +68,13 @@ jobs:
           cp cargo-release "$HOME"/.cargo/bin
           popd
 
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
       - name: Bump all crate versions
         if: inputs.crate == 'all'
         run: |
-          for PACKAGE in $(cargo ws list); do
+          for PACKAGE in $(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] .name'); do
             cargo release --package "$PACKAGE" --execute --no-confirm "${{ inputs.version }}"
             echo "Waiting for 60 seconds to avoid rate limiting..."
             sleep 60  # Wait for 60 seconds before processing the next crate

--- a/.github/workflows/release-pr-rust.yml
+++ b/.github/workflows/release-pr-rust.yml
@@ -68,9 +68,6 @@ jobs:
           cp cargo-release "$HOME"/.cargo/bin
           popd
 
-      - name: Install jq
-        run: apt-get update && apt-get install -y jq
-
       - name: Bump all crate versions
         if: inputs.crate == 'all'
         run: |

--- a/.github/workflows/release-pr-rust.yml
+++ b/.github/workflows/release-pr-rust.yml
@@ -69,7 +69,7 @@ jobs:
           popd
 
       - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
+        run: apt-get update && apt-get install -y jq
 
       - name: Bump all crate versions
         if: inputs.crate == 'all'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,8 +120,17 @@ jobs:
 
           anchor build
           cp -r ./target/deploy/*.so .
-          cargo release publish \
-            --workspace --execute --no-confirm
+
+          PACKAGES=("aligned-sized" "light-heap" "light-utils" "light-bounded-vec" "light-hasher" "light-macros" "light-hash-set" "light-merkle-tree-reference" "light-concurrent-merkle-tree" "light-indexed-merkle-tree" "light-circuitlib-rs" "light-verifier" "account-compression" "light-registry" "light-system-program" "light-compressed-token" "light-test-utils")
+          for PACKAGE in "${PACKAGES[@]}"; do
+            for attempt in {1..3}; do
+              echo "Attempt $attempt: Publishing $PACKAGE..."
+              cargo release publish --package "$PACKAGE" --execute --no-confirm && break || echo "Attempt $attempt failed, retrying in 60..."
+              sleep 60
+            done
+            echo "Sleeping for 60 seconds to handle rate limits..."
+            sleep 60
+          done
 
       - name: Release Rust project
         if: steps.extract-project.outputs.package != 'all' && steps.extract-project.outputs.language == 'rust'
@@ -140,8 +149,7 @@ jobs:
           cp -r ./target/deploy/*.so .
 
           cargo release publish \
-            --package "$PACKAGE" \
-            --token "$CARGO_REGISTRY_TOKEN"
+            --package "$PACKAGE"
 
       - name: Release TypeScript
         if: steps.extract-project.outputs.package != 'all' && steps.extract-project.outputs.language == 'ts'


### PR DESCRIPTION
- enforces order of crates for release all, loop individually 
- this should allow us to release all at once 

- adds missing crates to selection