### PR TITLE
chore: switch indexed array to vec

### DIFF
--- a/circuit-lib/light-prover-client/src/init_merkle_tree.rs
+++ b/circuit-lib/light-prover-client/src/init_merkle_tree.rs
@@ -70,7 +70,7 @@ pub fn non_inclusion_merkle_tree_inputs_26() -> NonInclusionMerkleProofInputs {
     const HEIGHT: usize = 26;
     const CANOPY: usize = 0;
     let mut indexed_tree = IndexedMerkleTree::<Poseidon, usize>::new(HEIGHT, CANOPY).unwrap();
-    let mut indexing_array = IndexedArray::<Poseidon, usize, 1024>::default();
+    let mut indexing_array = IndexedArray::<Poseidon, usize>::default();
 
     let bundle1 = indexing_array.append(&1_u32.to_biguint().unwrap()).unwrap();
     indexed_tree

--- a/circuit-lib/light-prover-client/src/non_inclusion/merkle_non_inclusion_proof_inputs.rs
+++ b/circuit-lib/light-prover-client/src/non_inclusion/merkle_non_inclusion_proof_inputs.rs
@@ -28,13 +28,13 @@ impl NonInclusionMerkleProofInputs {
 pub struct NonInclusionProofInputs<'a>(pub &'a [NonInclusionMerkleProofInputs]);
 
 // TODO: eliminate use of BigInt in favor of BigUint
-pub fn get_non_inclusion_proof_inputs<const INDEXED_ARRAY_SIZE: usize>(
+pub fn get_non_inclusion_proof_inputs(
     value: &[u8; 32],
     merkle_tree: &light_indexed_merkle_tree::reference::IndexedMerkleTree<
         light_hasher::Poseidon,
         usize,
     >,
-    indexed_array: &IndexedArray<light_hasher::Poseidon, usize, INDEXED_ARRAY_SIZE>,
+    indexed_array: &IndexedArray<light_hasher::Poseidon, usize>,
 ) -> NonInclusionMerkleProofInputs {
     let non_inclusion_proof = merkle_tree
         .get_non_inclusion_proof(&BigUint::from_be_bytes(value), indexed_array)

--- a/examples/token-escrow/programs/token-escrow/tests/test.rs
+++ b/examples/token-escrow/programs/token-escrow/tests/test.rs
@@ -197,7 +197,7 @@ async fn test_escrow_pda() {
 
 pub async fn perform_escrow<R: RpcConnection>(
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
     payer: &Keypair,
     escrow_amount: &u64,
@@ -265,7 +265,7 @@ pub async fn perform_escrow<R: RpcConnection>(
 
 pub async fn perform_escrow_with_event<R: RpcConnection>(
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
     payer: &Keypair,
     escrow_amount: &u64,
@@ -298,7 +298,7 @@ pub async fn perform_escrow_with_event<R: RpcConnection>(
 
 pub async fn perform_escrow_failing<R: RpcConnection>(
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
     payer: &Keypair,
     escrow_amount: &u64,
@@ -317,7 +317,7 @@ pub async fn perform_escrow_failing<R: RpcConnection>(
 
 pub async fn assert_escrow<R: RpcConnection>(
     rpc: &mut R,
-    test_indexer: &TestIndexer<200, R>,
+    test_indexer: &TestIndexer<R>,
     payer_pubkey: &Pubkey,
     amount: u64,
     escrow_amount: u64,
@@ -353,7 +353,7 @@ pub async fn assert_escrow<R: RpcConnection>(
 
 pub async fn perform_withdrawal<R: RpcConnection>(
     context: &mut R,
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
     payer: &Keypair,
     withdrawal_amount: &u64,
@@ -419,7 +419,7 @@ pub async fn perform_withdrawal<R: RpcConnection>(
 
 pub async fn perform_withdrawal_with_event<R: RpcConnection>(
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
     payer: &Keypair,
     withdrawal_amount: &u64,
@@ -449,7 +449,7 @@ pub async fn perform_withdrawal_with_event<R: RpcConnection>(
 
 pub async fn perform_withdrawal_failing<R: RpcConnection>(
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
     payer: &Keypair,
     withdrawal_amount: &u64,
@@ -473,7 +473,7 @@ pub async fn perform_withdrawal_failing<R: RpcConnection>(
     rpc.process_transaction(transaction).await
 }
 pub fn assert_withdrawal<R: RpcConnection>(
-    test_indexer: &TestIndexer<200, R>,
+    test_indexer: &TestIndexer<R>,
     payer_pubkey: &Pubkey,
     withdrawal_amount: u64,
     escrow_amount: u64,

--- a/examples/token-escrow/programs/token-escrow/tests/test_compressed_pda.rs
+++ b/examples/token-escrow/programs/token-escrow/tests/test_compressed_pda.rs
@@ -136,7 +136,7 @@ async fn test_escrow_with_compressed_pda() {
 }
 
 pub async fn perform_escrow_failing<R: RpcConnection>(
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     rpc: &mut R,
     env: &EnvAccounts,
     payer: &Keypair,
@@ -166,7 +166,7 @@ pub async fn perform_escrow_failing<R: RpcConnection>(
 }
 
 pub async fn perform_escrow_with_event<R: RpcConnection>(
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     rpc: &mut R,
     env: &EnvAccounts,
     payer: &Keypair,
@@ -204,7 +204,7 @@ pub async fn perform_escrow_with_event<R: RpcConnection>(
 
 async fn create_escrow_ix<R: RpcConnection>(
     payer: &Keypair,
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
     seed: [u8; 32],
     context: &mut R,
@@ -274,7 +274,7 @@ async fn create_escrow_ix<R: RpcConnection>(
 }
 
 pub async fn assert_escrow<R: RpcConnection>(
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
     payer: &Keypair,
     escrow_amount: &u64,
@@ -338,7 +338,7 @@ pub async fn assert_escrow<R: RpcConnection>(
 }
 pub async fn perform_withdrawal_with_event<R: RpcConnection>(
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
     payer: &Keypair,
     old_lock_up_time: u64,
@@ -369,7 +369,7 @@ pub async fn perform_withdrawal_with_event<R: RpcConnection>(
 
 pub async fn perform_withdrawal_failing<R: RpcConnection>(
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
     payer: &Keypair,
     old_lock_up_time: u64,
@@ -397,7 +397,7 @@ pub async fn perform_withdrawal_failing<R: RpcConnection>(
 }
 pub async fn perform_withdrawal<R: RpcConnection>(
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
     payer: &Keypair,
     old_lock_up_time: u64,
@@ -488,7 +488,7 @@ pub async fn perform_withdrawal<R: RpcConnection>(
 #[allow(clippy::too_many_arguments)]
 pub async fn assert_withdrawal<R: RpcConnection>(
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
     payer: &Keypair,
     withdrawal_amount: &u64,

--- a/forester/tests/e2e_test.rs
+++ b/forester/tests/e2e_test.rs
@@ -25,7 +25,7 @@ async fn test_state_tree_nullifier() {
         .await
         .unwrap();
 
-    let mut env = E2ETestEnv::<500, SolanaRpcConnection>::new(
+    let mut env = E2ETestEnv::< SolanaRpcConnection>::new(
         rpc,
         &env_accounts,
         keypair_action_config(),
@@ -70,7 +70,7 @@ async fn test_1_all() {
         .await
         .unwrap();
 
-    let mut env = E2ETestEnv::<500, SolanaRpcConnection>::new(
+    let mut env = E2ETestEnv::< SolanaRpcConnection>::new(
         rpc,
         &env_accounts,
         keypair_action_config(),

--- a/forester/tests/e2e_test.rs
+++ b/forester/tests/e2e_test.rs
@@ -25,7 +25,7 @@ async fn test_state_tree_nullifier() {
         .await
         .unwrap();
 
-    let mut env = E2ETestEnv::< SolanaRpcConnection>::new(
+    let mut env = E2ETestEnv::<SolanaRpcConnection>::new(
         rpc,
         &env_accounts,
         keypair_action_config(),
@@ -70,7 +70,7 @@ async fn test_1_all() {
         .await
         .unwrap();
 
-    let mut env = E2ETestEnv::< SolanaRpcConnection>::new(
+    let mut env = E2ETestEnv::<SolanaRpcConnection>::new(
         rpc,
         &env_accounts,
         keypair_action_config(),

--- a/forester/tests/empty_address_tree_test.rs
+++ b/forester/tests/empty_address_tree_test.rs
@@ -24,7 +24,7 @@ async fn empty_address_tree_test() {
         .await
         .unwrap();
 
-    let mut env = E2ETestEnv::< SolanaRpcConnection>::new(
+    let mut env = E2ETestEnv::<SolanaRpcConnection>::new(
         rpc,
         &env_accounts,
         keypair_action_config(),

--- a/forester/tests/empty_address_tree_test.rs
+++ b/forester/tests/empty_address_tree_test.rs
@@ -24,7 +24,7 @@ async fn empty_address_tree_test() {
         .await
         .unwrap();
 
-    let mut env = E2ETestEnv::<500, SolanaRpcConnection>::new(
+    let mut env = E2ETestEnv::< SolanaRpcConnection>::new(
         rpc,
         &env_accounts,
         keypair_action_config(),

--- a/forester/tests/interop_address_test.rs
+++ b/forester/tests/interop_address_test.rs
@@ -36,7 +36,7 @@ async fn test_photon_interop_address() {
         .await
         .unwrap();
 
-    let mut env = E2ETestEnv::<500, SolanaRpcConnection>::new(
+    let mut env = E2ETestEnv::<SolanaRpcConnection>::new(
         rpc,
         &env_accounts,
         keypair_action_config(),

--- a/forester/tests/interop_nullify_test.rs
+++ b/forester/tests/interop_nullify_test.rs
@@ -1,22 +1,14 @@
 use log::info;
 use solana_sdk::native_token::LAMPORTS_PER_SOL;
-use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signer;
 
-use forester::external_services_config::ExternalServicesConfig;
 use forester::indexer::PhotonIndexer;
 use forester::utils::LightValidatorConfig;
-use forester::ForesterConfig;
-use light_test_utils::e2e_test_env::{E2ETestEnv, GeneralActionConfig, KeypairActionConfig, User};
-use light_test_utils::indexer::Indexer;
-use light_test_utils::indexer::TestIndexer;
+use light_test_utils::e2e_test_env::{E2ETestEnv, GeneralActionConfig, KeypairActionConfig};
 use light_test_utils::rpc::rpc_connection::RpcConnection;
 use light_test_utils::rpc::solana_rpc::SolanaRpcUrl;
 use light_test_utils::rpc::SolanaRpcConnection;
 use light_test_utils::test_env::get_test_env_accounts;
-use light_test_utils::test_env::REGISTRY_ID_TEST_KEYPAIR;
-use solana_sdk::signer::keypair::Keypair;
-
 mod test_utils;
 use test_utils::*;
 

--- a/forester/tests/interop_nullify_test.rs
+++ b/forester/tests/interop_nullify_test.rs
@@ -21,7 +21,7 @@ mod test_utils;
 use test_utils::*;
 
 pub async fn assert_accounts_by_owner(
-    indexer: &mut TestIndexer<500, SolanaRpcConnection>,
+    indexer: &mut TestIndexer<SolanaRpcConnection>,
     user: &User,
     photon_indexer: &PhotonIndexer,
 ) {
@@ -54,7 +54,7 @@ pub async fn assert_accounts_by_owner(
 }
 
 pub async fn assert_account_proofs_for_photon_and_test_indexer(
-    indexer: &mut TestIndexer<500, SolanaRpcConnection>,
+    indexer: &mut TestIndexer<SolanaRpcConnection>,
     user_pubkey: &Pubkey,
     photon_indexer: &PhotonIndexer,
 ) {
@@ -128,7 +128,7 @@ async fn test_photon_interop_nullify_account() {
         .await
         .unwrap();
 
-    let mut env = E2ETestEnv::<500, SolanaRpcConnection>::new(
+    let mut env = E2ETestEnv::<SolanaRpcConnection>::new(
         rpc,
         &env_accounts,
         keypair_action_config(),

--- a/forester/tests/test_utils.rs
+++ b/forester/tests/test_utils.rs
@@ -11,11 +11,13 @@ use light_test_utils::test_env::{get_test_env_accounts, REGISTRY_ID_TEST_KEYPAIR
 use log::{info, LevelFilter};
 use solana_sdk::signature::{Keypair, Signer};
 
+#[allow(dead_code)]
 pub async fn init(config: Option<LightValidatorConfig>) {
     setup_logger();
     spawn_test_validator(config).await;
 }
 
+#[allow(dead_code)]
 pub fn setup_logger() {
     let _ = env_logger::Builder::from_env(
         env_logger::Env::default().default_filter_or(LevelFilter::Info.to_string()),
@@ -24,6 +26,7 @@ pub fn setup_logger() {
     .try_init();
 }
 
+#[allow(dead_code)]
 pub async fn spawn_test_validator(config: Option<LightValidatorConfig>) {
     if let Some(config) = config {
         spawn_validator(config).await;
@@ -64,6 +67,7 @@ pub fn general_action_config() -> GeneralActionConfig {
     }
 }
 
+#[allow(dead_code)]
 pub fn forester_config() -> ForesterConfig {
     let env_accounts = get_test_env_accounts();
     let registry_keypair = Keypair::from_bytes(&REGISTRY_ID_TEST_KEYPAIR).unwrap();
@@ -111,6 +115,7 @@ pub async fn get_address_queue_length<R: RpcConnection>(
 }
 
 // truncate to <254 bit
+#[allow(dead_code)]
 pub fn generate_pubkey_254() -> Pubkey {
     let mock_address: Pubkey = Pubkey::new_unique();
     let mut mock_address_less_than_254_bit: [u8; 32] = mock_address.to_bytes();
@@ -118,6 +123,7 @@ pub fn generate_pubkey_254() -> Pubkey {
     Pubkey::from(mock_address_less_than_254_bit)
 }
 
+#[allow(dead_code)]
 pub async fn assert_new_address_proofs_for_photon_and_test_indexer(
     indexer: &mut TestIndexer<SolanaRpcConnection>,
     trees: &[Pubkey],

--- a/merkle-tree/indexed/src/array.rs
+++ b/merkle-tree/indexed/src/array.rs
@@ -114,7 +114,7 @@ where
 }
 
 #[derive(Clone, Debug)]
-pub struct IndexedArray<H, I, const ELEMENTS: usize>
+pub struct IndexedArray<H, I>
 where
     H: Hasher,
     I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
@@ -127,7 +127,7 @@ where
     _hasher: PhantomData<H>,
 }
 
-impl<H, I, const ELEMENTS: usize> Default for IndexedArray<H, I, ELEMENTS>
+impl<H, I> Default for IndexedArray<H, I>
 where
     H: Hasher,
     I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
@@ -147,7 +147,7 @@ where
     }
 }
 
-impl<H, I, const ELEMENTS: usize> IndexedArray<H, I, ELEMENTS>
+impl<H, I> IndexedArray<H, I>
 where
     H: Hasher,
     I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
@@ -165,7 +165,7 @@ where
         self.current_node_index == I::zero()
     }
 
-    pub fn iter(&self) -> IndexingArrayIter<H, I, ELEMENTS> {
+    pub fn iter(&self) -> IndexingArrayIter<H, I> {
         IndexingArrayIter {
             indexing_array: self,
             front: 0,
@@ -346,9 +346,7 @@ where
         low_element_index: I,
         value: &BigUint,
     ) -> Result<IndexedElementBundle<I>, IndexedMerkleTreeError> {
-        if self.len() == ELEMENTS {
-            return Err(IndexedMerkleTreeError::ArrayFull);
-        }
+        // TOD0: add length check, and add field to with tree height here
 
         let old_low_element = &self.elements[usize::from(low_element_index)];
 
@@ -416,18 +414,18 @@ where
     }
 }
 
-pub struct IndexingArrayIter<'a, H, I, const MAX_ELEMENTS: usize>
+pub struct IndexingArrayIter<'a, H, I>
 where
     H: Hasher,
     I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
     usize: From<I>,
 {
-    indexing_array: &'a IndexedArray<H, I, MAX_ELEMENTS>,
+    indexing_array: &'a IndexedArray<H, I>,
     front: usize,
     back: usize,
 }
 
-impl<'a, H, I, const MAX_ELEMENTS: usize> Iterator for IndexingArrayIter<'a, H, I, MAX_ELEMENTS>
+impl<'a, H, I> Iterator for IndexingArrayIter<'a, H, I>
 where
     H: Hasher,
     I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
@@ -446,8 +444,7 @@ where
     }
 }
 
-impl<'a, H, I, const MAX_ELEMENTS: usize> DoubleEndedIterator
-    for IndexingArrayIter<'a, H, I, MAX_ELEMENTS>
+impl<'a, H, I> DoubleEndedIterator for IndexingArrayIter<'a, H, I>
 where
     H: Hasher,
     I: CheckedAdd + CheckedSub + Copy + Clone + PartialOrd + ToBytes + TryFrom<usize> + Unsigned,
@@ -535,7 +532,7 @@ mod test {
         // value      = [0] [0] [0] [0] [0] [0] [0] [0]
         // next_index = [0] [0] [0] [0] [0] [0] [0] [0]
         // ```
-        let mut indexed_array: IndexedArray<Poseidon, usize, 8> = IndexedArray::default();
+        let mut indexed_array: IndexedArray<Poseidon, usize> = IndexedArray::default();
 
         let nullifier1 = 30_u32.to_biguint().unwrap();
         let bundle1 = indexed_array.new_element(&nullifier1).unwrap();
@@ -897,7 +894,7 @@ mod test {
         // value      = [0] [0] [0] [0] [0] [0] [0] [0]
         // next_index = [0] [0] [0] [0] [0] [0] [0] [0]
         // ```
-        let mut indexing_array: IndexedArray<Poseidon, usize, 8> = IndexedArray::default();
+        let mut indexing_array: IndexedArray<Poseidon, usize> = IndexedArray::default();
 
         let low_element_index = 0;
         let nullifier1 = 30_u32.to_biguint().unwrap();
@@ -1116,7 +1113,7 @@ mod test {
         // value      = [0] [0] [0] [0] [0] [0] [0] [0]
         // next_index = [0] [0] [0] [0] [0] [0] [0] [0]
         // ```
-        let mut indexing_array: IndexedArray<Poseidon, usize, 8> = IndexedArray::default();
+        let mut indexing_array: IndexedArray<Poseidon, usize> = IndexedArray::default();
 
         // Append nullifier 30. The low nullifier is at index 0. The array
         // should look like:
@@ -1179,7 +1176,7 @@ mod test {
     /// nonexistent is provided.
     #[test]
     fn test_find_low_element_for_existent_element() {
-        let mut indexed_array: IndexedArray<Poseidon, usize, 8> = IndexedArray::default();
+        let mut indexed_array: IndexedArray<Poseidon, usize> = IndexedArray::default();
 
         // Append nullifiers 40 and 20.
         let low_element_index = 0;

--- a/merkle-tree/indexed/src/lib.rs
+++ b/merkle-tree/indexed/src/lib.rs
@@ -52,10 +52,7 @@ where
     _index: PhantomData<I>,
 }
 
-pub type IndexedMerkleTree22<H, I> = IndexedMerkleTree<H, I, 22, 12>;
 pub type IndexedMerkleTree26<H, I> = IndexedMerkleTree<H, I, 26, 16>;
-pub type IndexedMerkleTree32<H, I> = IndexedMerkleTree<H, I, 32, 22>;
-pub type IndexedMerkleTree40<H, I> = IndexedMerkleTree<H, I, 40, 30>;
 
 impl<H, I, const HEIGHT: usize, const NET_HEIGHT: usize> IndexedMerkleTree<H, I, HEIGHT, NET_HEIGHT>
 where
@@ -159,7 +156,7 @@ where
     pub fn add_highest_element(&mut self) -> Result<(), IndexedMerkleTreeError> {
         let init_value = BigUint::from_str_radix(HIGHEST_ADDRESS_PLUS_ONE, 10).unwrap();
 
-        let mut indexed_array = IndexedArray::<H, I, 2>::default();
+        let mut indexed_array = IndexedArray::<H, I>::default();
         let element_bundle = indexed_array.append(&init_value)?;
         let new_low_leaf = element_bundle
             .new_low_element

--- a/merkle-tree/indexed/src/reference.rs
+++ b/merkle-tree/indexed/src/reference.rs
@@ -63,7 +63,7 @@ where
     /// on-chain indexed concurrent merkle tree.
     /// Inserts the ranges 0 - BN254 Field Size - 1 into the tree.
     pub fn init(&mut self) -> Result<(), IndexedReferenceMerkleTreeError> {
-        let mut indexed_array = IndexedArray::<H, I, 2>::default();
+        let mut indexed_array = IndexedArray::<H, I>::default();
         let init_value = BigUint::from_str_radix(HIGHEST_ADDRESS_PLUS_ONE, 10).unwrap();
         let nullifier_bundle = indexed_array.append(&init_value)?;
         let new_low_leaf = nullifier_bundle
@@ -118,10 +118,10 @@ where
     }
 
     // TODO: add append with new value, so that we don't need to compute the lowlevel values manually
-    pub fn append<const T: usize>(
+    pub fn append(
         &mut self,
         value: &BigUint,
-        indexed_array: &mut IndexedArray<H, I, T>,
+        indexed_array: &mut IndexedArray<H, I>,
     ) -> Result<(), IndexedReferenceMerkleTreeError> {
         let nullifier_bundle = indexed_array.append(value).unwrap();
         self.update(
@@ -133,10 +133,10 @@ where
         Ok(())
     }
 
-    pub fn get_non_inclusion_proof<const T: usize>(
+    pub fn get_non_inclusion_proof(
         &self,
         value: &BigUint,
-        indexed_array: &IndexedArray<H, I, T>,
+        indexed_array: &IndexedArray<H, I>,
     ) -> Result<NonInclusionProof, IndexedReferenceMerkleTreeError> {
         let (low_element, _next_value) = indexed_array.find_low_element_for_nonexistent(value)?;
         let merkle_proof = self

--- a/merkle-tree/indexed/tests/tests.rs
+++ b/merkle-tree/indexed/tests/tests.rs
@@ -28,8 +28,6 @@ const NET_HEIGHT: usize = MERKLE_TREE_HEIGHT - MERKLE_TREE_CANOPY;
 const QUEUE_ELEMENTS: usize = 1024;
 const SAFETY_MARGIN: usize = 10;
 
-const INDEXING_ARRAY_ELEMENTS: usize = 1024;
-
 const NR_NULLIFIERS: usize = 2;
 
 /// A mock function which imitates a Merkle tree program instruction for
@@ -109,7 +107,7 @@ fn relayer_update<H>(
 where
     H: Hasher,
 {
-    let mut relayer_indexing_array = IndexedArray::<H, usize, INDEXING_ARRAY_ELEMENTS>::default();
+    let mut relayer_indexing_array = IndexedArray::<H, usize>::default();
     let mut relayer_merkle_tree =
         reference::IndexedMerkleTree::<H, usize>::new(MERKLE_TREE_HEIGHT, MERKLE_TREE_CANOPY)
             .unwrap();
@@ -432,7 +430,7 @@ where
     onchain_tree.borrow_mut().init().unwrap();
 
     // Local artifacts.
-    let mut local_indexed_array = IndexedArray::<H, usize, INDEXING_ARRAY_ELEMENTS>::default();
+    let mut local_indexed_array = IndexedArray::<H, usize>::default();
     let mut local_merkle_tree =
         reference::IndexedMerkleTree::<H, usize>::new(MERKLE_TREE_HEIGHT, MERKLE_TREE_CANOPY)
             .unwrap();
@@ -602,8 +600,7 @@ pub fn hash_reference_indexed_element() {
 
 #[test]
 pub fn functional_non_inclusion_test() {
-    let mut relayer_indexing_array =
-        IndexedArray::<Poseidon, usize, INDEXING_ARRAY_ELEMENTS>::default();
+    let mut relayer_indexing_array = IndexedArray::<Poseidon, usize>::default();
 
     // appends the first element
     let mut relayer_merkle_tree = reference::IndexedMerkleTree::<Poseidon, usize>::new(
@@ -703,7 +700,7 @@ pub fn functional_non_inclusion_test() {
 // #[test]
 // pub fn print_test_data() {
 //     let mut relayer_indexing_array =
-//         IndexedArray::<Poseidon, usize, INDEXING_ARRAY_ELEMENTS>::default();
+//         IndexedArray::<Poseidon, usize>::default();
 //     relayer_indexing_array.init().unwrap();
 //     let mut relayer_merkle_tree =
 //         reference::IndexedMerkleTree::<Poseidon, usize>::new(26, 10).unwrap();
@@ -1054,8 +1051,7 @@ fn perform_change_log_test<
     addresses: &[BigUint],
 ) {
     // Initialize the trees and indexed array.
-    let mut relayer_indexed_array =
-        IndexedArray::<Poseidon, usize, INDEXING_ARRAY_ELEMENTS>::default();
+    let mut relayer_indexed_array = IndexedArray::<Poseidon, usize>::default();
     relayer_indexed_array.init().unwrap();
     let mut relayer_merkle_tree =
         reference::IndexedMerkleTree::<Poseidon, usize>::new(HEIGHT, CANOPY).unwrap();

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -1333,7 +1333,7 @@ pub async fn test_setup_with_address_merkle_tree(
 ) -> (
     ProgramTestRpcConnection, // rpc
     Keypair,                  // payer
-    AddressMerkleTreeBundle<4800>,
+    AddressMerkleTreeBundle,
 ) {
     let mut program_test = ProgramTest::default();
     program_test.add_program("account_compression", ID, None);
@@ -1360,17 +1360,7 @@ pub async fn test_setup_with_address_merkle_tree(
     // Local indexing array and queue. We will use them to get the correct
     // elements and Merkle proofs, which we will modify later, to pass invalid
     // values. 😈
-    let mut local_indexed_array = Box::<
-        IndexedArray<
-            Poseidon,
-            usize,
-            // This is not a correct value you would normally use in relayer, A
-            // correct size would be number of leaves which the merkle tree can fit
-            // (`MERKLE_TREE_LEAVES`). Allocating an indexing array for over 4 mln
-            // elements ain't easy and is not worth doing here.
-            4800,
-        >,
-    >::default();
+    let mut local_indexed_array = Box::<IndexedArray<Poseidon, usize>>::default();
     local_indexed_array.init().unwrap();
 
     let mut local_merkle_tree = Box::new(
@@ -1381,7 +1371,7 @@ pub async fn test_setup_with_address_merkle_tree(
         .unwrap(),
     );
     local_merkle_tree.init().unwrap();
-    let address_merkle_tree_bundle = AddressMerkleTreeBundle::<4800> {
+    let address_merkle_tree_bundle = AddressMerkleTreeBundle {
         merkle_tree: local_merkle_tree,
         indexed_array: local_indexed_array,
         accounts: AddressMerkleTreeAccounts {
@@ -1398,7 +1388,7 @@ pub async fn test_with_invalid_low_element(
     address_queue_pubkey: Pubkey,
     address_merkle_tree_pubkey: Pubkey,
     address_queue: &HashSet,
-    address_merkle_tree_bundle: &AddressMerkleTreeBundle<4800>,
+    address_merkle_tree_bundle: &AddressMerkleTreeBundle,
     index: usize,
     expected_error: u32,
 ) {

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -150,6 +150,7 @@ async fn test_address_queue_and_tree_functional_custom() {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn initialize_address_merkle_tree_and_queue<R: RpcConnection>(
     context: &mut R,
     payer: &Keypair,
@@ -167,8 +168,8 @@ async fn initialize_address_merkle_tree_and_queue<R: RpcConnection>(
             .get_minimum_balance_for_rent_exemption(queue_size)
             .await
             .unwrap(),
-        &account_compression::ID,
-        Some(&queue_keypair),
+        &ID,
+        Some(queue_keypair),
     );
     let mt_account_create_ix = create_account_instruction(
         &payer.pubkey(),
@@ -177,8 +178,8 @@ async fn initialize_address_merkle_tree_and_queue<R: RpcConnection>(
             .get_minimum_balance_for_rent_exemption(merkle_tree_size)
             .await
             .unwrap(),
-        &account_compression::ID,
-        Some(&merkle_tree_keypair),
+        &ID,
+        Some(merkle_tree_keypair),
     );
 
     let instruction =
@@ -217,11 +218,10 @@ async fn test_address_queue_and_tree_invalid_sizes() {
     let queue_config = AddressQueueConfig::default();
     let merkle_tree_config = AddressMerkleTreeConfig::default();
 
-    let valid_queue_size = account_compression::state::QueueAccount::size(
-        account_compression::utils::constants::ADDRESS_QUEUE_VALUES as usize,
-    )
-    .unwrap();
-    let valid_tree_size = account_compression::state::AddressMerkleTreeAccount::size(
+    let valid_queue_size =
+        QueueAccount::size(account_compression::utils::constants::ADDRESS_QUEUE_VALUES as usize)
+            .unwrap();
+    let valid_tree_size = AddressMerkleTreeAccount::size(
         merkle_tree_config.height as usize,
         merkle_tree_config.changelog_size as usize,
         merkle_tree_config.roots_size as usize,
@@ -236,14 +236,10 @@ async fn test_address_queue_and_tree_invalid_sizes() {
     // (+ discriminator) up to the expected account size.
 
     // Invalid MT size + invalid queue size.
-    for tree_size in (8 + mem::size_of::<account_compression::state::AddressMerkleTreeAccount>()
-        ..=valid_tree_size)
-        .step_by(200_000)
+    for tree_size in
+        (8 + mem::size_of::<AddressMerkleTreeAccount>()..=valid_tree_size).step_by(200_000)
     {
-        for queue_size in (8 + mem::size_of::<account_compression::state::QueueAccount>()
-            ..=valid_queue_size)
-            .step_by(50_000)
-        {
+        for queue_size in (8 + mem::size_of::<QueueAccount>()..=valid_queue_size).step_by(50_000) {
             let result = initialize_address_merkle_tree_and_queue(
                 &mut context,
                 &payer,
@@ -262,9 +258,8 @@ async fn test_address_queue_and_tree_invalid_sizes() {
         }
     }
     // Invalid MT size + valid queue size.
-    for tree_size in (8 + mem::size_of::<account_compression::state::AddressMerkleTreeAccount>()
-        ..=valid_tree_size)
-        .step_by(200_000)
+    for tree_size in
+        (8 + mem::size_of::<AddressMerkleTreeAccount>()..=valid_tree_size).step_by(200_000)
     {
         let result = initialize_address_merkle_tree_and_queue(
             &mut context,
@@ -283,10 +278,7 @@ async fn test_address_queue_and_tree_invalid_sizes() {
         .unwrap()
     }
     // Valid MT size + invalid queue size.
-    for queue_size in (8 + mem::size_of::<account_compression::state::QueueAccount>()
-        ..=valid_queue_size)
-        .step_by(50_000)
-    {
+    for queue_size in (8 + mem::size_of::<QueueAccount>()..=valid_queue_size).step_by(50_000) {
         let result = initialize_address_merkle_tree_and_queue(
             &mut context,
             &payer,
@@ -320,11 +312,10 @@ async fn test_address_queue_and_tree_invalid_config() {
     let queue_config = AddressQueueConfig::default();
     let merkle_tree_config = AddressMerkleTreeConfig::default();
 
-    let queue_size = account_compression::state::QueueAccount::size(
-        account_compression::utils::constants::ADDRESS_QUEUE_VALUES as usize,
-    )
-    .unwrap();
-    let tree_size = account_compression::state::AddressMerkleTreeAccount::size(
+    let queue_size =
+        QueueAccount::size(account_compression::utils::constants::ADDRESS_QUEUE_VALUES as usize)
+            .unwrap();
+    let tree_size = AddressMerkleTreeAccount::size(
         merkle_tree_config.height as usize,
         merkle_tree_config.changelog_size as usize,
         merkle_tree_config.roots_size as usize,

--- a/test-programs/account-compression-test/tests/group_authority_tests.rs
+++ b/test-programs/account-compression-test/tests/group_authority_tests.rs
@@ -159,15 +159,15 @@ async fn test_create_and_update_group() {
         context.get_latest_blockhash().await.unwrap(),
     );
     context.process_transaction(transaction).await.unwrap();
-    let registerd_program_account = context
+    let registered_program_account = context
         .get_anchor_account::<RegisteredProgram>(&registered_program_pda)
         .await;
     assert_eq!(
-        registerd_program_account.registered_program_id,
+        registered_program_account.registered_program_id,
         system_program_id_keypair.pubkey()
     );
     assert_eq!(
-        registerd_program_account.group_authority_pda,
+        registered_program_account.group_authority_pda,
         group_accounts.0
     );
     // add new program to group with invalid authority

--- a/test-programs/account-compression-test/tests/merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/merkle_tree_tests.rs
@@ -255,7 +255,7 @@ async fn test_full_nullifier_queue(
     .await;
     let leaf: [u8; 32] = bigint_to_be_bytes_array(&1.to_biguint().unwrap()).unwrap();
     // append a leaf so that we have a leaf to nullify
-    let mut reference_merkle_tree_1 = light_merkle_tree_reference::MerkleTree::<Poseidon>::new(
+    let mut reference_merkle_tree_1 = MerkleTree::<Poseidon>::new(
         STATE_MERKLE_TREE_HEIGHT as usize,
         STATE_MERKLE_TREE_CANOPY_DEPTH as usize,
     );
@@ -984,7 +984,7 @@ async fn test_append_functional_and_failing(
             )
         })
         .collect::<Vec<(u8, [u8; 32])>>();
-    let mut reference_merkle_tree_1 = light_merkle_tree_reference::MerkleTree::<Poseidon>::new(
+    let mut reference_merkle_tree_1 = MerkleTree::<Poseidon>::new(
         STATE_MERKLE_TREE_HEIGHT as usize,
         STATE_MERKLE_TREE_CANOPY_DEPTH as usize,
     );
@@ -1002,7 +1002,7 @@ async fn test_append_functional_and_failing(
         (2, [3u8; 32]),
         (3, [4u8; 32]),
     ];
-    let mut reference_merkle_tree_2 = light_merkle_tree_reference::MerkleTree::<Poseidon>::new(
+    let mut reference_merkle_tree_2 = MerkleTree::<Poseidon>::new(
         STATE_MERKLE_TREE_HEIGHT as usize,
         STATE_MERKLE_TREE_CANOPY_DEPTH as usize,
     );
@@ -1110,7 +1110,7 @@ async fn test_nullify_leaves(
     .await;
 
     let elements = vec![(0, [1u8; 32]), (0, [2u8; 32])];
-    let mut reference_merkle_tree = light_merkle_tree_reference::MerkleTree::<Poseidon>::new(
+    let mut reference_merkle_tree = MerkleTree::<Poseidon>::new(
         merkle_tree_config.height as usize,
         merkle_tree_config.canopy_depth as usize,
     );
@@ -1236,7 +1236,7 @@ async fn test_nullify_leaves(
         &mut reference_merkle_tree,
         &elements[1].1,
         invalid_changelog_index,
-        valid_leaf_queue_index as u16,
+        valid_leaf_queue_index,
         element_one_index,
     )
     .await;
@@ -1272,7 +1272,7 @@ async fn test_nullify_leaves(
         &mut reference_merkle_tree,
         &elements[0].1,
         2,
-        valid_leaf_queue_index as u16,
+        valid_leaf_queue_index,
         element_index,
     )
     .await;
@@ -1431,7 +1431,7 @@ async fn insert_into_single_nullifier_queue<R: RpcConnection>(
     nullifier_queue_pubkey: &Pubkey,
     merkle_tree_pubkey: &Pubkey,
     context: &mut R,
-) -> Result<solana_sdk::signature::Signature, RpcError> {
+) -> Result<Signature, RpcError> {
     let instruction_data = account_compression::instruction::InsertIntoNullifierQueues {
         nullifiers: elements.to_vec(),
     };
@@ -1475,7 +1475,7 @@ async fn insert_into_nullifier_queues<R: RpcConnection>(
     payer: &Keypair,
     pubkeys: &[(Pubkey, Pubkey)],
     context: &mut R,
-) -> Result<solana_sdk::signature::Signature, RpcError> {
+) -> Result<Signature, RpcError> {
     let instruction_data = account_compression::instruction::InsertIntoNullifierQueues {
         nullifiers: elements.to_vec(),
     };
@@ -1505,6 +1505,7 @@ async fn insert_into_nullifier_queues<R: RpcConnection>(
     context.process_transaction(transaction.clone()).await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn initialize_state_merkle_tree_and_nullifier_queue<R: RpcConnection>(
     rpc: &mut R,
     payer_pubkey: &Pubkey,
@@ -1572,7 +1573,7 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_sizes
     merkle_tree_config: &StateMerkleTreeConfig,
     queue_config: &NullifierQueueConfig,
 ) {
-    let valid_tree_size = account_compression::state::StateMerkleTreeAccount::size(
+    let valid_tree_size = StateMerkleTreeAccount::size(
         merkle_tree_config.height as usize,
         merkle_tree_config.changelog_size as usize,
         merkle_tree_config.roots_size as usize,
@@ -1624,7 +1625,7 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_confi
     merkle_tree_config: &StateMerkleTreeConfig,
     queue_config: &NullifierQueueConfig,
 ) {
-    let merkle_tree_size = account_compression::state::StateMerkleTreeAccount::size(
+    let merkle_tree_size = StateMerkleTreeAccount::size(
         merkle_tree_config.height as usize,
         merkle_tree_config.changelog_size as usize,
         merkle_tree_config.roots_size as usize,
@@ -1641,7 +1642,7 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_confi
             merkle_tree_keypair,
             queue_keypair,
             &merkle_tree_config,
-            &queue_config,
+            queue_config,
             merkle_tree_size,
             queue_size,
         )
@@ -1662,7 +1663,7 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_confi
             merkle_tree_keypair,
             queue_keypair,
             &merkle_tree_config,
-            &queue_config,
+            queue_config,
             merkle_tree_size,
             queue_size,
         )
@@ -1683,7 +1684,7 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_confi
             merkle_tree_keypair,
             queue_keypair,
             &merkle_tree_config,
-            &queue_config,
+            queue_config,
             merkle_tree_size,
             queue_size,
         )
@@ -1704,7 +1705,7 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_confi
             merkle_tree_keypair,
             queue_keypair,
             &merkle_tree_config,
-            &queue_config,
+            queue_config,
             merkle_tree_size,
             queue_size,
         )
@@ -1726,7 +1727,7 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_confi
             payer_pubkey,
             merkle_tree_keypair,
             queue_keypair,
-            &merkle_tree_config,
+            merkle_tree_config,
             &queue_config,
             merkle_tree_size,
             queue_size,
@@ -1749,7 +1750,7 @@ async fn functional_1_initialize_state_merkle_tree_and_nullifier_queue<R: RpcCon
     merkle_tree_config: &StateMerkleTreeConfig,
     queue_config: &NullifierQueueConfig,
 ) -> Pubkey {
-    let merkle_tree_size = account_compression::state::StateMerkleTreeAccount::size(
+    let merkle_tree_size = StateMerkleTreeAccount::size(
         merkle_tree_config.height as usize,
         merkle_tree_config.changelog_size as usize,
         merkle_tree_config.roots_size as usize,
@@ -1844,7 +1845,7 @@ pub async fn fail_2_append_leaves_with_invalid_inputs<R: RpcConnection>(
 
 pub async fn functional_3_append_leaves_to_merkle_tree<R: RpcConnection>(
     context: &mut R,
-    reference_merkle_trees: &mut [&mut light_merkle_tree_reference::MerkleTree<Poseidon>],
+    reference_merkle_trees: &mut [&mut MerkleTree<Poseidon>],
     merkle_tree_pubkeys: &Vec<Pubkey>,
     leaves: &Vec<(u8, [u8; 32])>,
 ) {
@@ -1867,13 +1868,13 @@ pub async fn functional_3_append_leaves_to_merkle_tree<R: RpcConnection>(
             .or_insert_with(|| {
                 (
                     Vec::<[u8; 32]>::new(),
-                    pre_account_mt.lamports.clone(),
-                    old_merkle_tree.next_index().clone(),
+                    pre_account_mt.lamports,
+                    old_merkle_tree.next_index(),
                     *i as usize,
                 )
             })
             .0
-            .push(leaf.clone());
+            .push(*leaf);
     }
     let instruction = [create_insert_leaves_instruction(
         leaves.clone(),
@@ -1901,8 +1902,8 @@ pub async fn functional_3_append_leaves_to_merkle_tree<R: RpcConnection>(
         let merkle_tree =
             get_concurrent_merkle_tree::<StateMerkleTreeAccount, R, Poseidon, 26>(context, *pubkey)
                 .await;
-        assert_eq!(merkle_tree.next_index(), next_index + num_leaves as usize);
-        let leaves: Vec<&[u8; 32]> = leaves.iter().map(|leaf| leaf).collect();
+        assert_eq!(merkle_tree.next_index(), next_index + num_leaves);
+        let leaves: Vec<&[u8; 32]> = leaves.iter().collect();
 
         let reference_merkle_tree = &mut reference_merkle_trees[*mt_index];
         reference_merkle_tree.append_batch(&leaves).unwrap();
@@ -2060,7 +2061,7 @@ pub async fn set_nullifier_queue_to_full<R: RpcConnection>(
         let arbitrary_sequence_number = 0;
         for i in 0..capacity {
             hash_set
-                .insert(&(i).to_biguint().unwrap(), arbitrary_sequence_number)
+                .insert(&i.to_biguint().unwrap(), arbitrary_sequence_number)
                 .unwrap();
         }
     }
@@ -2078,7 +2079,7 @@ pub async fn set_nullifier_queue_to_full<R: RpcConnection>(
     let nullifier_queue = &mut unsafe { queue_from_bytes_zero_copy_mut(&mut data).unwrap() };
     for i in 0..capacity {
         assert!(nullifier_queue
-            .contains(&(i).to_biguint().unwrap(), None)
+            .contains(&i.to_biguint().unwrap(), None)
             .unwrap());
     }
 }
@@ -2092,10 +2093,9 @@ fn find_overlapping_probe_index(
         let replacement_value = start_replacement_value + salt;
 
         for i in 0..20 {
-            let probe_index = (initial_value.clone()
-                + i.to_biguint().unwrap() * i.to_biguint().unwrap())
+            let probe_index = (initial_value + i.to_biguint().unwrap() * i.to_biguint().unwrap())
                 % capacity_values.to_biguint().unwrap();
-            let replacement_probe_index = (replacement_value.clone()
+            let replacement_probe_index = (replacement_value
                 + i.to_biguint().unwrap() * i.to_biguint().unwrap())
                 % capacity_values.to_biguint().unwrap();
             if probe_index == replacement_probe_index {
@@ -2136,7 +2136,7 @@ pub async fn set_state_merkle_tree_sequence<R: RpcConnection>(
     {
         let merkle_tree_deserialized =
             &mut ConcurrentMerkleTreeZeroCopyMut::<Poseidon, 26>::from_bytes_zero_copy_mut(
-                &mut merkle_tree.data[8 + std::mem::size_of::<StateMerkleTreeAccount>()..],
+                &mut merkle_tree.data[8 + mem::size_of::<StateMerkleTreeAccount>()..],
             )
             .unwrap();
         unsafe {
@@ -2149,7 +2149,7 @@ pub async fn set_state_merkle_tree_sequence<R: RpcConnection>(
     let mut merkle_tree = rpc.get_account(*merkle_tree_pubkey).await.unwrap().unwrap();
     let merkle_tree_deserialized =
         ConcurrentMerkleTreeZeroCopyMut::<Poseidon, 26>::from_bytes_zero_copy_mut(
-            &mut merkle_tree.data[8 + std::mem::size_of::<StateMerkleTreeAccount>()..],
+            &mut merkle_tree.data[8 + mem::size_of::<StateMerkleTreeAccount>()..],
         )
         .unwrap();
     assert_eq!(
@@ -2177,7 +2177,7 @@ async fn functional_6_test_insert_into_two_nullifier_queues(
     queue_tree_pairs: &[(Pubkey, Pubkey)],
 ) {
     let payer = rpc.get_payer().insecure_clone();
-    insert_into_nullifier_queues(nullifiers, &payer, &payer, &queue_tree_pairs, rpc)
+    insert_into_nullifier_queues(nullifiers, &payer, &payer, queue_tree_pairs, rpc)
         .await
         .unwrap();
     assert_element_inserted_in_nullifier_queue(rpc, &queue_tree_pairs[0].0, nullifiers[0]).await;
@@ -2190,7 +2190,7 @@ async fn functional_7_test_insert_into_two_nullifier_queues_not_ordered(
     queue_tree_pairs: &[(Pubkey, Pubkey)],
 ) {
     let payer = rpc.get_payer().insecure_clone();
-    insert_into_nullifier_queues(nullifiers, &payer, &payer, &queue_tree_pairs, rpc)
+    insert_into_nullifier_queues(nullifiers, &payer, &payer, queue_tree_pairs, rpc)
         .await
         .unwrap();
     assert_element_inserted_in_nullifier_queue(rpc, &queue_tree_pairs[0].0, nullifiers[0]).await;

--- a/test-programs/compressed-token-test/tests/test.rs
+++ b/test-programs/compressed-token-test/tests/test.rs
@@ -48,8 +48,7 @@ async fn test_wrapped_sol() {
     let (mut rpc, env) = setup_test_programs_with_accounts(None).await;
     let payer = rpc.get_payer().insecure_clone();
     let mut test_indexer =
-        TestIndexer::<200, ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false)
-            .await;
+        TestIndexer::<ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false).await;
     let native_mint = spl_token::native_mint::ID;
     let token_account_keypair = Keypair::new();
     create_token_account(&mut rpc, &native_mint, &token_account_keypair, &payer)
@@ -108,8 +107,7 @@ async fn test_mint_to<const MINTS: usize, const ITER: usize>() {
     let payer = rpc.get_payer().insecure_clone();
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
     let mut test_indexer =
-        TestIndexer::<200, ProgramTestRpcConnection>::init_from_env(&payer, &env, false, false)
-            .await;
+        TestIndexer::<ProgramTestRpcConnection>::init_from_env(&payer, &env, false, false).await;
 
     let recipient_keypair = Keypair::new();
     let mint = create_mint_helper(&mut rpc, &payer).await;
@@ -232,8 +230,7 @@ async fn perform_transfer_test(inputs: usize, outputs: usize, amount: u64) {
     let payer = rpc.get_payer().insecure_clone();
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
     let mut test_indexer =
-        TestIndexer::<200, ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false)
-            .await;
+        TestIndexer::<ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false).await;
     let mint = create_mint_helper(&mut rpc, &payer).await;
     let sender = Keypair::new();
     mint_tokens_helper(
@@ -278,8 +275,7 @@ async fn test_decompression() {
     let payer = context.get_payer().insecure_clone();
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
     let mut test_indexer =
-        TestIndexer::<200, ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false)
-            .await;
+        TestIndexer::<ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false).await;
     let sender = Keypair::new();
     airdrop_lamports(&mut context, &sender.pubkey(), 1_000_000_000)
         .await
@@ -338,8 +334,7 @@ async fn test_delegation() {
     let payer = rpc.get_payer().insecure_clone();
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
     let mut test_indexer =
-        TestIndexer::<200, ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false)
-            .await;
+        TestIndexer::<ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false).await;
     let sender = Keypair::new();
     airdrop_lamports(&mut rpc, &sender.pubkey(), 1_000_000_000)
         .await
@@ -446,8 +441,7 @@ async fn test_revoke() {
     let payer = rpc.get_payer().insecure_clone();
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
     let mut test_indexer =
-        TestIndexer::<200, ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false)
-            .await;
+        TestIndexer::<ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false).await;
     let sender = Keypair::new();
     airdrop_lamports(&mut rpc, &sender.pubkey(), 1_000_000_000)
         .await
@@ -525,8 +519,7 @@ async fn test_burn() {
     let payer = rpc.get_payer().insecure_clone();
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
     let mut test_indexer =
-        TestIndexer::<200, ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false)
-            .await;
+        TestIndexer::<ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false).await;
     let sender = Keypair::new();
     airdrop_lamports(&mut rpc, &sender.pubkey(), 1_000_000_000)
         .await
@@ -659,8 +652,7 @@ async fn test_freeze_and_thaw() {
     let payer = rpc.get_payer().insecure_clone();
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
     let mut test_indexer =
-        TestIndexer::<200, ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false)
-            .await;
+        TestIndexer::<ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false).await;
     let sender = Keypair::new();
     airdrop_lamports(&mut rpc, &sender.pubkey(), 1_000_000_000)
         .await
@@ -805,8 +797,7 @@ async fn test_failing_decompression() {
     let payer = context.get_payer().insecure_clone();
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
     let mut test_indexer =
-        TestIndexer::<200, ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false)
-            .await;
+        TestIndexer::<ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false).await;
     let sender = Keypair::new();
     airdrop_lamports(&mut context, &sender.pubkey(), 1_000_000_000)
         .await
@@ -1012,10 +1003,10 @@ async fn test_failing_decompression() {
     kill_prover();
 }
 
-pub async fn failing_compress_decompress<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn failing_compress_decompress<R: RpcConnection>(
     payer: &Keypair,
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &mut TestIndexer<R>,
     input_compressed_accounts: Vec<TokenDataWithContext>,
     amount: u64,
     output_merkle_tree_pubkey: &Pubkey,
@@ -1148,8 +1139,7 @@ async fn test_invalid_inputs() {
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
     let nullifier_queue_pubkey = env.nullifier_queue_pubkey;
     let mut test_indexer =
-        TestIndexer::<200, ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false)
-            .await;
+        TestIndexer::<ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false).await;
     let recipient_keypair = Keypair::new();
     airdrop_lamports(&mut rpc, &recipient_keypair.pubkey(), 1_000_000_000)
         .await

--- a/test-programs/compressed-token-test/tests/test.rs
+++ b/test-programs/compressed-token-test/tests/test.rs
@@ -398,7 +398,7 @@ async fn test_delegation() {
             &[recipient, sender.pubkey()],
             &output_amounts,
             input_compressed_accounts.as_slice(),
-            &vec![env.merkle_tree_pubkey; 2],
+            &[env.merkle_tree_pubkey; 2],
             Some(1),
             None,
         )
@@ -423,7 +423,7 @@ async fn test_delegation() {
             &[recipient],
             &output_amounts,
             input_compressed_accounts.as_slice(),
-            &vec![env.merkle_tree_pubkey; 1],
+            &[env.merkle_tree_pubkey; 1],
             None,
             None,
         )
@@ -1003,6 +1003,7 @@ async fn test_failing_decompression() {
     kill_prover();
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn failing_compress_decompress<R: RpcConnection>(
     payer: &Keypair,
     rpc: &mut R,

--- a/test-programs/e2e-test/tests/test.rs
+++ b/test-programs/e2e-test/tests/test.rs
@@ -64,7 +64,7 @@ async fn test_address_tree_rollover() {
     env.create_address_tree(Some(0)).await;
     // create on transaction to fund the rollover fee
     env.create_address(None).await;
-    // rollover adddress Merkle tree
+    // rollover address Merkle tree
     env.rollover_address_merkle_tree_and_queue(0).await.unwrap();
 }
 

--- a/test-programs/e2e-test/tests/test.rs
+++ b/test-programs/e2e-test/tests/test.rs
@@ -9,7 +9,7 @@ use solana_sdk::signer::Signer;
 #[tokio::test]
 async fn test_10_all() {
     let (rpc, env_accounts) = setup_test_programs_with_accounts(None).await;
-    let mut env = E2ETestEnv::<500, ProgramTestRpcConnection>::new(
+    let mut env = E2ETestEnv::<ProgramTestRpcConnection>::new(
         rpc,
         &env_accounts,
         KeypairActionConfig::all_default(),
@@ -28,7 +28,7 @@ async fn test_10000_all() {
     // Will fail after inserting 500 addresses since the local indexed array is full
     // TODO: initialize the indexed array with heap memory so that the stack doesn't overflow with bigger size, write an indexed array vector abstraction for testing
     let (rpc, env_accounts) = setup_test_programs_with_accounts(None).await;
-    let mut env = E2ETestEnv::<500, ProgramTestRpcConnection>::new(
+    let mut env = E2ETestEnv::<ProgramTestRpcConnection>::new(
         rpc,
         &env_accounts,
         KeypairActionConfig::all_default_no_fee_assert(),
@@ -46,7 +46,7 @@ async fn test_address_tree_rollover() {
     // Will fail after inserting 500 addresses since the local indexed array is full
     // TODO: initialize the indexed array with heap memory so that the stack doesn't overflow with bigger size, write an indexed array vector abstraction for testing
     let (rpc, env_accounts) = setup_test_programs_with_accounts(None).await;
-    let mut env = E2ETestEnv::<500, ProgramTestRpcConnection>::new(
+    let mut env = E2ETestEnv::<ProgramTestRpcConnection>::new(
         rpc,
         &env_accounts,
         KeypairActionConfig::all_default_no_fee_assert(),
@@ -74,7 +74,7 @@ async fn test_state_tree_rollover() {
     // Will fail after inserting 500 addresses since the local indexed array is full
     // TODO: initialize the indexed array with heap memory so that the stack doesn't overflow with bigger size, write an indexed array vector abstraction for testing
     let (rpc, env_accounts) = setup_test_programs_with_accounts(None).await;
-    let mut env = E2ETestEnv::<500, ProgramTestRpcConnection>::new(
+    let mut env = E2ETestEnv::<ProgramTestRpcConnection>::new(
         rpc,
         &env_accounts,
         KeypairActionConfig::all_default_no_fee_assert(),

--- a/test-programs/system-cpi-test/tests/test.rs
+++ b/test-programs/system-cpi-test/tests/test.rs
@@ -413,7 +413,7 @@ async fn test_create_pda_in_program_owned_merkle_trees() {
 
 #[allow(clippy::too_many_arguments)]
 pub async fn perform_create_pda_failing<R: RpcConnection>(
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     rpc: &mut R,
     env: &EnvAccounts,
     payer: &Keypair,
@@ -447,7 +447,7 @@ pub async fn perform_create_pda_failing<R: RpcConnection>(
 
 #[allow(clippy::too_many_arguments)]
 pub async fn perform_create_pda_with_event<R: RpcConnection>(
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     rpc: &mut R,
     env: &EnvAccounts,
     payer: &Keypair,
@@ -481,7 +481,7 @@ pub async fn perform_create_pda_with_event<R: RpcConnection>(
 async fn perform_create_pda<R: RpcConnection>(
     env: &EnvAccounts,
     seed: [u8; 32],
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     rpc: &mut R,
     data: &[u8; 31],
     payer_pubkey: Pubkey,
@@ -521,7 +521,7 @@ async fn perform_create_pda<R: RpcConnection>(
 }
 
 pub async fn assert_created_pda<R: RpcConnection>(
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
     payer: &Keypair,
     seed: &[u8; 32],
@@ -565,7 +565,7 @@ pub async fn assert_created_pda<R: RpcConnection>(
 }
 
 pub async fn perform_with_input_accounts<R: RpcConnection>(
-    test_indexer: &mut TestIndexer<200, R>,
+    test_indexer: &mut TestIndexer<R>,
     rpc: &mut R,
     payer: &Keypair,
     compressed_account: &CompressedAccountWithMerkleContext,

--- a/test-programs/system-cpi-test/tests/test_program_owned_trees.rs
+++ b/test-programs/system-cpi-test/tests/test_program_owned_trees.rs
@@ -52,7 +52,7 @@ async fn test_program_owned_merkle_tree() {
     let cpi_context_keypair = Keypair::new();
 
     let mut test_indexer =
-        TestIndexer::<200, ProgramTestRpcConnection>::init_from_env(&payer, &env, true, true).await;
+        TestIndexer::<ProgramTestRpcConnection>::init_from_env(&payer, &env, true, true).await;
     test_indexer
         .add_state_merkle_tree(
             &mut rpc,

--- a/test-programs/system-test/tests/test.rs
+++ b/test-programs/system-test/tests/test.rs
@@ -150,7 +150,7 @@ async fn invoke_failing_test() {
 #[allow(clippy::too_many_arguments)]
 pub async fn failing_transaction_inputs(
     context: &mut ProgramTestRpcConnection,
-    test_indexer: &mut TestIndexer<200, ProgramTestRpcConnection>,
+    test_indexer: &mut TestIndexer<ProgramTestRpcConnection>,
     payer: &Keypair,
     env: &EnvAccounts,
     num_inputs: usize,
@@ -375,7 +375,7 @@ pub async fn failing_transaction_inputs_inner(
             .compressed_account
             .lamports = amount + 1;
         let error_code = if !inputs_struct.output_compressed_accounts.is_empty() {
-            // adapting compressed ouput account so that sumcheck passes
+            // adapting compressed output account so that sumcheck passes
             inputs_struct.output_compressed_accounts[0]
                 .compressed_account
                 .lamports += 1;

--- a/test-programs/system-test/tests/test.rs
+++ b/test-programs/system-test/tests/test.rs
@@ -95,7 +95,7 @@ async fn invoke_failing_test() {
     .unwrap();
 
     let mut test_indexer =
-        TestIndexer::<200, ProgramTestRpcConnection>::init_from_env(&payer, &env, true, true).await;
+        TestIndexer::<ProgramTestRpcConnection>::init_from_env(&payer, &env, true, true).await;
     // cicuit instantiations allow for 1, 2, 3, 4, 8 inclusion proofs
     let options = [0usize, 1usize, 2usize, 3usize, 4usize, 8usize];
 
@@ -857,7 +857,7 @@ async fn invoke_test() {
 
     let payer = context.get_payer().insecure_clone();
     let mut test_indexer =
-        TestIndexer::<200, ProgramTestRpcConnection>::init_from_env(&payer, &env, true, true).await;
+        TestIndexer::<ProgramTestRpcConnection>::init_from_env(&payer, &env, true, true).await;
 
     let payer_pubkey = payer.pubkey();
 
@@ -1111,7 +1111,7 @@ async fn test_with_address() {
     let (mut context, env) = setup_test_programs_with_accounts(None).await;
     let payer = context.get_payer().insecure_clone();
     let mut test_indexer =
-        TestIndexer::<200, ProgramTestRpcConnection>::init_from_env(&payer, &env, true, true).await;
+        TestIndexer::<ProgramTestRpcConnection>::init_from_env(&payer, &env, true, true).await;
 
     let payer_pubkey = payer.pubkey();
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
@@ -1297,8 +1297,7 @@ async fn test_with_compression() {
     let merkle_tree_pubkey = env.merkle_tree_pubkey;
     let nullifier_queue_pubkey = env.nullifier_queue_pubkey;
     let mut test_indexer =
-        TestIndexer::<200, ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false)
-            .await;
+        TestIndexer::<ProgramTestRpcConnection>::init_from_env(&payer, &env, true, false).await;
     let compress_amount = 1_000_000;
     let output_compressed_accounts = vec![CompressedAccount {
         lamports: compress_amount + 1,

--- a/test-utils/src/assert_compressed_tx.rs
+++ b/test-utils/src/assert_compressed_tx.rs
@@ -19,10 +19,9 @@ use num_traits::FromBytes;
 use solana_sdk::account::ReadableAccount;
 use solana_sdk::pubkey::Pubkey;
 
-pub struct AssertCompressedTransactionInputs<'a, const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>
-{
+pub struct AssertCompressedTransactionInputs<'a, R: RpcConnection> {
     pub rpc: &'a mut R,
-    pub test_indexer: &'a mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    pub test_indexer: &'a mut TestIndexer<R>,
     pub output_compressed_accounts: &'a [CompressedAccount],
     pub created_output_compressed_accounts: &'a [CompressedAccountWithMerkleContext],
     pub input_compressed_account_hashes: &'a [[u8; 32]],
@@ -48,8 +47,8 @@ pub struct AssertCompressedTransactionInputs<'a, const INDEXED_ARRAY_SIZE: usize
 /// 5. Merkle tree was updated correctly
 /// 6. TODO: Fees have been paid (after fee refactor)
 /// 7. Check compression amount was transferred
-pub async fn assert_compressed_transaction<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
-    input: AssertCompressedTransactionInputs<'_, INDEXED_ARRAY_SIZE, R>,
+pub async fn assert_compressed_transaction<R: RpcConnection>(
+    input: AssertCompressedTransactionInputs<'_, R>,
 ) {
     // CHECK 1
     assert_created_compressed_accounts(
@@ -249,10 +248,10 @@ pub struct MerkleTreeTestSnapShot {
 /// Asserts:
 /// 1. The root has been updated
 /// 2. The next index has been updated
-pub async fn assert_merkle_tree_after_tx<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn assert_merkle_tree_after_tx<R: RpcConnection>(
     rpc: &mut R,
     snapshots: &[MerkleTreeTestSnapShot],
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &mut TestIndexer<R>,
 ) -> Vec<MerkleTreeSequenceNumber> {
     let mut deduped_snapshots = snapshots.to_vec();
     deduped_snapshots.sort();
@@ -311,7 +310,7 @@ pub async fn assert_merkle_tree_after_tx<const INDEXED_ARRAY_SIZE: usize, R: Rpc
 /// 2. next_index
 /// 3. num_added_accounts // so that we can assert the expected next index after tx
 /// 4. lamports of all bundle accounts
-pub async fn get_merkle_tree_snapshots<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn get_merkle_tree_snapshots<R: RpcConnection>(
     rpc: &mut R,
     accounts: &[StateMerkleTreeAccounts],
 ) -> Vec<MerkleTreeTestSnapShot> {

--- a/test-utils/src/assert_token_tx.rs
+++ b/test-utils/src/assert_token_tx.rs
@@ -26,9 +26,9 @@ use anchor_lang::AnchorSerialize;
 /// 6. Check compression amount was transferred (outside of this function)
 /// No addresses in token transactions
 #[allow(clippy::too_many_arguments)]
-pub async fn assert_transfer<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn assert_transfer<R: RpcConnection>(
     context: &mut R,
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &mut TestIndexer<R>,
     out_compressed_accounts: &[TokenTransferOutputData],
     created_output_compressed_accounts: &[CompressedAccountWithMerkleContext],
     input_compressed_account_hashes: &[[u8; 32]],
@@ -81,8 +81,8 @@ pub async fn assert_transfer<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
     );
 }
 
-pub fn assert_compressed_token_accounts<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+pub fn assert_compressed_token_accounts<R: RpcConnection>(
+    test_indexer: &mut TestIndexer<R>,
     out_compressed_accounts: &[TokenTransferOutputData],
     output_merkle_tree_snapshots: &[MerkleTreeTestSnapShot],
     delegates: Option<Vec<Option<Pubkey>>>,
@@ -173,9 +173,9 @@ pub fn assert_compressed_token_accounts<const INDEXED_ARRAY_SIZE: usize, R: RpcC
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn assert_mint_to<'a, const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn assert_mint_to<'a, R: RpcConnection>(
     rpc: &mut R,
-    test_indexer: &'a mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &'a mut TestIndexer<R>,
     recipients: &[Pubkey],
     mint: Pubkey,
     amounts: &[u64],

--- a/test-utils/src/e2e_test_env.rs
+++ b/test-utils/src/e2e_test_env.rs
@@ -169,9 +169,9 @@ impl Stats {
     }
 }
 
-pub struct E2ETestEnv<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection> {
+pub struct E2ETestEnv<R: RpcConnection> {
     pub payer: Keypair,
-    pub indexer: TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    pub indexer: TestIndexer<R>,
     pub users: Vec<User>,
     pub mints: Vec<Pubkey>,
     pub rpc: R,
@@ -183,7 +183,7 @@ pub struct E2ETestEnv<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection> {
     pub stats: Stats,
 }
 
-impl<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection> E2ETestEnv<INDEXED_ARRAY_SIZE, R>
+impl<R: RpcConnection> E2ETestEnv<R>
 where
     R: RpcConnection,
 {
@@ -198,7 +198,7 @@ where
         let inclusion = keypair_action_config.transfer_sol.is_some()
             || keypair_action_config.transfer_spl.is_some();
         let non_inclusion = keypair_action_config.create_address.is_some();
-        let mut indexer = TestIndexer::<INDEXED_ARRAY_SIZE, R>::new(
+        let mut indexer = TestIndexer::<R>::new(
             vec![StateMerkleTreeAccounts {
                 merkle_tree: env_accounts.merkle_tree_pubkey,
                 nullifier_queue: env_accounts.nullifier_queue_pubkey,
@@ -531,7 +531,7 @@ where
             )
             .unwrap(),
         );
-        let mut indexed_array = Box::<IndexedArray<Poseidon, usize, INDEXED_ARRAY_SIZE>>::default();
+        let mut indexed_array = Box::<IndexedArray<Poseidon, usize>>::default();
         merkle_tree.append(&init_value, &mut indexed_array).unwrap();
 
         let queue_account = AccountZeroCopy::<account_compression::QueueAccount>::new(

--- a/test-utils/src/spl.rs
+++ b/test-utils/src/spl.rs
@@ -37,9 +37,9 @@ use solana_sdk::{
 use spl_token::instruction::initialize_mint;
 use spl_token::state::Mint;
 
-pub async fn mint_tokens_helper<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn mint_tokens_helper<R: RpcConnection>(
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &mut TestIndexer<R>,
     merkle_tree_pubkey: &Pubkey,
     mint_authority: &Keypair,
     mint: &Pubkey,
@@ -59,8 +59,7 @@ pub async fn mint_tokens_helper<const INDEXED_ARRAY_SIZE: usize, R: RpcConnectio
     let output_merkle_tree_accounts =
         test_indexer.get_state_merkle_tree_accounts(&vec![*merkle_tree_pubkey; amounts.len()]);
 
-    let snapshots =
-        get_merkle_tree_snapshots::<INDEXED_ARRAY_SIZE, R>(rpc, &output_merkle_tree_accounts).await;
+    let snapshots = get_merkle_tree_snapshots::<R>(rpc, &output_merkle_tree_accounts).await;
     let previous_mint_supply =
         spl_token::state::Mint::unpack(&rpc.get_account(*mint).await.unwrap().unwrap().data)
             .unwrap()
@@ -250,10 +249,10 @@ pub async fn create_token_account<R: RpcConnection>(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn compressed_transfer_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn compressed_transfer_test<R: RpcConnection>(
     payer: &Keypair,
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &mut TestIndexer<R>,
     mint: &Pubkey,
     from: &Keypair,
     recipients: &[Pubkey],
@@ -362,16 +361,10 @@ pub async fn compressed_transfer_test<const INDEXED_ARRAY_SIZE: usize, R: RpcCon
         test_indexer.get_state_merkle_tree_accounts(output_merkle_tree_pubkeys);
     let input_merkle_tree_accounts =
         test_indexer.get_state_merkle_tree_accounts(&input_merkle_tree_pubkeys);
-    let snapshots = get_merkle_tree_snapshots::<INDEXED_ARRAY_SIZE, R>(
-        rpc,
-        output_merkle_tree_accounts.as_slice(),
-    )
-    .await;
-    let input_snapshots = get_merkle_tree_snapshots::<INDEXED_ARRAY_SIZE, R>(
-        rpc,
-        input_merkle_tree_accounts.as_slice(),
-    )
-    .await;
+    let snapshots =
+        get_merkle_tree_snapshots::<R>(rpc, output_merkle_tree_accounts.as_slice()).await;
+    let input_snapshots =
+        get_merkle_tree_snapshots::<R>(rpc, input_merkle_tree_accounts.as_slice()).await;
     let authority_signer = if delegate_change_account_index.is_some() {
         payer
     } else {
@@ -415,10 +408,10 @@ pub async fn compressed_transfer_test<const INDEXED_ARRAY_SIZE: usize, R: RpcCon
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn decompress_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn decompress_test<R: RpcConnection>(
     payer: &Keypair,
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &mut TestIndexer<R>,
     input_compressed_accounts: Vec<TokenDataWithContext>,
     amount: u64,
     output_merkle_tree_pubkey: &Pubkey,
@@ -483,16 +476,10 @@ pub async fn decompress_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
         test_indexer.get_state_merkle_tree_accounts(&output_merkle_tree_pubkeys);
     let input_merkle_tree_accounts =
         test_indexer.get_state_merkle_tree_accounts(&input_merkle_tree_pubkeys);
-    let output_merkle_tree_test_snapshots = get_merkle_tree_snapshots::<INDEXED_ARRAY_SIZE, R>(
-        rpc,
-        output_merkle_tree_accounts.as_slice(),
-    )
-    .await;
-    let input_merkle_tree_test_snapshots = get_merkle_tree_snapshots::<INDEXED_ARRAY_SIZE, R>(
-        rpc,
-        input_merkle_tree_accounts.as_slice(),
-    )
-    .await;
+    let output_merkle_tree_test_snapshots =
+        get_merkle_tree_snapshots::<R>(rpc, output_merkle_tree_accounts.as_slice()).await;
+    let input_merkle_tree_test_snapshots =
+        get_merkle_tree_snapshots::<R>(rpc, input_merkle_tree_accounts.as_slice()).await;
     let recipient_token_account_data_pre = spl_token::state::Account::unpack(
         &rpc.get_account(*recipient_token_account)
             .await
@@ -546,10 +533,10 @@ pub async fn decompress_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn compress_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn compress_test<R: RpcConnection>(
     payer: &Keypair,
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &mut TestIndexer<R>,
     amount: u64,
     mint: &Pubkey,
     output_merkle_tree_pubkey: &Pubkey,
@@ -593,11 +580,8 @@ pub async fn compress_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
     let output_merkle_tree_pubkeys = vec![*output_merkle_tree_pubkey];
     let output_merkle_tree_accounts =
         test_indexer.get_state_merkle_tree_accounts(&output_merkle_tree_pubkeys);
-    let output_merkle_tree_test_snapshots = get_merkle_tree_snapshots::<INDEXED_ARRAY_SIZE, R>(
-        rpc,
-        output_merkle_tree_accounts.as_slice(),
-    )
-    .await;
+    let output_merkle_tree_test_snapshots =
+        get_merkle_tree_snapshots::<R>(rpc, output_merkle_tree_accounts.as_slice()).await;
     let input_merkle_tree_test_snapshots = Vec::new();
     let recipient_token_account_data_pre = spl_token::state::Account::unpack(
         &rpc.get_account(*sender_token_account)
@@ -653,10 +637,10 @@ pub async fn compress_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn approve_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn approve_test<R: RpcConnection>(
     authority: &Keypair,
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &mut TestIndexer<R>,
     input_compressed_accounts: Vec<TokenDataWithContext>,
     delegated_amount: u64,
     delegate: &Pubkey,
@@ -711,16 +695,10 @@ pub async fn approve_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
         test_indexer.get_state_merkle_tree_accounts(&output_merkle_tree_pubkeys);
     let input_merkle_tree_accounts =
         test_indexer.get_state_merkle_tree_accounts(&input_merkle_tree_pubkeys);
-    let output_merkle_tree_test_snapshots = get_merkle_tree_snapshots::<INDEXED_ARRAY_SIZE, R>(
-        rpc,
-        output_merkle_tree_accounts.as_slice(),
-    )
-    .await;
-    let input_merkle_tree_test_snapshots = get_merkle_tree_snapshots::<INDEXED_ARRAY_SIZE, R>(
-        rpc,
-        input_merkle_tree_accounts.as_slice(),
-    )
-    .await;
+    let output_merkle_tree_test_snapshots =
+        get_merkle_tree_snapshots::<R>(rpc, output_merkle_tree_accounts.as_slice()).await;
+    let input_merkle_tree_test_snapshots =
+        get_merkle_tree_snapshots::<R>(rpc, input_merkle_tree_accounts.as_slice()).await;
     let context_payer = rpc.get_payer().insecure_clone();
     let (event, _signature) = rpc
         .create_and_send_transaction_with_event::<PublicTransactionEvent>(
@@ -791,10 +769,10 @@ pub async fn approve_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn revoke_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn revoke_test<R: RpcConnection>(
     authority: &Keypair,
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &mut TestIndexer<R>,
     input_compressed_accounts: Vec<TokenDataWithContext>,
     output_account_merkle_tree: &Pubkey,
     transaction_params: Option<TransactionParams>,
@@ -840,16 +818,10 @@ pub async fn revoke_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
         test_indexer.get_state_merkle_tree_accounts(&output_merkle_tree_pubkeys);
     let input_merkle_tree_accounts =
         test_indexer.get_state_merkle_tree_accounts(&input_merkle_tree_pubkeys);
-    let output_merkle_tree_test_snapshots = get_merkle_tree_snapshots::<INDEXED_ARRAY_SIZE, R>(
-        rpc,
-        output_merkle_tree_accounts.as_slice(),
-    )
-    .await;
-    let input_merkle_tree_test_snapshots = get_merkle_tree_snapshots::<INDEXED_ARRAY_SIZE, R>(
-        rpc,
-        input_merkle_tree_accounts.as_slice(),
-    )
-    .await;
+    let output_merkle_tree_test_snapshots =
+        get_merkle_tree_snapshots::<R>(rpc, output_merkle_tree_accounts.as_slice()).await;
+    let input_merkle_tree_test_snapshots =
+        get_merkle_tree_snapshots::<R>(rpc, input_merkle_tree_accounts.as_slice()).await;
     let context_payer = rpc.get_payer().insecure_clone();
     let (event, _signature) = rpc
         .create_and_send_transaction_with_event::<PublicTransactionEvent>(
@@ -895,15 +867,15 @@ pub async fn revoke_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
     .await;
 }
 
-pub async fn freeze_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn freeze_test<R: RpcConnection>(
     authority: &Keypair,
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &mut TestIndexer<R>,
     input_compressed_accounts: Vec<TokenDataWithContext>,
     outputs_merkle_tree: &Pubkey,
     transaction_params: Option<TransactionParams>,
 ) {
-    freeze_or_thaw_test::<INDEXED_ARRAY_SIZE, R, true>(
+    freeze_or_thaw_test::<R, true>(
         authority,
         rpc,
         test_indexer,
@@ -914,15 +886,15 @@ pub async fn freeze_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
     .await;
 }
 
-pub async fn thaw_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn thaw_test<R: RpcConnection>(
     authority: &Keypair,
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &mut TestIndexer<R>,
     input_compressed_accounts: Vec<TokenDataWithContext>,
     outputs_merkle_tree: &Pubkey,
     transaction_params: Option<TransactionParams>,
 ) {
-    freeze_or_thaw_test::<INDEXED_ARRAY_SIZE, R, false>(
+    freeze_or_thaw_test::<R, false>(
         authority,
         rpc,
         test_indexer,
@@ -933,14 +905,10 @@ pub async fn thaw_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
     .await;
 }
 
-pub async fn freeze_or_thaw_test<
-    const INDEXED_ARRAY_SIZE: usize,
-    R: RpcConnection,
-    const FREEZE: bool,
->(
+pub async fn freeze_or_thaw_test<R: RpcConnection, const FREEZE: bool>(
     authority: &Keypair,
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &mut TestIndexer<R>,
     input_compressed_accounts: Vec<TokenDataWithContext>,
     outputs_merkle_tree: &Pubkey,
     transaction_params: Option<TransactionParams>,
@@ -986,16 +954,10 @@ pub async fn freeze_or_thaw_test<
         test_indexer.get_state_merkle_tree_accounts(&output_merkle_tree_pubkeys);
     let input_merkle_tree_accounts =
         test_indexer.get_state_merkle_tree_accounts(&input_merkle_tree_pubkeys);
-    let output_merkle_tree_test_snapshots = get_merkle_tree_snapshots::<INDEXED_ARRAY_SIZE, R>(
-        rpc,
-        output_merkle_tree_accounts.as_slice(),
-    )
-    .await;
-    let input_merkle_tree_test_snapshots = get_merkle_tree_snapshots::<INDEXED_ARRAY_SIZE, R>(
-        rpc,
-        input_merkle_tree_accounts.as_slice(),
-    )
-    .await;
+    let output_merkle_tree_test_snapshots =
+        get_merkle_tree_snapshots::<R>(rpc, output_merkle_tree_accounts.as_slice()).await;
+    let input_merkle_tree_test_snapshots =
+        get_merkle_tree_snapshots::<R>(rpc, input_merkle_tree_accounts.as_slice()).await;
     let context_payer = rpc.get_payer().insecure_clone();
     let (event, _signature) = rpc
         .create_and_send_transaction_with_event::<PublicTransactionEvent>(
@@ -1051,10 +1013,10 @@ pub async fn freeze_or_thaw_test<
     .await;
 }
 #[allow(clippy::too_many_arguments)]
-pub async fn burn_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn burn_test<R: RpcConnection>(
     authority: &Keypair,
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &mut TestIndexer<R>,
     input_compressed_accounts: Vec<TokenDataWithContext>,
     change_account_merkle_tree: &Pubkey,
     burn_amount: u64,
@@ -1108,22 +1070,15 @@ pub async fn burn_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
         let output_merkle_tree_accounts =
             test_indexer.get_state_merkle_tree_accounts(&output_merkle_tree_pubkeys);
 
-        get_merkle_tree_snapshots::<INDEXED_ARRAY_SIZE, R>(
-            rpc,
-            output_merkle_tree_accounts.as_slice(),
-        )
-        .await
+        get_merkle_tree_snapshots::<R>(rpc, output_merkle_tree_accounts.as_slice()).await
     } else {
         Vec::new()
     };
 
     let input_merkle_tree_accounts =
         test_indexer.get_state_merkle_tree_accounts(&input_merkle_tree_pubkeys);
-    let input_merkle_tree_test_snapshots = get_merkle_tree_snapshots::<INDEXED_ARRAY_SIZE, R>(
-        rpc,
-        input_merkle_tree_accounts.as_slice(),
-    )
-    .await;
+    let input_merkle_tree_test_snapshots =
+        get_merkle_tree_snapshots::<R>(rpc, input_merkle_tree_accounts.as_slice()).await;
     let context_payer = rpc.get_payer().insecure_clone();
     let (event, _signature) = rpc
         .create_and_send_transaction_with_event::<PublicTransactionEvent>(

--- a/test-utils/src/system_program.rs
+++ b/test-utils/src/system_program.rs
@@ -26,9 +26,9 @@ use solana_sdk::{
 };
 
 #[allow(clippy::too_many_arguments)]
-pub async fn create_addresses_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn create_addresses_test<R: RpcConnection>(
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &mut TestIndexer<R>,
     address_merkle_tree_pubkeys: &[Pubkey],
     address_merkle_tree_queue_pubkeys: &[Pubkey],
     mut output_merkle_tree_pubkeys: Vec<Pubkey>,
@@ -105,9 +105,9 @@ pub async fn create_addresses_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnec
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn compress_sol_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn compress_sol_test<R: RpcConnection>(
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &mut TestIndexer<R>,
     authority: &Keypair,
     input_compressed_accounts: &[CompressedAccountWithMerkleContext],
     create_out_compressed_accounts_for_input_compressed_accounts: bool,
@@ -164,9 +164,9 @@ pub async fn compress_sol_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn decompress_sol_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn decompress_sol_test<R: RpcConnection>(
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &mut TestIndexer<R>,
     authority: &Keypair,
     input_compressed_accounts: &[CompressedAccountWithMerkleContext],
     recipient: &Pubkey,
@@ -208,9 +208,9 @@ pub async fn decompress_sol_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnecti
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn transfer_compressed_sol_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn transfer_compressed_sol_test<R: RpcConnection>(
     rpc: &mut R,
-    test_indexer: &mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &mut TestIndexer<R>,
     authority: &Keypair,
     input_compressed_accounts: &[CompressedAccountWithMerkleContext],
     recipients: &[Pubkey],
@@ -274,9 +274,9 @@ pub async fn transfer_compressed_sol_test<const INDEXED_ARRAY_SIZE: usize, R: Rp
     compressed_transaction_test(inputs).await
 }
 
-pub struct CompressedTransactionTestInputs<'a, const INDEXED_ARRAY_SIZE: usize, R: RpcConnection> {
+pub struct CompressedTransactionTestInputs<'a, R: RpcConnection> {
     rpc: &'a mut R,
-    test_indexer: &'a mut TestIndexer<INDEXED_ARRAY_SIZE, R>,
+    test_indexer: &'a mut TestIndexer<R>,
     fee_payer: &'a Keypair,
     authority: &'a Keypair,
     input_compressed_accounts: &'a [CompressedAccountWithMerkleContext],
@@ -293,8 +293,8 @@ pub struct CompressedTransactionTestInputs<'a, const INDEXED_ARRAY_SIZE: usize, 
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn compressed_transaction_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
-    inputs: CompressedTransactionTestInputs<'_, INDEXED_ARRAY_SIZE, R>,
+pub async fn compressed_transaction_test<R: RpcConnection>(
+    inputs: CompressedTransactionTestInputs<'_, R>,
 ) -> Result<Signature, RpcError> {
     let mut compressed_account_hashes = Vec::new();
 
@@ -355,11 +355,8 @@ pub async fn compressed_transaction_test<const INDEXED_ARRAY_SIZE: usize, R: Rpc
         let input_merkle_tree_accounts = inputs
             .test_indexer
             .get_state_merkle_tree_accounts(state_input_merkle_trees.unwrap_or(&[]));
-        input_merkle_tree_snapshots = get_merkle_tree_snapshots::<INDEXED_ARRAY_SIZE, R>(
-            inputs.rpc,
-            input_merkle_tree_accounts.as_slice(),
-        )
-        .await;
+        input_merkle_tree_snapshots =
+            get_merkle_tree_snapshots::<R>(inputs.rpc, input_merkle_tree_accounts.as_slice()).await;
 
         if !inputs.new_address_params.is_empty() {
             for (i, input_address_params) in inputs.new_address_params.iter().enumerate() {
@@ -373,11 +370,8 @@ pub async fn compressed_transaction_test<const INDEXED_ARRAY_SIZE: usize, R: Rpc
     let output_merkle_tree_accounts = inputs
         .test_indexer
         .get_state_merkle_tree_accounts(inputs.output_merkle_tree_pubkeys);
-    let output_merkle_tree_snapshots = get_merkle_tree_snapshots::<INDEXED_ARRAY_SIZE, R>(
-        inputs.rpc,
-        output_merkle_tree_accounts.as_slice(),
-    )
-    .await;
+    let output_merkle_tree_snapshots =
+        get_merkle_tree_snapshots::<R>(inputs.rpc, output_merkle_tree_accounts.as_slice()).await;
     let instruction = create_invoke_instruction(
         &inputs.fee_payer.pubkey(),
         &inputs.authority.pubkey().clone(),

--- a/test-utils/src/test_forester.rs
+++ b/test-utils/src/test_forester.rs
@@ -251,10 +251,10 @@ pub enum RelayerUpdateError {}
 /// 1. Element has been marked correctly
 /// 2. Merkle tree has been updated correctly
 /// TODO: Event has been emitted, event doesn't exist yet
-pub async fn empty_address_queue_test<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection>(
+pub async fn empty_address_queue_test<R: RpcConnection>(
     forester: &Keypair,
     rpc: &mut R,
-    address_tree_bundle: &mut AddressMerkleTreeBundle<INDEXED_ARRAY_SIZE>,
+    address_tree_bundle: &mut AddressMerkleTreeBundle,
     signer_is_owner: bool,
 ) -> Result<(), RelayerUpdateError> {
     let address_merkle_tree_pubkey = address_tree_bundle.accounts.merkle_tree;


### PR DESCRIPTION
Changes:
- replace constant sized array and remove const generic from IndexedArray struct
- this will enable us to use bigger indexed arrays in tests