### PR TITLE
chore: Return errors for unsupported configurations

### DIFF
--- a/programs/account-compression/src/errors.rs
+++ b/programs/account-compression/src/errors.rs
@@ -52,4 +52,6 @@ pub enum AccountCompressionErrorCode {
     UnsupportedCanopyDepth,
     #[msg("Invalid sequence threshold")]
     InvalidSequenceThreshold,
+    #[msg("Unsupported close threshold")]
+    UnsupportedCloseThreshold,
 }

--- a/programs/account-compression/src/errors.rs
+++ b/programs/account-compression/src/errors.rs
@@ -46,4 +46,10 @@ pub enum AccountCompressionErrorCode {
     SizeMismatch,
     #[msg("InsufficientRolloverFee")]
     InsufficientRolloverFee,
+    #[msg("Unsupported Merkle tree height")]
+    UnsupportedHeight,
+    #[msg("Unsupported canopy depth")]
+    UnsupportedCanopyDepth,
+    #[msg("Invalid sequence threshold")]
+    InvalidSequenceThreshold,
 }

--- a/programs/account-compression/src/instructions/initialize_address_merkle_tree_and_queue.rs
+++ b/programs/account-compression/src/instructions/initialize_address_merkle_tree_and_queue.rs
@@ -76,6 +76,10 @@ pub fn process_initialize_address_merkle_tree_and_queue<'info>(
         );
         return err!(AccountCompressionErrorCode::UnsupportedCanopyDepth);
     }
+    if merkle_tree_config.close_threshold.is_some() {
+        msg!("close_threshold is not supported yet");
+        return err!(AccountCompressionErrorCode::UnsupportedCloseThreshold);
+    }
     let minimum_sequence_threshold = merkle_tree_config.roots_size + SAFETY_MARGIN;
     if queue_config.sequence_threshold < minimum_sequence_threshold {
         msg!(

--- a/programs/account-compression/src/instructions/initialize_address_merkle_tree_and_queue.rs
+++ b/programs/account-compression/src/instructions/initialize_address_merkle_tree_and_queue.rs
@@ -83,7 +83,8 @@ pub fn process_initialize_address_merkle_tree_and_queue<'info>(
     let minimum_sequence_threshold = merkle_tree_config.roots_size + SAFETY_MARGIN;
     if queue_config.sequence_threshold < minimum_sequence_threshold {
         msg!(
-            "Sequence threshold should be at least {}",
+            "Invalid sequence threshold: {}. Should be at least {}",
+            queue_config.sequence_threshold,
             minimum_sequence_threshold
         );
         return err!(AccountCompressionErrorCode::InvalidSequenceThreshold);

--- a/programs/account-compression/src/instructions/initialize_address_merkle_tree_and_queue.rs
+++ b/programs/account-compression/src/instructions/initialize_address_merkle_tree_and_queue.rs
@@ -1,6 +1,7 @@
 use anchor_lang::prelude::*;
 
 use crate::{
+    errors::AccountCompressionErrorCode,
     initialize_address_merkle_tree::process_initialize_address_merkle_tree,
     initialize_address_queue::process_initialize_address_queue,
     state::QueueAccount,
@@ -9,7 +10,7 @@ use crate::{
         ADDRESS_MERKLE_TREE_HEIGHT, ADDRESS_MERKLE_TREE_INDEXED_CHANGELOG,
         ADDRESS_MERKLE_TREE_ROOTS,
     },
-    AddressMerkleTreeAccount, NullifierQueueConfig,
+    AddressMerkleTreeAccount, NullifierQueueConfig, SAFETY_MARGIN,
 };
 
 #[derive(Debug, Clone, AnchorDeserialize, AnchorSerialize, PartialEq)]
@@ -59,6 +60,31 @@ pub fn process_initialize_address_merkle_tree_and_queue<'info>(
     merkle_tree_config: AddressMerkleTreeConfig,
     queue_config: AddressQueueConfig,
 ) -> Result<()> {
+    if merkle_tree_config.height as u64 != ADDRESS_MERKLE_TREE_HEIGHT {
+        msg!(
+            "Unsupported Merkle tree height: {}. The only currently supported height is: {}",
+            merkle_tree_config.height,
+            ADDRESS_MERKLE_TREE_HEIGHT
+        );
+        return err!(AccountCompressionErrorCode::UnsupportedHeight);
+    }
+    if merkle_tree_config.canopy_depth != ADDRESS_MERKLE_TREE_CANOPY_DEPTH {
+        msg!(
+            "Unsupported canopy depth: {}. The only currently supported depth is: {}",
+            merkle_tree_config.canopy_depth,
+            ADDRESS_MERKLE_TREE_CANOPY_DEPTH
+        );
+        return err!(AccountCompressionErrorCode::UnsupportedCanopyDepth);
+    }
+    let minimum_sequence_threshold = merkle_tree_config.roots_size + SAFETY_MARGIN;
+    if queue_config.sequence_threshold < minimum_sequence_threshold {
+        msg!(
+            "Sequence threshold should be at least {}",
+            minimum_sequence_threshold
+        );
+        return err!(AccountCompressionErrorCode::InvalidSequenceThreshold);
+    }
+
     let merkle_tree_rent = ctx.accounts.merkle_tree.get_lamports();
     process_initialize_address_queue(
         &ctx.accounts.queue.to_account_info(),

--- a/programs/account-compression/src/instructions/initialize_state_merkle_tree_and_nullifier_queue.rs
+++ b/programs/account-compression/src/instructions/initialize_state_merkle_tree_and_nullifier_queue.rs
@@ -99,7 +99,8 @@ pub fn process_initialize_state_merkle_tree_and_nullifier_queue(
     let minimum_sequence_threshold = state_merkle_tree_config.roots_size + SAFETY_MARGIN;
     if nullifier_queue_config.sequence_threshold < minimum_sequence_threshold {
         msg!(
-            "Sequence threshold should be at least {}",
+            "Invalid sequence threshold: {}. Should be at least: {}",
+            nullifier_queue_config.sequence_threshold,
             minimum_sequence_threshold
         );
         return err!(AccountCompressionErrorCode::InvalidSequenceThreshold);

--- a/programs/account-compression/src/instructions/initialize_state_merkle_tree_and_nullifier_queue.rs
+++ b/programs/account-compression/src/instructions/initialize_state_merkle_tree_and_nullifier_queue.rs
@@ -92,6 +92,10 @@ pub fn process_initialize_state_merkle_tree_and_nullifier_queue(
         );
         return err!(AccountCompressionErrorCode::UnsupportedCanopyDepth);
     }
+    if state_merkle_tree_config.close_threshold.is_some() {
+        msg!("close_threshold is not supported yet");
+        return err!(AccountCompressionErrorCode::UnsupportedCloseThreshold);
+    }
     let minimum_sequence_threshold = state_merkle_tree_config.roots_size + SAFETY_MARGIN;
     if nullifier_queue_config.sequence_threshold < minimum_sequence_threshold {
         msg!(

--- a/test-programs/account-compression-test/tests/merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/merkle_tree_tests.rs
@@ -1651,6 +1651,25 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_confi
         )
         .unwrap();
     }
+    for invalid_height in (27..50).step_by(5) {
+        let mut merkle_tree_config = merkle_tree_config.clone();
+        merkle_tree_config.height = invalid_height;
+        let result = initialize_state_merkle_tree_and_nullifier_queue(
+            rpc,
+            payer_pubkey,
+            merkle_tree_keypair,
+            queue_keypair,
+            &merkle_tree_config,
+            &queue_config,
+            merkle_tree_size,
+            queue_size,
+        )
+        .await;
+        assert_rpc_error(
+            result, 2, 6021, // AccountCompressionErrorCode::UnsupportedHeight
+        )
+        .unwrap();
+    }
     for invalid_canopy_depth in (0..10).step_by(3) {
         let mut merkle_tree_config = merkle_tree_config.clone();
         merkle_tree_config.canopy_depth = invalid_canopy_depth;

--- a/test-programs/account-compression-test/tests/merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/merkle_tree_tests.rs
@@ -1552,7 +1552,7 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_sizes
                 merkle_tree_pubkey,
                 queue_keypair.pubkey(),
                 merkle_tree_config.clone(),
-                NullifierQueueConfig::default(),
+                queue_config.clone(),
                 None,
                 1,
                 0,


### PR DESCRIPTION
Return errors for:

- Height different than 26.
- Canopy depth different than 10.
- Sequence threshold lower than roots + safety margin.