### PR TITLE
test: Ensure that `iter_from()` returns an empty iterator when out of bounds

### DIFF
--- a/merkle-tree/bounded-vec/src/lib.rs
+++ b/merkle-tree/bounded-vec/src/lib.rs
@@ -7,12 +7,14 @@ use std::{
 
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum BoundedVecError {
     #[error("The vector is full, cannot push any new elements")]
     Full,
     #[error("Requested array of size {0}, but the vector has {1} elements")]
     ArraySize(usize, usize),
+    #[error("The requested start index is out of bounds.")]
+    IterFromOutOfBounds,
 }
 
 #[cfg(feature = "solana")]
@@ -21,6 +23,7 @@ impl From<BoundedVecError> for u32 {
         match e {
             BoundedVecError::Full => 8001,
             BoundedVecError::ArraySize(_, _) => 8002,
+            BoundedVecError::IterFromOutOfBounds => 8003,
         }
     }
 }
@@ -463,12 +466,18 @@ where
     }
 
     #[inline]
-    pub fn iter_from(&self, start: usize) -> CyclicBoundedVecIterator<'_, T> {
-        CyclicBoundedVecIterator {
+    pub fn iter_from(
+        &self,
+        start: usize,
+    ) -> Result<CyclicBoundedVecIterator<'_, T>, BoundedVecError> {
+        if start >= self.len() {
+            return Err(BoundedVecError::IterFromOutOfBounds);
+        }
+        Ok(CyclicBoundedVecIterator {
             vec: self,
             current: start,
             is_finished: false,
-        }
+        })
     }
 
     #[inline]
@@ -689,7 +698,7 @@ mod test {
         assert_eq!(elements.len(), 1);
         assert_eq!(elements.as_slice(), &[&0]);
 
-        let elements = cyclic_bounded_vec.iter_from(0).collect::<Vec<_>>();
+        let elements = cyclic_bounded_vec.iter_from(0).unwrap().collect::<Vec<_>>();
         assert_eq!(elements.len(), 1);
         assert_eq!(elements.as_slice(), &[&0]);
     }
@@ -728,7 +737,7 @@ mod test {
         assert_eq!(cyclic_bounded_vec.first_index, 0);
         assert_eq!(cyclic_bounded_vec.last_index, 5);
 
-        let elements = cyclic_bounded_vec.iter_from(2).collect::<Vec<_>>();
+        let elements = cyclic_bounded_vec.iter_from(2).unwrap().collect::<Vec<_>>();
         assert_eq!(elements.len(), 4);
         assert_eq!(elements.as_slice(), &[&2, &3, &4, &5]);
     }
@@ -766,7 +775,7 @@ mod test {
         assert_eq!(cyclic_bounded_vec.first_index, 0);
         assert_eq!(cyclic_bounded_vec.last_index, 4);
 
-        let elements = cyclic_bounded_vec.iter_from(2).collect::<Vec<_>>();
+        let elements = cyclic_bounded_vec.iter_from(2).unwrap().collect::<Vec<_>>();
         assert_eq!(elements.len(), 3);
         assert_eq!(elements.as_slice(), &[&2, &3, &4]);
     }
@@ -805,7 +814,7 @@ mod test {
         assert_eq!(cyclic_bounded_vec.first_index, 0);
         assert_eq!(cyclic_bounded_vec.last_index, 7);
 
-        let elements = cyclic_bounded_vec.iter_from(2).collect::<Vec<_>>();
+        let elements = cyclic_bounded_vec.iter_from(2).unwrap().collect::<Vec<_>>();
         assert_eq!(elements.len(), 6);
         assert_eq!(elements.as_slice(), &[&2, &3, &4, &5, &6, &7]);
     }
@@ -850,7 +859,7 @@ mod test {
         assert_eq!(cyclic_bounded_vec.first_index, 4);
         assert_eq!(cyclic_bounded_vec.last_index, 3);
 
-        let elements = cyclic_bounded_vec.iter_from(6).collect::<Vec<_>>();
+        let elements = cyclic_bounded_vec.iter_from(6).unwrap().collect::<Vec<_>>();
         assert_eq!(elements.len(), 6);
         assert_eq!(elements.as_slice(), &[&6, &7, &8, &9, &10, &11]);
     }
@@ -865,7 +874,7 @@ mod test {
 
         // Try `start` values in bounds.
         for i in 0..4 {
-            let elements = cyclic_bounded_vec.iter_from(i).collect::<Vec<_>>();
+            let elements = cyclic_bounded_vec.iter_from(i).unwrap().collect::<Vec<_>>();
             assert_eq!(elements.len(), 4 - i);
             let expected = (i..4).collect::<Vec<_>>();
             // Just to coerce it to have references...
@@ -875,8 +884,11 @@ mod test {
 
         // Try `start` values out of bounds.
         for i in 4..1000 {
-            let elements = cyclic_bounded_vec.iter_from(i).collect::<Vec<_>>();
-            assert!(elements.is_empty());
+            let elements = cyclic_bounded_vec.iter_from(i);
+            assert!(matches!(
+                elements,
+                Err(BoundedVecError::IterFromOutOfBounds)
+            ));
         }
     }
 
@@ -890,8 +902,24 @@ mod test {
 
         // Try different `start` values which are out of bounds.
         for start in 8..1000 {
-            let elements = cyclic_bounded_vec.iter_from(start).collect::<Vec<_>>();
-            assert!(elements.is_empty());
+            let elements = cyclic_bounded_vec.iter_from(start);
+            assert!(matches!(
+                elements,
+                Err(BoundedVecError::IterFromOutOfBounds)
+            ));
+        }
+    }
+
+    #[test]
+    fn test_cyclic_bounded_vec_iter_from_out_of_bounds_iter_from() {
+        let mut cyclic_bounded_vec = CyclicBoundedVec::with_capacity(8);
+
+        for i in 0..8 {
+            assert!(matches!(
+                cyclic_bounded_vec.iter_from(i),
+                Err(BoundedVecError::IterFromOutOfBounds)
+            ));
+            cyclic_bounded_vec.push(i);
         }
     }
 

--- a/merkle-tree/bounded-vec/src/lib.rs
+++ b/merkle-tree/bounded-vec/src/lib.rs
@@ -838,7 +838,7 @@ mod test {
     ///
     /// Should iterate over elements 6..7 and 8..11 - 6 iterations.
     #[test]
-    fn test_cyclic_bounded_vec_iter_reset() {
+    fn test_cyclic_bounded_vec_iter_from_reset() {
         let mut cyclic_bounded_vec = CyclicBoundedVec::with_capacity(8);
 
         for i in 0..12 {
@@ -853,6 +853,46 @@ mod test {
         let elements = cyclic_bounded_vec.iter_from(6).collect::<Vec<_>>();
         assert_eq!(elements.len(), 6);
         assert_eq!(elements.as_slice(), &[&6, &7, &8, &9, &10, &11]);
+    }
+
+    #[test]
+    fn test_cyclic_bounded_vec_iter_from_out_of_bounds_not_full() {
+        let mut cyclic_bounded_vec = CyclicBoundedVec::with_capacity(8);
+
+        for i in 0..4 {
+            cyclic_bounded_vec.push(i);
+        }
+
+        // Try `start` values in bounds.
+        for i in 0..4 {
+            let elements = cyclic_bounded_vec.iter_from(i).collect::<Vec<_>>();
+            assert_eq!(elements.len(), 4 - i);
+            let expected = (i..4).collect::<Vec<_>>();
+            // Just to coerce it to have references...
+            let expected = expected.iter().collect::<Vec<_>>();
+            assert_eq!(elements.as_slice(), expected.as_slice());
+        }
+
+        // Try `start` values out of bounds.
+        for i in 4..1000 {
+            let elements = cyclic_bounded_vec.iter_from(i).collect::<Vec<_>>();
+            assert!(elements.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_cyclic_bounded_vec_iter_from_out_of_bounds_full() {
+        let mut cyclic_bounded_vec = CyclicBoundedVec::with_capacity(8);
+
+        for i in 0..12 {
+            cyclic_bounded_vec.push(i);
+        }
+
+        // Try different `start` values which are out of bounds.
+        for start in 8..1000 {
+            let elements = cyclic_bounded_vec.iter_from(start).collect::<Vec<_>>();
+            assert!(elements.is_empty());
+        }
     }
 
     #[test]

--- a/merkle-tree/concurrent/src/lib.rs
+++ b/merkle-tree/concurrent/src/lib.rs
@@ -775,7 +775,8 @@ where
     pub fn changelog_entries(
         &self,
         changelog_index: usize,
-    ) -> Skip<CyclicBoundedVecIterator<'_, ChangelogEntry<HEIGHT>>> {
+    ) -> Result<Skip<CyclicBoundedVecIterator<'_, ChangelogEntry<HEIGHT>>>, ConcurrentMerkleTreeError>
+    {
         // `CyclicBoundedVec::iter_from` returns an iterator which includes also
         // the element indicated by the provided index.
         //
@@ -787,7 +788,7 @@ where
         // `changelog_index + 1` would point to the **oldest** changelog entry.
         // That would result in iterating over the whole changelog - from the
         // oldest to the newest element.
-        self.changelog.iter_from(changelog_index).skip(1)
+        Ok(self.changelog.iter_from(changelog_index)?.skip(1))
     }
 
     /// Updates the given Merkle proof.
@@ -818,7 +819,7 @@ where
         //
         // Since we are interested only in subsequent, new changelog entries,
         // skip the first result.
-        for changelog_entry in self.changelog_entries(changelog_index) {
+        for changelog_entry in self.changelog_entries(changelog_index)? {
             changelog_entry.update_proof(leaf_index, proof)?;
         }
 

--- a/merkle-tree/concurrent/tests/tests.rs
+++ b/merkle-tree/concurrent/tests/tests.rs
@@ -2788,6 +2788,12 @@ where
     let changelog_entries = merkle_tree.changelog_entries(1).collect::<Vec<_>>();
     assert!(changelog_entries.is_empty());
 
+    // Try getting changelog entries out of bounds.
+    for start in merkle_tree.changelog.len()..1000 {
+        let changelog_entries = merkle_tree.changelog_entries(start).collect::<Vec<_>>();
+        assert!(changelog_entries.is_empty());
+    }
+
     merkle_tree
         .append(&[
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2818,6 +2824,12 @@ where
             ]
         ]
     );
+
+    // Try getting changelog entries out of bounds.
+    for start in merkle_tree.changelog.len()..1000 {
+        let changelog_entries = merkle_tree.changelog_entries(start).collect::<Vec<_>>();
+        assert!(changelog_entries.is_empty());
+    }
 
     for i in 4_u8..16_u8 {
         merkle_tree
@@ -2861,6 +2873,12 @@ where
             ]
         ]
     );
+
+    // Try getting changelog entries out of bounds.
+    for start in merkle_tree.changelog.len()..1000 {
+        let changelog_entries = merkle_tree.changelog_entries(start).collect::<Vec<_>>();
+        assert!(changelog_entries.is_empty());
+    }
 }
 
 #[test]

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -414,27 +414,27 @@ async fn update_address_merkle_tree_failing_tests() {
     .unwrap();
 
     // TODO: enable once cyclic bounded vec iter_from is fixed
-    // let invalid_changelog_index_high = changelog_index + 2;
-    // let error_invalid_changelog_index_high = update_merkle_tree(
-    //     &mut context,
-    //     address_queue_pubkey,
-    //     address_merkle_tree_pubkey,
-    //     value_index,
-    //     low_element.index as u64,
-    //     bigint_to_be_bytes_array(&low_element.value).unwrap(),
-    //     low_element.next_index as u64,
-    //     bigint_to_be_bytes_array(&low_element_next_value).unwrap(),
-    //     low_element_proof.to_array().unwrap(),
-    //     Some(invalid_changelog_index_high as u16),
-    // )
-    // .await
-    // .unwrap_err();
-    // assert_rpc_error(
-    //     Err(error_invalid_changelog_index_high),
-    //     0,
-    //     10008, // ConcurrentMerkleTreeError::InvalidProof
-    // )
-    // .unwrap();
+    let invalid_changelog_index_high = changelog_index + 2;
+    let error_invalid_changelog_index_high = update_merkle_tree(
+        &mut context,
+        address_queue_pubkey,
+        address_merkle_tree_pubkey,
+        value_index,
+        low_element.index as u64,
+        bigint_to_be_bytes_array(&low_element.value).unwrap(),
+        low_element.next_index as u64,
+        bigint_to_be_bytes_array(&low_element_next_value).unwrap(),
+        low_element_proof.to_array().unwrap(),
+        Some(invalid_changelog_index_high as u16),
+    )
+    .await
+    .unwrap_err();
+    assert_rpc_error(
+        Err(error_invalid_changelog_index_high),
+        0,
+        8003, // BoundedVecError::IterFromOutOfBounds
+    )
+    .unwrap();
     // CHECK: 11 invalid queue account
     let invalid_queue = address_merkle_tree_pubkey;
     let error_invalid_queue = update_merkle_tree(


### PR DESCRIPTION
Make sure that:

* `CyclicBoundedVec::iter_from()`
* `ConcurrentMerkleTree::changelog_entries()`

return an empty iterator when the provided `start` value is out of bounds.