### PR TITLE
feat: add sequence number to Reference Merkle tree

### DIFF
--- a/merkle-tree/reference/src/lib.rs
+++ b/merkle-tree/reference/src/lib.rs
@@ -27,6 +27,7 @@ where
     pub layers: Vec<Vec<[u8; 32]>>,
     pub roots: Vec<[u8; 32]>,
     pub rightmost_index: usize,
+    pub sequence_number: usize,
 
     _hasher: PhantomData<H>,
 }
@@ -43,6 +44,7 @@ where
             layers: vec![Vec::new(); height],
             roots: vec![H::zero_bytes()[height]],
             rightmost_index: 0,
+            sequence_number: 0,
 
             _hasher: PhantomData,
         }
@@ -97,6 +99,8 @@ where
 
         self.update_upper_layers(i)?;
 
+        self.sequence_number += 1;
+
         Ok(())
     }
 
@@ -110,6 +114,8 @@ where
             .ok_or(ReferenceMerkleTreeError::LeafDoesNotExist(leaf_index))? = *leaf;
 
         self.update_upper_layers(leaf_index)?;
+
+        self.sequence_number += 1;
 
         Ok(())
     }

--- a/merkle-tree/reference/tests/tests.rs
+++ b/merkle-tree/reference/tests/tests.rs
@@ -386,3 +386,17 @@ fn test_update_poseidon() {
 fn test_update_sha256() {
     update::<Sha256>()
 }
+
+#[test]
+fn test_sequence_number() {
+    let mut merkle_tree = MerkleTree::<Poseidon>::new(4, 0);
+    assert_eq!(merkle_tree.sequence_number, 0);
+
+    let leaf1 = Poseidon::hash(&[1u8; 32]).unwrap();
+    merkle_tree.append(&leaf1).unwrap();
+    assert_eq!(merkle_tree.sequence_number, 1);
+
+    let leaf2 = Poseidon::hash(&[2u8; 32]).unwrap();
+    merkle_tree.update(&leaf2, 0).unwrap();
+    assert_eq!(merkle_tree.sequence_number, 2);
+}


### PR DESCRIPTION
Added a sequence number to the Merkle tree. Implemented sequence incrementation on every append and update method call. Added a test to verify sequence incrementation behavior.