### PR TITLE
feat: public transaction event add seq

### DIFF
--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -628,7 +628,7 @@ export type LightCompressedToken = {
                         type: 'publicKey';
                     },
                     {
-                        name: 'sequenceNumber';
+                        name: 'seq';
                         type: 'u64';
                     },
                 ];
@@ -1646,7 +1646,7 @@ export const IDL: LightCompressedToken = {
                         type: 'publicKey',
                     },
                     {
-                        name: 'sequenceNumber',
+                        name: 'seq',
                         type: 'u64',
                     },
                 ],

--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -619,6 +619,22 @@ export type LightCompressedToken = {
             };
         },
         {
+            name: 'MerkleTreeSequenceNumber';
+            type: {
+                kind: 'struct';
+                fields: [
+                    {
+                        name: 'pubkey';
+                        type: 'publicKey';
+                    },
+                    {
+                        name: 'sequenceNumber';
+                        type: 'u64';
+                    },
+                ];
+            };
+        },
+        {
             name: 'PublicTransactionEvent';
             type: {
                 kind: 'struct';
@@ -651,6 +667,14 @@ export type LightCompressedToken = {
                         name: 'outputLeafIndices';
                         type: {
                             vec: 'u32';
+                        };
+                    },
+                    {
+                        name: 'sequenceNumbers';
+                        type: {
+                            vec: {
+                                defined: 'MerkleTreeSequenceNumber';
+                            };
                         };
                     },
                     {
@@ -1613,6 +1637,22 @@ export const IDL: LightCompressedToken = {
             },
         },
         {
+            name: 'MerkleTreeSequenceNumber',
+            type: {
+                kind: 'struct',
+                fields: [
+                    {
+                        name: 'pubkey',
+                        type: 'publicKey',
+                    },
+                    {
+                        name: 'sequenceNumber',
+                        type: 'u64',
+                    },
+                ],
+            },
+        },
+        {
             name: 'PublicTransactionEvent',
             type: {
                 kind: 'struct',
@@ -1646,6 +1686,14 @@ export const IDL: LightCompressedToken = {
                         name: 'outputLeafIndices',
                         type: {
                             vec: 'u32',
+                        },
+                    },
+                    {
+                        name: 'sequenceNumbers',
+                        type: {
+                            vec: {
+                                defined: 'MerkleTreeSequenceNumber',
+                            },
                         },
                     },
                     {

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -628,7 +628,7 @@ export type LightCompressedToken = {
                         type: 'publicKey';
                     },
                     {
-                        name: 'sequenceNumber';
+                        name: 'seq';
                         type: 'u64';
                     },
                 ];
@@ -1646,7 +1646,7 @@ export const IDL: LightCompressedToken = {
                         type: 'publicKey',
                     },
                     {
-                        name: 'sequenceNumber',
+                        name: 'seq',
                         type: 'u64',
                     },
                 ],

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -619,6 +619,22 @@ export type LightCompressedToken = {
             };
         },
         {
+            name: 'MerkleTreeSequenceNumber';
+            type: {
+                kind: 'struct';
+                fields: [
+                    {
+                        name: 'pubkey';
+                        type: 'publicKey';
+                    },
+                    {
+                        name: 'sequenceNumber';
+                        type: 'u64';
+                    },
+                ];
+            };
+        },
+        {
             name: 'PublicTransactionEvent';
             type: {
                 kind: 'struct';
@@ -651,6 +667,14 @@ export type LightCompressedToken = {
                         name: 'outputLeafIndices';
                         type: {
                             vec: 'u32';
+                        };
+                    },
+                    {
+                        name: 'sequenceNumbers';
+                        type: {
+                            vec: {
+                                defined: 'MerkleTreeSequenceNumber';
+                            };
                         };
                     },
                     {
@@ -1613,6 +1637,22 @@ export const IDL: LightCompressedToken = {
             },
         },
         {
+            name: 'MerkleTreeSequenceNumber',
+            type: {
+                kind: 'struct',
+                fields: [
+                    {
+                        name: 'pubkey',
+                        type: 'publicKey',
+                    },
+                    {
+                        name: 'sequenceNumber',
+                        type: 'u64',
+                    },
+                ],
+            },
+        },
+        {
             name: 'PublicTransactionEvent',
             type: {
                 kind: 'struct',
@@ -1646,6 +1686,14 @@ export const IDL: LightCompressedToken = {
                         name: 'outputLeafIndices',
                         type: {
                             vec: 'u32',
+                        },
+                    },
+                    {
+                        name: 'sequenceNumbers',
+                        type: {
+                            vec: {
+                                defined: 'MerkleTreeSequenceNumber',
+                            },
                         },
                     },
                     {

--- a/js/stateless.js/src/idls/light_system_program.ts
+++ b/js/stateless.js/src/idls/light_system_program.ts
@@ -581,6 +581,22 @@ export type LightSystemProgram = {
             };
         },
         {
+            name: 'MerkleTreeSequenceNumber';
+            type: {
+                kind: 'struct';
+                fields: [
+                    {
+                        name: 'pubkey';
+                        type: 'publicKey';
+                    },
+                    {
+                        name: 'sequenceNumber';
+                        type: 'u64';
+                    },
+                ];
+            };
+        },
+        {
             name: 'PublicTransactionEvent';
             type: {
                 kind: 'struct';
@@ -613,6 +629,14 @@ export type LightSystemProgram = {
                         name: 'outputLeafIndices';
                         type: {
                             vec: 'u32';
+                        };
+                    },
+                    {
+                        name: 'sequenceNumbers';
+                        type: {
+                            vec: {
+                                defined: 'MerkleTreeSequenceNumber';
+                            };
                         };
                     },
                     {
@@ -1434,6 +1458,22 @@ export const IDL: LightSystemProgram = {
             },
         },
         {
+            name: 'MerkleTreeSequenceNumber',
+            type: {
+                kind: 'struct',
+                fields: [
+                    {
+                        name: 'pubkey',
+                        type: 'publicKey',
+                    },
+                    {
+                        name: 'sequenceNumber',
+                        type: 'u64',
+                    },
+                ],
+            },
+        },
+        {
             name: 'PublicTransactionEvent',
             type: {
                 kind: 'struct',
@@ -1467,6 +1507,14 @@ export const IDL: LightSystemProgram = {
                         name: 'outputLeafIndices',
                         type: {
                             vec: 'u32',
+                        },
+                    },
+                    {
+                        name: 'sequenceNumbers',
+                        type: {
+                            vec: {
+                                defined: 'MerkleTreeSequenceNumber',
+                            },
                         },
                     },
                     {

--- a/js/stateless.js/src/idls/light_system_program.ts
+++ b/js/stateless.js/src/idls/light_system_program.ts
@@ -590,7 +590,7 @@ export type LightSystemProgram = {
                         type: 'publicKey';
                     },
                     {
-                        name: 'sequenceNumber';
+                        name: 'seq';
                         type: 'u64';
                     },
                 ];
@@ -1467,7 +1467,7 @@ export const IDL: LightSystemProgram = {
                         type: 'publicKey',
                     },
                     {
-                        name: 'sequenceNumber',
+                        name: 'seq',
                         type: 'u64',
                     },
                 ],

--- a/programs/system/src/invoke/append_state.rs
+++ b/programs/system/src/invoke/append_state.rs
@@ -1,7 +1,10 @@
 use crate::{
     errors::CompressedPdaError,
     invoke_cpi::verify_signer::check_program_owner_state_merkle_tree,
-    sdk::accounts::{InvokeAccounts, SignerAccounts},
+    sdk::{
+        accounts::{InvokeAccounts, SignerAccounts},
+        event::MerkleTreeSequenceNumber,
+    },
     InstructionDataInvoke,
 };
 use anchor_lang::solana_program::program::invoke_signed;
@@ -27,6 +30,7 @@ pub fn insert_output_compressed_accounts_into_state_merkle_tree<
     addresses: &'a mut Vec<Option<[u8; 32]>>,
     invoking_program: &Option<Pubkey>,
     hashed_pubkeys: &'a mut Vec<(Pubkey, [u8; 32])>,
+    sequence_numbers: &'a mut Vec<MerkleTreeSequenceNumber>,
 ) -> Result<()> {
     bench_sbf_start!("cpda_append_data_init");
     let mut account_infos = vec![
@@ -76,10 +80,15 @@ pub fn insert_output_compressed_accounts_into_state_merkle_tree<
         let account_info = ctx.remaining_accounts
             [inputs.output_compressed_accounts[current_index as usize].merkle_tree_index as usize]
             .to_account_info();
-        (mt_next_index, _) = check_program_owner_state_merkle_tree(
+        let seq;
+        (mt_next_index, _, seq) = check_program_owner_state_merkle_tree(
             &ctx.remaining_accounts[current_index as usize],
             invoking_program,
         )?;
+        sequence_numbers.push(MerkleTreeSequenceNumber {
+            pubkey: account_info.key(),
+            sequence_number: seq,
+        });
         hashed_merkle_tree = match hashed_pubkeys.iter().find(|x| x.0 == account_info.key()) {
             Some(hashed_merkle_tree) => hashed_merkle_tree.1,
             None => {
@@ -108,7 +117,8 @@ pub fn insert_output_compressed_accounts_into_state_merkle_tree<
             // do nothing, but is the most common case.
         } else if account.merkle_tree_index != current_index {
             current_index = account.merkle_tree_index;
-            (mt_next_index, _) = check_program_owner_state_merkle_tree(
+            let seq;
+            (mt_next_index, _, seq) = check_program_owner_state_merkle_tree(
                 &ctx.remaining_accounts[account.merkle_tree_index as usize],
                 invoking_program,
             )?;
@@ -118,6 +128,10 @@ pub fn insert_output_compressed_accounts_into_state_merkle_tree<
                 pubkey: account_info.key(),
                 is_signer: false,
                 is_writable: true,
+            });
+            sequence_numbers.push(MerkleTreeSequenceNumber {
+                pubkey: account_info.key(),
+                sequence_number: seq,
             });
             hashed_merkle_tree = match hashed_pubkeys.iter().find(|x| x.0 == account_info.key()) {
                 Some(hashed_merkle_tree) => hashed_merkle_tree.1,

--- a/programs/system/src/invoke/append_state.rs
+++ b/programs/system/src/invoke/append_state.rs
@@ -87,7 +87,7 @@ pub fn insert_output_compressed_accounts_into_state_merkle_tree<
         )?;
         sequence_numbers.push(MerkleTreeSequenceNumber {
             pubkey: account_info.key(),
-            sequence_number: seq,
+            seq,
         });
         hashed_merkle_tree = match hashed_pubkeys.iter().find(|x| x.0 == account_info.key()) {
             Some(hashed_merkle_tree) => hashed_merkle_tree.1,
@@ -131,7 +131,7 @@ pub fn insert_output_compressed_accounts_into_state_merkle_tree<
             });
             sequence_numbers.push(MerkleTreeSequenceNumber {
                 pubkey: account_info.key(),
-                sequence_number: seq,
+                seq,
             });
             hashed_merkle_tree = match hashed_pubkeys.iter().find(|x| x.0 == account_info.key()) {
                 Some(hashed_merkle_tree) => hashed_merkle_tree.1,

--- a/programs/system/src/invoke/emit_event.rs
+++ b/programs/system/src/invoke/emit_event.rs
@@ -9,7 +9,7 @@ use crate::{
     errors::CompressedPdaError,
     sdk::{
         accounts::InvokeAccounts,
-        event::{PublicTransactionEvent, SizedEvent},
+        event::{MerkleTreeSequenceNumber, PublicTransactionEvent, SizedEvent},
     },
     InstructionDataInvoke,
 };
@@ -19,6 +19,7 @@ pub fn emit_state_transition_event<'a, 'b, 'c: 'info, 'info, A: InvokeAccounts<'
     input_compressed_account_hashes: Vec<[u8; 32]>,
     output_compressed_account_hashes: Vec<[u8; 32]>,
     output_leaf_indices: Vec<u32>,
+    sequence_numbers: Vec<MerkleTreeSequenceNumber>,
 ) -> Result<()> {
     // TODO: add message and compression_lamports
     let event = PublicTransactionEvent {
@@ -26,6 +27,7 @@ pub fn emit_state_transition_event<'a, 'b, 'c: 'info, 'info, A: InvokeAccounts<'
         output_compressed_account_hashes,
         output_compressed_accounts: inputs.output_compressed_accounts,
         output_leaf_indices,
+        sequence_numbers,
         relay_fee: inputs.relay_fee,
         pubkey_array: ctx.remaining_accounts.iter().map(|x| x.key()).collect(),
         compression_lamports: inputs.compression_lamports,

--- a/programs/system/src/invoke/nullify_state.rs
+++ b/programs/system/src/invoke/nullify_state.rs
@@ -61,7 +61,7 @@ pub fn insert_nullifiers<
             is_writable: true,
         });
         account_infos.push(account_info.clone());
-        let (_, network_fee) = check_program_owner_state_merkle_tree(
+        let (_, network_fee, _) = check_program_owner_state_merkle_tree(
             &ctx.remaining_accounts[account.merkle_context.merkle_tree_pubkey_index as usize],
             invoking_program,
         )?;

--- a/programs/system/src/invoke/processor.rs
+++ b/programs/system/src/invoke/processor.rs
@@ -184,7 +184,14 @@ pub fn process<
         return err!(CompressedPdaError::ProofIsSome);
     }
     bench_sbf_end!("cpda_nullifiers");
+    let mut num_distinct_output_merkle_trees = inputs
+        .output_compressed_accounts
+        .iter()
+        .map(|x| x.merkle_tree_index)
+        .collect::<Vec<_>>();
+    num_distinct_output_merkle_trees.dedup();
 
+    let mut sequence_numbers = Vec::with_capacity(num_distinct_output_merkle_trees.len());
     // insert leaves (output compressed account hashes) ---------------------------------------------------
     if !inputs.output_compressed_accounts.is_empty() {
         bench_sbf_start!("cpda_append");
@@ -196,6 +203,7 @@ pub fn process<
             &mut input_compressed_account_addresses,
             &invoking_program,
             &mut hashed_pubkeys,
+            &mut sequence_numbers,
         )?;
         bench_sbf_end!("cpda_append");
     }
@@ -209,6 +217,7 @@ pub fn process<
         input_compressed_account_hashes,
         output_compressed_account_hashes,
         output_leaf_indices,
+        sequence_numbers,
     )?;
     bench_sbf_end!("emit_state_transition_event");
 

--- a/programs/system/src/sdk/event.rs
+++ b/programs/system/src/sdk/event.rs
@@ -1,11 +1,11 @@
+use crate::OutputCompressedAccountWithPackedContext;
 use anchor_lang::{solana_program::pubkey::Pubkey, AnchorDeserialize, AnchorSerialize};
 use std::{io::Write, mem};
 
-use crate::OutputCompressedAccountWithPackedContext;
 #[derive(Debug, Clone, AnchorSerialize, AnchorDeserialize, Default, PartialEq)]
 pub struct MerkleTreeSequenceNumber {
     pub pubkey: Pubkey,
-    pub sequence_number: u64,
+    pub seq: u64,
 }
 
 #[derive(Debug, Clone, AnchorSerialize, AnchorDeserialize, Default, PartialEq)]
@@ -71,10 +71,11 @@ impl PublicTransactionEvent {
         for index in self.output_leaf_indices.iter() {
             writer.write_all(&index.to_le_bytes())?;
         }
+
         writer.write_all(&(self.sequence_numbers.len() as u32).to_le_bytes())?;
         for element in self.sequence_numbers.iter() {
             writer.write_all(&element.pubkey.to_bytes())?;
-            writer.write_all(&element.sequence_number.to_le_bytes())?;
+            writer.write_all(&element.seq.to_le_bytes())?;
         }
         match self.relay_fee {
             Some(relay_fee) => {
@@ -141,11 +142,11 @@ pub mod test {
             sequence_numbers: vec![
                 MerkleTreeSequenceNumber {
                     pubkey: Keypair::new().pubkey(),
-                    sequence_number: 10,
+                    seq: 10,
                 },
                 MerkleTreeSequenceNumber {
                     pubkey: Keypair::new().pubkey(),
-                    sequence_number: 2,
+                    seq: 2,
                 },
             ],
             output_leaf_indices: vec![4, 5, 6],
@@ -209,7 +210,7 @@ pub mod test {
                 sequence_numbers: (0..rng.gen_range(1..10))
                     .map(|_| MerkleTreeSequenceNumber {
                         pubkey: Keypair::new().pubkey(),
-                        sequence_number: rng.gen(),
+                        seq: rng.gen(),
                     })
                     .collect(),
                 relay_fee: if rng.gen() { Some(rng.gen()) } else { None },

--- a/test-utils/src/assert_compressed_tx.rs
+++ b/test-utils/src/assert_compressed_tx.rs
@@ -253,7 +253,7 @@ pub fn assert_public_transaction_event(
                 merkle_tree_pubkey
             );
         } else {
-            index.as_mut().unwrap().sequence_number += 1;
+            index.as_mut().unwrap().seq += 1;
         }
     }
     for sequence_number in updated_sequence_numbers.iter() {
@@ -297,7 +297,7 @@ pub async fn assert_merkle_tree_after_tx<const INDEXED_ARRAY_SIZE: usize, R: Rpc
             .unwrap();
         sequence_numbers.push(MerkleTreeSequenceNumber {
             pubkey: snapshot.accounts.merkle_tree,
-            sequence_number: merkle_tree.sequence_number as u64,
+            seq: merkle_tree.sequence_number as u64,
         });
         if merkle_tree.root() == snapshot.root {
             println!("deduped_snapshots: {:?}", deduped_snapshots);

--- a/test-utils/src/assert_compressed_tx.rs
+++ b/test-utils/src/assert_compressed_tx.rs
@@ -5,6 +5,7 @@ use crate::{
     AccountZeroCopy,
 };
 use account_compression::{state::QueueAccount, StateMerkleTreeAccount};
+use light_system_program::sdk::event::MerkleTreeSequenceNumber;
 use light_system_program::sdk::{
     compressed_account::{CompressedAccount, CompressedAccountWithMerkleContext},
     event::PublicTransactionEvent,
@@ -75,6 +76,14 @@ pub async fn assert_compressed_transaction<const INDEXED_ARRAY_SIZE: usize, R: R
     )
     .await;
 
+    // CHECK 5
+    let sequence_numbers = assert_merkle_tree_after_tx(
+        input.rpc,
+        input.output_merkle_tree_snapshots,
+        input.test_indexer,
+    )
+    .await;
+
     // CHECK 4
     assert_public_transaction_event(
         input.event,
@@ -93,14 +102,8 @@ pub async fn assert_compressed_transaction<const INDEXED_ARRAY_SIZE: usize, R: R
         input.compression_lamports,
         input.is_compress,
         input.relay_fee,
+        sequence_numbers,
     );
-    // CHECK 5
-    assert_merkle_tree_after_tx(
-        input.rpc,
-        input.output_merkle_tree_snapshots,
-        input.test_indexer,
-    )
-    .await;
 
     // CHECK 7
     if let Some(compression_lamports) = input.compression_lamports {
@@ -194,6 +197,7 @@ pub fn assert_created_compressed_accounts(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn assert_public_transaction_event(
     event: &PublicTransactionEvent,
     input_compressed_account_hashes: Option<&Vec<[u8; 32]>>,
@@ -202,6 +206,7 @@ pub fn assert_public_transaction_event(
     compression_lamports: Option<u64>,
     is_compress: bool,
     relay_fee: Option<u64>,
+    sequence_numbers: Vec<MerkleTreeSequenceNumber>,
 ) {
     assert_eq!(
         event.input_compressed_account_hashes,
@@ -234,6 +239,26 @@ pub fn assert_public_transaction_event(
         event.relay_fee, relay_fee,
         "assert_public_transaction_event: relay fee mismatch"
     );
+    let mut updated_sequence_numbers = event.sequence_numbers.clone();
+    for account in event.output_compressed_accounts.iter() {
+        let merkle_tree_pubkey = event.pubkey_array[account.merkle_tree_index as usize];
+        let index = &mut updated_sequence_numbers
+            .iter_mut()
+            .find(|x| x.pubkey == merkle_tree_pubkey);
+        if index.is_none() {
+            println!("reference sequence numbers: {:?}", sequence_numbers);
+            println!("event: {:?}", event);
+            panic!(
+                "merkle tree pubkey not found in sequence numbers : {:?}",
+                merkle_tree_pubkey
+            );
+        } else {
+            index.as_mut().unwrap().sequence_number += 1;
+        }
+    }
+    for sequence_number in updated_sequence_numbers.iter() {
+        sequence_numbers.iter().any(|x| x == sequence_number);
+    }
 }
 
 #[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
@@ -257,10 +282,11 @@ pub async fn assert_merkle_tree_after_tx<const INDEXED_ARRAY_SIZE: usize, R: Rpc
     rpc: &mut R,
     snapshots: &[MerkleTreeTestSnapShot],
     test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
-) {
+) -> Vec<MerkleTreeSequenceNumber> {
     let mut deduped_snapshots = snapshots.to_vec();
     deduped_snapshots.sort();
     deduped_snapshots.dedup();
+    let mut sequence_numbers = Vec::new();
     for (i, snapshot) in deduped_snapshots.iter().enumerate() {
         let merkle_tree_account =
             AccountZeroCopy::<StateMerkleTreeAccount>::new(rpc, snapshot.accounts.merkle_tree)
@@ -269,6 +295,10 @@ pub async fn assert_merkle_tree_after_tx<const INDEXED_ARRAY_SIZE: usize, R: Rpc
             .deserialized()
             .copy_merkle_tree()
             .unwrap();
+        sequence_numbers.push(MerkleTreeSequenceNumber {
+            pubkey: snapshot.accounts.merkle_tree,
+            sequence_number: merkle_tree.sequence_number as u64,
+        });
         if merkle_tree.root() == snapshot.root {
             println!("deduped_snapshots: {:?}", deduped_snapshots);
             println!("i: {:?}", i);
@@ -312,6 +342,7 @@ pub async fn assert_merkle_tree_after_tx<const INDEXED_ARRAY_SIZE: usize, R: Rpc
             panic!("merkle tree root update failed");
         }
     }
+    sequence_numbers
 }
 
 /// Takes a snapshot of the provided the onchain Merkle trees.

--- a/test-utils/src/assert_token_tx.rs
+++ b/test-utils/src/assert_token_tx.rs
@@ -56,6 +56,9 @@ pub async fn assert_transfer<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
         vec = input_compressed_account_hashes.to_vec();
         Some(&vec)
     };
+    // CHECK 4
+    let sequence_numbers =
+        assert_merkle_tree_after_tx(context, output_merkle_tree_snapshots, test_indexer).await;
     // CHECK 3
     assert_public_transaction_event(
         event,
@@ -72,9 +75,8 @@ pub async fn assert_transfer<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
         None,
         false,
         None,
+        sequence_numbers,
     );
-    // CHECK 4
-    assert_merkle_tree_after_tx(context, output_merkle_tree_snapshots, test_indexer).await;
 }
 
 pub fn assert_compressed_token_accounts<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(


### PR DESCRIPTION
Issue:
- we removed changelog events
- public transaction events contain the input compressed account hashes but no sequence number

Changes:
- add sequence number for every output state Merkle tree to public transaction event