### PR TITLE
feat: combined proofs and validityProof refactor in rpc-interface

### DIFF
--- a/js/stateless.js/src/actions/create-account.ts
+++ b/js/stateless.js/src/actions/create-account.ts
@@ -127,12 +127,10 @@ export async function createAccountWithLamports(
         payer.publicKey,
     );
 
-    console.log('ca1: ', compressedAccounts);
     const [inputAccounts] = selectMinCompressedSolAccountsForTransfer(
         compressedAccounts,
         lamports,
     );
-    console.log('ca2: ', inputAccounts);
 
     const { blockhash } = await rpc.getLatestBlockhash();
 

--- a/js/stateless.js/src/actions/create-account.ts
+++ b/js/stateless.js/src/actions/create-account.ts
@@ -5,8 +5,10 @@ import {
     Signer,
     TransactionSignature,
 } from '@solana/web3.js';
-
-import { LightSystemProgram } from '../programs';
+import {
+    LightSystemProgram,
+    selectMinCompressedSolAccountsForTransfer,
+} from '../programs';
 import { Rpc } from '../rpc';
 import {
     NewAddressParams,
@@ -14,28 +16,29 @@ import {
     deriveAddress,
     sendAndConfirmTx,
 } from '../utils';
-import { BN } from '@coral-xyz/anchor';
 import { defaultTestStateTreeAccounts } from '../constants';
-import { TestRpc } from '../test-helpers';
 import { bn } from '../state';
+import { BN } from '@coral-xyz/anchor';
 
 /**
- * Compress lamports to a solana address
+ * Create compressed account with address
  *
- * @param rpc             RPC to use
- * @param payer           Payer of the transaction and initialization fees
- * @param seed            Seed to derive the new account address
- * @param programId       Owner of the new account
- * @param addressTree     Optional address tree. Defaults to a current shared address tree.
- * @param addressQueue    Optional address queue. Defaults to a current shared address queue.
- * @param outputStateTree Optional output state tree. Defaults to a current shared state tree.
- * @param confirmOptions  Options for confirming the transaction
+ * @param rpc               RPC to use
+ * @param payer             Payer of the transaction and initialization fees
+ * @param seed              Seed to derive the new account address
+ * @param programId         Owner of the new account
+ * @param addressTree       Optional address tree. Defaults to a current shared
+ *                          address tree.
+ * @param addressQueue      Optional address queue. Defaults to a current shared
+ *                          address queue.
+ * @param outputStateTree   Optional output state tree. Defaults to a current
+ *                          shared state tree.
+ * @param confirmOptions    Options for confirming the transaction
  *
- * @return Transaction signature
+ * @return                  Transaction signature
  */
-/// TODO: test-rpc -> rpc
 export async function createAccount(
-    rpc: TestRpc,
+    rpc: Rpc,
     payer: Signer,
     seed: Uint8Array,
     programId: PublicKey,
@@ -53,7 +56,9 @@ export async function createAccount(
     const address = await deriveAddress(seed, addressTree);
 
     /// TODO: pass trees
-    const proof = await rpc.getNewAddressValidityProof(address);
+    const proof = await rpc.getValidityProof(undefined, [
+        bn(address.toBytes()),
+    ]);
 
     const params: NewAddressParams = {
         seed: seed,
@@ -67,6 +72,98 @@ export async function createAccount(
         newAddressParams: params,
         newAddress: Array.from(address.toBytes()),
         recentValidityProof: proof.compressedProof,
+        programId,
+        outputStateTree: outputStateTree
+            ? outputStateTree
+            : defaultTestStateTreeAccounts().merkleTree, // TODO: should fetch the current shared state tree
+    });
+
+    const tx = buildAndSignTx(
+        [ComputeBudgetProgram.setComputeUnitLimit({ units: 1_000_000 }), ix],
+        payer,
+        blockhash,
+        [],
+    );
+
+    const txId = await sendAndConfirmTx(rpc, tx, confirmOptions);
+
+    return txId;
+}
+
+/**
+ * Create compressed account with address and lamports
+ *
+ * @param rpc               RPC to use
+ * @param payer             Payer of the transaction and initialization fees
+ * @param seed              Seed to derive the new account address
+ * @param lamports          Number of compressed lamports to initialize the
+ *                          account with
+ * @param programId         Owner of the new account
+ * @param addressTree       Optional address tree. Defaults to a current shared
+ *                          address tree.
+ * @param addressQueue      Optional address queue. Defaults to a current shared
+ *                          address queue.
+ * @param outputStateTree   Optional output state tree. Defaults to a current
+ *                          shared state tree.
+ * @param confirmOptions    Options for confirming the transaction
+ *
+ * @return                  Transaction signature
+ */
+// TODO: add support for payer != user owner
+export async function createAccountWithLamports(
+    rpc: Rpc,
+    payer: Signer,
+    seed: Uint8Array,
+    lamports: number | BN,
+    programId: PublicKey,
+    addressTree?: PublicKey,
+    addressQueue?: PublicKey,
+    outputStateTree?: PublicKey,
+    confirmOptions?: ConfirmOptions,
+): Promise<TransactionSignature> {
+    lamports = bn(lamports);
+
+    const compressedAccounts = await rpc.getCompressedAccountsByOwner(
+        payer.publicKey,
+    );
+
+    console.log('ca1: ', compressedAccounts);
+    const [inputAccounts] = selectMinCompressedSolAccountsForTransfer(
+        compressedAccounts,
+        lamports,
+    );
+    console.log('ca2: ', inputAccounts);
+
+    const { blockhash } = await rpc.getLatestBlockhash();
+
+    addressTree = addressTree ?? defaultTestStateTreeAccounts().addressTree;
+    addressQueue = addressQueue ?? defaultTestStateTreeAccounts().addressQueue;
+
+    /// TODO: enforce program-derived
+    const address = await deriveAddress(seed, addressTree);
+
+    const proof = await rpc.getValidityProof(
+        inputAccounts.map(account => bn(account.hash)),
+        [bn(address.toBytes())],
+    );
+
+    const params: NewAddressParams = {
+        seed: seed,
+        addressMerkleTreeRootIndex:
+            proof.rootIndices[proof.rootIndices.length - 1], // TODO: confirm
+        addressMerkleTreePubkey:
+            proof.merkleTrees[proof.merkleTrees.length - 1],
+        addressQueuePubkey:
+            proof.nullifierQueues[proof.nullifierQueues.length - 1],
+    };
+
+    const ix = await LightSystemProgram.createAccount({
+        payer: payer.publicKey,
+        newAddressParams: params,
+        newAddress: Array.from(address.toBytes()),
+        recentValidityProof: proof.compressedProof,
+        inputCompressedAccounts: inputAccounts,
+        inputStateRootIndices: proof.rootIndices,
         programId,
         outputStateTree: outputStateTree
             ? outputStateTree

--- a/js/stateless.js/src/actions/create-account.ts
+++ b/js/stateless.js/src/actions/create-account.ts
@@ -145,10 +145,13 @@ export async function createAccountWithLamports(
         [bn(address.toBytes())],
     );
 
+    /// TODO: Adapt before supporting addresses in rpc / cranked address trees.
+    /// Currently expects address roots to be consistent with one another and
+    /// static. See test-rpc.ts for more details.
     const params: NewAddressParams = {
         seed: seed,
         addressMerkleTreeRootIndex:
-            proof.rootIndices[proof.rootIndices.length - 1], // TODO: confirm
+            proof.rootIndices[proof.rootIndices.length - 1],
         addressMerkleTreePubkey:
             proof.merkleTrees[proof.merkleTrees.length - 1],
         addressQueuePubkey:

--- a/js/stateless.js/src/actions/create-account.ts
+++ b/js/stateless.js/src/actions/create-account.ts
@@ -145,7 +145,7 @@ export async function createAccountWithLamports(
         [bn(address.toBytes())],
     );
 
-    /// TODO: Adapt before supporting addresses in rpc / cranked address trees.
+    /// TODO(crank): Adapt before supporting addresses in rpc / cranked address trees.
     /// Currently expects address roots to be consistent with one another and
     /// static. See test-rpc.ts for more details.
     const params: NewAddressParams = {

--- a/js/stateless.js/src/actions/transfer.ts
+++ b/js/stateless.js/src/actions/transfer.ts
@@ -48,7 +48,7 @@ export async function transfer(
     );
 
     const [inputAccounts] = selectMinCompressedSolAccountsForTransfer(
-        compressedAccounts, 
+        compressedAccounts,
         lamports,
     );
 

--- a/js/stateless.js/src/actions/transfer.ts
+++ b/js/stateless.js/src/actions/transfer.ts
@@ -48,7 +48,7 @@ export async function transfer(
     );
 
     const [inputAccounts] = selectMinCompressedSolAccountsForTransfer(
-        compressedAccounts,
+        compressedAccounts, 
         lamports,
     );
 

--- a/js/stateless.js/src/constants.ts
+++ b/js/stateless.js/src/constants.ts
@@ -96,13 +96,12 @@ export const STATE_MERKLE_TREE_ROLLOVER_FEE = new BN(181);
  */
 export const ADDRESS_QUEUE_ROLLOVER_FEE = new BN(181);
 
+/**
+ * Is charged if the transaction nullifies at least one compressed account.
+ */
 export const STATE_MERKLE_TREE_NETWORK_FEE = new BN(5000);
 
 /**
- * Fee to provide continous funding for the address queue and address Merkle tree.
- * Once the address Merkle tree is at 95% capacity the accumulated fees
- * will be used to fund the next address queue and address tree with the same parameters.
- *
- * Is charged per the transaction creates at least one address.
+ * Is charged if the transaction creates at least one address.
  */
 export const ADDRESS_TREE_NETWORK_FEE = new BN(5000);

--- a/js/stateless.js/src/programs/system.ts
+++ b/js/stateless.js/src/programs/system.ts
@@ -381,8 +381,7 @@ export class LightSystemProgram {
             compressionLamports: null,
             isCompress: false,
         };
-        console.log('rawData: ', rawData);
-        console.log('rawData JSON: ', JSON.stringify(rawData));
+
         /// Encode instruction data
         const ixData = this.program.coder.types.encode(
             'InstructionDataInvoke',

--- a/js/stateless.js/src/rpc-interface.ts
+++ b/js/stateless.js/src/rpc-interface.ts
@@ -413,5 +413,8 @@ export interface CompressionApiInterface {
 
     getIndexerSlot(): Promise<number>;
 
-    getValidityProof(hashes: BN254[]): Promise<CompressedProofWithContext>;
+    getValidityProof(
+        hashes: BN254[],
+        newAddresses: BN254[],
+    ): Promise<CompressedProofWithContext>;
 }

--- a/js/stateless.js/src/rpc.ts
+++ b/js/stateless.js/src/rpc.ts
@@ -862,18 +862,23 @@ export class Rpc extends Connection implements CompressionApiInterface {
     }
 
     /**
-     * Fetch the latest validity proof for compressed accounts specified by an
-     * array of account hashes.
+     * Fetch the latest validity proof for (1) compressed accounts specified by
+     * an array of account hashes. (2) new unique addresses specified by an
+     * array of addresses.
      *
-     * Validity proofs prove the presence of compressed accounts in state trees,
-     * enabling verification without recomputing the merkle proof path, thus
+     * Validity proofs prove the presence of compressed accounts in state trees
+     * and the non-existence of addresses in address trees, respectively. They
+     * enable verification without recomputing the merkle proof path, thus
      * lowering verification and data costs.
      *
-     * @param hashes    Array of BN254 hashes.
-     * @returns         validity proof with context
+     * @param hashes        Array of BN254 hashes.
+     * @param newAddresses  Array of BN254 new addresses.
+     * @returns             validity proof with context
      */
+
     async getValidityProof(
-        hashes: BN254[],
+        hashes: BN254[] = [],
+        newAddresses: BN254[] = [],
     ): Promise<CompressedProofWithContext> {
         /// get merkle proofs
         const merkleProofsWithContext =
@@ -881,6 +886,7 @@ export class Rpc extends Connection implements CompressionApiInterface {
 
         /// to hex
         const inputs: HexInputsForProver[] = [];
+
         for (let i = 0; i < merkleProofsWithContext.length; i++) {
             const input: HexInputsForProver = {
                 root: toHex(merkleProofsWithContext[i].root),

--- a/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
@@ -500,9 +500,9 @@ export class TestRpc extends Connection implements CompressionApiInterface {
         const allAddresses: BN[] = [];
         indexedArray.init();
         const hashes: BN[] = [];
-        // TODO: add support for cranked address tree. The Merkle tree root
-        // doesnt actually advance beyond init() unless we start emptying the
-        // address queue.
+        // TODO(crank): add support for cranked address tree in 'allAddresses'.
+        // The Merkle tree root doesnt actually advance beyond init() unless we
+        // start emptying the address queue.
         for (let i = 0; i < allAddresses.length; i++) {
             indexedArray.append(bn(allAddresses[i]));
         }
@@ -621,7 +621,10 @@ export class TestRpc extends Connection implements CompressionApiInterface {
             validityProof = {
                 compressedProof,
                 roots: newAddressProofs.map(proof => proof.root),
-                rootIndices: newAddressProofs.map(_ => 3), // TODO: make dynamic to account for forester
+                // TODO(crank): make dynamic to enable forester support in
+                // test-rpc.ts. Currently this is a static root because the
+                // address tree doesn't advance.
+                rootIndices: newAddressProofs.map(_ => 3),
                 leafIndices: newAddressProofs.map(
                     proof => proof.leafIndex.toNumber(), // TODO: support >32bit
                 ),
@@ -658,7 +661,10 @@ export class TestRpc extends Connection implements CompressionApiInterface {
                     .concat(newAddressProofs.map(proof => proof.root)),
                 rootIndices: merkleProofsWithContext
                     .map(proof => proof.rootIndex)
-                    .concat(newAddressProofs.map(_ => 3)), // TODO: make dynamic to account for forester
+                    // TODO(crank): make dynamic to enable forester support in
+                    // test-rpc.ts. Currently this is a static root because the
+                    // address tree doesn't advance.
+                    .concat(newAddressProofs.map(_ => 3)),
                 leafIndices: merkleProofsWithContext
                     .map(proof => proof.leafIndex)
                     .concat(

--- a/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
@@ -644,17 +644,12 @@ export class TestRpc extends Connection implements CompressionApiInterface {
             const newAddressInputs =
                 convertNonInclusionMerkleProofInputsToHex(newAddressProofs);
 
-            console.log('inputs', JSON.stringify(inputs));
-            console.log('newAddressInputs', JSON.stringify(newAddressInputs));
-
             const compressedProof = await proverRequest(
                 this.proverEndpoint,
                 'combined',
                 [inputs, newAddressInputs],
                 this.log,
             );
-
-            console.log('compressedProof', JSON.stringify(compressedProof));
 
             validityProof = {
                 compressedProof,
@@ -683,8 +678,6 @@ export class TestRpc extends Connection implements CompressionApiInterface {
                         newAddressProofs.map(proof => proof.nullifierQueue),
                     ),
             };
-
-            console.log('validityProof', JSON.stringify(validityProof));
         } else throw new Error('Invalid input');
 
         return validityProof;
@@ -769,10 +762,4 @@ function convertNonInclusionMerkleProofInputsToHex(
         inputs.push(input);
     }
     return inputs;
-}
-
-//@ts-ignore
-if (import.meta.vitest) {
-    //@ts-ignore
-    const { it, expect, describe } = import.meta.vitest;
 }

--- a/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
@@ -18,7 +18,6 @@ import { toHex } from '../../utils/conversion';
 import {
     CompressedTransaction,
     HexInputsForProver,
-    HexBatchInputsForProver,
     SignatureWithMetadata,
 } from '../../rpc-interface';
 import {
@@ -30,6 +29,7 @@ import {
 import {
     BN254,
     CompressedAccountWithMerkleContext,
+    CompressedProof,
     MerkleContextWithMerkleProof,
     PublicTransactionEvent,
     bn,
@@ -37,16 +37,78 @@ import {
 import { proofFromJsonStruct, negateAndCompressProof } from '../../utils';
 import { IndexedArray } from '../merkle-tree';
 
+/** @internal */
+export const proverRequest = async (
+    proverEndpoint: string,
+    method: 'inclusion' | 'new-address' | 'combined',
+    params: any = [],
+    log = false,
+): Promise<CompressedProof> => {
+    let logMsg: string = '';
+
+    if (log) {
+        logMsg = `Proof generation for method:${method}`;
+        console.time(logMsg);
+    }
+
+    let body;
+    if (method === 'inclusion') {
+        body = JSON.stringify({ 'input-compressed-accounts': params });
+    } else if (method === 'new-address') {
+        body = JSON.stringify({ 'new-addresses': params });
+    } else if (method === 'combined') {
+        body = JSON.stringify({
+            'input-compressed-accounts': params[0],
+            'new-addresses': params[1],
+        });
+    }
+
+    const response = await fetch(`${proverEndpoint}/prove`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: body,
+    });
+
+    if (!response.ok) {
+        throw new Error(`Error fetching proof: ${response.statusText}`);
+    }
+    /// TODO: Move compression into the gnark prover to save bandwidth.
+    const data: any = await response.json();
+    const parsed = proofFromJsonStruct(data);
+    const compressedProof = negateAndCompressProof(parsed);
+
+    if (log) console.timeEnd(logMsg);
+
+    return compressedProof;
+};
+
 export interface TestRpcConfig {
-    /** Address of the state tree to index. Default: public default test state
-     * tree */
+    /**
+     * Address of the state tree to index. Default: public default test state
+     * tree.
+     */
     merkleTreeAddress?: PublicKey;
-    /** Nullifier queue associated with merkleTreeAddress */
+    /**
+     * Nullifier queue associated with merkleTreeAddress
+     */
     nullifierQueueAddress?: PublicKey;
-    /** Depth of state tree. Defaults to the public default test state tree depth */
+    /**
+     * Depth of state tree. Defaults to the public default test state tree depth
+     */
     depth?: number;
-    /** Log proof generation time */
+    /**
+     * Log proof generation time
+     */
     log?: boolean;
+    /**
+     * Address of the address tree to index. Default: public default test
+     * address tree.
+     */
+    addressTreeAddress?: PublicKey;
+    /**
+     * Address queue associated with addressTreeAddress
+     */
+    addressQueueAddress?: PublicKey;
 }
 
 export interface LightWasm {
@@ -112,6 +174,8 @@ export class TestRpc extends Connection implements CompressionApiInterface {
     proverEndpoint: string;
     merkleTreeAddress: PublicKey;
     nullifierQueueAddress: PublicKey;
+    addressTreeAddress: PublicKey;
+    addressQueueAddress: PublicKey;
     lightWasm: LightWasm;
     depth: number;
     log = false;
@@ -140,15 +204,28 @@ export class TestRpc extends Connection implements CompressionApiInterface {
         this.compressionApiEndpoint = compressionApiEndpoint;
         this.proverEndpoint = proverEndpoint;
 
-        const { merkleTreeAddress, nullifierQueueAddress, depth, log } =
-            testRpcConfig ?? {};
+        const {
+            merkleTreeAddress,
+            nullifierQueueAddress,
+            depth,
+            log,
+            addressTreeAddress,
+            addressQueueAddress,
+        } = testRpcConfig ?? {};
 
-        const { merkleTree, nullifierQueue, merkleTreeHeight } =
-            defaultTestStateTreeAccounts();
+        const {
+            merkleTree,
+            nullifierQueue,
+            merkleTreeHeight,
+            addressQueue,
+            addressTree,
+        } = defaultTestStateTreeAccounts();
 
         this.lightWasm = hasher;
         this.merkleTreeAddress = merkleTreeAddress ?? merkleTree;
         this.nullifierQueueAddress = nullifierQueueAddress ?? nullifierQueue;
+        this.addressTreeAddress = addressTreeAddress ?? addressTree;
+        this.addressQueueAddress = addressQueueAddress ?? addressQueue;
         this.depth = depth ?? merkleTreeHeight;
         this.log = log ?? false;
     }
@@ -237,30 +314,22 @@ export class TestRpc extends Connection implements CompressionApiInterface {
             allLeaves.map(leaf => bn(leaf).toString()),
         );
 
-        /// create merkle proofs
-        const leafIndices = hashes.map(hash => tree.indexOf(hash.toString()));
-
-        const bnPathElementsAll = leafIndices.map(leafIndex => {
-            const pathElements: string[] = tree.path(leafIndex).pathElements;
-
-            const bnPathElements = pathElements.map(value => bn(value));
-
-            return bnPathElements;
-        });
-
-        const roots = new Array(hashes.length).fill(bn(tree.root()));
-
-        /// assemble return type
+        /// create merkle proofs and assemble return type
         const merkleProofs: MerkleContextWithMerkleProof[] = [];
+
         for (let i = 0; i < hashes.length; i++) {
+            const leafIndex = tree.indexOf(hashes[i].toString());
+            const pathElements = tree.path(leafIndex).pathElements;
+            const bnPathElements = pathElements.map(value => bn(value));
+            const root = bn(tree.root());
             const merkleProof: MerkleContextWithMerkleProof = {
                 hash: hashes[i].toArray(undefined, 32),
                 merkleTree: this.merkleTreeAddress,
-                leafIndex: leafIndices[i],
-                merkleProof: bnPathElementsAll[i], // hexPathElementsAll[i].map(hex => bn(hex)),
+                leafIndex: leafIndex,
+                merkleProof: bnPathElements,
                 nullifierQueue: this.nullifierQueueAddress,
                 rootIndex: allLeaves.length,
-                root: roots[i],
+                root: root,
             };
             merkleProofs.push(merkleProof);
         }
@@ -268,7 +337,7 @@ export class TestRpc extends Connection implements CompressionApiInterface {
         /// Validate
         merkleProofs.forEach((proof, index) => {
             const leafIndex = proof.leafIndex;
-            const computedHash = tree.elements()[leafIndex]; //.toString();
+            const computedHash = tree.elements()[leafIndex];
             const hashArr = bn(computedHash).toArray(undefined, 32);
             if (!hashArr.every((val, index) => val === proof.hash[index])) {
                 throw new Error(
@@ -425,34 +494,15 @@ export class TestRpc extends Connection implements CompressionApiInterface {
         return 1;
     }
 
-    async getNewAddressValidityProof(address: PublicKey) {
-        const treePublicKey = defaultTestStateTreeAccounts().addressTree;
-        const queuePublicKey = defaultTestStateTreeAccounts().addressQueue;
-
-        // TODO: The Merkle tree root doesnt actually advance at all unless we
-        // start emptying the address queue.
-        const allAddresses: number[][] = [];
-        // indexedArray const events: PublicTransactionEvent[] = await
-        // getParsedEvents( this, ).then(events => events.reverse());
-        // for (const event of events) {
-        //     for (
-        //         let index = 0;
-        //         index < event.outputCompressedAccounts.length;
-        //         index++
-        //     ) {
-        //         const address =
-        //             event.outputCompressedAccounts[index].compressedAccount
-        //                 .address;
-        //         if (address) {
-        //             allAddresses.push(address);
-        //         }
-        //     }
-        // }
-
+    async getMultipleNewAddressProofs(addresses: BN254[]) {
+        /// Build tree
         const indexedArray = IndexedArray.default();
+        const allAddresses: BN[] = [];
         indexedArray.init();
         const hashes: BN[] = [];
-
+        // TODO: add support for cranked address tree. The Merkle tree root
+        // doesnt actually advance beyond init() unless we start emptying the
+        // address queue.
         for (let i = 0; i < allAddresses.length; i++) {
             indexedArray.append(bn(allAddresses[i]));
         }
@@ -466,188 +516,180 @@ export class TestRpc extends Connection implements CompressionApiInterface {
             hashes.map(hash => bn(hash).toString()),
         );
 
-        /// Creates merkle proof
-        const [lowElement] = indexedArray.findLowElement(bn(address.toBytes()));
-        if (!lowElement) {
-            throw new Error('Address not found');
-        }
-        const leafIndex = lowElement.index;
+        /// Creates proof for each address
+        const newAddressProofs: MerkleContextWithNewAddressProof[] = [];
 
-        const bnPathElementsAll = [leafIndex].map(leafIndex => {
+        for (let i = 0; i < addresses.length; i++) {
+            const [lowElement] = indexedArray.findLowElement(addresses[i]);
+            if (!lowElement) throw new Error('Address not found');
+
+            const leafIndex = lowElement.index;
+
             const pathElements: string[] = tree.path(leafIndex).pathElements;
-
             const bnPathElements = pathElements.map(value => bn(value));
 
-            return bnPathElements;
-        });
+            const higherRangeValue = indexedArray.get(
+                lowElement.nextIndex,
+            )!.value;
+            const root = bn(tree.root());
 
-        const higherRangeValue = indexedArray.get(lowElement.nextIndex)!.value;
-
-        const nonInclusionMerkleProofInputs: NonInclusionMerkleProofInputs = {
-            root: bn(tree.root()),
-            value: bn(bn(address.toBytes()).toArray('be', 32)),
-            leaf_lower_range_value: lowElement.value,
-            leaf_higher_range_value: higherRangeValue,
-            leaf_index: bn(lowElement.nextIndex),
-            merkle_proof_hashed_indexed_element_leaf: bnPathElementsAll[0],
-            index_hashed_indexed_element_leaf: bn(lowElement.index), // ??
-        };
-
-        /// from_non_inclusion_proof_inputs
-        const nonInclusionJsonStruct: NonInclusionJsonStruct = {
-            root: toHex(nonInclusionMerkleProofInputs.root),
-            value: toHex(nonInclusionMerkleProofInputs.value),
-            pathIndex:
-                nonInclusionMerkleProofInputs.index_hashed_indexed_element_leaf.toNumber(),
-            pathElements:
-                nonInclusionMerkleProofInputs.merkle_proof_hashed_indexed_element_leaf.map(
-                    hex => toHex(hex),
-                ),
-            leafIndex: nonInclusionMerkleProofInputs.leaf_index.toNumber(),
-            leafLowerRangeValue: toHex(
-                nonInclusionMerkleProofInputs.leaf_lower_range_value,
-            ),
-            leafHigherRangeValue: toHex(
-                nonInclusionMerkleProofInputs.leaf_higher_range_value,
-            ),
-        };
-        const batch = {
-            'new-addresses': [nonInclusionJsonStruct],
-        };
-
-        /// The starting root is 3. New addresses arent directly inserted into
-        /// the address tree, so unless the address queue gets emptied, the root
-        /// will always be 3.
-        /// TODO: make dynamic to account for forester.
-        const addressRootIndices = [3];
-
-        // req
-        const inputsData = JSON.stringify(batch);
-
-        let logMsg: string = '';
-        if (this.log) {
-            logMsg = `Proof generation for depth:${this.depth} n:${hashes.length}`;
-            console.time(logMsg);
+            const proof: MerkleContextWithNewAddressProof = {
+                root,
+                value: addresses[i],
+                leafLowerRangeValue: lowElement.value,
+                leafHigherRangeValue: higherRangeValue,
+                leafIndex: bn(lowElement.nextIndex),
+                merkleProofHashedIndexedElementLeaf: bnPathElements,
+                indexHashedIndexedElementLeaf: bn(lowElement.index),
+                merkleTree: this.addressTreeAddress,
+                nullifierQueue: this.addressQueueAddress,
+            };
+            newAddressProofs.push(proof);
         }
-
-        const PROOF_URL = `${this.proverEndpoint}/prove`;
-        const response = await fetch(PROOF_URL, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: inputsData,
-        });
-        if (!response.ok) {
-            throw new Error(`Error fetching proof: ${response.statusText}`);
-        }
-
-        // TOOD: add type coercion
-        const data: any = await response.json();
-        const parsed = proofFromJsonStruct(data);
-        const compressedProof = negateAndCompressProof(parsed);
-
-        if (this.log) console.timeEnd(logMsg);
-
-        const value: CompressedProofWithContext = {
-            compressedProof,
-            roots: [bn(tree.root())],
-            rootIndices: addressRootIndices,
-            leafIndices: [leafIndex],
-            leaves: [bn(address.toBytes())],
-            merkleTrees: [treePublicKey],
-            nullifierQueues: [queuePublicKey],
-        };
-
-        return value;
+        return newAddressProofs;
     }
 
     /**
-     * Fetch the latest validity proof for compressed accounts specified by an
-     * array of account hashes.
+     * Fetch the latest validity proof for (1) compressed accounts specified by
+     * an array of account hashes. (2) new unique addresses specified by an
+     * array of addresses.
      *
-     * Validity proofs prove the presence of compressed accounts in state trees,
-     * enabling verification without recomputing the merkle proof path, thus
+     * Validity proofs prove the presence of compressed accounts in state trees
+     * and the non-existence of addresses in address trees, respectively. They
+     * enable verification without recomputing the merkle proof path, thus
      * lowering verification and data costs.
      *
-     * @param hashes    Array of BN254 hashes.
-     * @returns         validity proof with context
+     * @param hashes        Array of BN254 hashes.
+     * @param newAddresses  Array of BN254 new addresses.
+     * @returns             validity proof with context
      */
     async getValidityProof(
-        hashes: BN254[],
+        hashes: BN254[] = [],
+        newAddresses: BN254[] = [],
     ): Promise<CompressedProofWithContext> {
-        const merkleProofsWithContext =
-            await this.getMultipleCompressedAccountProofs(hashes);
+        let validityProof: CompressedProofWithContext;
 
-        const inputs: HexInputsForProver[] = [];
-        for (let i = 0; i < merkleProofsWithContext.length; i++) {
-            const input: HexInputsForProver = {
-                root: toHex(merkleProofsWithContext[i].root),
-                pathIndex: merkleProofsWithContext[i].leafIndex,
-                pathElements: merkleProofsWithContext[i].merkleProof.map(hex =>
-                    toHex(hex),
+        if (hashes.length === 0 && newAddresses.length === 0) {
+            throw new Error(
+                'Empty input. Provide hashes and/or new addresses.',
+            );
+        } else if (hashes.length > 0 && newAddresses.length === 0) {
+            /// inclusion
+            const merkleProofsWithContext =
+                await this.getMultipleCompressedAccountProofs(hashes);
+            const inputs = convertMerkleProofsWithContextToHex(
+                merkleProofsWithContext,
+            );
+            const compressedProof = await proverRequest(
+                this.proverEndpoint,
+                'inclusion',
+                inputs,
+                this.log,
+            );
+            validityProof = {
+                compressedProof,
+                roots: merkleProofsWithContext.map(proof => proof.root),
+                rootIndices: merkleProofsWithContext.map(
+                    proof => proof.rootIndex,
                 ),
-                leaf: toHex(bn(merkleProofsWithContext[i].hash)),
+                leafIndices: merkleProofsWithContext.map(
+                    proof => proof.leafIndex,
+                ),
+                leaves: merkleProofsWithContext.map(proof => bn(proof.hash)),
+                merkleTrees: merkleProofsWithContext.map(
+                    proof => proof.merkleTree,
+                ),
+                nullifierQueues: merkleProofsWithContext.map(
+                    proof => proof.nullifierQueue,
+                ),
             };
-            inputs.push(input);
-        }
+        } else if (hashes.length === 0 && newAddresses.length > 0) {
+            /// new-address
+            const newAddressProofs: MerkleContextWithNewAddressProof[] =
+                await this.getMultipleNewAddressProofs(newAddresses);
 
-        const batchInputs: HexBatchInputsForProver = {
-            'input-compressed-accounts': inputs,
-        };
+            const inputs =
+                convertNonInclusionMerkleProofInputsToHex(newAddressProofs);
 
-        const inputsData = JSON.stringify(batchInputs);
+            const compressedProof = await proverRequest(
+                this.proverEndpoint,
+                'new-address',
+                inputs,
+                this.log,
+            );
 
-        let logMsg: string = '';
-        if (this.log) {
-            logMsg = `Proof generation for depth:${this.depth} n:${hashes.length}`;
-            console.time(logMsg);
-        }
+            validityProof = {
+                compressedProof,
+                roots: newAddressProofs.map(proof => proof.root),
+                rootIndices: newAddressProofs.map(_ => 3), // TODO: make dynamic to account for forester
+                leafIndices: newAddressProofs.map(
+                    proof => proof.leafIndex.toNumber(), // TODO: support >32bit
+                ),
+                leaves: newAddressProofs.map(proof => bn(proof.value)),
+                merkleTrees: newAddressProofs.map(proof => proof.merkleTree),
+                nullifierQueues: newAddressProofs.map(
+                    proof => proof.nullifierQueue,
+                ),
+            };
+        } else if (hashes.length > 0 && newAddresses.length > 0) {
+            /// combined
+            const merkleProofsWithContext =
+                await this.getMultipleCompressedAccountProofs(hashes);
+            const inputs = convertMerkleProofsWithContextToHex(
+                merkleProofsWithContext,
+            );
+            const newAddressProofs: MerkleContextWithNewAddressProof[] =
+                await this.getMultipleNewAddressProofs(newAddresses);
 
-        const PROOF_URL = `${this.proverEndpoint}/prove`;
-        const response = await fetch(PROOF_URL, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: inputsData,
-        });
-        if (!response.ok) {
-            throw new Error(`Error fetching proof: ${response.statusText}`);
-        }
+            const newAddressInputs =
+                convertNonInclusionMerkleProofInputsToHex(newAddressProofs);
 
-        // TOOD: add type coercion
-        const data: any = await response.json();
-        const parsed = proofFromJsonStruct(data);
-        const compressedProof = negateAndCompressProof(parsed);
+            console.log('inputs', JSON.stringify(inputs));
+            console.log('newAddressInputs', JSON.stringify(newAddressInputs));
 
-        if (this.log) console.timeEnd(logMsg);
+            const compressedProof = await proverRequest(
+                this.proverEndpoint,
+                'combined',
+                [inputs, newAddressInputs],
+                this.log,
+            );
 
-        const value: CompressedProofWithContext = {
-            compressedProof,
-            roots: merkleProofsWithContext.map(proof => proof.root),
-            rootIndices: merkleProofsWithContext.map(proof => proof.rootIndex),
-            leafIndices: merkleProofsWithContext.map(proof => proof.leafIndex),
-            leaves: merkleProofsWithContext.map(proof => bn(proof.hash)),
-            merkleTrees: merkleProofsWithContext.map(proof => proof.merkleTree),
-            nullifierQueues: merkleProofsWithContext.map(
-                proof => proof.nullifierQueue,
-            ),
-        };
+            console.log('compressedProof', JSON.stringify(compressedProof));
 
-        return value;
+            validityProof = {
+                compressedProof,
+                roots: merkleProofsWithContext
+                    .map(proof => proof.root)
+                    .concat(newAddressProofs.map(proof => proof.root)),
+                rootIndices: merkleProofsWithContext
+                    .map(proof => proof.rootIndex)
+                    .concat(newAddressProofs.map(_ => 3)), // TODO: make dynamic to account for forester
+                leafIndices: merkleProofsWithContext
+                    .map(proof => proof.leafIndex)
+                    .concat(
+                        newAddressProofs.map(
+                            proof => proof.leafIndex.toNumber(), // TODO: support >32bit
+                        ),
+                    ),
+                leaves: merkleProofsWithContext
+                    .map(proof => bn(proof.hash))
+                    .concat(newAddressProofs.map(proof => bn(proof.value))),
+                merkleTrees: merkleProofsWithContext
+                    .map(proof => proof.merkleTree)
+                    .concat(newAddressProofs.map(proof => proof.merkleTree)),
+                nullifierQueues: merkleProofsWithContext
+                    .map(proof => proof.nullifierQueue)
+                    .concat(
+                        newAddressProofs.map(proof => proof.nullifierQueue),
+                    ),
+            };
+
+            console.log('validityProof', JSON.stringify(validityProof));
+        } else throw new Error('Invalid input');
+
+        return validityProof;
     }
 }
-
-// type NonInclusionProof = {
-//      root: string,
-//      value: string,
-//      leaf_lower_range_value: string,
-//      leaf_higher_range_value: string,
-//      leaf_index: usize,
-//      next_index: usize,
-//      merkle_proof: BoundedVec<'a, [u8; 32]>,
-// }
 
 export type NonInclusionMerkleProofInputs = {
     root: BN;
@@ -659,6 +701,18 @@ export type NonInclusionMerkleProofInputs = {
     index_hashed_indexed_element_leaf: BN;
 };
 
+export type MerkleContextWithNewAddressProof = {
+    root: BN;
+    value: BN;
+    leafLowerRangeValue: BN;
+    leafHigherRangeValue: BN;
+    leafIndex: BN;
+    merkleProofHashedIndexedElementLeaf: BN[];
+    indexHashedIndexedElementLeaf: BN;
+    merkleTree: PublicKey;
+    nullifierQueue: PublicKey;
+};
+
 export type NonInclusionJsonStruct = {
     root: string;
     value: string;
@@ -668,3 +722,57 @@ export type NonInclusionJsonStruct = {
     leafHigherRangeValue: string;
     leafIndex: number;
 };
+
+function convertMerkleProofsWithContextToHex(
+    merkleProofsWithContext: MerkleContextWithMerkleProof[],
+): HexInputsForProver[] {
+    const inputs: HexInputsForProver[] = [];
+
+    for (let i = 0; i < merkleProofsWithContext.length; i++) {
+        const input: HexInputsForProver = {
+            root: toHex(merkleProofsWithContext[i].root),
+            pathIndex: merkleProofsWithContext[i].leafIndex,
+            pathElements: merkleProofsWithContext[i].merkleProof.map(hex =>
+                toHex(hex),
+            ),
+            leaf: toHex(bn(merkleProofsWithContext[i].hash)),
+        };
+        inputs.push(input);
+    }
+
+    return inputs;
+}
+
+function convertNonInclusionMerkleProofInputsToHex(
+    nonInclusionMerkleProofInputs: MerkleContextWithNewAddressProof[],
+): NonInclusionJsonStruct[] {
+    const inputs: NonInclusionJsonStruct[] = [];
+    for (let i = 0; i < nonInclusionMerkleProofInputs.length; i++) {
+        const input: NonInclusionJsonStruct = {
+            root: toHex(nonInclusionMerkleProofInputs[i].root),
+            value: toHex(nonInclusionMerkleProofInputs[i].value),
+            pathIndex:
+                nonInclusionMerkleProofInputs[
+                    i
+                ].indexHashedIndexedElementLeaf.toNumber(),
+            pathElements: nonInclusionMerkleProofInputs[
+                i
+            ].merkleProofHashedIndexedElementLeaf.map(hex => toHex(hex)),
+            leafIndex: nonInclusionMerkleProofInputs[i].leafIndex.toNumber(),
+            leafLowerRangeValue: toHex(
+                nonInclusionMerkleProofInputs[i].leafLowerRangeValue,
+            ),
+            leafHigherRangeValue: toHex(
+                nonInclusionMerkleProofInputs[i].leafHigherRangeValue,
+            ),
+        };
+        inputs.push(input);
+    }
+    return inputs;
+}
+
+//@ts-ignore
+if (import.meta.vitest) {
+    //@ts-ignore
+    const { it, expect, describe } = import.meta.vitest;
+}

--- a/js/stateless.js/tests/e2e/compress.test.ts
+++ b/js/stateless.js/tests/e2e/compress.test.ts
@@ -171,7 +171,6 @@ describe('compress', () => {
                 txFees([{ in: 0, out: 1 }]),
         );
 
-        /// create account with lamports
         await createAccountWithLamports(
             rpc as TestRpc,
             payer,
@@ -183,7 +182,6 @@ describe('compress', () => {
             LightSystemProgram.programId,
         );
 
-        /// assert balance after account creation
         const postCreateAccountBalance = await rpc.getBalance(payer.publicKey);
         assert.equal(
             postCreateAccountBalance,

--- a/js/stateless.js/tests/e2e/compress.test.ts
+++ b/js/stateless.js/tests/e2e/compress.test.ts
@@ -2,20 +2,63 @@ import { describe, it, assert, beforeAll, expect } from 'vitest';
 import { Signer } from '@solana/web3.js';
 import {
     STATE_MERKLE_TREE_NETWORK_FEE,
+    ADDRESS_QUEUE_ROLLOVER_FEE,
     STATE_MERKLE_TREE_ROLLOVER_FEE,
     defaultTestStateTreeAccounts,
+    ADDRESS_TREE_NETWORK_FEE,
 } from '../../src/constants';
 import { newAccountWithLamports } from '../../src/utils/test-utils';
 import { Rpc } from '../../src/rpc';
 import {
     LightSystemProgram,
+    bn,
     compress,
     createAccount,
+    createAccountWithLamports,
     decompress,
 } from '../../src';
 import { TestRpc, getTestRpc } from '../../src/test-helpers/test-rpc';
 import { WasmFactory } from '@lightprotocol/hasher.rs';
 
+/// TODO: make available to developers via utils
+function txFees(
+    txs: {
+        in: number;
+        out: number;
+        addr?: number;
+        base?: number;
+    }[],
+): number {
+    let totalFee = bn(0);
+
+    txs.forEach(tx => {
+        const solanaBaseFee = tx.base === 0 ? bn(0) : bn(tx.base || 5000);
+
+        /// Fee per output
+        const stateOutFee = STATE_MERKLE_TREE_ROLLOVER_FEE.mul(bn(tx.out));
+
+        /// Fee per new address created
+        const addrFee = tx.addr
+            ? ADDRESS_QUEUE_ROLLOVER_FEE.mul(bn(tx.addr))
+            : bn(0);
+
+        /// Fee if the tx nullifies at least one input account
+        const networkInFee = tx.in ? STATE_MERKLE_TREE_NETWORK_FEE : bn(0);
+
+        /// Fee if the tx creates at least one address
+        const networkAddressFee = tx.addr ? ADDRESS_TREE_NETWORK_FEE : bn(0);
+
+        totalFee = totalFee.add(
+            solanaBaseFee
+                .add(stateOutFee)
+                .add(addrFee)
+                .add(networkInFee)
+                .add(networkAddressFee),
+        );
+    });
+
+    return totalFee.toNumber();
+}
 /// TODO: add test case for payer != address
 describe('compress', () => {
     const { merkleTree } = defaultTestStateTreeAccounts();
@@ -29,6 +72,8 @@ describe('compress', () => {
     });
 
     it('should create account with address', async () => {
+        const preCreateAccountsBalance = await rpc.getBalance(payer.publicKey);
+
         await createAccount(
             rpc as TestRpc,
             payer,
@@ -36,6 +81,17 @@ describe('compress', () => {
                 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
                 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
             ]),
+            LightSystemProgram.programId,
+        );
+
+        await createAccountWithLamports(
+            rpc as TestRpc,
+            payer,
+            new Uint8Array([
+                1, 2, 255, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+                19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+            ]),
+            0,
             LightSystemProgram.programId,
         );
 
@@ -69,14 +125,24 @@ describe('compress', () => {
                 LightSystemProgram.programId,
             ),
         ).rejects.toThrow();
+        const postCreateAccountsBalance = await rpc.getBalance(payer.publicKey);
+        assert.equal(
+            postCreateAccountsBalance,
+            preCreateAccountsBalance -
+                txFees([
+                    { in: 0, out: 1, addr: 1 },
+                    { in: 0, out: 1, addr: 1 },
+                    { in: 0, out: 1, addr: 1 },
+                    { in: 0, out: 1, addr: 1 },
+                ]),
+        );
     });
 
-    it('should compress lamports and then decompress', async () => {
+    it('should compress lamports and create an account with address and lamports', async () => {
         payer = await newAccountWithLamports(rpc, 1e9, 256);
 
         const compressLamportsAmount = 1e7;
         const preCompressBalance = await rpc.getBalance(payer.publicKey);
-        /// 3 createAccounts costing 5000+332 lamports each (treedepth 26)  - 5332 * 3
         assert.equal(preCompressBalance, 1e9);
 
         await compress(
@@ -102,8 +168,61 @@ describe('compress', () => {
             postCompressBalance,
             preCompressBalance -
                 compressLamportsAmount -
-                5000 -
-                STATE_MERKLE_TREE_ROLLOVER_FEE.toNumber(),
+                txFees([{ in: 0, out: 1 }]),
+        );
+
+        /// create account with lamports
+        await createAccountWithLamports(
+            rpc as TestRpc,
+            payer,
+            new Uint8Array([
+                1, 255, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+                19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+            ]),
+            100,
+            LightSystemProgram.programId,
+        );
+
+        /// assert balance after account creation
+        const postCreateAccountBalance = await rpc.getBalance(payer.publicKey);
+        assert.equal(
+            postCreateAccountBalance,
+            postCompressBalance - txFees([{ in: 1, out: 2, addr: 1 }]),
+        );
+    });
+
+    it('should compress lamports and then decompress', async () => {
+        payer = await newAccountWithLamports(rpc, 1e9, 256);
+
+        const compressLamportsAmount = 1e7;
+        const preCompressBalance = await rpc.getBalance(payer.publicKey);
+
+        assert.equal(preCompressBalance, 1e9);
+
+        await compress(
+            rpc,
+            payer,
+            compressLamportsAmount,
+            payer.publicKey,
+            merkleTree,
+        );
+
+        const compressedAccounts = await rpc.getCompressedAccountsByOwner(
+            payer.publicKey,
+        );
+        assert.equal(compressedAccounts.length, 1);
+        assert.equal(
+            Number(compressedAccounts[0].lamports),
+            compressLamportsAmount,
+        );
+
+        assert.equal(compressedAccounts[0].data, null);
+        const postCompressBalance = await rpc.getBalance(payer.publicKey);
+        assert.equal(
+            postCompressBalance,
+            preCompressBalance -
+                compressLamportsAmount -
+                txFees([{ in: 0, out: 1 }]),
         );
 
         /// Decompress
@@ -131,9 +250,7 @@ describe('compress', () => {
             postDecompressBalance,
             postCompressBalance +
                 decompressLamportsAmount -
-                5000 -
-                STATE_MERKLE_TREE_ROLLOVER_FEE.toNumber() -
-                STATE_MERKLE_TREE_NETWORK_FEE.toNumber(),
+                txFees([{ in: 1, out: 1 }]),
         );
     });
 });

--- a/programs/account-compression/src/instructions/insert_address.rs
+++ b/programs/account-compression/src/instructions/insert_address.rs
@@ -109,7 +109,6 @@ pub fn process_insert_addresses<'a, 'b, 'c: 'info, 'info>(
                 unsafe { address_queue_from_bytes_zero_copy_mut(&mut address_queue)? };
 
             for address in queue_bundle.elements.iter() {
-                msg!("Inserting address {:?}", address);
                 let address = BigUint::from_bytes_be(address.as_slice());
                 address_queue
                     .insert(&address, sequence_number)


### PR DESCRIPTION
* refactors test-rpc
* combined proofs as part of getValidityProof with unified interface
* added test coverage for account creation with compressed lamports (using combined proofs)
* removes an address print on-chain
