### PR TITLE
test: Test different queue configs (for real)

### DIFF
--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -256,7 +256,7 @@ async fn test_address_queue_and_tree_invalid_sizes() {
             )
             .await;
             assert_rpc_error(
-                result, 3, 9006, // HashSetError::BufferSize
+                result, 2, 9006, // HashSetError::BufferSize
             )
             .unwrap()
         }
@@ -278,7 +278,7 @@ async fn test_address_queue_and_tree_invalid_sizes() {
         )
         .await;
         assert_rpc_error(
-            result, 3, 10012, // ConcurrentMerkleTreeError::BufferSize
+            result, 2, 10012, // ConcurrentMerkleTreeError::BufferSize
         )
         .unwrap()
     }
@@ -299,7 +299,7 @@ async fn test_address_queue_and_tree_invalid_sizes() {
         )
         .await;
         assert_rpc_error(
-            result, 3, 9006, // HashSetError::BufferSize
+            result, 2, 9006, // HashSetError::BufferSize
         )
         .unwrap()
     }
@@ -347,7 +347,7 @@ async fn test_address_queue_and_tree_invalid_config() {
         )
         .await;
         assert_rpc_error(
-            result, 3, 6021, // AccountCompressionErrorCode::UnsupportedHeight
+            result, 2, 6021, // AccountCompressionErrorCode::UnsupportedHeight
         )
         .unwrap();
     }
@@ -366,7 +366,7 @@ async fn test_address_queue_and_tree_invalid_config() {
         )
         .await;
         assert_rpc_error(
-            result, 3, 6021, // AccountCompressionErrorCode::UnsupportedHeight
+            result, 2, 6021, // AccountCompressionErrorCode::UnsupportedHeight
         )
         .unwrap();
     }
@@ -385,7 +385,7 @@ async fn test_address_queue_and_tree_invalid_config() {
         )
         .await;
         assert_rpc_error(
-            result, 3, 6022, // AccountCompressionErrorCode::UnsupportedCanopyDepth
+            result, 2, 6022, // AccountCompressionErrorCode::UnsupportedCanopyDepth
         )
         .unwrap();
     }
@@ -404,7 +404,7 @@ async fn test_address_queue_and_tree_invalid_config() {
         )
         .await;
         assert_rpc_error(
-            result, 3, 6024, // AccountCompressionErrorCode::UnsupportedCloseThreshold
+            result, 2, 6024, // AccountCompressionErrorCode::UnsupportedCloseThreshold
         )
         .unwrap();
     }
@@ -425,7 +425,7 @@ async fn test_address_queue_and_tree_invalid_config() {
         )
         .await;
         assert_rpc_error(
-            result, 3, 6023, // AccountCompressionErrorCode::InvalidSequenceThreshold
+            result, 2, 6023, // AccountCompressionErrorCode::InvalidSequenceThreshold
         )
         .unwrap();
     }

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -294,27 +294,21 @@ async fn test_address_queue_and_tree_invalid_sizes() {
         ..=valid_queue_size)
         .step_by(50_000)
     {
-        for invalid_tree_size in (8 + mem::size_of::<
-            account_compression::state::AddressMerkleTreeAccount,
-        >()..valid_tree_size)
-            .step_by(200_000)
-        {
-            let result = initialize_address_merkle_tree_and_queue(
-                &mut context,
-                &payer,
-                &address_merkle_tree_keypair,
-                &address_queue_keypair,
-                &merkle_tree_config,
-                &queue_config,
-                invalid_tree_size,
-                invalid_queue_size,
-            )
-            .await;
-            assert_rpc_error(
-                result, 3, 9006, // HashSetError::BufferSize
-            )
-            .unwrap()
-        }
+        let result = initialize_address_merkle_tree_and_queue(
+            &mut context,
+            &payer,
+            &address_merkle_tree_keypair,
+            &address_queue_keypair,
+            &merkle_tree_config,
+            &queue_config,
+            valid_tree_size,
+            queue_size,
+        )
+        .await;
+        assert_rpc_error(
+            result, 3, 9006, // HashSetError::BufferSize
+        )
+        .unwrap()
     }
 }
 

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -193,7 +193,7 @@ async fn initialize_address_merkle_tree_and_queue<R: RpcConnection>(
             queue_config.clone(),
         );
     let c_ix =
-        solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(10_000_000);
+        solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(1_400_000);
     let transaction = Transaction::new_signed_with_payer(
         &[
             c_ix,

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -192,15 +192,8 @@ async fn initialize_address_merkle_tree_and_queue<R: RpcConnection>(
             merkle_tree_config.clone(),
             queue_config.clone(),
         );
-    let c_ix =
-        solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(1_400_000);
     let transaction = Transaction::new_signed_with_payer(
-        &[
-            c_ix,
-            queue_account_create_ix,
-            mt_account_create_ix,
-            instruction,
-        ],
+        &[queue_account_create_ix, mt_account_create_ix, instruction],
         Some(&payer.pubkey()),
         &vec![&payer, &queue_keypair, &merkle_tree_keypair],
         context.get_latest_blockhash().await.unwrap(),


### PR DESCRIPTION
Before this change, we were not passing the `queue_config` to the instruction.