### PR TITLE
refactor: events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,9 +1059,9 @@ checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.3"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
+checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
 dependencies = [
  "bytemuck_derive",
 ]

--- a/merkle-tree/concurrent/src/event.rs
+++ b/merkle-tree/concurrent/src/event.rs
@@ -1,5 +1,4 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use light_bounded_vec::Pod;
 #[derive(BorshDeserialize, BorshSerialize, Debug)]
 pub struct MerkleTreeEvents {
     pub events: Vec<MerkleTreeEvent>,
@@ -43,7 +42,7 @@ pub struct NullifierEvent {
     /// Public key of the tree.
     pub id: [u8; 32],
     /// Indices of leaves that were nullified.
-    /// Nullified means updated with [u8;32].
+    /// Nullified means updated with [0u8;32].
     pub nullified_leaves_indices: Vec<u64>,
     /// Number of successful operations on the on-chain tree.
     /// seq corresponds to leaves[0].
@@ -54,19 +53,18 @@ pub struct NullifierEvent {
 #[derive(Debug, Default, Clone, Copy, BorshSerialize, BorshDeserialize)]
 pub struct RawIndexedElement<I>
 where
-    I: Clone + Pod,
+    I: Clone,
 {
     pub value: [u8; 32],
     pub next_index: I,
     pub next_value: [u8; 32],
     pub index: I,
 }
-unsafe impl<I> Pod for RawIndexedElement<I> where I: Pod + Clone {}
 
 #[derive(BorshDeserialize, BorshSerialize, Debug, Clone)]
 pub struct IndexedMerkleTreeUpdate<I>
 where
-    I: Clone + Pod,
+    I: Clone,
 {
     pub new_low_element: RawIndexedElement<I>,
     /// Leaf hash in new_low_element.index.

--- a/merkle-tree/concurrent/src/event.rs
+++ b/merkle-tree/concurrent/src/event.rs
@@ -69,8 +69,11 @@ where
     I: Clone + Pod,
 {
     pub new_low_element: RawIndexedElement<I>,
+    /// Leaf hash in new_low_element.index.
     pub new_low_element_hash: [u8; 32],
     pub new_high_element: RawIndexedElement<I>,
+    /// Leaf hash in new_high_element.index,
+    /// is equivalent with next_index.
     pub new_high_element_hash: [u8; 32],
 }
 
@@ -78,7 +81,7 @@ where
 pub struct IndexedMerkleTreeEvent {
     /// Public key of the tree.
     pub id: [u8; 32],
-    pub leaves: Vec<IndexedMerkleTreeUpdate<usize>>,
+    pub updates: Vec<IndexedMerkleTreeUpdate<usize>>,
     /// Number of successful operations on the on-chain tree.
     /// seq corresponds to leaves[0].
     /// seq + 1 corresponds to leaves[1].

--- a/merkle-tree/concurrent/src/lib.rs
+++ b/merkle-tree/concurrent/src/lib.rs
@@ -4,7 +4,6 @@ use event::{ChangelogEvent, MerkleTreeEvent};
 use light_bounded_vec::{BoundedVec, CyclicBoundedVec, CyclicBoundedVecIterator};
 pub use light_hasher;
 use light_hasher::Hasher;
-use std::{marker::PhantomData, mem, slice};
 pub mod changelog;
 pub mod errors;
 pub mod event;

--- a/merkle-tree/concurrent/src/lib.rs
+++ b/merkle-tree/concurrent/src/lib.rs
@@ -1,10 +1,10 @@
 use std::{iter::Skip, marker::PhantomData, mem, slice};
 
-use event::{ChangelogEvent, ChangelogEventV1};
+use event::{ChangelogEvent, MerkleTreeEvent};
 use light_bounded_vec::{BoundedVec, CyclicBoundedVec, CyclicBoundedVecIterator};
 pub use light_hasher;
 use light_hasher::Hasher;
-
+use std::{marker::PhantomData, mem, slice};
 pub mod changelog;
 pub mod errors;
 pub mod event;
@@ -1063,7 +1063,7 @@ where
         first_changelog_index: usize,
         first_sequence_number: usize,
         num_changelog_entries: usize,
-    ) -> Result<ChangelogEvent, ConcurrentMerkleTreeError> {
+    ) -> Result<MerkleTreeEvent, ConcurrentMerkleTreeError> {
         let mut paths = Vec::with_capacity(num_changelog_entries);
         for i in 0..num_changelog_entries {
             let changelog_index = (first_changelog_index + i) % self.changelog_capacity;
@@ -1094,7 +1094,7 @@ where
             .index
             .try_into()
             .map_err(|_| ConcurrentMerkleTreeError::IntegerOverflow)?;
-        Ok(ChangelogEvent::V1(ChangelogEventV1 {
+        Ok(MerkleTreeEvent::V1(ChangelogEvent {
             id: merkle_tree_account_pubkey,
             paths,
             seq: first_sequence_number as u64,

--- a/merkle-tree/concurrent/tests/tests.rs
+++ b/merkle-tree/concurrent/tests/tests.rs
@@ -4,7 +4,7 @@ use ark_bn254::Fr;
 use ark_ff::{BigInteger, PrimeField, UniformRand};
 use light_bounded_vec::{BoundedVec, CyclicBoundedVec};
 use light_concurrent_merkle_tree::{
-    changelog::ChangelogEntry, errors::ConcurrentMerkleTreeError, event::ChangelogEvent,
+    changelog::ChangelogEntry, errors::ConcurrentMerkleTreeError, event::MerkleTreeEvent,
     ConcurrentMerkleTree,
 };
 use light_hash_set::HashSet;
@@ -607,8 +607,9 @@ where
             )
             .unwrap();
         let changelog_event_1 = match changelog_event_1 {
-            ChangelogEvent::V1(changelog_event_1) => changelog_event_1,
-            ChangelogEvent::V2(_) => unreachable!(),
+            MerkleTreeEvent::V1(changelog_event_1) => changelog_event_1,
+            MerkleTreeEvent::V2(_) => unreachable!(),
+            MerkleTreeEvent::V3(_) => unreachable!(),
         };
 
         let mut changelog_index = 0;
@@ -620,8 +621,9 @@ where
             .get_changelog_event([0u8; 32], changelog_index, sequence_number, 1)
             .unwrap();
         let changelog_event_2 = match changelog_event_2 {
-            ChangelogEvent::V1(changelog_event_2) => changelog_event_2,
-            ChangelogEvent::V2(_) => unreachable!(),
+            MerkleTreeEvent::V1(changelog_event_2) => changelog_event_2,
+            MerkleTreeEvent::V2(_) => unreachable!(),
+            MerkleTreeEvent::V3(_) => unreachable!(),
         };
 
         for leaf in leaves {
@@ -1863,8 +1865,9 @@ fn test_changelog_event_v1() {
     for i in 0..leaves {
         let changelog_event = merkle_tree.get_changelog_event([0u8; 32], i, i, 1).unwrap();
         let changelog_event = match changelog_event {
-            ChangelogEvent::V1(changelog_event) => changelog_event,
-            ChangelogEvent::V2(_) => unreachable!(),
+            MerkleTreeEvent::V1(changelog_event) => changelog_event,
+            MerkleTreeEvent::V2(_) => unreachable!(),
+            MerkleTreeEvent::V3(_) => unreachable!(),
         };
 
         let spl_changelog_entry = Box::new(spl_merkle_tree.change_logs[i]);

--- a/merkle-tree/indexed/src/copy.rs
+++ b/merkle-tree/indexed/src/copy.rs
@@ -2,12 +2,13 @@ use std::{marker::PhantomData, mem, slice};
 
 use light_bounded_vec::{BoundedVec, CyclicBoundedVec};
 use light_concurrent_merkle_tree::{
-    changelog::ChangelogEntry, errors::ConcurrentMerkleTreeError, ConcurrentMerkleTree,
+    changelog::ChangelogEntry, errors::ConcurrentMerkleTreeError, event::RawIndexedElement,
+    ConcurrentMerkleTree,
 };
 use light_hasher::Hasher;
 use num_traits::{CheckedAdd, CheckedSub, ToBytes, Unsigned};
 
-use crate::{errors::IndexedMerkleTreeError, IndexedMerkleTree, RawIndexedElement};
+use crate::{errors::IndexedMerkleTreeError, IndexedMerkleTree};
 
 #[derive(Debug)]
 pub struct IndexedMerkleTreeCopy<'a, H, I, const HEIGHT: usize>(

--- a/merkle-tree/indexed/src/zero_copy.rs
+++ b/merkle-tree/indexed/src/zero_copy.rs
@@ -2,12 +2,13 @@ use std::mem;
 
 use light_bounded_vec::{BoundedVec, CyclicBoundedVec};
 use light_concurrent_merkle_tree::{
-    changelog::ChangelogEntry, errors::ConcurrentMerkleTreeError, ConcurrentMerkleTree,
+    changelog::ChangelogEntry, errors::ConcurrentMerkleTreeError, event::RawIndexedElement,
+    ConcurrentMerkleTree,
 };
 use light_hasher::Hasher;
 use num_traits::{CheckedAdd, CheckedSub, ToBytes, Unsigned};
 
-use crate::{errors::IndexedMerkleTreeError, IndexedMerkleTree, RawIndexedElement};
+use crate::{errors::IndexedMerkleTreeError, IndexedMerkleTree};
 
 #[derive(Debug)]
 pub struct IndexedMerkleTreeZeroCopy<'a, H, I, const HEIGHT: usize>

--- a/programs/account-compression/src/instructions/update_address_merkle_tree.rs
+++ b/programs/account-compression/src/instructions/update_address_merkle_tree.rs
@@ -95,7 +95,7 @@ pub fn process_update_address_merkle_tree<'info>(
 
     let address_event = MerkleTreeEvent::V3(IndexedMerkleTreeEvent {
         id: ctx.accounts.merkle_tree.key().to_bytes(),
-        leaves: vec![indexed_merkle_tree_update],
+        updates: vec![indexed_merkle_tree_update],
         // Address Merkle tree update does one update and one append,
         // thus the first seq number is final seq - 1.
         seq: merkle_tree.merkle_tree.merkle_tree.sequence_number as u64 - 1,

--- a/test-programs/account-compression-test/tests/merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/merkle_tree_tests.rs
@@ -11,7 +11,7 @@ use account_compression::{
     NullifierQueueConfig, StateMerkleTreeAccount, StateMerkleTreeConfig, ID,
 };
 use anchor_lang::{system_program, InstructionData, ToAccountMetas};
-use light_concurrent_merkle_tree::{event::ChangelogEvent, ConcurrentMerkleTree26};
+use light_concurrent_merkle_tree::{event::MerkleTreeEvent, ConcurrentMerkleTree26};
 use light_hash_set::HashSetError;
 use light_hasher::{zero_bytes::poseidon::ZERO_BYTES, Hasher, Poseidon};
 use light_merkle_tree_reference::MerkleTree;
@@ -1026,7 +1026,7 @@ pub async fn nullify(
         ),
     ];
 
-    let event = create_and_send_transaction_with_event::<ChangelogEvent>(
+    let event = create_and_send_transaction_with_event::<MerkleTreeEvent>(
         context,
         &instructions,
         &payer.pubkey(),
@@ -1089,12 +1089,12 @@ pub async fn nullify(
     );
     let event = event.as_ref().unwrap();
     match event {
-        ChangelogEvent::V1(_) => panic!("Expected V2 event"),
-        ChangelogEvent::V2(event_v1) => {
+        MerkleTreeEvent::V1(_) => panic!("Expected V2 event"),
+        MerkleTreeEvent::V2(event_v1) => {
             assert_eq!(event_v1.id, merkle_tree_pubkey.to_bytes());
-            assert_eq!(event_v1.leaves[0].leaf_index, element_index);
-            assert_eq!(event_v1.leaves[0].leaf, [0u8; 32]);
+            assert_eq!(event_v1.nullified_leaves_indices[0], element_index);
         }
+        MerkleTreeEvent::V3(_) => panic!("Expected V2 event"),
     }
     Ok(())
 }

--- a/test-utils/src/test_forester.rs
+++ b/test-utils/src/test_forester.rs
@@ -277,74 +277,65 @@ pub async fn empty_address_queue_test<const INDEXED_ARRAY_SIZE: usize>(
                     MerkleTreeEvent::V3(event) => {
                         assert_eq!(event.id, address_merkle_tree_pubkey.to_bytes());
                         assert_eq!(event.seq, old_sequence_number as u64 + 1);
-                        assert_eq!(event.leaves.len(), 1);
-                        let event = &event.leaves[0];
-                        // let new_low_element_leaf = address_bundle
-                        //     .new_low_element
-                        //     .hash::<Poseidon>(&address_bundle.new_element.value);
-                        // assert_eq!(
-                        //     event.leaves[0].leaf,
-                        //     new_low_element_leaf.unwrap(),
-                        //     "New low element leaf mismatch."
-                        // );
-                        // let new_element_leaf = address_bundle
-                        //     .new_element
-                        //     .hash::<Poseidon>(&address_bundle.new_element_next_value);
-                        // assert_eq!(
-                        //     event.leaves[1].leaf,
-                        //     new_element_leaf.unwrap(),
-                        //     "New element leaf mismatch."
-                        // );
-                        // assert_eq!(event.leaves[0].leaf_index, old_low_address.index as u64);
-                        // assert_eq!(
-                        //     event.leaves[1].leaf_index,
-                        //     address_bundle.new_element.index as u64
-                        // );
+                        assert_eq!(event.updates.len(), 1);
+                        let event = &event.updates[0];
                         assert_eq!(
-                            event.new_low_element.index,
-                            address_bundle.new_low_element.index
+                            event.new_low_element.index, address_bundle.new_low_element.index,
+                            "Empty Address Queue Test: invalid new_low_element.index"
                         );
                         assert_eq!(
                             event.new_low_element.next_index,
-                            address_bundle.new_low_element.next_index
+                            address_bundle.new_low_element.next_index,
+                            "Empty Address Queue Test: invalid new_low_element.next_index"
                         );
                         assert_eq!(
                             event.new_low_element.value,
                             bigint_to_be_bytes_array::<32>(&address_bundle.new_low_element.value)
-                                .unwrap()
+                                .unwrap(),
+                            "Empty Address Queue Test: invalid new_low_element.value"
                         );
                         assert_eq!(
                             event.new_low_element.next_value,
                             bigint_to_be_bytes_array::<32>(&address_bundle.new_element.value)
-                                .unwrap()
+                                .unwrap(),
+                            "Empty Address Queue Test: invalid new_low_element.next_value"
                         );
                         let leaf_hash = address_bundle
                             .new_low_element
                             .hash::<Poseidon>(&address_bundle.new_element.value)
                             .unwrap();
-                        assert_eq!(event.new_low_element_hash, leaf_hash);
+                        assert_eq!(
+                            event.new_low_element_hash, leaf_hash,
+                            "Empty Address Queue Test: invalid new_low_element_hash"
+                        );
                         let leaf_hash = address_bundle
                             .new_element
                             .hash::<Poseidon>(&address_bundle.new_element_next_value)
                             .unwrap();
-                        assert_eq!(event.new_high_element_hash, leaf_hash);
                         assert_eq!(
-                            event.new_high_element.index,
-                            address_bundle.new_element.index
+                            event.new_high_element_hash, leaf_hash,
+                            "Empty Address Queue Test: invalid new_high_element_hash"
+                        );
+                        assert_eq!(
+                            event.new_high_element.index, address_bundle.new_element.index,
+                            "Empty Address Queue Test: invalid new_high_element.index"
                         );
                         assert_eq!(
                             event.new_high_element.next_index,
-                            address_bundle.new_element.next_index
+                            address_bundle.new_element.next_index,
+                            "Empty Address Queue Test: invalid new_high_element.next_index"
                         );
                         assert_eq!(
                             event.new_high_element.value,
                             bigint_to_be_bytes_array::<32>(&address_bundle.new_element.value)
-                                .unwrap()
+                                .unwrap(),
+                            "Empty Address Queue Test: invalid new_high_element.value"
                         );
                         assert_eq!(
                             event.new_high_element.next_value,
                             bigint_to_be_bytes_array::<32>(&address_bundle.new_element_next_value)
-                                .unwrap()
+                                .unwrap(),
+                            "Empty Address Queue Test: invalid new_high_element.next_value"
                         );
                     }
                     _ => {

--- a/test-utils/src/test_forester.rs
+++ b/test-utils/src/test_forester.rs
@@ -8,7 +8,7 @@ use account_compression::{instruction::InsertAddresses, StateMerkleTreeAccount, 
 use account_compression::{AddressMerkleTreeAccount, AddressQueueAccount};
 use anchor_lang::system_program;
 use anchor_lang::{InstructionData, ToAccountMetas};
-use light_concurrent_merkle_tree::event::ChangelogEvent;
+use light_concurrent_merkle_tree::event::MerkleTreeEvent;
 use light_hasher::Poseidon;
 use light_utils::bigint::bigint_to_be_bytes_array;
 use solana_program_test::{BanksClientError, ProgramTestContext};
@@ -100,7 +100,7 @@ pub async fn nullify_compressed_accounts(
             ),
         ];
 
-        let event = create_and_send_transaction_with_event::<ChangelogEvent>(
+        let event = create_and_send_transaction_with_event::<MerkleTreeEvent>(
             context,
             &instructions,
             &payer.pubkey(),
@@ -112,12 +112,11 @@ pub async fn nullify_compressed_accounts(
         .unwrap();
 
         match event {
-            ChangelogEvent::V2(event) => {
+            MerkleTreeEvent::V2(event) => {
                 assert_eq!(event.id, state_tree_bundle.accounts.merkle_tree.to_bytes());
                 assert_eq!(event.seq, onchain_merkle_tree.sequence_number as u64 + 1);
-                assert_eq!(event.leaves.len(), 1);
-                assert_eq!(event.leaves[0].leaf, [0u8; 32]);
-                assert_eq!(event.leaves[0].leaf_index, leaf_index as u64);
+                assert_eq!(event.nullified_leaves_indices.len(), 1);
+                assert_eq!(event.nullified_leaves_indices[0], leaf_index as u64);
             }
             _ => {
                 panic!("Wrong event type.");
@@ -275,30 +274,77 @@ pub async fn empty_address_queue_test<const INDEXED_ARRAY_SIZE: usize>(
             Ok(event) => {
                 let event = event.unwrap();
                 match event {
-                    ChangelogEvent::V2(event) => {
+                    MerkleTreeEvent::V3(event) => {
                         assert_eq!(event.id, address_merkle_tree_pubkey.to_bytes());
                         assert_eq!(event.seq, old_sequence_number as u64 + 1);
-                        assert_eq!(event.leaves.len(), 2);
-                        let new_low_element_leaf = address_bundle
+                        assert_eq!(event.leaves.len(), 1);
+                        let event = &event.leaves[0];
+                        // let new_low_element_leaf = address_bundle
+                        //     .new_low_element
+                        //     .hash::<Poseidon>(&address_bundle.new_element.value);
+                        // assert_eq!(
+                        //     event.leaves[0].leaf,
+                        //     new_low_element_leaf.unwrap(),
+                        //     "New low element leaf mismatch."
+                        // );
+                        // let new_element_leaf = address_bundle
+                        //     .new_element
+                        //     .hash::<Poseidon>(&address_bundle.new_element_next_value);
+                        // assert_eq!(
+                        //     event.leaves[1].leaf,
+                        //     new_element_leaf.unwrap(),
+                        //     "New element leaf mismatch."
+                        // );
+                        // assert_eq!(event.leaves[0].leaf_index, old_low_address.index as u64);
+                        // assert_eq!(
+                        //     event.leaves[1].leaf_index,
+                        //     address_bundle.new_element.index as u64
+                        // );
+                        assert_eq!(
+                            event.new_low_element.index,
+                            address_bundle.new_low_element.index
+                        );
+                        assert_eq!(
+                            event.new_low_element.next_index,
+                            address_bundle.new_low_element.next_index
+                        );
+                        assert_eq!(
+                            event.new_low_element.value,
+                            bigint_to_be_bytes_array::<32>(&address_bundle.new_low_element.value)
+                                .unwrap()
+                        );
+                        assert_eq!(
+                            event.new_low_element.next_value,
+                            bigint_to_be_bytes_array::<32>(&address_bundle.new_element.value)
+                                .unwrap()
+                        );
+                        let leaf_hash = address_bundle
                             .new_low_element
-                            .hash::<Poseidon>(&address_bundle.new_element.value);
-                        assert_eq!(
-                            event.leaves[0].leaf,
-                            new_low_element_leaf.unwrap(),
-                            "New low element leaf mismatch."
-                        );
-                        let new_element_leaf = address_bundle
+                            .hash::<Poseidon>(&address_bundle.new_element.value)
+                            .unwrap();
+                        assert_eq!(event.new_low_element_hash, leaf_hash);
+                        let leaf_hash = address_bundle
                             .new_element
-                            .hash::<Poseidon>(&address_bundle.new_element_next_value);
+                            .hash::<Poseidon>(&address_bundle.new_element_next_value)
+                            .unwrap();
+                        assert_eq!(event.new_high_element_hash, leaf_hash);
                         assert_eq!(
-                            event.leaves[1].leaf,
-                            new_element_leaf.unwrap(),
-                            "New element leaf mismatch."
+                            event.new_high_element.index,
+                            address_bundle.new_element.index
                         );
-                        assert_eq!(event.leaves[0].leaf_index, old_low_address.index as u64);
                         assert_eq!(
-                            event.leaves[1].leaf_index,
-                            address_bundle.new_element.index as u64
+                            event.new_high_element.next_index,
+                            address_bundle.new_element.next_index
+                        );
+                        assert_eq!(
+                            event.new_high_element.value,
+                            bigint_to_be_bytes_array::<32>(&address_bundle.new_element.value)
+                                .unwrap()
+                        );
+                        assert_eq!(
+                            event.new_high_element.next_value,
+                            bigint_to_be_bytes_array::<32>(&address_bundle.new_element_next_value)
+                                .unwrap()
                         );
                     }
                     _ => {
@@ -389,7 +435,7 @@ pub async fn update_merkle_tree(
     low_address_next_index: u64,
     low_address_next_value: [u8; 32],
     low_address_proof: [[u8; 32]; 16],
-) -> Result<Option<ChangelogEvent>, BanksClientError> {
+) -> Result<Option<MerkleTreeEvent>, BanksClientError> {
     let changelog_index = {
         // TODO: figure out why I get an invalid memory reference error here when I try to replace 183-190 with this
         let address_merkle_tree =
@@ -424,7 +470,7 @@ pub async fn update_merkle_tree(
         data: instruction_data.data(),
     };
     let payer = context.payer.insecure_clone();
-    create_and_send_transaction_with_event::<ChangelogEvent>(
+    create_and_send_transaction_with_event::<MerkleTreeEvent>(
         context,
         &[update_ix],
         &context.payer.pubkey(),

--- a/xtask/src/type_sizes.rs
+++ b/xtask/src/type_sizes.rs
@@ -11,9 +11,11 @@ use account_compression::{
     },
     AddressMerkleTreeAccount, AddressQueueAccount, StateMerkleTreeAccount,
 };
-use light_concurrent_merkle_tree::{changelog::ChangelogEntry26, ConcurrentMerkleTree26};
+use light_concurrent_merkle_tree::{
+    changelog::ChangelogEntry26, event::RawIndexedElement, ConcurrentMerkleTree26,
+};
 use light_hasher::Poseidon;
-use light_indexed_merkle_tree::{IndexedMerkleTree26, RawIndexedElement};
+use light_indexed_merkle_tree::IndexedMerkleTree26;
 use tabled::{Table, Tabled};
 
 #[derive(Tabled)]


### PR DESCRIPTION
Issue:
- previous address event was not emitting enough data
- previous nullify event was emitting unnecessary data
- unfortunately unifying both events into one failed

Changes:
- rename ``ChangelogEvent`` -> ``MerkleTreeEvent``
- refactor ``MerkleTreeEvent::V2`` -> ``NullifierEvent``
- add ``MerkleTreeEvent::V3`` -> ``IndexedMerkleTreeEvent``