### PR TITLE
fix: e2e test nullification, remove broken hashset iterator

### DIFF
--- a/merkle-tree/hash-set/src/zero_copy.rs
+++ b/merkle-tree/hash-set/src/zero_copy.rs
@@ -2,7 +2,7 @@ use std::{marker::PhantomData, mem, ptr::NonNull};
 
 use num_bigint::BigUint;
 
-use crate::{HashSet, HashSetCell, HashSetError, HashSetIterator};
+use crate::{HashSet, HashSetCell, HashSetError};
 
 /// A `HashSet` wrapper which can be instantiated from Solana account bytes
 /// without copying them.
@@ -161,10 +161,6 @@ impl<'a> HashSetZeroCopy<'a> {
         self.hash_set
             .mark_with_sequence_number(value, sequence_number)
     }
-
-    pub fn iter(&self) -> HashSetIterator {
-        self.hash_set.iter()
-    }
 }
 
 impl<'a> Drop for HashSetZeroCopy<'a> {
@@ -218,8 +214,6 @@ mod test {
             // Ensure that the underlying data were properly initialized.
             assert_eq!(hs.hash_set.capacity, VALUES);
             assert_eq!(hs.hash_set.sequence_threshold, SEQUENCE_THRESHOLD);
-            let mut iterator = hs.iter();
-            assert_eq!(iterator.next(), None);
             for i in 0..VALUES {
                 assert!(unsafe { &*hs.hash_set.buckets.as_ptr().add(i) }.is_none());
             }

--- a/test-utils/src/e2e_test_env.rs
+++ b/test-utils/src/e2e_test_env.rs
@@ -1033,7 +1033,7 @@ impl Default for GeneralActionConfig {
             add_keypair: Some(0.3),
             create_state_mt: Some(1.0),
             create_address_mt: Some(1.0),
-            nullify_compressed_accounts: Some(0.1),
+            nullify_compressed_accounts: Some(1.0),
             empty_address_queue: Some(1.0),
         }
     }


### PR DESCRIPTION
Issue:
- iterator of hashset was broken
- hash_set.iter().collect returned []

Changes:
- test_forester.rs
  - use get_bucket instead of iterator
- hashset
  - remove iterator 