### PR TITLE
chore: build system & compressed-token programs with cpi-context feature enabled via programs/package.json

### DIFF
--- a/programs/package.json
+++ b/programs/package.json
@@ -4,7 +4,9 @@
   "license": "GPL-3.0",
   "scripts": {
     "push-idls": "../scripts/push-stateless-js-idls.sh && ../scripts/push-compressed-token-idl.sh",
-    "build": "anchor build && pnpm push-idls",
+    "build": "anchor build && pnpm build-system && pnpm build-compressed-token && pnpm push-idls",
+    "build-system": "anchor build --program-name light_system_program -- --features cpi-context",
+    "build-compressed-token": "anchor build --program-name light_compressed_token -- --features cpi-context",
     "test": "pnpm test-account-compression && pnpm test-system && pnpm test-compressed-token && pnpm test-registry",
     "test-account-compression": "cargo-test-sbf -p account-compression-test -- --test-threads=1",
     "test-system": "cargo test-sbf -p system-test -- --test-threads=1",


### PR DESCRIPTION
Attempting to build and test the light-protocol from a clean state results in an error. 
This pull request fixes the problem by rebuilding the programs with the `cpi-context` feature enabled.

```
[2024-06-03T11:48:46.184015370Z DEBUG solana_runtime::message_processor::stable_log] Program log: Instruction: Transfer
[2024-06-03T11:48:46.184230185Z DEBUG solana_runtime::message_processor::stable_log] Program log: panicked at programs/compressed-token/src/process_transfer.rs:220:9:
    not implemented: cpi-context feature is not enabled
[2024-06-03T11:48:46.184241553Z DEBUG solana_runtime::message_processor::stable_log] Program HXVfQ44ATEi9WBKLSCCwM54KokdkzqXci9xCQ7ST9SYN consumed 24514 of 1358937 compute units
[2024-06-03T11:48:46.184259832Z DEBUG solana_runtime::message_processor::stable_log] Program HXVfQ44ATEi9WBKLSCCwM54KokdkzqXci9xCQ7ST9SYN failed: SBF program panicked
[2024-06-03T11:48:46.184265132Z DEBUG solana_runtime::message_processor::stable_log] Program GRLu2hKaAiMbxpkAM1HeXzks9YeGuz18SEgXEizVvPqX consumed 65577 of 1400000 compute units
[2024-06-03T11:48:46.184268566Z DEBUG solana_runtime::message_processor::stable_log] Program GRLu2hKaAiMbxpkAM1HeXzks9YeGuz18SEgXEizVvPqX failed: Program failed to complete
FAILED

failures:

---- test_escrow_with_compressed_pda stdout ----
thread 'test_escrow_with_compressed_pda' panicked at examples/token-escrow/programs/token-escrow/tests/test_compressed_pda.rs:82:6:
called `Result::unwrap()` on an `Err` value: TransactionError(InstructionError(0, ProgramFailedToComplete))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test_escrow_with_compressed_pda

```