### PR TITLE
chore: add flexible changelog root history arrays e2e test

### DIFF
--- a/forester/tests/e2e_test.rs
+++ b/forester/tests/e2e_test.rs
@@ -91,6 +91,7 @@ async fn test_1_all() {
             mint_spl: Some(1.0),
             transfer_spl: Some(1.0),
             max_output_accounts: Some(3),
+            fee_assert: true,
         },
         GeneralActionConfig {
             add_keypair: Some(1.0),

--- a/forester/tests/empty_address_tree_test.rs
+++ b/forester/tests/empty_address_tree_test.rs
@@ -49,6 +49,7 @@ async fn empty_address_tree_test() {
             mint_spl: None,
             transfer_spl: None,
             max_output_accounts: Some(3),
+            fee_assert: true,
         },
         GeneralActionConfig {
             add_keypair: Some(1.0),

--- a/programs/account-compression/src/processor/initialize_address_merkle_tree.rs
+++ b/programs/account-compression/src/processor/initialize_address_merkle_tree.rs
@@ -48,6 +48,7 @@ pub fn process_initialize_address_merkle_tree(
         roots_size as usize,
         address_changelog_size as usize,
     )?;
+    msg!("Initialized address merkle tree");
     merkle_tree.init().map_err(ProgramError::from)?;
     // Initialize the address merkle tree with the bn254 Fr field size - 1
     // This is the highest value that you can poseidon hash with poseidon syscalls.

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -12,7 +12,6 @@ use anchor_lang::error::ErrorCode;
 use light_hash_set::{HashSet, HashSetError};
 use light_hasher::Poseidon;
 use light_indexed_merkle_tree::{array::IndexedArray, errors::IndexedMerkleTreeError, reference};
-use light_test_utils::get_indexed_merkle_tree;
 use light_test_utils::rpc::errors::assert_rpc_error;
 use light_test_utils::{
     address_tree_rollover::perform_address_merkle_tree_roll_over, create_account_instruction,
@@ -28,6 +27,7 @@ use light_test_utils::{
     test_forester::{empty_address_queue_test, insert_addresses},
 };
 use light_test_utils::{airdrop_lamports, rpc::rpc_connection::RpcConnection};
+use light_test_utils::{get_indexed_merkle_tree, transaction_params::FeeConfig};
 use light_utils::bigint::bigint_to_be_bytes_array;
 use num_bigint::ToBigUint;
 use solana_program_test::ProgramTest;
@@ -959,6 +959,7 @@ pub async fn test_setup_with_address_merkle_tree(
             merkle_tree: address_merkle_tree_keypair.pubkey(),
             queue: address_queue_keypair.pubkey(),
         },
+        rollover_fee: FeeConfig::default().address_queue_rollover as i64,
     };
     (context, payer, address_merkle_tree_bundle)
 }

--- a/test-programs/e2e-test/tests/test.rs
+++ b/test-programs/e2e-test/tests/test.rs
@@ -29,7 +29,7 @@ async fn test_10000_all() {
     let mut env = E2ETestEnv::<500, ProgramTestRpcConnection>::new(
         rpc,
         &env_accounts,
-        KeypairActionConfig::all_default(),
+        KeypairActionConfig::all_default_no_fee_assert(),
         GeneralActionConfig::default(),
         10000,
         None,

--- a/test-programs/system-cpi-test/tests/test_program_owned_trees.rs
+++ b/test-programs/system-cpi-test/tests/test_program_owned_trees.rs
@@ -6,7 +6,9 @@ use solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::Signer, transaction
 
 use account_compression::sdk::create_insert_leaves_instruction;
 use account_compression::utils::constants::{CPI_AUTHORITY_PDA_SEED, STATE_NULLIFIER_QUEUE_VALUES};
-use account_compression::{AddressMerkleTreeConfig, QueueAccount, StateMerkleTreeAccount};
+use account_compression::{
+    AddressMerkleTreeConfig, QueueAccount, StateMerkleTreeAccount, StateMerkleTreeConfig,
+};
 use light_compressed_token::mint_sdk::create_mint_to_instruction;
 use light_hasher::Poseidon;
 use light_registry::get_forester_epoch_pda_address;
@@ -195,6 +197,7 @@ async fn test_invalid_registered_program() {
         &invalid_group_nullifier_queue,
         None,
         3,
+        StateMerkleTreeConfig::default(),
     )
     .await;
     let invalid_group_address_merkle_tree = Keypair::new();

--- a/test-utils/src/assert_queue.rs
+++ b/test-utils/src/assert_queue.rs
@@ -100,22 +100,18 @@ pub async fn assert_address_queue<R: RpcConnection>(
         .unwrap()
         .lamports;
     // The address queue is the only account that collects the rollover fees.
-    let expected_rollover_fee = compute_rollover_fee(
-        associated_tree_config
-            .rollover_threshold
-            .unwrap_or_default(),
-        associated_tree_config.height,
-        balance_queue,
-    )
-    .unwrap()
-        + compute_rollover_fee(
-            associated_tree_config
-                .rollover_threshold
-                .unwrap_or_default(),
-            associated_tree_config.height,
-            balance_merkle_tree,
-        )
-        .unwrap();
+    let expected_rollover_fee = match associated_tree_config.rollover_threshold {
+        Some(threshold) => {
+            compute_rollover_fee(threshold, associated_tree_config.height, balance_queue).unwrap()
+                + compute_rollover_fee(
+                    threshold,
+                    associated_tree_config.height,
+                    balance_merkle_tree,
+                )
+                .unwrap()
+        }
+        None => 0,
+    };
     assert_queue(
         rpc,
         queue_pubkey,

--- a/test-utils/src/test_env.rs
+++ b/test-utils/src/test_env.rs
@@ -205,6 +205,7 @@ pub async fn setup_test_programs_with_accounts(
         &nullifier_queue_keypair,
         None,
         1,
+        StateMerkleTreeConfig::default(),
     )
     .await;
 
@@ -347,6 +348,7 @@ pub fn get_test_env_accounts() -> EnvAccounts {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn create_state_merkle_tree_and_queue_account<R: RpcConnection>(
     payer: &Keypair,
     owner: &Pubkey,
@@ -355,12 +357,13 @@ pub async fn create_state_merkle_tree_and_queue_account<R: RpcConnection>(
     nullifier_queue_keypair: &Keypair,
     program_owner: Option<Pubkey>,
     index: u64,
+    config: StateMerkleTreeConfig,
 ) {
     let size = account_compression::state::StateMerkleTreeAccount::size(
-        account_compression::utils::constants::STATE_MERKLE_TREE_HEIGHT as usize,
-        account_compression::utils::constants::STATE_MERKLE_TREE_CHANGELOG as usize,
-        account_compression::utils::constants::STATE_MERKLE_TREE_ROOTS as usize,
-        account_compression::utils::constants::STATE_MERKLE_TREE_CANOPY_DEPTH as usize,
+        config.height as usize,
+        config.changelog_size as usize,
+        config.roots_size as usize,
+        config.canopy_depth as usize,
     );
 
     let merkle_tree_account_create_ix = create_account_instruction(
@@ -391,7 +394,7 @@ pub async fn create_state_merkle_tree_and_queue_account<R: RpcConnection>(
         *owner,
         merkle_tree_keypair.pubkey(),
         nullifier_queue_keypair.pubkey(),
-        StateMerkleTreeConfig::default(),
+        config,
         NullifierQueueConfig::default(),
         program_owner,
         index,
@@ -471,7 +474,7 @@ pub async fn create_address_merkle_tree_and_queue_account<R: RpcConnection>(
         queue_config.clone(),
     );
     let c_ix =
-        solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(10_000_000);
+        solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(1_400_000);
     let transaction = Transaction::new_signed_with_payer(
         &[c_ix, account_create_ix, mt_account_create_ix, instruction],
         Some(&payer.pubkey()),

--- a/test-utils/src/transaction_params.rs
+++ b/test-utils/src/transaction_params.rs
@@ -11,6 +11,9 @@ pub struct TransactionParams {
 pub struct FeeConfig {
     pub state_merkle_tree_rollover: u64,
     pub address_queue_rollover: u64,
+    // TODO: refactor to allow multiple state and address tree configs
+    // pub state_tree_configs: Vec<StateMerkleTreeConfig>,
+    // pub address_tree_configs: Vec<AddressMerkleTreeConfig>,
     pub network_fee: u64,
     pub address_network_fee: u64,
     pub solana_network_fee: i64,
@@ -22,6 +25,9 @@ impl Default for FeeConfig {
             // rollover fee plus additonal lamports for the cpi account
             state_merkle_tree_rollover: 185,
             address_queue_rollover: 202,
+            // TODO: refactor to allow multiple state and address tree configs
+            // state_tree_configs: vec![StateMerkleTreeConfig::default()],
+            // address_tree_configs: vec![AddressMerkleTreeConfig::default()],
             network_fee: 5000,
             address_network_fee: 5000,
             solana_network_fee: 5000,


### PR DESCRIPTION
depends on: https://github.com/Lightprotocol/light-protocol/pull/872

Changes:
- add option to init trees with random changelog, root history array and rollover threshold parameters