### PR TITLE
chore: Provide clear distinction in `find_low_element_*` methods

### DIFF
--- a/merkle-tree/indexed/src/errors.rs
+++ b/merkle-tree/indexed/src/errors.rs
@@ -17,6 +17,10 @@ pub enum IndexedMerkleTreeError {
     LowElementGreaterOrEqualToNewElement,
     #[error("The provided new element is greater or equal to the next element.")]
     NewElementGreaterOrEqualToNextElement,
+    #[error("The element already exists, but was expected to be absent.")]
+    ElementAlreadyExists,
+    #[error("The element does not exist, but was expected to be present.")]
+    ElementDoesNotExist,
     #[error("Invalid changelog buffer size, expected {0}, got {1}")]
     ChangelogBufferSize(usize, usize),
     #[error("Hasher error: {0}")]
@@ -40,7 +44,9 @@ impl From<IndexedMerkleTreeError> for u32 {
             IndexedMerkleTreeError::LowElementNotFound => 11003,
             IndexedMerkleTreeError::LowElementGreaterOrEqualToNewElement => 11004,
             IndexedMerkleTreeError::NewElementGreaterOrEqualToNextElement => 11005,
-            IndexedMerkleTreeError::ChangelogBufferSize(_, _) => 11006,
+            IndexedMerkleTreeError::ElementAlreadyExists => 11006,
+            IndexedMerkleTreeError::ElementDoesNotExist => 11007,
+            IndexedMerkleTreeError::ChangelogBufferSize(_, _) => 11008,
             IndexedMerkleTreeError::Hasher(e) => e.into(),
             IndexedMerkleTreeError::ConcurrentMerkleTree(e) => e.into(),
             IndexedMerkleTreeError::Utils(e) => e.into(),

--- a/merkle-tree/indexed/src/reference.rs
+++ b/merkle-tree/indexed/src/reference.rs
@@ -130,7 +130,7 @@ where
         value: &BigUint,
         indexed_array: &IndexedArray<H, I, T>,
     ) -> Result<NonInclusionProof, IndexedReferenceMerkleTreeError> {
-        let (low_element, _next_value) = indexed_array.find_low_element(value)?;
+        let (low_element, _next_value) = indexed_array.find_low_element_for_nonexistent(value)?;
         let merkle_proof = self
             .get_proof_of_leaf(usize::from(low_element.index), true)
             .unwrap();

--- a/merkle-tree/indexed/tests/tests.rs
+++ b/merkle-tree/indexed/tests/tests.rs
@@ -114,7 +114,7 @@ where
 
         // Create new element from the dequeued value.
         let (old_low_nullifier, old_low_nullifier_next_value) = relayer_indexing_array
-            .find_low_element(&lowest_from_queue.value)
+            .find_low_element_for_nonexistent(&lowest_from_queue.value)
             .unwrap();
         let nullifier_bundle = relayer_indexing_array
             .new_element_with_low_element_index(old_low_nullifier.index, &lowest_from_queue.value)
@@ -289,9 +289,10 @@ where
     program_insert::<H>(onchain_queue.borrow_mut(), [nullifier1, nullifier2]).unwrap();
 
     // Try inserting the same pair into the queue. It should fail with an error.
+    let res = program_insert::<H>(onchain_queue.borrow_mut(), [nullifier1, nullifier2]);
     assert!(matches!(
-        program_insert::<H>(onchain_queue.borrow_mut(), [nullifier1, nullifier2]),
-        Err(IndexedMerkleTreeError::LowElementGreaterOrEqualToNewElement),
+        res,
+        Err(IndexedMerkleTreeError::ElementAlreadyExists),
     ));
 
     // Update the on-chain tree (so it contains the nullifiers we inserted).
@@ -628,7 +629,6 @@ pub fn functional_non_inclusion_test() {
 //     let address_bundle = relayer_indexing_array
 //         .new_element_with_low_element_index(old_low_address.index, &address_2)
 //         .unwrap();
-
 //     let mut low_element_proof = relayer_merkle_tree
 //         .get_proof_of_leaf(old_low_address.index, false)
 //         .unwrap();

--- a/test-utils/src/test_forester.rs
+++ b/test-utils/src/test_forester.rs
@@ -219,7 +219,7 @@ pub async fn empty_address_queue_test<const INDEXED_ARRAY_SIZE: usize>(
         let (address, address_hashset_index) = address.unwrap();
         // Create new element from the dequeued value.
         let (old_low_address, old_low_address_next_value) = relayer_indexing_array
-            .find_low_element(&address.value_biguint())
+            .find_low_element_for_nonexistent(&address.value_biguint())
             .unwrap();
         let address_bundle = relayer_indexing_array
             .new_element_with_low_element_index(old_low_address.index, &address.value_biguint())


### PR DESCRIPTION
Make a clear distinction between methods, which should be used when **inserting** a new element and finding a low element for such insertion operation:

* `find_low_element_for_nonexistent`
* `find_low_element_index_for_nonexistent`

And methods, which should be used for determining a low element for **already existing** element:

* `find_low_element_for_existent`
* `find_low_element_index_for_existent`