### PR TITLE
chore: update rustflags for aarch64-apple-darwin target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -32,7 +32,7 @@ rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/opt/llvm/bin/ld64.lld"]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 
 


### PR DESCRIPTION
The path to lld linker for the aarch64-apple-darwin target in rustflags has been simplified. 
The previous long path has been replaced with the shorter "-fuse-ld=lld".