### PR TITLE
chore: rm mintAuthorityPda as proxy signer for mintTo

### DIFF
--- a/cli/src/commands/create-mint/index.ts
+++ b/cli/src/commands/create-mint/index.ts
@@ -4,10 +4,9 @@ import {
   CustomLoader,
   defaultSolanaWalletKeypair,
   generateSolanaTransactionURL,
-  getSolanaRpcUrl,
 } from "../../utils/utils";
 import { createMint } from "@lightprotocol/compressed-token";
-import { Keypair } from "@solana/web3.js";
+import { Keypair, PublicKey } from "@solana/web3.js";
 import { getTestRpc } from "@lightprotocol/stateless.js";
 import { WasmFactory } from "@lightprotocol/hasher.rs";
 
@@ -25,8 +24,7 @@ class CreateMintCommand extends Command {
       required: false,
     }),
     "mint-authority": Flags.string({
-      description:
-        "Specify a path to the mint authority keypair file. Defaults to your default local solana wallet file path",
+      description: "Address of the mint authority. Defaults to the fee payer",
       required: false,
     }),
     "mint-decimals": Flags.integer({
@@ -47,7 +45,7 @@ class CreateMintCommand extends Command {
       const payer = defaultSolanaWalletKeypair();
       const mintDecimals = this.getMintDecimals(flags);
       const mintKeypair = await this.getMintKeypair(flags);
-      const mintAuthority = await this.getMintAuthority(flags, payer);
+      const mintAuthority = await this.getMintAuthority(flags, payer.publicKey);
       const lightWasm = await WasmFactory.getInstance();
       const rpc = await getTestRpc(lightWasm);
       const { mint, transactionSignature } = await createMint(
@@ -82,10 +80,10 @@ class CreateMintCommand extends Command {
     return keypair;
   }
 
-  async getMintAuthority(flags: any, payer: Keypair): Promise<Keypair> {
+  async getMintAuthority(flags: any, feePayer: PublicKey): Promise<PublicKey> {
     return flags["mint-authority"]
-      ? await getKeypairFromFile(flags["mint-authority"])
-      : payer;
+      ? new PublicKey(flags["mint-authority"])
+      : feePayer;
   }
 }
 

--- a/cli/src/commands/register-mint/index.ts
+++ b/cli/src/commands/register-mint/index.ts
@@ -22,11 +22,6 @@ class RegisterMintCommand extends Command {
       description: "Provide a base58 encoded mint address to register",
       required: true,
     }),
-    "mint-authority": Flags.string({
-      description:
-        "Specify a path to the mint authority keypair file. Defaults to your default local solana wallet file path",
-      required: false,
-    }),
   };
 
   static args = {};
@@ -39,10 +34,9 @@ class RegisterMintCommand extends Command {
     try {
       const payer = defaultSolanaWalletKeypair();
       const mintAddress = new PublicKey(flags.mint);
-      const mintAuthority = await this.getMintAuthority(flags, payer);
       const lightWasm = await WasmFactory.getInstance();
       const rpc = await getTestRpc(lightWasm);
-      const txId = await registerMint(rpc, payer, mintAuthority, mintAddress);
+      const txId = await registerMint(rpc, payer, mintAddress);
       loader.stop(false);
       console.log("\x1b[1mMint public key:\x1b[0m ", mintAddress.toBase58());
       console.log(
@@ -53,12 +47,6 @@ class RegisterMintCommand extends Command {
     } catch (error) {
       this.error(`Failed to register-mint!\n${error}`);
     }
-  }
-
-  async getMintAuthority(flags: any, payer: Keypair): Promise<Keypair> {
-    return flags["mint-authority"]
-      ? await getKeypairFromFile(flags["mint-authority"])
-      : payer;
   }
 }
 

--- a/cli/test/commands/create-mint/index.test.ts
+++ b/cli/test/commands/create-mint/index.test.ts
@@ -10,10 +10,12 @@ describe("create-mint", () => {
     await requestAirdrop(mintAuthority.publicKey);
   });
 
-  /// TODO: add flags once the command is being executed
   test
     .stdout({ print: true })
-    .command(["create-mint"])
+    .command([
+      "create-mint",
+      `--mint-authority=${mintAuthority.publicKey.toBase58()}`,
+    ])
     .it(
       `create mint for mintAuthority: ${mintAuthority.publicKey.toBase58()}`,
       (ctx: any) => {

--- a/cli/test/helpers/helpers.ts
+++ b/cli/test/helpers/helpers.ts
@@ -37,7 +37,7 @@ export async function createTestMint(mintKeypair: Keypair) {
   const { mint, transactionSignature } = await createMint(
     rpc,
     await getPayer(),
-    await getPayer(),
+    (await getPayer()).publicKey,
     9,
     mintKeypair,
   );

--- a/examples/token-escrow/README.md
+++ b/examples/token-escrow/README.md
@@ -9,8 +9,11 @@ This example program escrows compressed tokens into (1) a regular Solana program
 In the monorepo root, run the build.sh script
 
 ```bash
-. ./scripts/devenv.sh
-./scripts/build.sh
+    source ./scripts/devenv.sh
+    ./scripts/build.sh
+    mkdir -p ./target/deploy
+    cp ./third-party/solana-program-library/spl_noop.so ./target/deploy/spl_noop.so
+    anchor build
 ```
 
 Then navigate to the token-escrow directory and run the rust tests:
@@ -20,4 +23,4 @@ cd examples/token-escrow/programs/token-escrow
 cargo test-sbf -- --test-threads=1
 ```
 
-##  This program is unsafe; don't use it in production.
+## This program is unsafe; don't use it in production.

--- a/js/compressed-token/src/actions/create-mint.ts
+++ b/js/compressed-token/src/actions/create-mint.ts
@@ -19,7 +19,7 @@ import {
  *
  * @param rpc             RPC to use
  * @param payer           Payer of the transaction and initialization fees
- * @param mintAuthority   Account or multisig that will control minting. Is signer.
+ * @param mintAuthority   Account or multisig that will control minting
  * @param decimals        Location of the decimal place
  * @param keypair         Optional keypair, defaulting to a new random one
  * @param confirmOptions  Options for confirming the transaction
@@ -29,7 +29,7 @@ import {
 export async function createMint(
     rpc: Rpc,
     payer: Signer,
-    mintAuthority: Signer,
+    mintAuthority: PublicKey,
     decimals: number,
     keypair = Keypair.generate(),
     confirmOptions?: ConfirmOptions,
@@ -41,14 +41,14 @@ export async function createMint(
         feePayer: payer.publicKey,
         mint: keypair.publicKey,
         decimals,
-        authority: mintAuthority.publicKey,
+        authority: mintAuthority,
         freezeAuthority: null, // TODO: add feature
         rentExemptBalance,
     });
 
     const { blockhash } = await rpc.getLatestBlockhash();
 
-    const additionalSigners = dedupeSigner(payer, [mintAuthority, keypair]);
+    const additionalSigners = dedupeSigner(payer, [keypair]);
 
     const tx = buildAndSignTx(ixs, payer, blockhash, additionalSigners);
 

--- a/js/compressed-token/src/actions/register-mint.ts
+++ b/js/compressed-token/src/actions/register-mint.ts
@@ -26,21 +26,17 @@ import {
 export async function registerMint(
     rpc: Rpc,
     payer: Signer,
-    mintAuthority: Signer,
     mintAddress: PublicKey,
     confirmOptions?: ConfirmOptions,
 ): Promise<TransactionSignature> {
-    const ixs = await CompressedTokenProgram.registerMint({
+    const ix = await CompressedTokenProgram.registerMint({
         feePayer: payer.publicKey,
         mint: mintAddress,
-        authority: mintAuthority.publicKey,
     });
 
     const { blockhash } = await rpc.getLatestBlockhash();
 
-    const additionalSigners = dedupeSigner(payer, [mintAuthority]);
-
-    const tx = buildAndSignTx(ixs, payer, blockhash, additionalSigners);
+    const tx = buildAndSignTx([ix], payer, blockhash);
 
     const txId = await sendAndConfirmTx(rpc, tx, confirmOptions);
 

--- a/js/compressed-token/src/constants.ts
+++ b/js/compressed-token/src/constants.ts
@@ -1,10 +1,5 @@
-import { utils } from '@coral-xyz/anchor';
-
 export const POOL_SEED = Buffer.from('pool');
 
 export const CPI_AUTHORITY_SEED = Buffer.from('cpi_authority');
-
-export const MINT_AUTHORITY_SEED =
-    utils.bytes.utf8.encode('mint_authority_pda');
 
 export const SPL_TOKEN_MINT_RENT_EXEMPT_BALANCE = 1461600;

--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -24,11 +24,6 @@ export type LightCompressedToken = {
                     isSigner: true;
                 },
                 {
-                    name: 'authority';
-                    isMut: true;
-                    isSigner: true;
-                },
-                {
                     name: 'tokenPoolPda';
                     isMut: true;
                     isSigner: false;
@@ -40,11 +35,6 @@ export type LightCompressedToken = {
                 },
                 {
                     name: 'mint';
-                    isMut: true;
-                    isSigner: false;
-                },
-                {
-                    name: 'mintAuthorityPda';
                     isMut: true;
                     isSigner: false;
                 },
@@ -75,8 +65,8 @@ export type LightCompressedToken = {
                     isSigner: true;
                 },
                 {
-                    name: 'mintAuthorityPda';
-                    isMut: true;
+                    name: 'cpiAuthorityPda';
+                    isMut: false;
                     isSigner: false;
                 },
                 {
@@ -147,10 +137,6 @@ export type LightCompressedToken = {
                     type: {
                         vec: 'u64';
                     };
-                },
-                {
-                    name: 'bump';
-                    type: 'u8';
                 },
             ];
         },
@@ -1014,11 +1000,6 @@ export const IDL: LightCompressedToken = {
                     isSigner: true,
                 },
                 {
-                    name: 'authority',
-                    isMut: true,
-                    isSigner: true,
-                },
-                {
                     name: 'tokenPoolPda',
                     isMut: true,
                     isSigner: false,
@@ -1030,11 +1011,6 @@ export const IDL: LightCompressedToken = {
                 },
                 {
                     name: 'mint',
-                    isMut: true,
-                    isSigner: false,
-                },
-                {
-                    name: 'mintAuthorityPda',
                     isMut: true,
                     isSigner: false,
                 },
@@ -1065,8 +1041,8 @@ export const IDL: LightCompressedToken = {
                     isSigner: true,
                 },
                 {
-                    name: 'mintAuthorityPda',
-                    isMut: true,
+                    name: 'cpiAuthorityPda',
+                    isMut: false,
                     isSigner: false,
                 },
                 {
@@ -1137,10 +1113,6 @@ export const IDL: LightCompressedToken = {
                     type: {
                         vec: 'u64',
                     },
-                },
-                {
-                    name: 'bump',
-                    type: 'u8',
                 },
             ],
         },

--- a/js/compressed-token/src/program.ts
+++ b/js/compressed-token/src/program.ts
@@ -29,14 +29,8 @@ import {
     createInitializeMint2Instruction,
     createMintToInstruction,
 } from '@solana/spl-token';
-import {
-    CPI_AUTHORITY_SEED,
-    MINT_AUTHORITY_SEED,
-    POOL_SEED,
-} from './constants';
-import { Buffer } from 'buffer';
+import { CPI_AUTHORITY_SEED, POOL_SEED } from './constants';
 import { packCompressedTokenAccounts } from './instructions/pack-compressed-token-accounts';
-import { PackedTokenTransferOutputData } from './types';
 
 type CompressParams = {
     /**

--- a/js/compressed-token/src/program.ts
+++ b/js/compressed-token/src/program.ts
@@ -181,8 +181,6 @@ export type MintToParams = {
 export type RegisterMintParams = {
     /** Tx feepayer */
     feePayer: PublicKey;
-    /** Mint authority */
-    authority: PublicKey;
     /** Mint public key */
     mint: PublicKey;
 };
@@ -384,17 +382,6 @@ export class CompressedTokenProgram {
     }
 
     /** @internal */
-    static deriveMintAuthorityPda = (
-        authority: PublicKey,
-        mint: PublicKey,
-    ): [PublicKey, number] => {
-        return PublicKey.findProgramAddressSync(
-            [MINT_AUTHORITY_SEED, authority.toBuffer(), mint.toBuffer()],
-            this.programId,
-        );
-    };
-
-    /** @internal */
     static deriveTokenPoolPda(mint: PublicKey): PublicKey {
         const seeds = [POOL_SEED, mint.toBuffer()];
         const [address, _] = PublicKey.findProgramAddressSync(
@@ -430,47 +417,20 @@ export class CompressedTokenProgram {
             space: MINT_SIZE,
         });
 
-        const [mintAuthorityPda] = this.deriveMintAuthorityPda(authority, mint);
-
         const initializeMintInstruction = createInitializeMint2Instruction(
             mint,
             params.decimals,
-            mintAuthorityPda,
+            authority,
             params.freezeAuthority,
             TOKEN_PROGRAM_ID,
         );
 
-        /// Fund the mint authority PDA. The authority is system-owned in order
-        /// to natively mint compressed tokens.
-        const fundAuthorityPdaInstruction = SystemProgram.transfer({
-            fromPubkey: feePayer,
-            toPubkey: mintAuthorityPda,
-            lamports: rentExemptBalance,
+        const ix = await this.registerMint({
+            feePayer,
+            mint,
         });
 
-        const tokenPoolPda = this.deriveTokenPoolPda(mint);
-
-        /// Create omnibus compressed mint account
-        const ix = await this.program.methods
-            .createMint()
-            .accounts({
-                mint,
-                feePayer,
-                authority,
-                tokenPoolPda,
-                systemProgram: SystemProgram.programId,
-                mintAuthorityPda,
-                tokenProgram: TOKEN_PROGRAM_ID,
-                cpiAuthorityPda: this.deriveCpiAuthorityPda,
-            })
-            .instruction();
-
-        return [
-            createMintAccountInstruction,
-            initializeMintInstruction,
-            fundAuthorityPdaInstruction,
-            ix,
-        ];
+        return [createMintAccountInstruction, initializeMintInstruction, ix];
     }
 
     /**
@@ -479,10 +439,8 @@ export class CompressedTokenProgram {
      */
     static async registerMint(
         params: RegisterMintParams,
-    ): Promise<TransactionInstruction[]> {
-        const { mint, authority, feePayer } = params;
-
-        const [mintAuthorityPda] = this.deriveMintAuthorityPda(authority, mint);
+    ): Promise<TransactionInstruction> {
+        const { mint, feePayer } = params;
 
         const tokenPoolPda = this.deriveTokenPoolPda(mint);
 
@@ -491,16 +449,14 @@ export class CompressedTokenProgram {
             .accounts({
                 mint,
                 feePayer,
-                authority,
                 tokenPoolPda,
                 systemProgram: SystemProgram.programId,
-                mintAuthorityPda,
                 tokenProgram: TOKEN_PROGRAM_ID,
                 cpiAuthorityPda: this.deriveCpiAuthorityPda,
             })
             .instruction();
 
-        return [ix];
+        return ix;
     }
 
     /**
@@ -513,20 +469,16 @@ export class CompressedTokenProgram {
             params;
 
         const tokenPoolPda = this.deriveTokenPoolPda(mint);
-        const [mintAuthorityPda, bump] = this.deriveMintAuthorityPda(
-            authority,
-            mint,
-        );
 
         const amounts = toArray<BN | number>(amount).map(amount => bn(amount));
 
         const toPubkeys = toArray(toPubkey);
         const instruction = await this.program.methods
-            .mintTo(toPubkeys, amounts, bump)
+            .mintTo(toPubkeys, amounts)
             .accounts({
                 feePayer,
                 authority,
-                mintAuthorityPda,
+                cpiAuthorityPda: this.deriveCpiAuthorityPda,
                 mint,
                 tokenPoolPda,
                 tokenProgram: TOKEN_PROGRAM_ID,
@@ -559,7 +511,7 @@ export class CompressedTokenProgram {
 
         const amount: bigint = BigInt(params.amount.toString());
 
-        /// 1. Mint to mint authority ATA
+        /// 1. Mint to existing ATA of mintAuthority.
         const splMintToInstruction = createMintToInstruction(
             mint,
             authorityTokenAccount,
@@ -567,26 +519,18 @@ export class CompressedTokenProgram {
             amount,
         );
 
-        /// 2. Compressed token program mintTo
-        const approveInstruction = createApproveInstruction(
-            authorityTokenAccount,
-            this.deriveCpiAuthorityPda,
-            authority,
-            amount,
-        );
-
-        /// 3. Compress from mint authority ATA to recipient compressed account
-        const ixs = await this.compress({
+        /// 2. Compress from mint authority ATA to recipient compressed account
+        const [approveInstruction, compressInstruction] = await this.compress({
             payer: feePayer,
             owner: authority,
             source: authorityTokenAccount,
             toAddress: toPubkey,
             mint,
-            amount: bn(amount.toString()),
+            amount: params.amount,
             outputStateTree: merkleTree,
         });
 
-        return [splMintToInstruction, approveInstruction, ...ixs];
+        return [splMintToInstruction, approveInstruction, compressInstruction];
     }
     /**
      * Construct transfer instruction for compressed tokens

--- a/js/compressed-token/tests/e2e/approve-and-mint-to.test.ts
+++ b/js/compressed-token/tests/e2e/approve-and-mint-to.test.ts
@@ -74,7 +74,7 @@ describe('approveAndMintTo', () => {
         await createTestSplMint(rpc, payer, mintKeypair, mintAuthority);
 
         /// Register mint
-        await registerMint(rpc, payer, mintAuthority, mint);
+        await registerMint(rpc, payer, mint);
     });
 
     it('should mintTo compressed account with external spl mint', async () => {

--- a/js/compressed-token/tests/e2e/compress.test.ts
+++ b/js/compressed-token/tests/e2e/compress.test.ts
@@ -76,7 +76,7 @@ describe('compress', () => {
             await createMint(
                 rpc,
                 payer,
-                mintAuthority,
+                mintAuthority.publicKey,
                 TEST_TOKEN_DECIMALS,
                 mintKeypair,
             )

--- a/js/compressed-token/tests/e2e/create-mint.test.ts
+++ b/js/compressed-token/tests/e2e/create-mint.test.ts
@@ -24,14 +24,7 @@ async function assertCreateMint(
     const mintAcc = await rpc.getAccountInfo(mint);
     const unpackedMint = unpackMint(mint, mintAcc);
 
-    const [mintAuthority] = CompressedTokenProgram.deriveMintAuthorityPda(
-        authority,
-        mint,
-    );
-
-    expect(unpackedMint.mintAuthority?.toString()).toBe(
-        mintAuthority.toString(),
-    );
+    expect(unpackedMint.mintAuthority?.toString()).toBe(authority.toString());
     expect(unpackedMint.supply).toBe(0n);
     expect(unpackedMint.decimals).toBe(decimals);
     expect(unpackedMint.isInitialized).toBe(true);
@@ -72,7 +65,7 @@ describe('createMint', () => {
             await createMint(
                 rpc,
                 payer,
-                mintAuthority,
+                mintAuthority.publicKey,
                 TEST_TOKEN_DECIMALS,
                 mintKeypair,
             )
@@ -94,7 +87,7 @@ describe('createMint', () => {
             createMint(
                 rpc,
                 payer,
-                mintAuthority,
+                mintAuthority.publicKey,
                 TEST_TOKEN_DECIMALS,
                 mintKeypair,
             ),
@@ -102,7 +95,9 @@ describe('createMint', () => {
     });
 
     it('should create mint with payer as authority', async () => {
-        mint = (await createMint(rpc, payer, payer, TEST_TOKEN_DECIMALS)).mint;
+        mint = (
+            await createMint(rpc, payer, payer.publicKey, TEST_TOKEN_DECIMALS)
+        ).mint;
 
         const poolAccount = CompressedTokenProgram.deriveTokenPoolPda(mint);
 

--- a/js/compressed-token/tests/e2e/decompress.test.ts
+++ b/js/compressed-token/tests/e2e/decompress.test.ts
@@ -78,7 +78,7 @@ describe('decompress', () => {
             await createMint(
                 rpc,
                 payer,
-                mintAuthority,
+                mintAuthority.publicKey,
                 TEST_TOKEN_DECIMALS,
                 mintKeypair,
             )

--- a/js/compressed-token/tests/e2e/mint-to.test.ts
+++ b/js/compressed-token/tests/e2e/mint-to.test.ts
@@ -60,7 +60,7 @@ describe('mintTo', () => {
             await createMint(
                 rpc,
                 payer,
-                mintAuthority,
+                mintAuthority.publicKey,
                 TEST_TOKEN_DECIMALS,
                 mintKeypair,
             )

--- a/js/compressed-token/tests/e2e/register-mint.test.ts
+++ b/js/compressed-token/tests/e2e/register-mint.test.ts
@@ -117,13 +117,13 @@ describe('registerMint', () => {
             createMint(
                 rpc,
                 payer,
-                mintAuthority,
+                mintAuthority.publicKey,
                 TEST_TOKEN_DECIMALS,
                 mintKeypair,
             ),
         ).rejects.toThrow();
 
-        await registerMint(rpc, payer, mintAuthority, mint);
+        await registerMint(rpc, payer, mint);
 
         await assertRegisterMint(
             mint,
@@ -134,9 +134,7 @@ describe('registerMint', () => {
         );
 
         /// Mint already registered
-        await expect(
-            registerMint(rpc, payer, mintAuthority, mint),
-        ).rejects.toThrow();
+        await expect(registerMint(rpc, payer, mint)).rejects.toThrow();
     });
 
     it('should create mint with payer as authority', async () => {
@@ -144,7 +142,7 @@ describe('registerMint', () => {
         mintKeypair = Keypair.generate();
         mint = mintKeypair.publicKey;
         await createTestSplMint(rpc, payer, mintKeypair, payer as Keypair);
-        await registerMint(rpc, payer, payer, mint);
+        await registerMint(rpc, payer, mint);
 
         const poolAccount = CompressedTokenProgram.deriveTokenPoolPda(mint);
         await assertRegisterMint(

--- a/js/compressed-token/tests/e2e/rpc-token-interop.test.ts
+++ b/js/compressed-token/tests/e2e/rpc-token-interop.test.ts
@@ -36,7 +36,7 @@ describe('rpc-interop token', () => {
             await createMint(
                 rpc,
                 payer,
-                mintAuthority,
+                mintAuthority.publicKey,
                 TEST_TOKEN_DECIMALS,
                 mintKeypair,
             )

--- a/js/compressed-token/tests/e2e/transfer.test.ts
+++ b/js/compressed-token/tests/e2e/transfer.test.ts
@@ -91,7 +91,7 @@ describe('transfer', () => {
             await createMint(
                 rpc,
                 payer,
-                mintAuthority,
+                mintAuthority.publicKey,
                 TEST_TOKEN_DECIMALS,
                 mintKeypair,
             )

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -24,11 +24,6 @@ export type LightCompressedToken = {
                     isSigner: true;
                 },
                 {
-                    name: 'authority';
-                    isMut: true;
-                    isSigner: true;
-                },
-                {
                     name: 'tokenPoolPda';
                     isMut: true;
                     isSigner: false;
@@ -40,11 +35,6 @@ export type LightCompressedToken = {
                 },
                 {
                     name: 'mint';
-                    isMut: true;
-                    isSigner: false;
-                },
-                {
-                    name: 'mintAuthorityPda';
                     isMut: true;
                     isSigner: false;
                 },
@@ -75,8 +65,8 @@ export type LightCompressedToken = {
                     isSigner: true;
                 },
                 {
-                    name: 'mintAuthorityPda';
-                    isMut: true;
+                    name: 'cpiAuthorityPda';
+                    isMut: false;
                     isSigner: false;
                 },
                 {
@@ -147,10 +137,6 @@ export type LightCompressedToken = {
                     type: {
                         vec: 'u64';
                     };
-                },
-                {
-                    name: 'bump';
-                    type: 'u8';
                 },
             ];
         },
@@ -1014,11 +1000,6 @@ export const IDL: LightCompressedToken = {
                     isSigner: true,
                 },
                 {
-                    name: 'authority',
-                    isMut: true,
-                    isSigner: true,
-                },
-                {
                     name: 'tokenPoolPda',
                     isMut: true,
                     isSigner: false,
@@ -1030,11 +1011,6 @@ export const IDL: LightCompressedToken = {
                 },
                 {
                     name: 'mint',
-                    isMut: true,
-                    isSigner: false,
-                },
-                {
-                    name: 'mintAuthorityPda',
                     isMut: true,
                     isSigner: false,
                 },
@@ -1065,8 +1041,8 @@ export const IDL: LightCompressedToken = {
                     isSigner: true,
                 },
                 {
-                    name: 'mintAuthorityPda',
-                    isMut: true,
+                    name: 'cpiAuthorityPda',
+                    isMut: false,
                     isSigner: false,
                 },
                 {
@@ -1137,10 +1113,6 @@ export const IDL: LightCompressedToken = {
                     type: {
                         vec: 'u64',
                     },
-                },
-                {
-                    name: 'bump',
-                    type: 'u8',
                 },
             ],
         },

--- a/js/stateless.js/src/test-helpers/merkle-tree/indexed-array.ts
+++ b/js/stateless.js/src/test-helpers/merkle-tree/indexed-array.ts
@@ -1,7 +1,4 @@
 import { LightWasm } from '../test-rpc/test-rpc';
-// TODO: remove import
-// import { WasmFactory } from '@lightprotocol/hasher.rs';
-
 import { BN } from '@coral-xyz/anchor';
 import { bn } from '../../state';
 import { MerkleTree } from './merkle-tree';
@@ -37,15 +34,8 @@ export class IndexedElement {
                 bn(nextValue.toArray('be', 32)).toString(),
             ]);
             return hash;
-            // const hash = H.hashv([
-            //     bigintToBeBytesArray<32>(this.value),
-            //     this.nextIndex.toBytes(),
-            //     bigintToBeBytesArray<32>(nextValue),
-            // ]);
-            // return [hash, undefined];
         } catch (error) {
             throw new Error('Hashing failed');
-            // return [0, new IndexedMerkleTreeError('Hashing failed')];
         }
     }
 }
@@ -189,15 +179,7 @@ export class IndexedArray {
             bn(element.value.toArray('be', 32)).toString(),
             bn(element.nextIndex).toString(),
             bn(nextElement.value.toArray('be', 32)).toString(),
-            // bigintToBeBytesArray<32>(element.value),
-            // bigintToBeBytesArray<32>(element.nextIndex),
-            // bigintToBeBytesArray<32>(nextElement.value),
         ]);
-        // const hash = this.hasher.hashv([
-        //     element.value.toBuffer(),
-        //     new Uint8Array(new Uint32Array([element.nextIndex]).buffer),
-        //     nextElement.value.toBuffer(),
-        // ]);
 
         return hash;
     }

--- a/programs/compressed-token/src/lib.rs
+++ b/programs/compressed-token/src/lib.rs
@@ -41,9 +41,8 @@ pub mod light_compressed_token {
         ctx: Context<'_, '_, '_, 'info, MintToInstruction<'info>>,
         public_keys: Vec<Pubkey>,
         amounts: Vec<u64>,
-        // bump: u8,
     ) -> Result<()> {
-        process_mint_to(ctx, public_keys, amounts)//, bump)
+        process_mint_to(ctx, public_keys, amounts)
     }
 
     pub fn transfer<'info>(

--- a/programs/compressed-token/src/lib.rs
+++ b/programs/compressed-token/src/lib.rs
@@ -41,9 +41,9 @@ pub mod light_compressed_token {
         ctx: Context<'_, '_, '_, 'info, MintToInstruction<'info>>,
         public_keys: Vec<Pubkey>,
         amounts: Vec<u64>,
-        bump: u8,
+        // bump: u8,
     ) -> Result<()> {
-        process_mint_to(ctx, public_keys, amounts, bump)
+        process_mint_to(ctx, public_keys, amounts)//, bump)
     }
 
     pub fn transfer<'info>(

--- a/programs/compressed-token/src/process_mint.rs
+++ b/programs/compressed-token/src/process_mint.rs
@@ -14,7 +14,7 @@ use light_utils::hash_to_bn254_field_size_be;
 
 use std::mem;
 pub const POOL_SEED: &[u8] = b"pool";
-pub const MINT_AUTHORITY_SEED: &[u8] = b"mint_authority_pda";
+// pub const MINT_AUTHORITY_SEED: &[u8] = b"mint_authority_pda";
 
 /// creates a token pool account which is owned by the token authority pda
 #[derive(Accounts)]
@@ -37,9 +37,6 @@ pub struct CreateMintInstruction<'info> {
     /// CHECK:
     #[account(mut)]
     pub mint: Account<'info, Mint>,
-    /// CHECK:
-    #[account(mut, seeds=[MINT_AUTHORITY_SEED, authority.key().to_bytes().as_slice(), mint.key().to_bytes().as_slice()], bump)]
-    pub mint_authority_pda: AccountInfo<'info>,
     pub token_program: Program<'info, Token>,
     /// CHECK: TODO
     #[account(seeds = [b"cpi_authority"], bump)]
@@ -51,7 +48,7 @@ pub fn process_mint_to<'info>(
     ctx: Context<'_, '_, '_, 'info, MintToInstruction<'info>>,
     compression_public_keys: Vec<Pubkey>,
     amounts: Vec<u64>,
-    bump: u8,
+    // bump: u8,
 ) -> Result<()> {
     if compression_public_keys.len() != amounts.len() {
         msg!(
@@ -81,16 +78,16 @@ pub fn process_mint_to<'info>(
         let authority_bytes = ctx.accounts.authority.key().to_bytes();
         let mint_bytes = ctx.accounts.mint.key().to_bytes();
 
-        let bump = &[bump];
-        let seeds = [
-            MINT_AUTHORITY_SEED,
-            authority_bytes.as_slice(),
-            mint_bytes.as_slice(),
-            bump,
-        ];
-        let signer_seeds = &[&seeds[..]];
+        // let bump = &[bump];
+        // let seeds = [
+        //     MINT_AUTHORITY_SEED,
+        //     authority_bytes.as_slice(),
+        //     mint_bytes.as_slice(),
+        //     bump,
+        // ];
+        // let signer_seeds = &[&seeds[..]];
         // 7,912 CU
-        mint_spl_to_pool_pda(&ctx, &amounts, signer_seeds)?;
+        mint_spl_to_pool_pda(&ctx, &amounts)?; // signer_seeds
         bench_sbf_end!("tm_mint_spl_to_pool_pda");
         let hashed_mint =
             hash_to_bn254_field_size_be(ctx.accounts.mint.to_account_info().key().as_ref())
@@ -118,7 +115,7 @@ pub fn process_mint_to<'info>(
             output_compressed_accounts,
             &mut inputs,
             pre_compressed_acounts_pos,
-            signer_seeds,
+            // signer_seeds,
         )?;
     }
     Ok(())
@@ -191,14 +188,14 @@ pub fn cpi_execute_compressed_transaction_mint_to<'info>(
     output_compressed_accounts: Vec<OutputCompressedAccountWithPackedContext>,
     inputs: &mut Vec<u8>,
     pre_compressed_acounts_pos: usize,
-    signer_seeds: &[&[&[u8]]],
+    // signer_seeds: &[&[&[u8]]],
 ) -> Result<()> {
     light_heap::bench_sbf_start!("tm_cpi");
 
     // 4300 CU for 10 accounts
     // 6700 CU for 20 accounts
     // 7,978 CU for 25 accounts
-    serialize_mint_to_cpi_instruction_data(inputs, output_compressed_accounts, signer_seeds);
+    serialize_mint_to_cpi_instruction_data(inputs, output_compressed_accounts); // ,signer_seeds);
 
     light_heap::GLOBAL_ALLOCATOR.free_heap(pre_compressed_acounts_pos);
 
@@ -212,7 +209,8 @@ pub fn cpi_execute_compressed_transaction_mint_to<'info>(
     // 1300 CU
     let account_infos = vec![
         ctx.accounts.fee_payer.to_account_info(),
-        ctx.accounts.mint_authority_pda.to_account_info(),
+        ctx.accounts.authority.to_account_info(), // 
+        // ctx.accounts.mint_authority_pda.to_account_info(),
         ctx.accounts.registered_program_pda.to_account_info(),
         ctx.accounts.noop_program.to_account_info(),
         ctx.accounts.account_compression_authority.to_account_info(),
@@ -293,13 +291,13 @@ pub fn cpi_execute_compressed_transaction_mint_to<'info>(
     };
 
     light_heap::bench_sbf_end!("tm_cpi");
-    light_heap::bench_sbf_start!("tm_invoke_signed");
-    anchor_lang::solana_program::program::invoke_signed(
+    light_heap::bench_sbf_start!("tm_invoke");
+    anchor_lang::solana_program::program::invoke( // invoke_signed
         &instruction,
         account_infos.as_slice(),
-        signer_seeds,
+        // signer_seeds,
     )?;
-    light_heap::bench_sbf_end!("tm_invoke_signed");
+    light_heap::bench_sbf_end!("tm_invoke");
     Ok(())
 }
 
@@ -307,7 +305,7 @@ pub fn cpi_execute_compressed_transaction_mint_to<'info>(
 pub fn serialize_mint_to_cpi_instruction_data(
     inputs: &mut Vec<u8>,
     output_compressed_accounts: Vec<OutputCompressedAccountWithPackedContext>,
-    seeds: &[&[&[u8]]],
+    // seeds: &[&[&[u8]]],
 ) {
     let len = output_compressed_accounts.len();
     // proof (option None)
@@ -322,17 +320,17 @@ pub fn serialize_mint_to_cpi_instruction_data(
     // relay_fee and compression lamports, is compress bool
     inputs.extend_from_slice(&[0u8; 3]);
     // seeds
-    let seeds: Vec<Vec<u8>> = seeds[0].iter().map(|seed| seed.to_vec()).collect();
+    // let seeds: Vec<Vec<u8>> = seeds[0].iter().map(|seed| seed.to_vec()).collect();
 
-    seeds.serialize(inputs).unwrap();
-    inputs.extend_from_slice(&[0u8]);
+    // seeds.serialize(inputs).unwrap();
+    // inputs.extend_from_slice(&[0u8]);
 }
 
 #[inline(never)]
 pub fn mint_spl_to_pool_pda<'info>(
     ctx: &Context<'_, '_, '_, 'info, MintToInstruction<'info>>,
     amounts: &[u64],
-    signer_seeds: &[&[&[u8]]],
+    // signer_seeds: &[&[&[u8]]],
 ) -> Result<()> {
     let mut mint_amount: u64 = 0;
     for amount in amounts.iter() {
@@ -340,14 +338,14 @@ pub fn mint_spl_to_pool_pda<'info>(
     }
 
     let cpi_accounts = anchor_spl::token::MintTo {
-        authority: ctx.accounts.mint_authority_pda.to_account_info(),
+        authority: ctx.accounts.authority.to_account_info(),
         mint: ctx.accounts.mint.to_account_info(),
         to: ctx.accounts.token_pool_pda.to_account_info(),
     };
-    let cpi_ctx = CpiContext::new_with_signer(
+    let cpi_ctx = CpiContext::new(
         ctx.accounts.token_program.to_account_info(),
         cpi_accounts,
-        signer_seeds,
+        // signer_seeds,
     );
 
     anchor_spl::token::mint_to(cpi_ctx, mint_amount)?;
@@ -361,11 +359,11 @@ pub struct MintToInstruction<'info> {
     #[account(mut)]
     pub authority: Signer<'info>,
     // This is the cpi signer
-    /// CHECK: that mint authority is derived from signer
-    #[account(mut, seeds = [MINT_AUTHORITY_SEED, authority.key().to_bytes().as_slice(), mint.key().to_bytes().as_slice()], bump,)]
-    pub mint_authority_pda: UncheckedAccount<'info>,
+    // /// CHECK: that mint authority is derived from signer
+    // #[account(mut)]
+    // pub mint_authority_pda: UncheckedAccount<'info>,
     /// CHECK: that authority is mint authority
-    #[account(mut, constraint = mint.mint_authority.unwrap() == mint_authority_pda.key())]
+    #[account(mut, constraint = mint.mint_authority.unwrap() == authority.key())]
     pub mint: Account<'info, Mint>,
     /// CHECK: this account
     #[account(mut)]
@@ -390,16 +388,16 @@ pub struct MintToInstruction<'info> {
     pub system_program: Program<'info, System>,
 }
 
-pub fn get_token_authority_pda(signer: &Pubkey, mint: &Pubkey) -> (Pubkey, u8) {
-    let signer_seed = signer.to_bytes();
-    let mint_seed = mint.to_bytes();
-    let seeds = &[
-        MINT_AUTHORITY_SEED,
-        signer_seed.as_slice(),
-        mint_seed.as_slice(),
-    ];
-    Pubkey::find_program_address(seeds, &crate::ID)
-}
+// pub fn get_token_authority_pda(signer: &Pubkey, mint: &Pubkey) -> (Pubkey, u8) {
+//     let signer_seed = signer.to_bytes();
+//     let mint_seed = mint.to_bytes();
+//     let seeds = &[
+//         MINT_AUTHORITY_SEED,
+//         signer_seed.as_slice(),
+//         mint_seed.as_slice(),
+//     ];
+//     Pubkey::find_program_address(seeds, &crate::ID)
+// }
 
 pub fn get_token_pool_pda(mint: &Pubkey) -> Pubkey {
     let seeds = &[POOL_SEED, mint.as_ref()];
@@ -409,7 +407,7 @@ pub fn get_token_pool_pda(mint: &Pubkey) -> Pubkey {
 
 #[cfg(not(target_os = "solana"))]
 pub mod mint_sdk {
-    use crate::{get_cpi_authority_pda, get_token_authority_pda, get_token_pool_pda};
+    use crate::{get_cpi_authority_pda, get_token_pool_pda};
     use anchor_lang::{system_program, InstructionData, ToAccountMetas};
     use anchor_spl;
     use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
@@ -420,7 +418,7 @@ pub mod mint_sdk {
         mint: &Pubkey,
     ) -> Instruction {
         let token_pool_pda = get_token_pool_pda(mint);
-        let mint_authority_pda = get_token_authority_pda(authority, mint).0;
+        // let mint_authority_pda = get_token_authority_pda(authority, mint).0;
         let instruction_data = crate::instruction::CreateMint {};
 
         let accounts = crate::accounts::CreateMintInstruction {
@@ -429,7 +427,7 @@ pub mod mint_sdk {
             token_pool_pda,
             system_program: system_program::ID,
             mint: *mint,
-            mint_authority_pda,
+            // mint_authority_pda,
             token_program: anchor_spl::token::ID,
             cpi_authority_pda: get_cpi_authority_pda().0,
         };
@@ -450,17 +448,17 @@ pub mod mint_sdk {
         public_keys: Vec<Pubkey>,
     ) -> Instruction {
         let token_pool_pda = get_token_pool_pda(mint);
-        let (mint_authority_pda, bump) = get_token_authority_pda(authority, mint);
+        // let (mint_authority_pda, bump) = get_token_authority_pda(authority, mint);
         let instruction_data = crate::instruction::MintTo {
             amounts,
             public_keys,
-            bump,
+            // bump,
         };
 
         let accounts = crate::accounts::MintToInstruction {
             fee_payer: *fee_payer,
             authority: *authority,
-            mint_authority_pda,
+            // mint_authority_pda,
             mint: *mint,
             token_pool_pda,
             token_program: anchor_spl::token::ID,
@@ -527,16 +525,17 @@ fn test_manual_ix_data_serialization_borsh_compat() {
             merkle_tree_index: 0,
         };
     }
-    let authority_bytes = Pubkey::new_unique().to_bytes();
-    let mint_bytes = Pubkey::new_unique().to_bytes();
-    let bump = &[255];
-    let seeds = [
-        MINT_AUTHORITY_SEED,
-        authority_bytes.as_slice(),
-        mint_bytes.as_slice(),
-        bump,
-    ];
-    let inputs_struct = light_system_program::InstructionDataInvokeCpi {
+    // let authority_bytes = Pubkey::new_unique().to_bytes();
+    // let mint_bytes = Pubkey::new_unique().to_bytes();
+    // let bump = &[255];
+    // let seeds = [
+    //     MINT_AUTHORITY_SEED,
+    //     authority_bytes.as_slice(),
+    //     mint_bytes.as_slice(),
+    //     bump,
+    // ];
+    // TODO: check if cpi ??
+    let inputs_struct = light_system_program::InstructionDataInvoke {
         relay_fee: None,
         input_compressed_accounts_with_merkle_context: Vec::with_capacity(0),
         output_compressed_accounts: output_compressed_accounts.clone(),
@@ -544,13 +543,13 @@ fn test_manual_ix_data_serialization_borsh_compat() {
         new_address_params: Vec::with_capacity(0),
         compression_lamports: None,
         is_compress: false,
-        signer_seeds: seeds.iter().map(|seed| seed.to_vec()).collect(),
-        cpi_context: None,
+        // signer_seeds: seeds.iter().map(|seed| seed.to_vec()).collect(),
+        // cpi_context: None,
     };
     let mut reference = Vec::<u8>::new();
     inputs_struct.serialize(&mut reference).unwrap();
     let mut inputs = Vec::<u8>::new();
-    serialize_mint_to_cpi_instruction_data(&mut inputs, output_compressed_accounts, &[&seeds]);
+    serialize_mint_to_cpi_instruction_data(&mut inputs, output_compressed_accounts);//, &[&seeds]);
 
     assert_eq!(inputs.len(), reference.len());
     for (j, i) in inputs.iter().zip(reference.iter()).enumerate() {

--- a/programs/compressed-token/src/process_mint.rs
+++ b/programs/compressed-token/src/process_mint.rs
@@ -179,7 +179,6 @@ pub fn cpi_execute_compressed_transaction_mint_to<'info>(
 ) -> Result<()> {
     light_heap::bench_sbf_start!("tm_cpi");
 
-    // TODO: confirm that it's better to get the vec outside instead of inside serialize fn
     let signer_seeds = get_cpi_signer_seeds();
     let signer_seeds_vec = signer_seeds.iter().map(|seed| seed.to_vec()).collect();
 

--- a/programs/compressed-token/src/process_mint.rs
+++ b/programs/compressed-token/src/process_mint.rs
@@ -340,8 +340,6 @@ pub struct MintToInstruction<'info> {
     pub fee_payer: Signer<'info>,
     #[account(mut)]
     pub authority: Signer<'info>,
-    // This is the cpi signer.
-    // TODO: double check security
     /// CHECK: that mint authority is derived from signer
     #[account(seeds = [b"cpi_authority"], bump,)]
     pub cpi_authority_pda: UncheckedAccount<'info>,

--- a/programs/compressed-token/src/process_mint.rs
+++ b/programs/compressed-token/src/process_mint.rs
@@ -16,7 +16,6 @@ use light_utils::hash_to_bn254_field_size_be;
 
 use std::mem;
 pub const POOL_SEED: &[u8] = b"pool";
-// pub const MINT_AUTHORITY_SEED: &[u8] = b"mint_authority_pda";
 
 /// creates a token pool account which is owned by the token authority pda
 #[derive(Accounts)]
@@ -326,9 +325,9 @@ pub fn mint_spl_to_pool_pda<'info>(
     }
 
     let cpi_accounts = anchor_spl::token::MintTo {
-        authority: ctx.accounts.authority.to_account_info(),
         mint: ctx.accounts.mint.to_account_info(),
         to: ctx.accounts.token_pool_pda.to_account_info(),
+        authority: ctx.accounts.authority.to_account_info(),
     };
     let cpi_ctx = CpiContext::new(ctx.accounts.token_program.to_account_info(), cpi_accounts);
 

--- a/programs/compressed-token/src/process_transfer.rs
+++ b/programs/compressed-token/src/process_transfer.rs
@@ -191,6 +191,14 @@ pub fn add_token_data_to_input_compressed_accounts(
     Ok(())
 }
 
+// TODO: consider to helpers
+/// Get static cpi signer seeds
+pub fn get_cpi_signer_seeds() -> [&'static [u8]; 2] {
+    let bump: &[u8; 1] = &[255];
+    let seeds: [&'static [u8]; 2] = [b"cpi_authority", bump];
+    seeds
+}
+
 #[inline(never)]
 pub fn cpi_execute_compressed_transaction_transfer<'info>(
     ctx: &Context<'_, '_, '_, 'info, TransferInstruction<'info>>,
@@ -201,10 +209,11 @@ pub fn cpi_execute_compressed_transaction_transfer<'info>(
 ) -> Result<()> {
     bench_sbf_start!("t_cpi_prep");
 
-    let bump = &[255];
-    let seeds: [&[u8]; 2] = [b"cpi_authority".as_slice(), bump];
+    let signer_seeds = get_cpi_signer_seeds();
+    let signer_seeds_ref = &[&signer_seeds[..]];
 
-    let signer_seeds = &[&seeds[..]];
+
+    // let signer_seeds = &[&seeds[..]];
     let cpi_context_account = cpi_context.map(|cpi_context| {
         ctx.remaining_accounts[cpi_context.cpi_context_account_index as usize].to_account_info()
     });
@@ -216,7 +225,7 @@ pub fn cpi_execute_compressed_transaction_transfer<'info>(
         new_address_params: Vec::new(),
         compression_lamports: None,
         is_compress: false,
-        signer_seeds: seeds.iter().map(|seed| seed.to_vec()).collect(),
+        signer_seeds: signer_seeds.iter().map(|seed| seed.to_vec()).collect(),
         cpi_context,
     };
     let mut inputs = Vec::new();
@@ -238,7 +247,7 @@ pub fn cpi_execute_compressed_transaction_transfer<'info>(
     let mut cpi_ctx = CpiContext::new_with_signer(
         ctx.accounts.light_system_program.to_account_info(),
         cpi_accounts,
-        signer_seeds,
+        signer_seeds_ref,
     );
 
     cpi_ctx.remaining_accounts = ctx.remaining_accounts.to_vec();

--- a/programs/compressed-token/src/process_transfer.rs
+++ b/programs/compressed-token/src/process_transfer.rs
@@ -212,7 +212,6 @@ pub fn cpi_execute_compressed_transaction_transfer<'info>(
     let signer_seeds = get_cpi_signer_seeds();
     let signer_seeds_ref = &[&signer_seeds[..]];
 
-
     // let signer_seeds = &[&seeds[..]];
     let cpi_context_account = cpi_context.map(|cpi_context| {
         ctx.remaining_accounts[cpi_context.cpi_context_account_index as usize].to_account_info()

--- a/programs/compressed-token/src/process_transfer.rs
+++ b/programs/compressed-token/src/process_transfer.rs
@@ -191,7 +191,7 @@ pub fn add_token_data_to_input_compressed_accounts(
     Ok(())
 }
 
-// TODO: consider to helpers
+// TODO: consider moving this function to helpers
 /// Get static cpi signer seeds
 pub fn get_cpi_signer_seeds() -> [&'static [u8]; 2] {
     let bump: &[u8; 1] = &[255];

--- a/programs/compressed-token/src/process_transfer.rs
+++ b/programs/compressed-token/src/process_transfer.rs
@@ -212,7 +212,6 @@ pub fn cpi_execute_compressed_transaction_transfer<'info>(
     let signer_seeds = get_cpi_signer_seeds();
     let signer_seeds_ref = &[&signer_seeds[..]];
 
-    // let signer_seeds = &[&seeds[..]];
     let cpi_context_account = cpi_context.map(|cpi_context| {
         ctx.remaining_accounts[cpi_context.cpi_context_account_index as usize].to_account_info()
     });

--- a/programs/system/src/invoke_cpi/verify_signer.rs
+++ b/programs/system/src/invoke_cpi/verify_signer.rs
@@ -45,7 +45,7 @@ pub fn cpi_signer_check(
     if derived_signer != *signer {
         msg!(
                     "Signer/Program cannot write into an account it doesn't own. Write access check failed derived cpi signer {} !=  signer {}",
-                    signer,
+                    derived_signer,
                     signer
                 );
         msg!("seeds: {:?}", seeds);

--- a/test-utils/src/assert_token_tx.rs
+++ b/test-utils/src/assert_token_tx.rs
@@ -5,9 +5,7 @@ use crate::{
     },
     test_indexer::{TestIndexer, TokenDataWithContext},
 };
-use light_compressed_token::{
-    get_cpi_authority_pda, get_token_pool_pda, TokenTransferOutputData,
-};
+use light_compressed_token::{get_cpi_authority_pda, get_token_pool_pda, TokenTransferOutputData};
 use light_system_program::sdk::{
     compressed_account::CompressedAccountWithMerkleContext, event::PublicTransactionEvent,
 };
@@ -229,7 +227,6 @@ pub async fn assert_create_mint<R: RpcConnection>(
     let mint_account: spl_token::state::Mint =
         spl_token::state::Mint::unpack(&context.get_account(*mint).await.unwrap().unwrap().data)
             .unwrap();
-    // let mint_authority = get_token_authority_pda(authority, mint).0;
     assert_eq!(mint_account.supply, 0);
     assert_eq!(mint_account.decimals, 2);
     assert_eq!(mint_account.mint_authority.unwrap(), *authority);

--- a/test-utils/src/assert_token_tx.rs
+++ b/test-utils/src/assert_token_tx.rs
@@ -6,7 +6,7 @@ use crate::{
     test_indexer::{TestIndexer, TokenDataWithContext},
 };
 use light_compressed_token::{
-    get_cpi_authority_pda, get_token_authority_pda, get_token_pool_pda, TokenTransferOutputData,
+    get_cpi_authority_pda, get_token_pool_pda, TokenTransferOutputData,
 };
 use light_system_program::sdk::{
     compressed_account::CompressedAccountWithMerkleContext, event::PublicTransactionEvent,
@@ -229,10 +229,10 @@ pub async fn assert_create_mint<R: RpcConnection>(
     let mint_account: spl_token::state::Mint =
         spl_token::state::Mint::unpack(&context.get_account(*mint).await.unwrap().unwrap().data)
             .unwrap();
-    let mint_authority = get_token_authority_pda(authority, mint).0;
+    // let mint_authority = get_token_authority_pda(authority, mint).0;
     assert_eq!(mint_account.supply, 0);
     assert_eq!(mint_account.decimals, 2);
-    assert_eq!(mint_account.mint_authority.unwrap(), mint_authority);
+    assert_eq!(mint_account.mint_authority.unwrap(), *authority);
     assert_eq!(mint_account.freeze_authority, None.into());
     assert!(mint_account.is_initialized);
     let mint_account: spl_token::state::Account =

--- a/test-utils/src/spl.rs
+++ b/test-utils/src/spl.rs
@@ -9,7 +9,7 @@ use crate::{
 use crate::rpc::rpc_connection::RpcConnection;
 use crate::transaction_params::TransactionParams;
 use light_compressed_token::{
-    get_cpi_authority_pda, get_token_authority_pda, get_token_pool_pda,
+    get_cpi_authority_pda, get_token_pool_pda,
     mint_sdk::{create_initialize_mint_instruction, create_mint_to_instruction},
     transfer_sdk::create_transfer_instruction,
     TokenTransferOutputData,
@@ -163,11 +163,11 @@ pub fn create_initialize_mint_instructions(
     );
 
     let mint_pubkey = mint_keypair.pubkey();
-    let mint_authority = get_token_authority_pda(authority, &mint_pubkey).0;
+    // let mint_authority = get_token_authority_pda(authority, &mint_pubkey).0;
     let create_mint_instruction = initialize_mint(
         &anchor_spl::token::ID,
         &mint_keypair.pubkey(),
-        &mint_authority,
+        &authority,
         None,
         decimals,
     )

--- a/test-utils/src/spl.rs
+++ b/test-utils/src/spl.rs
@@ -163,11 +163,10 @@ pub fn create_initialize_mint_instructions(
     );
 
     let mint_pubkey = mint_keypair.pubkey();
-    // let mint_authority = get_token_authority_pda(authority, &mint_pubkey).0;
     let create_mint_instruction = initialize_mint(
         &anchor_spl::token::ID,
         &mint_keypair.pubkey(),
-        &authority,
+        authority,
         None,
         decimals,
     )
@@ -175,7 +174,7 @@ pub fn create_initialize_mint_instructions(
     let transfer_ix =
         anchor_lang::solana_program::system_instruction::transfer(payer, &mint_pubkey, rent);
 
-    let instruction = create_initialize_mint_instruction(payer, authority, &mint_pubkey);
+    let instruction = create_initialize_mint_instruction(payer, &mint_pubkey);
     let pool_pubkey = get_token_pool_pda(&mint_pubkey);
     (
         [

--- a/test-utils/src/test_indexer.rs
+++ b/test-utils/src/test_indexer.rs
@@ -30,7 +30,7 @@ use {
         },
     },
     light_compressed_token::{
-        constants::TOKEN_COMPRESSED_ACCOUNT_DISCRIMINATOR, get_token_authority_pda,
+        constants::TOKEN_COMPRESSED_ACCOUNT_DISCRIMINATOR,
         get_token_pool_pda, mint_sdk::create_initialize_mint_instruction, token_data::TokenData,
     },
     light_hasher::Poseidon,
@@ -739,11 +739,11 @@ pub fn create_initialize_mint_instructions(
     );
 
     let mint_pubkey = mint_keypair.pubkey();
-    let mint_authority = get_token_authority_pda(authority, &mint_pubkey);
+    // let mint_authority = get_token_authority_pda(authority, &mint_pubkey);
     let create_mint_instruction = initialize_mint(
         &anchor_spl::token::ID,
         &mint_keypair.pubkey(),
-        &mint_authority.0,
+        &authority,
         None,
         decimals,
     )

--- a/test-utils/src/test_indexer.rs
+++ b/test-utils/src/test_indexer.rs
@@ -30,8 +30,8 @@ use {
         },
     },
     light_compressed_token::{
-        constants::TOKEN_COMPRESSED_ACCOUNT_DISCRIMINATOR,
-        get_token_pool_pda, mint_sdk::create_initialize_mint_instruction, token_data::TokenData,
+        constants::TOKEN_COMPRESSED_ACCOUNT_DISCRIMINATOR, get_token_pool_pda,
+        mint_sdk::create_initialize_mint_instruction, token_data::TokenData,
     },
     light_hasher::Poseidon,
     light_indexed_merkle_tree::{array::IndexedArray, reference::IndexedMerkleTree},
@@ -739,11 +739,10 @@ pub fn create_initialize_mint_instructions(
     );
 
     let mint_pubkey = mint_keypair.pubkey();
-    // let mint_authority = get_token_authority_pda(authority, &mint_pubkey);
     let create_mint_instruction = initialize_mint(
         &anchor_spl::token::ID,
         &mint_keypair.pubkey(),
-        &authority,
+        authority,
         None,
         decimals,
     )
@@ -751,7 +750,7 @@ pub fn create_initialize_mint_instructions(
     let transfer_ix =
         anchor_lang::solana_program::system_instruction::transfer(payer, &mint_pubkey, rent);
 
-    let instruction = create_initialize_mint_instruction(payer, authority, &mint_pubkey);
+    let instruction = create_initialize_mint_instruction(payer, &mint_pubkey);
     let pool_pubkey = get_token_pool_pda(&mint_pubkey);
     (
         [


### PR DESCRIPTION
### Changes 

compressed-token program:

* `create-mint`: 
    * Remove any `authority` signer account. `Create-mint` registers the mint by creating the `tokenPoolPda`
    * `tokenPoolPda` is derived from `Mint`, not from `authority`.
    * Anyone can create this PDA, which allows any account to compress tokens of said mint.
        * This is required so that mints with burned `mintAuthority` can still be compressed.

* `Mint-to`
    * `process_mint_to`
        * Removed `mintAuthorityPda`, instead...  
        * Use static `cpiAuthority` to CPI into the system program. 
        * No `mintAuthority` check in our system is required because `mint_spl_to_pool_pda` already does the `mintAuthority` signer check
            * CPI into SPL mint-to passes authority (`mintAuthority`), which has to sign the tx


* Added `get_cpi_signer_seeds`() helper because its reused in process_transfer
* Removed `get_token_authority_pda` because it is unused now


All this simplifies the JS client and CLI:

* `createMint` can now reuse `registerMint` logic because authorities are dealt with consistently.
* `mintAuthority` is no longer required as TX signer for `register-mint` (this was prev. unchecked), and `create-mint`. So we pass it as pubkeys now. 


