### PR TITLE
fix: asserts in rpc-interop tests

### DIFF
--- a/js/compressed-token/tests/e2e/rpc-token-interop.test.ts
+++ b/js/compressed-token/tests/e2e/rpc-token-interop.test.ts
@@ -45,8 +45,8 @@ describe('rpc-interop token', () => {
         charlie = await newAccountWithLamports(rpc, 1e9, 256);
 
         await mintTo(rpc, payer, mint, bob.publicKey, mintAuthority, bn(1000));
-
-        await transfer(rpc, payer, mint, bn(700), bob, charlie.publicKey);
+        /// TODO: replace for Rpc once 'getValidityProof' in Photon is working.
+        await transfer(testRpc, payer, mint, bn(700), bob, charlie.publicKey);
     });
 
     it('getCompressedTokenAccountsByOwner should match', async () => {

--- a/js/stateless.js/src/actions/transfer.ts
+++ b/js/stateless.js/src/actions/transfer.ts
@@ -12,7 +12,7 @@ import {
     selectMinCompressedSolAccountsForTransfer,
 } from '../programs';
 import { Rpc } from '../rpc';
-import { defaultTestStateTreeAccounts } from '../constants';
+
 import { bn } from '../state';
 import { buildAndSignTx, sendAndConfirmTx } from '../utils';
 

--- a/js/stateless.js/src/rpc.ts
+++ b/js/stateless.js/src/rpc.ts
@@ -1052,7 +1052,7 @@ export class Rpc extends Connection implements CompressionApiInterface {
      * @param newAddresses  Array of BN254 new addresses.
      * @returns             validity proof with context
      */
-    async getValidityProof(
+    async getValidityProof_direct(
         hashes: BN254[] = [],
         newAddresses: BN254[] = [],
     ): Promise<CompressedProofWithContext> {
@@ -1200,11 +1200,11 @@ export class Rpc extends Connection implements CompressionApiInterface {
      */
     // FIXME: debug photon zkp. For debugging use either
     // testRpc.getValidityProof or rpc.getValidityProof to test against
-    async getValidityProofDebug(
+    async getValidityProof(
         hashes: BN254[] = [],
         _newAddresses: BN254[] = [],
     ): Promise<CompressedProofWithContext> {
-        console.log("log: calling photon 'getValidityProof'");
+        console.log("log [debug]: calling photon 'getValidityProof'");
         const unsafeRes = await rpcRequest(
             this.compressionApiEndpoint,
             'getValidityProof',
@@ -1223,7 +1223,7 @@ export class Rpc extends Connection implements CompressionApiInterface {
                 `failed to get ValidityProof for compressed accounts ${hashes.map(hash => hash.toString())}`,
             );
         }
-        console.log(res.result);
+        console.log("log [debug]: 'getValidityProof‘ response", res.result);
         const value: CompressedProofWithContext = {
             compressedProof: res.result.compressedProof,
             merkleTrees: res.result.merkleTrees,

--- a/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
@@ -519,7 +519,7 @@ export class TestRpc extends Connection implements CompressionApiInterface {
     }
 
     /// TODO: remove once photon 'getValidityProof' is fixed
-    async getValidityProofDebug(
+    async getValidityProof_direct(
         hashes: BN254[] = [],
         newAddresses: BN254[] = [],
     ): Promise<CompressedProofWithContext> {


### PR DESCRIPTION
* don't compare zkps by value, instead use them to execute a transaction.
