### PR TITLE
chore: rpc-interop with photon 0.21.0

### DIFF
--- a/cli/src/utils/constants.ts
+++ b/cli/src/utils/constants.ts
@@ -16,7 +16,7 @@ export const SOLANA_VALIDATOR_PROCESS_NAME = "solana-test-validator";
 export const LIGHT_PROVER_PROCESS_NAME = "light-prover";
 export const INDEXER_PROCESS_NAME = "photon";
 
-export const PHOTON_VERSION = "0.18.0";
+export const PHOTON_VERSION = "0.21.0";
 
 export const LIGHT_PROTOCOL_PROGRAMS_DIR_ENV = "LIGHT_PROTOCOL_PROGRAMS_DIR";
 export const BASE_PATH = "../../bin/";

--- a/js/compressed-token/package.json
+++ b/js/compressed-token/package.json
@@ -40,7 +40,7 @@
         "test:e2e:compress": "pnpm test-validator && vitest run tests/e2e/compress.test.ts --reporter=verbose",
         "test:e2e:decompress": "pnpm test-validator && vitest run tests/e2e/decompress.test.ts --reporter=verbose",
         "test:e2e:rpc-token-interop": "pnpm test-validator && vitest run tests/e2e/rpc-token-interop.test.ts --reporter=verbose",
-        "test:e2e:all": "pnpm test-validator && vitest run tests/e2e/create-mint.test.ts && vitest run tests/e2e/mint-to.test.ts && vitest run tests/e2e/transfer.test.ts && vitest run tests/e2e/compress.test.ts && vitest run tests/e2e/decompress.test.ts && vitest run tests/e2e/register-mint.test.ts && vitest run tests/e2e/approve-and-mint-to.test.ts",
+        "test:e2e:all": "pnpm test-validator && vitest run tests/e2e/create-mint.test.ts && vitest run tests/e2e/mint-to.test.ts && vitest run tests/e2e/transfer.test.ts && vitest run tests/e2e/compress.test.ts && vitest run tests/e2e/decompress.test.ts && vitest run tests/e2e/register-mint.test.ts && vitest run tests/e2e/approve-and-mint-to.test.ts && vitest run tests/e2e/rpc-token-interop.test.ts",
         "pull-idl": "../../scripts/push-compressed-token-idl.sh",
         "build": "rimraf dist && pnpm run pull-idl && pnpm build:bundle",
         "build:bundle": "rollup -c",

--- a/js/stateless.js/package.json
+++ b/js/stateless.js/package.json
@@ -87,7 +87,7 @@
         "test:e2e:test-rpc": "pnpm test-validator && vitest run tests/e2e/test-rpc.test.ts",
         "test:e2e:rpc-interop": "pnpm test-validator && vitest run tests/e2e/rpc-interop.test.ts",
         "test:e2e:browser": "pnpm playwright test",
-        "test:e2e:all": "pnpm test-validator && vitest run tests/e2e/test-rpc.test.ts && vitest run tests/e2e/compress.test.ts && vitest run tests/e2e/transfer.test.ts",
+        "test:e2e:all": "pnpm test-validator && vitest run tests/e2e/test-rpc.test.ts && vitest run tests/e2e/compress.test.ts && vitest run tests/e2e/transfer.test.ts && vitest run tests/e2e/rpc-interop.test.ts",
         "test:index": "vitest run tests/e2e/program.test.ts",
         "test:e2e:serde": "vitest run tests/e2e/serde.test.ts",
         "test:verbose": "vitest run --reporter=verbose",

--- a/js/stateless.js/src/rpc-interface.ts
+++ b/js/stateless.js/src/rpc-interface.ts
@@ -270,6 +270,7 @@ export const MerkeProofResult = pick({
     merkleTree: PublicKeyFromString,
     proof: array(BN254FromString),
     rootSeq: number(),
+    root: BN254FromString,
 });
 
 /**

--- a/js/stateless.js/src/rpc-interface.ts
+++ b/js/stateless.js/src/rpc-interface.ts
@@ -276,6 +276,21 @@ export const MerkeProofResult = pick({
 /**
  * @internal
  */
+export const NewAddressProofResult = pick({
+    address: BN254FromString,
+    leafIndex: number(),
+    merkleTree: PublicKeyFromString,
+    proof: array(BN254FromString), // this is: merkleProofHashedIndexedElementLeaf
+    rootSeq: number(),
+    root: BN254FromString,
+    lowerRangeAddress: BN254FromString, // this is: leafLowerRangeValue.
+    higherRangeAddress: BN254FromString, // this is: leafHigherRangeValue
+    lowElementLeafIndex: BN254FromString, // this is: indexHashedIndexedElementLeaf
+});
+
+/**
+ * @internal
+ */
 const CompressedProofResult = pick({
     a: array(number()),
     b: array(number()),

--- a/js/stateless.js/src/rpc-interface.ts
+++ b/js/stateless.js/src/rpc-interface.ts
@@ -276,6 +276,29 @@ export const MerkeProofResult = pick({
 /**
  * @internal
  */
+const CompressedProofResult = pick({
+    a: array(number()),
+    b: array(number()),
+    c: array(number()),
+});
+
+/**
+ * @internal
+ */
+export const ValidityProofResult = pick({
+    compressedProof: CompressedProofResult,
+    leafIndices: array(number()),
+    leaves: array(BN254FromString),
+    rootIndices: array(number()),
+    roots: array(BN254FromString),
+    merkleTrees: array(PublicKeyFromString),
+    // TODO: enable nullifierQueues
+    // nullifierQueues: array(PublicKeyFromString),
+});
+
+/**
+ * @internal
+ */
 export const MultipleMerkleProofsResult = array(MerkeProofResult);
 
 /**

--- a/js/stateless.js/src/rpc.ts
+++ b/js/stateless.js/src/rpc.ts
@@ -391,18 +391,18 @@ export class Rpc extends Connection implements CompressionApiInterface {
             );
         }
 
-        const proofWithoutRoot = res.result.value.proof.slice(0, -1);
+        // const proofWithoutRoot = res.result.value.proof.slice(0, -1);
 
-        const root = res.result.value.proof[res.result.value.proof.length - 1];
+        // const root = res.result.value.proof[res.result.value.proof.length - 1];
 
         const value: MerkleContextWithMerkleProof = {
             hash: res.result.value.hash.toArray(undefined, 32),
             merkleTree: res.result.value.merkleTree,
             leafIndex: res.result.value.leafIndex,
-            merkleProof: proofWithoutRoot,
+            merkleProof: res.result.value.proof, //proofWithoutRoot,
             nullifierQueue: mockNullifierQueue, // TODO: use nullifierQueue from indexer
             rootIndex: res.result.value.rootSeq % 2400, // TODO: rootSeq % rootHistoryArray.length
-            root, // TODO: validate correct root
+            root: res.result.value.root, // TODO: validate correct root
         };
         return value;
     }
@@ -486,17 +486,17 @@ export class Rpc extends Connection implements CompressionApiInterface {
         const merkleProofs: MerkleContextWithMerkleProof[] = [];
 
         for (const proof of res.result.value) {
-            const proofWithoutRoot: BN[] = proof.proof.slice(0, -1);
-            const root = proof.proof[proof.proof.length - 1];
+            // const proofWithoutRoot: BN[] = proof.proof.slice(0, -1);
+            // const root = proof.proof[proof.proof.length - 1];
 
             const value: MerkleContextWithMerkleProof = {
                 hash: proof.hash.toArray(undefined, 32),
                 merkleTree: proof.merkleTree,
                 leafIndex: proof.leafIndex,
-                merkleProof: proofWithoutRoot,
+                merkleProof: proof.proof,
                 nullifierQueue: mockNullifierQueue, // TODO: emit outputhash nullifierQueue in txevent
                 rootIndex: proof.rootSeq % 2400, // TODO: rootSeq % rootHistoryArray.length
-                root: root, // TODO: validate correct root
+                root: proof.root, // TODO: validate correct root
             };
             merkleProofs.push(value);
         }

--- a/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
@@ -36,7 +36,12 @@ import {
 } from '../../state';
 import { proofFromJsonStruct, negateAndCompressProof } from '../../utils';
 import { IndexedArray } from '../merkle-tree';
-import { MerkleContextWithNewAddressProof, proverRequest } from '../../rpc';
+import {
+    MerkleContextWithNewAddressProof,
+    convertMerkleProofsWithContextToHex,
+    convertNonInclusionMerkleProofInputsToHex,
+    proverRequest,
+} from '../../rpc';
 
 export interface TestRpcConfig {
     /**
@@ -511,6 +516,14 @@ export class TestRpc extends Connection implements CompressionApiInterface {
             newAddressProofs.push(proof);
         }
         return newAddressProofs;
+    }
+
+    /// TODO: remove once photon 'getValidityProof' is fixed
+    async getValidityProofDebug(
+        hashes: BN254[] = [],
+        newAddresses: BN254[] = [],
+    ): Promise<CompressedProofWithContext> {
+        return this.getValidityProof(hashes, newAddresses);
     }
 
     /**

--- a/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
@@ -36,51 +36,7 @@ import {
 } from '../../state';
 import { proofFromJsonStruct, negateAndCompressProof } from '../../utils';
 import { IndexedArray } from '../merkle-tree';
-
-/** @internal */
-export const proverRequest = async (
-    proverEndpoint: string,
-    method: 'inclusion' | 'new-address' | 'combined',
-    params: any = [],
-    log = false,
-): Promise<CompressedProof> => {
-    let logMsg: string = '';
-
-    if (log) {
-        logMsg = `Proof generation for method:${method}`;
-        console.time(logMsg);
-    }
-
-    let body;
-    if (method === 'inclusion') {
-        body = JSON.stringify({ 'input-compressed-accounts': params });
-    } else if (method === 'new-address') {
-        body = JSON.stringify({ 'new-addresses': params });
-    } else if (method === 'combined') {
-        body = JSON.stringify({
-            'input-compressed-accounts': params[0],
-            'new-addresses': params[1],
-        });
-    }
-
-    const response = await fetch(`${proverEndpoint}/prove`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: body,
-    });
-
-    if (!response.ok) {
-        throw new Error(`Error fetching proof: ${response.statusText}`);
-    }
-    /// TODO: Move compression into the gnark prover to save bandwidth.
-    const data: any = await response.json();
-    const parsed = proofFromJsonStruct(data);
-    const compressedProof = negateAndCompressProof(parsed);
-
-    if (log) console.timeEnd(logMsg);
-
-    return compressedProof;
-};
+import { MerkleContextWithNewAddressProof, proverRequest } from '../../rpc';
 
 export interface TestRpcConfig {
     /**
@@ -494,6 +450,14 @@ export class TestRpc extends Connection implements CompressionApiInterface {
         return 1;
     }
 
+    /**
+     * Fetch the latest address proofs for new unique addresses specified by an
+     * array of addresses.
+     *
+     * the proof states that said address have not yet been created in respective address tree.
+     * @param addresses Array of BN254 new addresses
+     * @returns Array of validity proofs for new addresses
+     */
     async getMultipleNewAddressProofs(addresses: BN254[]) {
         /// Build tree
         const indexedArray = IndexedArray.default();
@@ -688,84 +652,4 @@ export class TestRpc extends Connection implements CompressionApiInterface {
 
         return validityProof;
     }
-}
-
-export type NonInclusionMerkleProofInputs = {
-    root: BN;
-    value: BN;
-    leaf_lower_range_value: BN;
-    leaf_higher_range_value: BN;
-    leaf_index: BN;
-    merkle_proof_hashed_indexed_element_leaf: BN[];
-    index_hashed_indexed_element_leaf: BN;
-};
-
-export type MerkleContextWithNewAddressProof = {
-    root: BN;
-    value: BN;
-    leafLowerRangeValue: BN;
-    leafHigherRangeValue: BN;
-    leafIndex: BN;
-    merkleProofHashedIndexedElementLeaf: BN[];
-    indexHashedIndexedElementLeaf: BN;
-    merkleTree: PublicKey;
-    nullifierQueue: PublicKey;
-};
-
-export type NonInclusionJsonStruct = {
-    root: string;
-    value: string;
-    pathIndex: number;
-    pathElements: string[];
-    leafLowerRangeValue: string;
-    leafHigherRangeValue: string;
-    leafIndex: number;
-};
-
-function convertMerkleProofsWithContextToHex(
-    merkleProofsWithContext: MerkleContextWithMerkleProof[],
-): HexInputsForProver[] {
-    const inputs: HexInputsForProver[] = [];
-
-    for (let i = 0; i < merkleProofsWithContext.length; i++) {
-        const input: HexInputsForProver = {
-            root: toHex(merkleProofsWithContext[i].root),
-            pathIndex: merkleProofsWithContext[i].leafIndex,
-            pathElements: merkleProofsWithContext[i].merkleProof.map(hex =>
-                toHex(hex),
-            ),
-            leaf: toHex(bn(merkleProofsWithContext[i].hash)),
-        };
-        inputs.push(input);
-    }
-
-    return inputs;
-}
-
-function convertNonInclusionMerkleProofInputsToHex(
-    nonInclusionMerkleProofInputs: MerkleContextWithNewAddressProof[],
-): NonInclusionJsonStruct[] {
-    const inputs: NonInclusionJsonStruct[] = [];
-    for (let i = 0; i < nonInclusionMerkleProofInputs.length; i++) {
-        const input: NonInclusionJsonStruct = {
-            root: toHex(nonInclusionMerkleProofInputs[i].root),
-            value: toHex(nonInclusionMerkleProofInputs[i].value),
-            pathIndex:
-                nonInclusionMerkleProofInputs[
-                    i
-                ].indexHashedIndexedElementLeaf.toNumber(),
-            pathElements: nonInclusionMerkleProofInputs[
-                i
-            ].merkleProofHashedIndexedElementLeaf.map(hex => toHex(hex)),
-            leafIndex: nonInclusionMerkleProofInputs[i].leafIndex.toNumber(),
-            leafLowerRangeValue: toHex(
-                nonInclusionMerkleProofInputs[i].leafLowerRangeValue,
-            ),
-            leafHigherRangeValue: toHex(
-                nonInclusionMerkleProofInputs[i].leafHigherRangeValue,
-            ),
-        };
-        inputs.push(input);
-    }
-    return inputs;
 }

--- a/js/stateless.js/tests/e2e/rpc-interop.test.ts
+++ b/js/stateless.js/tests/e2e/rpc-interop.test.ts
@@ -29,7 +29,7 @@ describe('rpc-interop', () => {
     const transferAmount = 1e4;
     const numberOfTransfers = 15;
 
-    it.only('getValidityProof should match', async () => {
+    it.skip('getValidityProof [noforester] (inclusion) should match', async () => {
         const senderAccounts = await rpc.getCompressedAccountsByOwner(
             payer.publicKey,
         );
@@ -43,7 +43,7 @@ describe('rpc-interop', () => {
         // accounts are the same
         assert.isTrue(hash.eq(hashTest));
 
-        const validityProof = await rpc.getValidityProof([hash]);
+        const validityProof = await rpc.getValidityProofDebug([hash]);
         const validityProofTest = await testRpc.getValidityProof([hashTest]);
 
         validityProof.leafIndices.forEach((leafIndex, index) => {
@@ -94,6 +94,210 @@ describe('rpc-interop', () => {
                 `Mismatch in compressedProof.c expected: ${validityProofTest.compressedProof.c} got: ${validityProof.compressedProof.c}`,
             );
         });
+    });
+
+    it.skip('getValidityProof [noforester] (new-addresses) should match', async () => {
+        const newAddress = bn(
+            new Uint8Array([
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 42, 42, 42, 14, 15, 16, 17, 18,
+                19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+            ]),
+        );
+
+        const validityProof = await rpc.getValidityProofDebug([], [newAddress]);
+        const validityProofTest = await testRpc.getValidityProof(
+            [],
+            [newAddress],
+        );
+
+        validityProof.leafIndices.forEach((leafIndex, index) => {
+            assert.equal(leafIndex, validityProofTest.leafIndices[index]);
+        });
+        validityProof.leaves.forEach((leaf, index) => {
+            assert.isTrue(leaf.eq(validityProofTest.leaves[index]));
+        });
+        validityProof.roots.forEach((elem, index) => {
+            assert.isTrue(elem.eq(validityProofTest.roots[index]));
+        });
+        validityProof.rootIndices.forEach((elem, index) => {
+            assert.equal(elem, validityProofTest.rootIndices[index]);
+        });
+        validityProof.merkleTrees.forEach((elem, index) => {
+            assert.isTrue(elem.equals(validityProofTest.merkleTrees[index]));
+        });
+        validityProof.nullifierQueues.forEach((elem, index) => {
+            assert.isTrue(
+                elem.equals(validityProofTest.nullifierQueues[index]),
+            );
+        });
+
+        /// FIXME: debug photon zkp
+        validityProof.compressedProof.a.forEach((elem, index) => {
+            const expected = validityProofTest.compressedProof.a[index];
+            assert.equal(
+                elem,
+                expected,
+                `Mismatch in compressedProof.a expected: ${validityProofTest.compressedProof.a} got: ${validityProof.compressedProof.a}`,
+            );
+        });
+
+        validityProof.compressedProof.b.forEach((elem, index) => {
+            const expected = validityProofTest.compressedProof.b[index];
+            assert.equal(
+                elem,
+                expected,
+                `Mismatch in compressedProof.b expected: ${validityProofTest.compressedProof.b} got: ${validityProof.compressedProof.b}`,
+            );
+        });
+
+        validityProof.compressedProof.c.forEach((elem, index) => {
+            const expected = validityProofTest.compressedProof.c[index];
+            assert.equal(
+                elem,
+                expected,
+                `Mismatch in compressedProof.c expected: ${validityProofTest.compressedProof.c} got: ${validityProof.compressedProof.c}`,
+            );
+        });
+    });
+
+    it.skip('getValidityProof [noforester] (combined) should match', async () => {
+        const senderAccounts = await rpc.getCompressedAccountsByOwner(
+            payer.publicKey,
+        );
+        const senderAccountsTest = await testRpc.getCompressedAccountsByOwner(
+            payer.publicKey,
+        );
+
+        const hash = bn(senderAccounts[0].hash);
+        const hashTest = bn(senderAccountsTest[0].hash);
+
+        // accounts are the same
+        assert.isTrue(hash.eq(hashTest));
+
+        const newAddress = bn(
+            new Uint8Array([
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 42, 42, 42, 14, 15, 16, 17, 18,
+                19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+            ]),
+        );
+
+        const validityProof = await rpc.getValidityProofDebug(
+            [hash],
+            [newAddress],
+        );
+        const validityProofTest = await testRpc.getValidityProof(
+            [hashTest],
+            [newAddress],
+        );
+
+        validityProof.leafIndices.forEach((leafIndex, index) => {
+            assert.equal(leafIndex, validityProofTest.leafIndices[index]);
+        });
+        validityProof.leaves.forEach((leaf, index) => {
+            assert.isTrue(leaf.eq(validityProofTest.leaves[index]));
+        });
+        validityProof.roots.forEach((elem, index) => {
+            assert.isTrue(elem.eq(validityProofTest.roots[index]));
+        });
+        validityProof.rootIndices.forEach((elem, index) => {
+            assert.equal(elem, validityProofTest.rootIndices[index]);
+        });
+        validityProof.merkleTrees.forEach((elem, index) => {
+            assert.isTrue(elem.equals(validityProofTest.merkleTrees[index]));
+        });
+        validityProof.nullifierQueues.forEach((elem, index) => {
+            assert.isTrue(
+                elem.equals(validityProofTest.nullifierQueues[index]),
+            );
+        });
+
+        /// FIXME: debug photon zkp
+        validityProof.compressedProof.a.forEach((elem, index) => {
+            const expected = validityProofTest.compressedProof.a[index];
+            assert.equal(
+                elem,
+                expected,
+                `Mismatch in compressedProof.a expected: ${validityProofTest.compressedProof.a} got: ${validityProof.compressedProof.a}`,
+            );
+        });
+
+        validityProof.compressedProof.b.forEach((elem, index) => {
+            const expected = validityProofTest.compressedProof.b[index];
+            assert.equal(
+                elem,
+                expected,
+                `Mismatch in compressedProof.b expected: ${validityProofTest.compressedProof.b} got: ${validityProof.compressedProof.b}`,
+            );
+        });
+
+        validityProof.compressedProof.c.forEach((elem, index) => {
+            const expected = validityProofTest.compressedProof.c[index];
+            assert.equal(
+                elem,
+                expected,
+                `Mismatch in compressedProof.c expected: ${validityProofTest.compressedProof.c} got: ${validityProof.compressedProof.c}`,
+            );
+        });
+    });
+
+    it.skip('getMultipleNewAddressProofs [noforester] should match', async () => {
+        const newAddress = bn(
+            new Uint8Array([
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 42, 42, 42, 14, 15, 16, 17, 18,
+                19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+            ]),
+        );
+        const newAddressProof = (
+            await rpc.getMultipleNewAddressProofs([newAddress])
+        )[0];
+        const newAddressProofTest = (
+            await testRpc.getMultipleNewAddressProofs([newAddress])
+        )[0];
+
+        assert.isTrue(
+            newAddressProof.indexHashedIndexedElementLeaf.eq(
+                newAddressProofTest.indexHashedIndexedElementLeaf,
+            ),
+        );
+        assert.isTrue(
+            newAddressProof.leafHigherRangeValue.eq(
+                newAddressProofTest.leafHigherRangeValue,
+            ),
+        );
+        assert.isTrue(
+            newAddressProof.leafIndex.eq(newAddressProofTest.leafIndex),
+        );
+        assert.isTrue(
+            newAddressProof.leafLowerRangeValue.eq(
+                newAddressProofTest.leafLowerRangeValue,
+            ),
+        );
+
+        assert.isTrue(
+            newAddressProof.merkleTree.equals(newAddressProofTest.merkleTree),
+        );
+        assert.isTrue(
+            newAddressProof.nullifierQueue.equals(
+                newAddressProofTest.nullifierQueue,
+            ),
+        );
+
+        assert.isTrue(newAddressProof.root.eq(newAddressProofTest.root));
+        assert.isTrue(newAddressProof.value.eq(newAddressProofTest.value));
+
+        newAddressProof.merkleProofHashedIndexedElementLeaf.forEach(
+            (elem, index) => {
+                const expected =
+                    newAddressProofTest.merkleProofHashedIndexedElementLeaf[
+                        index
+                    ];
+                assert.equal(
+                    elem,
+                    expected,
+                    `Mismatch in merkleProofHashedIndexedElementLeaf expected: ${newAddressProofTest.merkleProofHashedIndexedElementLeaf} got: ${newAddressProof.merkleProofHashedIndexedElementLeaf}`,
+                );
+            },
+        );
     });
 
     it('getMultipleCompressedAccountProofs in transfer loop should match', async () => {

--- a/js/stateless.js/tests/e2e/rpc-interop.test.ts
+++ b/js/stateless.js/tests/e2e/rpc-interop.test.ts
@@ -29,6 +29,73 @@ describe('rpc-interop', () => {
     const transferAmount = 1e4;
     const numberOfTransfers = 15;
 
+    it.only('getValidityProof should match', async () => {
+        const senderAccounts = await rpc.getCompressedAccountsByOwner(
+            payer.publicKey,
+        );
+        const senderAccountsTest = await testRpc.getCompressedAccountsByOwner(
+            payer.publicKey,
+        );
+
+        const hash = bn(senderAccounts[0].hash);
+        const hashTest = bn(senderAccountsTest[0].hash);
+
+        // accounts are the same
+        assert.isTrue(hash.eq(hashTest));
+
+        const validityProof = await rpc.getValidityProof([hash]);
+        const validityProofTest = await testRpc.getValidityProof([hashTest]);
+
+        validityProof.leafIndices.forEach((leafIndex, index) => {
+            assert.equal(leafIndex, validityProofTest.leafIndices[index]);
+        });
+        validityProof.leaves.forEach((leaf, index) => {
+            assert.isTrue(leaf.eq(validityProofTest.leaves[index]));
+        });
+        validityProof.roots.forEach((elem, index) => {
+            assert.isTrue(elem.eq(validityProofTest.roots[index]));
+        });
+        validityProof.rootIndices.forEach((elem, index) => {
+            assert.equal(elem, validityProofTest.rootIndices[index]);
+        });
+        validityProof.merkleTrees.forEach((elem, index) => {
+            assert.isTrue(elem.equals(validityProofTest.merkleTrees[index]));
+        });
+        validityProof.nullifierQueues.forEach((elem, index) => {
+            assert.isTrue(
+                elem.equals(validityProofTest.nullifierQueues[index]),
+            );
+        });
+
+        /// FIXME: debug photon zkp
+        validityProof.compressedProof.a.forEach((elem, index) => {
+            const expected = validityProofTest.compressedProof.a[index];
+            assert.equal(
+                elem,
+                expected,
+                `Mismatch in compressedProof.a expected: ${validityProofTest.compressedProof.a} got: ${validityProof.compressedProof.a}`,
+            );
+        });
+
+        validityProof.compressedProof.b.forEach((elem, index) => {
+            const expected = validityProofTest.compressedProof.b[index];
+            assert.equal(
+                elem,
+                expected,
+                `Mismatch in compressedProof.b expected: ${validityProofTest.compressedProof.b} got: ${validityProof.compressedProof.b}`,
+            );
+        });
+
+        validityProof.compressedProof.c.forEach((elem, index) => {
+            const expected = validityProofTest.compressedProof.c[index];
+            assert.equal(
+                elem,
+                expected,
+                `Mismatch in compressedProof.c expected: ${validityProofTest.compressedProof.c} got: ${validityProof.compressedProof.c}`,
+            );
+        });
+    });
+
     it('getMultipleCompressedAccountProofs in transfer loop should match', async () => {
         for (let round = 0; round < numberOfTransfers; round++) {
             const prePayerAccounts = await rpc.getCompressedAccountsByOwner(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,6 +506,10 @@ importers:
         specifier: ^0.34.6
         version: 0.34.6(@vitest/browser@0.34.6)(playwright@1.40.1)
 
+  hasher.rs/src/main/wasm: {}
+
+  hasher.rs/src/main/wasm-simd: {}
+
   js/compressed-token:
     dependencies:
       '@coral-xyz/anchor':

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -117,8 +117,8 @@ JQ_VERSION="jq-1.7.1"
 CIRCOM_VERSION=$(latest_release Lightprotocol circom)
 MACRO_CIRCOM_VERSION=$(latest_release Lightprotocol macro-circom)
 LIGHT_PROTOCOL_VERSION=$(latest_release Lightprotocol light-protocol)
-PHOTON_VERSION="0.18.0"
-PHOTON_BRANCH="nullify"
+PHOTON_VERSION="0.21.0"
+PHOTON_BRANCH=""
 
 case "${OS}" in
     "Darwin")


### PR DESCRIPTION
1) updated to photon 0.21.0. prev. interop tests are now again enabled in CI.

2) added new interop tests  for:
* getValidityProof (inclusion, non-inclusion, combined)
* getMultipleNewAddressProofs 

none of those work with photon yet, therefore these tests are being skipped in CI.

To run them locally for debugging Photon, remove the `.skip` part for the test you want to run.

file: js/stateless.js/tests/e2e/rpc-interop.test.ts
run: `pnpm test:e2e:rpc-interop`

Note than in TS those do not cover foresting events yet (emptying nullifier queue, emptying address queue), but i think fixing these should be a good starting point.
