### PR TITLE
refactor: ci deny warnings

### DIFF
--- a/.github/workflows/light-system-programs-tests.yml
+++ b/.github/workflows/light-system-programs-tests.yml
@@ -39,31 +39,31 @@ jobs:
         include:
           - program: account-compression
             sub-tests: '[
-              "cargo-test-sbf -p account-compression-test -- --test-threads=1"
+              "RUSTFLAGS="-D warnings" cargo-test-sbf -p account-compression-test -- --test-threads=1"
             ]'
           - program: light-system-program
             sub-tests: '[
-              "cargo-test-sbf -p system-test -- --test-threads=1"
+              "RUSTFLAGS="-D warnings" cargo-test-sbf -p system-test -- --test-threads=1"
             ]'
           - program: light-registry
             sub-tests: '[
-              "cargo-test-sbf -p registry-test -- --test-threads=1"
+              "RUSTFLAGS="-D warnings" cargo-test-sbf -p registry-test -- --test-threads=1"
             ]'
           - program: light-compressed-token
             sub-tests: '[
-              "cargo-test-sbf -p compressed-token-test -- --test-threads=1"
+              "RUSTFLAGS="-D warnings" cargo-test-sbf -p compressed-token-test -- --test-threads=1"
             ]'
           - program: token-escrow
             sub-tests: '[
-              "cargo-test-sbf -p token-escrow -- --test-threads=1"
+              "RUSTFLAGS="-D warnings" cargo-test-sbf -p token-escrow -- --test-threads=1"
             ]'
           - program: program-owned-account-test
             sub-tests: '[
-              "cargo-test-sbf -p program-owned-account-test -- --test-threads=1"
+              "RUSTFLAGS="-D warnings" cargo-test-sbf -p program-owned-account-test -- --test-threads=1"
             ]'
           - program: random-e2e-test
             sub-tests: '[
-              "cargo-test-sbf -p e2e-test -- --nocapture"
+              "RUSTFLAGS="-D warnings" cargo-test-sbf -p e2e-test -- --nocapture"
             ]'
 
     steps:
@@ -87,5 +87,5 @@ jobs:
           for subtest in "${sub_tests[@]}"
           do
             echo "$subtest"
-            RUSTFLAGS="-D warnings" "$subtest"
+            eval "$subtest"
           done

--- a/.github/workflows/light-system-programs-tests.yml
+++ b/.github/workflows/light-system-programs-tests.yml
@@ -87,5 +87,5 @@ jobs:
           for subtest in "${sub_tests[@]}"
           do
             echo "$subtest"
-            eval "$subtest"
+            RUSTFLAGS="-D warnings" "$subtest"
           done

--- a/.github/workflows/light-system-programs-tests.yml
+++ b/.github/workflows/light-system-programs-tests.yml
@@ -39,31 +39,31 @@ jobs:
         include:
           - program: account-compression
             sub-tests: '[
-              "RUSTFLAGS="-D warnings" cargo-test-sbf -p account-compression-test -- --test-threads=1"
+              "cargo-test-sbf -p account-compression-test -- --test-threads=1"
             ]'
           - program: light-system-program
             sub-tests: '[
-              "RUSTFLAGS="-D warnings" cargo-test-sbf -p system-test -- --test-threads=1"
+              "cargo-test-sbf -p system-test -- --test-threads=1"
             ]'
           - program: light-registry
             sub-tests: '[
-              "RUSTFLAGS="-D warnings" cargo-test-sbf -p registry-test -- --test-threads=1"
+              "cargo-test-sbf -p registry-test -- --test-threads=1"
             ]'
           - program: light-compressed-token
             sub-tests: '[
-              "RUSTFLAGS="-D warnings" cargo-test-sbf -p compressed-token-test -- --test-threads=1"
+              "cargo-test-sbf -p compressed-token-test -- --test-threads=1"
             ]'
           - program: token-escrow
             sub-tests: '[
-              "RUSTFLAGS="-D warnings" cargo-test-sbf -p token-escrow -- --test-threads=1"
+              "cargo-test-sbf -p token-escrow -- --test-threads=1"
             ]'
           - program: program-owned-account-test
             sub-tests: '[
-              "RUSTFLAGS="-D warnings" cargo-test-sbf -p program-owned-account-test -- --test-threads=1"
+              "cargo-test-sbf -p program-owned-account-test -- --test-threads=1"
             ]'
           - program: random-e2e-test
             sub-tests: '[
-              "RUSTFLAGS="-D warnings" cargo-test-sbf -p e2e-test -- --nocapture"
+              "cargo-test-sbf -p e2e-test -- --nocapture"
             ]'
 
     steps:
@@ -87,5 +87,5 @@ jobs:
           for subtest in "${sub_tests[@]}"
           do
             echo "$subtest"
-            eval "$subtest"
+            eval "RUSTFLAGS=\"-D warnings\" $subtest"
           done

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,7 @@ on:
       - "**/*.rs"
       - "**/Cargo.*"
       - "gnark-prover/**"
+      - ".github/workflows/rust.yml"
   pull_request:
     branches:
       - main
@@ -13,6 +14,7 @@ on:
       - "**/*.rs"
       - "**/Cargo.*"
       - "gnark-prover/**"
+      - ".github/workflows/rust.yml"
 
     types:
       - opened
@@ -44,19 +46,8 @@ jobs:
         run: |
           source ./scripts/devenv.sh
           echo "Rust version: $(rustc --version)"
-          cargo build --workspace --all-targets
-
-      - name: Build @lightprotocol/programs
-        run: |
-          source ./scripts/devenv.sh
-          npx nx build @lightprotocol/programs
-
-      - name: Build CLI
-        run: |
-          source ./scripts/devenv.sh
-          npx nx build @lightprotocol/zk-compression-cli
 
       - name: Test workspace
         run:  |
           source ./scripts/devenv.sh
-          RUST_MIN_STACK=8388608 cargo test --workspace --all-targets
+          RUST_MIN_STACK=8388608 RUSTFLAGS="-D warnings" cargo test --workspace --all-targets


### PR DESCRIPTION
Issue:
- warnings in tests are dangerous and should not exist

Changes:
- add -D warnings rust flag for rust and program ci workflows
- removed unnecessary build in rust ci workflow