### PR TITLE
chore: simplify build.sh & test.sh

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -49,6 +49,7 @@
     "which": "^4.0.0"
   },
   "devDependencies": {
+    "@lightprotocol/programs": "workspace:*",
     "@oclif/test": "2.3.9",
     "@solana/spl-token": "^0.3.11",
     "@types/bn.js": "^5.1.5",

--- a/js/compressed-token/package.json
+++ b/js/compressed-token/package.json
@@ -74,6 +74,7 @@
     "devDependencies": {
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
         "@lightprotocol/hasher.rs": "workspace:*",
+        "@lightprotocol/programs": "workspace:*",
         "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/js/stateless.js/package.json
+++ b/js/stateless.js/package.json
@@ -47,6 +47,7 @@
     "devDependencies": {
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
         "@lightprotocol/hasher.rs": "workspace:*",
+        "@lightprotocol/programs": "workspace:*",
         "@playwright/test": "^1.43.1",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
     devDependencies:
+      '@lightprotocol/programs':
+        specifier: workspace:*
+        version: link:../programs
       '@oclif/test':
         specifier: 2.3.9
         version: 2.3.9(@types/node@20.12.7)(typescript@5.3.2)
@@ -488,10 +491,6 @@ importers:
         specifier: ^0.34.6
         version: 0.34.6(@vitest/browser@0.34.6)(playwright@1.40.1)
 
-  hasher.rs/src/main/wasm: {}
-
-  hasher.rs/src/main/wasm-simd: {}
-
   js/compressed-token:
     dependencies:
       '@coral-xyz/anchor':
@@ -519,6 +518,9 @@ importers:
       '@lightprotocol/hasher.rs':
         specifier: workspace:*
         version: link:../../hasher.rs
+      '@lightprotocol/programs':
+        specifier: workspace:*
+        version: link:../../programs
       '@rollup/plugin-alias':
         specifier: ^5.1.0
         version: 5.1.0(rollup@4.6.1)
@@ -637,6 +639,9 @@ importers:
       '@lightprotocol/hasher.rs':
         specifier: workspace:*
         version: link:../../hasher.rs
+      '@lightprotocol/programs':
+        specifier: workspace:*
+        version: link:../../programs
       '@playwright/test':
         specifier: ^1.43.1
         version: 1.43.1

--- a/programs/package.json
+++ b/programs/package.json
@@ -3,7 +3,8 @@
   "version": "0.3.0",
   "license": "GPL-3.0",
   "scripts": {
-    "build": "anchor build",
+    "push-idls": "../scripts/push-stateless-js-idls.sh && ../scripts/push-compressed-token-idl.sh",
+    "build": "anchor build && pnpm push-idls",
     "test": "pnpm test-account-compression && pnpm test-system && pnpm test-compressed-token && pnpm test-registry",
     "test-account-compression": "cargo-test-sbf -p account-compression-test -- --test-threads=1",
     "test-system": "cargo test-sbf -p system-test -- --test-threads=1",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,19 +9,8 @@ set -eux
 
 pnpm install || { echo >&2 "Failed to install dependencies. Aborting."; exit 1; }
 
-npx nx run-many --target=build --all \
-  --exclude=web-wallet \
-  --exclude=@lightprotocol/zk-compression-cli \
-  --exclude=@lightprotocol/stateless.js \
-  --exclude=@lightprotocol/compressed-token && \
-wget https://github.com/Lightprotocol/light-protocol/releases/download/spl-noop-v0.2.0/spl_noop.so && \
-mv spl_noop.so ./target/deploy/spl_noop.so && \
-# Distribute IDL files to client libraries
-./scripts/push-stateless-js-idls.sh && \
-./scripts/push-compressed-token-idl.sh
-# Enforce build order of dependent projects
-npx nx run @lightprotocol/stateless.js:build
-npx nx run @lightprotocol/compressed-token:build
-npx nx run @lightprotocol/zk-compression-cli:build
+mkdir -p target/deploy && cp third-party/solana-program-library/spl_noop.so target/deploy
+
+npx nx run-many --target=build --all
 
 echo "Build process completed successfully."

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,6 +4,4 @@
 
 set -eux
 
-npx nx run-many --target=test --all --parallel=false \
-  --exclude cli \
-  --exclude web-wallet
+npx nx run-many --target=test --all --parallel=false


### PR DESCRIPTION
Simplify build.sh & test.sh  by introducing @lightprotocol/programs dependency for js packages and moving idls scripts to programs build phase