### PR TITLE
test: Use on-chain queues with different sizes

### DIFF
--- a/programs/account-compression/src/instructions/initialize_address_merkle_tree_and_queue.rs
+++ b/programs/account-compression/src/instructions/initialize_address_merkle_tree_and_queue.rs
@@ -59,10 +59,6 @@ pub fn process_initialize_address_merkle_tree_and_queue<'info>(
     merkle_tree_config: AddressMerkleTreeConfig,
     queue_config: AddressQueueConfig,
 ) -> Result<()> {
-    if queue_config != AddressQueueConfig::default() {
-        unimplemented!("Only default address queue config is supported.");
-    }
-
     let merkle_tree_rent = ctx.accounts.merkle_tree.get_lamports();
     process_initialize_address_queue(
         &ctx.accounts.queue.to_account_info(),

--- a/programs/account-compression/src/instructions/initialize_state_merkle_tree_and_nullifier_queue.rs
+++ b/programs/account-compression/src/instructions/initialize_state_merkle_tree_and_nullifier_queue.rs
@@ -75,9 +75,6 @@ pub fn process_initialize_state_merkle_tree_and_nullifier_queue(
     nullifier_queue_config: NullifierQueueConfig,
     additional_rent: u64,
 ) -> Result<()> {
-    if nullifier_queue_config != NullifierQueueConfig::default() {
-        unimplemented!("Only default nullifier queue config is supported.");
-    }
     // Will be used to configure rollover fees for additional accounts (cpi
     // context account).
     if additional_rent != 0 {

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -6,7 +6,7 @@ use account_compression::{
     errors::AccountCompressionErrorCode,
     state::QueueAccount,
     utils::constants::{ADDRESS_MERKLE_TREE_CANOPY_DEPTH, ADDRESS_MERKLE_TREE_HEIGHT},
-    AddressMerkleTreeAccount, AddressMerkleTreeConfig, AddressQueueConfig, ID,
+    AddressMerkleTreeAccount, AddressMerkleTreeConfig, AddressQueueConfig, ID, SAFETY_MARGIN,
 };
 use anchor_lang::error::ErrorCode;
 use light_hash_set::{HashSet, HashSetError};
@@ -134,7 +134,7 @@ async fn test_address_queue_and_tree_functional_custom() {
                     },
                     &AddressQueueConfig {
                         capacity: queue_capacity,
-                        sequence_threshold: roots_size,
+                        sequence_threshold: roots_size + SAFETY_MARGIN,
                         network_fee: None,
                     },
                 )
@@ -706,7 +706,7 @@ async fn update_address_merkle_tree_failing_tests_custom() {
                     },
                     &AddressQueueConfig {
                         capacity: queue_capacity,
-                        sequence_threshold: roots_size,
+                        sequence_threshold: roots_size + SAFETY_MARGIN,
                         network_fee: None,
                     },
                 )
@@ -946,7 +946,7 @@ async fn test_address_merkle_tree_and_queue_rollover_custom() {
                     },
                     &AddressQueueConfig {
                         capacity: queue_capacity,
-                        sequence_threshold: roots_size,
+                        sequence_threshold: roots_size + SAFETY_MARGIN,
                         network_fee: None,
                     },
                 )

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -42,10 +42,13 @@ use solana_sdk::{
 /// 2. inserts two addresses to the queue
 /// 3. inserts two addresses into the address Merkle tree
 /// 4. insert third address
-async fn address_queue_and_tree_functional(merkle_tree_config: &AddressMerkleTreeConfig) {
+async fn address_queue_and_tree_functional(
+    merkle_tree_config: &AddressMerkleTreeConfig,
+    queue_config: &AddressQueueConfig,
+) {
     // CHECK: 1 create address Merkle tree and queue accounts
     let (mut context, _, mut address_merkle_tree_bundle) =
-        test_setup_with_address_merkle_tree(merkle_tree_config).await;
+        test_setup_with_address_merkle_tree(merkle_tree_config, queue_config).await;
     let payer = context.get_payer().insecure_clone();
     let address_queue_pubkey = address_merkle_tree_bundle.accounts.queue;
     let address_merkle_tree_pubkey = address_merkle_tree_bundle.accounts.merkle_tree;
@@ -104,26 +107,39 @@ async fn address_queue_and_tree_functional(merkle_tree_config: &AddressMerkleTre
 
 #[tokio::test]
 async fn test_address_queue_and_tree_functional_default() {
-    address_queue_and_tree_functional(&AddressMerkleTreeConfig::default()).await
+    address_queue_and_tree_functional(
+        &AddressMerkleTreeConfig::default(),
+        &AddressQueueConfig::default(),
+    )
+    .await
 }
 
 #[tokio::test]
 async fn test_address_queue_and_tree_functional_custom() {
-    for changelog_size in (500..5000).step_by(500) {
-        let roots_size = changelog_size * 2;
+    for changelog_size in (1000..5000).step_by(1000) {
+        for queue_capacity in [5003, 6857, 7901] {
+            let roots_size = changelog_size * 2;
 
-        for address_changelog_size in (250..1000).step_by(250) {
-            address_queue_and_tree_functional(&AddressMerkleTreeConfig {
-                height: ADDRESS_MERKLE_TREE_HEIGHT as u32,
-                changelog_size,
-                roots_size,
-                canopy_depth: ADDRESS_MERKLE_TREE_CANOPY_DEPTH,
-                address_changelog_size,
-                network_fee: Some(5000),
-                rollover_threshold: Some(95),
-                close_threshold: None,
-            })
-            .await;
+            for address_changelog_size in (250..1000).step_by(250) {
+                address_queue_and_tree_functional(
+                    &AddressMerkleTreeConfig {
+                        height: ADDRESS_MERKLE_TREE_HEIGHT as u32,
+                        changelog_size,
+                        roots_size,
+                        canopy_depth: ADDRESS_MERKLE_TREE_CANOPY_DEPTH,
+                        address_changelog_size,
+                        network_fee: Some(5000),
+                        rollover_threshold: Some(95),
+                        close_threshold: None,
+                    },
+                    &AddressQueueConfig {
+                        capacity: queue_capacity,
+                        sequence_threshold: roots_size,
+                        network_fee: None,
+                    },
+                )
+                .await;
+            }
         }
     }
 }
@@ -241,9 +257,12 @@ async fn test_address_queue_and_tree_invalid_sizes() {
 /// 11. invalid queue account
 /// 12. invalid Merkle tree account
 /// 13. non-associated Merkle tree
-async fn update_address_merkle_tree_failing_tests(merkle_tree_config: &AddressMerkleTreeConfig) {
+async fn update_address_merkle_tree_failing_tests(
+    merkle_tree_config: &AddressMerkleTreeConfig,
+    queue_config: &AddressQueueConfig,
+) {
     let (mut context, payer, mut address_merkle_tree_bundle) =
-        test_setup_with_address_merkle_tree(merkle_tree_config).await;
+        test_setup_with_address_merkle_tree(merkle_tree_config, queue_config).await;
     let address_queue_pubkey = address_merkle_tree_bundle.accounts.queue;
     let address_merkle_tree_pubkey = address_merkle_tree_bundle.accounts.merkle_tree;
     // Insert a pair of addresses, correctly. Just do it with relayer.
@@ -627,6 +646,7 @@ async fn update_address_merkle_tree_failing_tests(merkle_tree_config: &AddressMe
         &invalid_address_queue_keypair,
         None,
         merkle_tree_config,
+        queue_config,
         2,
     )
     .await;
@@ -659,26 +679,39 @@ async fn update_address_merkle_tree_failing_tests(merkle_tree_config: &AddressMe
 
 #[tokio::test]
 async fn update_address_merkle_tree_failing_tests_default() {
-    update_address_merkle_tree_failing_tests(&AddressMerkleTreeConfig::default()).await
+    update_address_merkle_tree_failing_tests(
+        &AddressMerkleTreeConfig::default(),
+        &AddressQueueConfig::default(),
+    )
+    .await
 }
 
 #[tokio::test]
 async fn update_address_merkle_tree_failing_tests_custom() {
-    for changelog_size in (500..5000).step_by(500) {
-        let roots_size = changelog_size * 2;
+    for changelog_size in (1000..5000).step_by(1000) {
+        for queue_capacity in [5003, 6857, 7901] {
+            let roots_size = changelog_size * 2;
 
-        for address_changelog_size in (250..1000).step_by(250) {
-            update_address_merkle_tree_failing_tests(&AddressMerkleTreeConfig {
-                height: ADDRESS_MERKLE_TREE_HEIGHT as u32,
-                changelog_size,
-                roots_size,
-                canopy_depth: ADDRESS_MERKLE_TREE_CANOPY_DEPTH,
-                address_changelog_size,
-                network_fee: Some(5000),
-                rollover_threshold: Some(95),
-                close_threshold: None,
-            })
-            .await;
+            for address_changelog_size in (250..1000).step_by(250) {
+                update_address_merkle_tree_failing_tests(
+                    &AddressMerkleTreeConfig {
+                        height: ADDRESS_MERKLE_TREE_HEIGHT as u32,
+                        changelog_size,
+                        roots_size,
+                        canopy_depth: ADDRESS_MERKLE_TREE_CANOPY_DEPTH,
+                        address_changelog_size,
+                        network_fee: Some(5000),
+                        rollover_threshold: Some(95),
+                        close_threshold: None,
+                    },
+                    &AddressQueueConfig {
+                        capacity: queue_capacity,
+                        sequence_threshold: roots_size,
+                        network_fee: None,
+                    },
+                )
+                .await;
+            }
         }
     }
 }
@@ -690,9 +723,12 @@ async fn update_address_merkle_tree_failing_tests_custom() {
 /// 4. Merkle tree and queue not associated (Invalid Merkle tree).
 /// 5. Successful rollover.
 /// 6. Attempt to rollover already rolled over Queue and Merkle tree.
-async fn address_merkle_tree_and_queue_rollover(merkle_tree_config: &AddressMerkleTreeConfig) {
+async fn address_merkle_tree_and_queue_rollover(
+    merkle_tree_config: &AddressMerkleTreeConfig,
+    queue_config: &AddressQueueConfig,
+) {
     let (mut context, payer, bundle) =
-        test_setup_with_address_merkle_tree(merkle_tree_config).await;
+        test_setup_with_address_merkle_tree(merkle_tree_config, queue_config).await;
     let address_merkle_tree_pubkey = bundle.accounts.merkle_tree;
     let address_queue_pubkey = bundle.accounts.queue;
     let address_merkle_tree_keypair_2 = Keypair::new();
@@ -705,6 +741,7 @@ async fn address_merkle_tree_and_queue_rollover(merkle_tree_config: &AddressMerk
         &address_queue_keypair_2,
         None,
         merkle_tree_config,
+        queue_config,
         2,
     )
     .await;
@@ -722,6 +759,7 @@ async fn address_merkle_tree_and_queue_rollover(merkle_tree_config: &AddressMerk
         &address_merkle_tree_pubkey,
         &address_queue_pubkey,
         merkle_tree_config,
+        queue_config,
     )
     .await;
 
@@ -770,6 +808,7 @@ async fn address_merkle_tree_and_queue_rollover(merkle_tree_config: &AddressMerk
         &address_merkle_tree_pubkey,
         &address_queue_pubkey,
         merkle_tree_config,
+        queue_config,
     )
     .await;
 
@@ -796,6 +835,7 @@ async fn address_merkle_tree_and_queue_rollover(merkle_tree_config: &AddressMerk
         &address_merkle_tree_pubkey,
         &address_queue_keypair_2.pubkey(),
         merkle_tree_config,
+        queue_config,
     )
     .await;
 
@@ -814,6 +854,7 @@ async fn address_merkle_tree_and_queue_rollover(merkle_tree_config: &AddressMerk
         &address_merkle_tree_keypair_2.pubkey(),
         &address_queue_pubkey,
         merkle_tree_config,
+        queue_config,
     )
     .await;
 
@@ -838,6 +879,7 @@ async fn address_merkle_tree_and_queue_rollover(merkle_tree_config: &AddressMerk
         &address_merkle_tree_pubkey,
         &address_queue_pubkey,
         merkle_tree_config,
+        queue_config,
     )
     .await
     .unwrap();
@@ -863,6 +905,7 @@ async fn address_merkle_tree_and_queue_rollover(merkle_tree_config: &AddressMerk
         &address_merkle_tree_pubkey,
         &address_queue_pubkey,
         merkle_tree_config,
+        queue_config,
     )
     .await;
 
@@ -876,32 +919,46 @@ async fn address_merkle_tree_and_queue_rollover(merkle_tree_config: &AddressMerk
 
 #[tokio::test]
 async fn test_address_merkle_tree_and_queue_rollover_default() {
-    address_merkle_tree_and_queue_rollover(&AddressMerkleTreeConfig::default()).await
+    address_merkle_tree_and_queue_rollover(
+        &AddressMerkleTreeConfig::default(),
+        &AddressQueueConfig::default(),
+    )
+    .await
 }
 
 #[tokio::test]
 async fn test_address_merkle_tree_and_queue_rollover_custom() {
-    for changelog_size in (500..5000).step_by(500) {
-        let roots_size = changelog_size * 2;
+    for changelog_size in (1000..5000).step_by(1000) {
+        for queue_capacity in [5003, 6857, 7901] {
+            let roots_size = changelog_size * 2;
 
-        for address_changelog_size in (250..1000).step_by(250) {
-            address_merkle_tree_and_queue_rollover(&AddressMerkleTreeConfig {
-                height: ADDRESS_MERKLE_TREE_HEIGHT as u32,
-                changelog_size,
-                roots_size,
-                canopy_depth: ADDRESS_MERKLE_TREE_CANOPY_DEPTH,
-                address_changelog_size,
-                network_fee: Some(5000),
-                rollover_threshold: Some(95),
-                close_threshold: None,
-            })
-            .await;
+            for address_changelog_size in (250..1000).step_by(250) {
+                address_merkle_tree_and_queue_rollover(
+                    &AddressMerkleTreeConfig {
+                        height: ADDRESS_MERKLE_TREE_HEIGHT as u32,
+                        changelog_size,
+                        roots_size,
+                        canopy_depth: ADDRESS_MERKLE_TREE_CANOPY_DEPTH,
+                        address_changelog_size,
+                        network_fee: Some(5000),
+                        rollover_threshold: Some(95),
+                        close_threshold: None,
+                    },
+                    &AddressQueueConfig {
+                        capacity: queue_capacity,
+                        sequence_threshold: roots_size,
+                        network_fee: None,
+                    },
+                )
+                .await;
+            }
         }
     }
 }
 
 pub async fn test_setup_with_address_merkle_tree(
     merkle_tree_config: &AddressMerkleTreeConfig,
+    queue_config: &AddressQueueConfig,
 ) -> (
     ProgramTestRpcConnection, // rpc
     Keypair,                  // payer
@@ -924,6 +981,7 @@ pub async fn test_setup_with_address_merkle_tree(
         &address_queue_keypair,
         None,
         merkle_tree_config,
+        queue_config,
         1,
     )
     .await;

--- a/test-programs/account-compression-test/tests/merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/merkle_tree_tests.rs
@@ -731,6 +731,7 @@ async fn test_init_and_rollover_state_merkle_tree(
         &merkle_tree_pubkey,
         &nullifier_queue_pubkey,
         merkle_tree_config,
+        queue_config,
         None,
     )
     .await;
@@ -749,6 +750,7 @@ async fn test_init_and_rollover_state_merkle_tree(
         &merkle_tree_pubkey,
         &nullifier_queue_pubkey,
         merkle_tree_config,
+        queue_config,
         Some(StateMerkleTreeRolloverMode::QueueInvalidSize),
     )
     .await;
@@ -761,6 +763,7 @@ async fn test_init_and_rollover_state_merkle_tree(
         &merkle_tree_pubkey,
         &nullifier_queue_pubkey,
         merkle_tree_config,
+        queue_config,
         Some(StateMerkleTreeRolloverMode::TreeInvalidSize),
     )
     .await;
@@ -781,6 +784,7 @@ async fn test_init_and_rollover_state_merkle_tree(
         &merkle_tree_pubkey,
         &nullifier_queue_keypair_2.pubkey(),
         merkle_tree_config,
+        queue_config,
         None,
     )
     .await;
@@ -799,6 +803,7 @@ async fn test_init_and_rollover_state_merkle_tree(
         &merkle_tree_pubkey_2,
         &nullifier_queue_keypair.pubkey(),
         merkle_tree_config,
+        queue_config,
         None,
     )
     .await;
@@ -824,6 +829,7 @@ async fn test_init_and_rollover_state_merkle_tree(
         &merkle_tree_pubkey,
         &nullifier_queue_pubkey,
         merkle_tree_config,
+        queue_config,
         None,
     )
     .await
@@ -849,6 +855,7 @@ async fn test_init_and_rollover_state_merkle_tree(
         &merkle_tree_pubkey,
         &nullifier_queue_pubkey,
         merkle_tree_config,
+        queue_config,
         None,
     )
     .await;

--- a/test-programs/system-cpi-test/tests/test_program_owned_trees.rs
+++ b/test-programs/system-cpi-test/tests/test_program_owned_trees.rs
@@ -7,7 +7,7 @@ use solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::Signer, transaction
 use account_compression::sdk::create_insert_leaves_instruction;
 use account_compression::utils::constants::{CPI_AUTHORITY_PDA_SEED, STATE_NULLIFIER_QUEUE_VALUES};
 use account_compression::{
-    AddressMerkleTreeConfig, QueueAccount, StateMerkleTreeAccount, StateMerkleTreeConfig,
+    AddressMerkleTreeConfig, AddressQueueConfig, QueueAccount, StateMerkleTreeAccount, StateMerkleTreeConfig,
 };
 use light_compressed_token::mint_sdk::create_mint_to_instruction;
 use light_hasher::Poseidon;
@@ -210,6 +210,7 @@ async fn test_invalid_registered_program() {
         &invalid_group_address_queue,
         None,
         &AddressMerkleTreeConfig::default(),
+        &AddressQueueConfig::default(),
         3,
     )
     .await;

--- a/test-programs/system-cpi-test/tests/test_program_owned_trees.rs
+++ b/test-programs/system-cpi-test/tests/test_program_owned_trees.rs
@@ -7,7 +7,8 @@ use solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::Signer, transaction
 use account_compression::sdk::create_insert_leaves_instruction;
 use account_compression::utils::constants::{CPI_AUTHORITY_PDA_SEED, STATE_NULLIFIER_QUEUE_VALUES};
 use account_compression::{
-    AddressMerkleTreeConfig, AddressQueueConfig, QueueAccount, StateMerkleTreeAccount, StateMerkleTreeConfig,
+    AddressMerkleTreeConfig, AddressQueueConfig, QueueAccount, StateMerkleTreeAccount,
+    StateMerkleTreeConfig,
 };
 use light_compressed_token::mint_sdk::create_mint_to_instruction;
 use light_hasher::Poseidon;

--- a/test-utils/src/address_tree_rollover.rs
+++ b/test-utils/src/address_tree_rollover.rs
@@ -10,11 +10,11 @@ use crate::{
     },
     get_hash_set,
 };
-use account_compression::AddressMerkleTreeConfig;
 use account_compression::{
     accounts, initialize_address_merkle_tree::AccountLoader, instruction, state::QueueAccount,
     AddressMerkleTreeAccount,
 };
+use account_compression::{AddressMerkleTreeConfig, AddressQueueConfig};
 use anchor_lang::{InstructionData, Key, Lamports, ToAccountMetas};
 use light_hasher::Poseidon;
 use light_indexed_merkle_tree::zero_copy::IndexedMerkleTreeZeroCopyMut;
@@ -62,11 +62,10 @@ pub async fn perform_address_merkle_tree_roll_over<R: RpcConnection>(
     old_merkle_tree_pubkey: &Pubkey,
     old_queue_pubkey: &Pubkey,
     merkle_tree_config: &AddressMerkleTreeConfig,
+    queue_config: &AddressQueueConfig,
 ) -> Result<solana_sdk::signature::Signature, RpcError> {
     let payer = context.get_payer().insecure_clone();
-    let size =
-        QueueAccount::size(account_compression::utils::constants::ADDRESS_QUEUE_VALUES as usize)
-            .unwrap();
+    let size = QueueAccount::size(queue_config.capacity as usize).unwrap();
     let account_create_ix = crate::create_account_instruction(
         &payer.pubkey(),
         size,

--- a/test-utils/src/e2e_test_env.rs
+++ b/test-utils/src/e2e_test_env.rs
@@ -99,7 +99,9 @@ use account_compression::utils::constants::{
 use light_hasher::Poseidon;
 use light_indexed_merkle_tree::{array::IndexedArray, reference::IndexedMerkleTree};
 
-use account_compression::{AddressMerkleTreeConfig, AddressQueueConfig, StateMerkleTreeConfig};
+use account_compression::{
+    AddressMerkleTreeConfig, AddressQueueConfig, NullifierQueueConfig, StateMerkleTreeConfig,
+};
 use light_system_program::sdk::compressed_account::CompressedAccountWithMerkleContext;
 use light_utils::bigint::bigint_to_be_bytes_array;
 use num_bigint::{BigUint, RandBigInt};
@@ -575,6 +577,7 @@ where
             &bundle.merkle_tree,
             &bundle.nullifier_queue,
             &StateMerkleTreeConfig::default(),
+            &NullifierQueueConfig::default(),
             None,
         )
         .await

--- a/test-utils/src/e2e_test_env.rs
+++ b/test-utils/src/e2e_test_env.rs
@@ -99,7 +99,7 @@ use account_compression::utils::constants::{
 use light_hasher::Poseidon;
 use light_indexed_merkle_tree::{array::IndexedArray, reference::IndexedMerkleTree};
 
-use account_compression::{AddressMerkleTreeConfig, StateMerkleTreeConfig};
+use account_compression::{AddressMerkleTreeConfig, AddressQueueConfig, StateMerkleTreeConfig};
 use light_system_program::sdk::compressed_account::CompressedAccountWithMerkleContext;
 use light_utils::bigint::bigint_to_be_bytes_array;
 use num_bigint::{BigUint, RandBigInt};
@@ -438,6 +438,7 @@ where
             &nullifier_queue_keypair,
             None,
             &config,
+            &AddressQueueConfig::default(),
             self.indexer.address_merkle_trees.len() as u64,
         )
         .await;

--- a/test-utils/src/indexer/test_indexer.rs
+++ b/test-utils/src/indexer/test_indexer.rs
@@ -4,7 +4,7 @@ use solana_sdk::bs58;
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 
-use account_compression::{AddressMerkleTreeConfig, StateMerkleTreeConfig};
+use account_compression::{AddressMerkleTreeConfig, AddressQueueConfig, StateMerkleTreeConfig};
 use light_compressed_token::constants::TOKEN_COMPRESSED_ACCOUNT_DISCRIMINATOR;
 use light_compressed_token::mint_sdk::create_create_token_pool_instruction;
 use light_compressed_token::{get_token_pool_pda, TokenData};
@@ -488,6 +488,7 @@ impl<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection> TestIndexer<INDEXED_ARRA
             queue_keypair,
             owning_program_id,
             &AddressMerkleTreeConfig::default(),
+            &AddressQueueConfig::default(),
             self.address_merkle_trees.len() as u64,
         )
         .await;

--- a/test-utils/src/state_tree_rollover.rs
+++ b/test-utils/src/state_tree_rollover.rs
@@ -9,10 +9,10 @@ use crate::{
     },
     create_account_instruction, get_hash_set,
 };
+use account_compression::NullifierQueueConfig;
 use account_compression::{
     self, initialize_address_merkle_tree::AccountLoader, state::QueueAccount,
-    utils::constants::STATE_NULLIFIER_QUEUE_VALUES, StateMerkleTreeAccount, StateMerkleTreeConfig,
-    ID,
+    StateMerkleTreeAccount, StateMerkleTreeConfig, ID,
 };
 use anchor_lang::{InstructionData, Lamports, ToAccountMetas};
 use light_concurrent_merkle_tree::{
@@ -41,10 +41,11 @@ pub async fn perform_state_merkle_tree_roll_over<R: RpcConnection>(
     merkle_tree_pubkey: &Pubkey,
     nullifier_queue_pubkey: &Pubkey,
     merkle_tree_config: &StateMerkleTreeConfig,
+    queue_config: &NullifierQueueConfig,
     mode: Option<StateMerkleTreeRolloverMode>,
 ) -> Result<solana_sdk::signature::Signature, RpcError> {
     let payer_pubkey = rpc.get_payer().pubkey();
-    let mut size = QueueAccount::size(STATE_NULLIFIER_QUEUE_VALUES as usize).unwrap();
+    let mut size = QueueAccount::size(queue_config.capacity as usize).unwrap();
     if let Some(StateMerkleTreeRolloverMode::QueueInvalidSize) = mode {
         size += 1;
     }

--- a/test-utils/src/state_tree_rollover.rs
+++ b/test-utils/src/state_tree_rollover.rs
@@ -34,6 +34,7 @@ pub enum StateMerkleTreeRolloverMode {
     TreeInvalidSize,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn perform_state_merkle_tree_roll_over<R: RpcConnection>(
     rpc: &mut R,
     new_nullifier_queue_keypair: &Keypair,

--- a/test-utils/src/test_forester.rs
+++ b/test-utils/src/test_forester.rs
@@ -452,7 +452,7 @@ pub async fn empty_address_queue_test<const INDEXED_ARRAY_SIZE: usize, R: RpcCon
                     .unwrap()
                     .sequence_number()
                     .unwrap(),
-                old_sequence_number + ADDRESS_MERKLE_TREE_ROOTS as usize + SAFETY_MARGIN as usize
+                old_sequence_number + address_queue.sequence_threshold
             );
 
             relayer_merkle_tree

--- a/utils/src/prime.rs
+++ b/utils/src/prime.rs
@@ -86,17 +86,21 @@ mod test {
         assert_eq!(find_next_prime(10.0), 11.0);
         assert_eq!(find_next_prime(28.0), 29.0);
 
+        assert_eq!(find_next_prime(100.0), 101.0);
         assert_eq!(find_next_prime(102.0), 103.0);
         assert_eq!(find_next_prime(105.0), 107.0);
 
-        assert_eq!(find_next_prime(100.0), 101.0);
         assert_eq!(find_next_prime(1000.0), 1009.0);
+        assert_eq!(find_next_prime(2000.0), 2003.0);
+        assert_eq!(find_next_prime(3000.0), 3001.0);
+        assert_eq!(find_next_prime(4000.0), 4001.0);
 
         assert_eq!(find_next_prime(4800.0), 4801.0);
         assert_eq!(find_next_prime(5000.0), 5003.0);
         assert_eq!(find_next_prime(6000.0), 6007.0);
         assert_eq!(find_next_prime(6850.0), 6857.0);
 
+        assert_eq!(find_next_prime(7000.0), 7001.0);
         assert_eq!(find_next_prime(7900.0), 7901.0);
         assert_eq!(find_next_prime(7907.0), 7907.0);
     }


### PR DESCRIPTION
Initialize queues with non-default sizes and use them in all functional tests to make sure that zero-copy serialization works.