### PR TITLE
chore: add "deps" and "deps-dev" to pr.yml workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,3 +36,5 @@ jobs:
             aligned-sized
             macro-circom
             merkle-tree
+            deps
+            deps-dev


### PR DESCRIPTION
The "deps" and "deps-dev" have been added to the .github/workflows/pr.yml file.