### PR TITLE
chore: review-cleanup

### DIFF
--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -626,24 +626,6 @@ export type LightCompressedToken = {
             ];
         },
     ];
-    accounts: [
-        {
-            name: 'RegisteredProgram';
-            type: {
-                kind: 'struct';
-                fields: [
-                    {
-                        name: 'registeredProgramId';
-                        type: 'publicKey';
-                    },
-                    {
-                        name: 'groupAuthorityPda';
-                        type: 'publicKey';
-                    },
-                ];
-            };
-        },
-    ];
     types: [
         {
             name: 'AccessMetadata';
@@ -658,7 +640,7 @@ export type LightCompressedToken = {
                     {
                         name: 'programOwner';
                         docs: [
-                            'Delegate of the Merkle tree. This will be used for program owned Merkle trees.',
+                            'Program owner of the Merkle tree. This will be used for program owned Merkle trees.',
                         ];
                         type: 'publicKey';
                     },
@@ -1363,108 +1345,23 @@ export type LightCompressedToken = {
     errors: [
         {
             code: 6000;
-            name: 'PublicKeyAmountMissmatch';
-            msg: 'public keys and amounts must be of same length';
+            name: 'SignerCheckFailed';
+            msg: 'Signer check failed';
         },
         {
             code: 6001;
-            name: 'SignerCheckFailed';
-            msg: 'SignerCheckFailed';
+            name: 'CreateTransferInstructionFailed';
+            msg: 'Create transfer instruction failed';
         },
         {
             code: 6002;
-            name: 'ComputeInputSumFailed';
-            msg: 'ComputeInputSumFailed';
+            name: 'AccountNotFound';
+            msg: 'Account not found';
         },
         {
             code: 6003;
-            name: 'ComputeOutputSumFailed';
-            msg: 'ComputeOutputSumFailed';
-        },
-        {
-            code: 6004;
-            name: 'ComputeCompressSumFailed';
-            msg: 'ComputeCompressSumFailed';
-        },
-        {
-            code: 6005;
-            name: 'ComputeDecompressSumFailed';
-            msg: 'ComputeDecompressSumFailed';
-        },
-        {
-            code: 6006;
-            name: 'SumCheckFailed';
-            msg: 'SumCheckFailed';
-        },
-        {
-            code: 6007;
-            name: 'DecompressRecipientUndefinedForDecompress';
-            msg: 'DecompressRecipientUndefinedForDecompress';
-        },
-        {
-            code: 6008;
-            name: 'CompressedPdaUndefinedForDecompress';
-            msg: 'CompressedPdaUndefinedForDecompress';
-        },
-        {
-            code: 6009;
-            name: 'DeCompressAmountUndefinedForDecompress';
-            msg: 'DeCompressAmountUndefinedForDecompress';
-        },
-        {
-            code: 6010;
-            name: 'CompressedPdaUndefinedForCompress';
-            msg: 'CompressedPdaUndefinedForCompress';
-        },
-        {
-            code: 6011;
-            name: 'DeCompressAmountUndefinedForCompress';
-            msg: 'DeCompressAmountUndefinedForCompress';
-        },
-        {
-            code: 6012;
-            name: 'DelegateUndefined';
-            msg: 'DelegateUndefined while delegated amount is defined';
-        },
-        {
-            code: 6013;
-            name: 'DelegateSignerCheckFailed';
-            msg: 'DelegateSignerCheckFailed';
-        },
-        {
-            code: 6014;
-            name: 'SplTokenSupplyMismatch';
-            msg: 'SplTokenSupplyMismatch';
-        },
-        {
-            code: 6015;
-            name: 'HeapMemoryCheckFailed';
-            msg: 'HeapMemoryCheckFailed';
-        },
-        {
-            code: 6016;
-            name: 'InstructionNotCallable';
-            msg: 'The instruction is not callable';
-        },
-        {
-            code: 6017;
-            name: 'ArithmeticUnderflow';
-            msg: 'ArithmeticUnderflow';
-        },
-        {
-            code: 6018;
-            name: 'InvalidDelegate';
-            msg: 'InvalidDelegate';
-        },
-        {
-            code: 6019;
-            name: 'HashToFieldError';
-            msg: 'HashToFieldError';
-        },
-        {
-            code: 6020;
-            name: 'InvalidMint';
-            msg: 'InvalidMint';
+            name: 'SerializationError';
+            msg: 'Serialization error';
         },
     ];
 };
@@ -2096,24 +1993,6 @@ export const IDL: LightCompressedToken = {
             ],
         },
     ],
-    accounts: [
-        {
-            name: 'RegisteredProgram',
-            type: {
-                kind: 'struct',
-                fields: [
-                    {
-                        name: 'registeredProgramId',
-                        type: 'publicKey',
-                    },
-                    {
-                        name: 'groupAuthorityPda',
-                        type: 'publicKey',
-                    },
-                ],
-            },
-        },
-    ],
     types: [
         {
             name: 'AccessMetadata',
@@ -2128,7 +2007,7 @@ export const IDL: LightCompressedToken = {
                     {
                         name: 'programOwner',
                         docs: [
-                            'Delegate of the Merkle tree. This will be used for program owned Merkle trees.',
+                            'Program owner of the Merkle tree. This will be used for program owned Merkle trees.',
                         ],
                         type: 'publicKey',
                     },
@@ -2838,108 +2717,23 @@ export const IDL: LightCompressedToken = {
     errors: [
         {
             code: 6000,
-            name: 'PublicKeyAmountMissmatch',
-            msg: 'public keys and amounts must be of same length',
+            name: 'SignerCheckFailed',
+            msg: 'Signer check failed',
         },
         {
             code: 6001,
-            name: 'SignerCheckFailed',
-            msg: 'SignerCheckFailed',
+            name: 'CreateTransferInstructionFailed',
+            msg: 'Create transfer instruction failed',
         },
         {
             code: 6002,
-            name: 'ComputeInputSumFailed',
-            msg: 'ComputeInputSumFailed',
+            name: 'AccountNotFound',
+            msg: 'Account not found',
         },
         {
             code: 6003,
-            name: 'ComputeOutputSumFailed',
-            msg: 'ComputeOutputSumFailed',
-        },
-        {
-            code: 6004,
-            name: 'ComputeCompressSumFailed',
-            msg: 'ComputeCompressSumFailed',
-        },
-        {
-            code: 6005,
-            name: 'ComputeDecompressSumFailed',
-            msg: 'ComputeDecompressSumFailed',
-        },
-        {
-            code: 6006,
-            name: 'SumCheckFailed',
-            msg: 'SumCheckFailed',
-        },
-        {
-            code: 6007,
-            name: 'DecompressRecipientUndefinedForDecompress',
-            msg: 'DecompressRecipientUndefinedForDecompress',
-        },
-        {
-            code: 6008,
-            name: 'CompressedPdaUndefinedForDecompress',
-            msg: 'CompressedPdaUndefinedForDecompress',
-        },
-        {
-            code: 6009,
-            name: 'DeCompressAmountUndefinedForDecompress',
-            msg: 'DeCompressAmountUndefinedForDecompress',
-        },
-        {
-            code: 6010,
-            name: 'CompressedPdaUndefinedForCompress',
-            msg: 'CompressedPdaUndefinedForCompress',
-        },
-        {
-            code: 6011,
-            name: 'DeCompressAmountUndefinedForCompress',
-            msg: 'DeCompressAmountUndefinedForCompress',
-        },
-        {
-            code: 6012,
-            name: 'DelegateUndefined',
-            msg: 'DelegateUndefined while delegated amount is defined',
-        },
-        {
-            code: 6013,
-            name: 'DelegateSignerCheckFailed',
-            msg: 'DelegateSignerCheckFailed',
-        },
-        {
-            code: 6014,
-            name: 'SplTokenSupplyMismatch',
-            msg: 'SplTokenSupplyMismatch',
-        },
-        {
-            code: 6015,
-            name: 'HeapMemoryCheckFailed',
-            msg: 'HeapMemoryCheckFailed',
-        },
-        {
-            code: 6016,
-            name: 'InstructionNotCallable',
-            msg: 'The instruction is not callable',
-        },
-        {
-            code: 6017,
-            name: 'ArithmeticUnderflow',
-            msg: 'ArithmeticUnderflow',
-        },
-        {
-            code: 6018,
-            name: 'InvalidDelegate',
-            msg: 'InvalidDelegate',
-        },
-        {
-            code: 6019,
-            name: 'HashToFieldError',
-            msg: 'HashToFieldError',
-        },
-        {
-            code: 6020,
-            name: 'InvalidMint',
-            msg: 'InvalidMint',
+            name: 'SerializationError',
+            msg: 'Serialization error',
         },
     ],
 };

--- a/js/stateless.js/src/idls/account_compression.ts
+++ b/js/stateless.js/src/idls/account_compression.ts
@@ -296,7 +296,8 @@ export type AccountCompression = {
         {
             name: 'initializeGroupAuthority';
             docs: [
-                'initialize group (a group can be used to give multiple programs access to the same Merkle trees by registering the programs to the group)',
+                'initialize group (a group can be used to give multiple programs access',
+                'to the same Merkle trees by registering the programs to the group)',
             ];
             accounts: [
                 {
@@ -531,7 +532,7 @@ export type AccountCompression = {
                     };
                 },
                 {
-                    name: 'indices';
+                    name: 'leafIndices';
                     type: {
                         vec: 'u64';
                     };
@@ -633,22 +634,6 @@ export type AccountCompression = {
     ];
     accounts: [
         {
-            name: 'groupAuthority';
-            type: {
-                kind: 'struct';
-                fields: [
-                    {
-                        name: 'authority';
-                        type: 'publicKey';
-                    },
-                    {
-                        name: 'seed';
-                        type: 'publicKey';
-                    },
-                ];
-            };
-        },
-        {
             name: 'registeredProgram';
             type: {
                 kind: 'struct';
@@ -677,7 +662,7 @@ export type AccountCompression = {
                     {
                         name: 'programOwner';
                         docs: [
-                            'Delegate of the Merkle tree. This will be used for program owned Merkle trees.',
+                            'Program owner of the Merkle tree. This will be used for program owned Merkle trees.',
                         ];
                         type: 'publicKey';
                     },
@@ -694,6 +679,22 @@ export type AccountCompression = {
                         type: {
                             defined: 'MerkleTreeMetadata';
                         };
+                    },
+                ];
+            };
+        },
+        {
+            name: 'groupAuthority';
+            type: {
+                kind: 'struct';
+                fields: [
+                    {
+                        name: 'authority';
+                        type: 'publicKey';
+                    },
+                    {
+                        name: 'seed';
+                        type: 'publicKey';
                     },
                 ];
             };
@@ -987,96 +988,86 @@ export type AccountCompression = {
         },
         {
             code: 6002;
-            name: 'InvalidVerifier';
-            msg: 'InvalidVerifier';
-        },
-        {
-            code: 6003;
             name: 'NumberOfLeavesMismatch';
             msg: 'Leaves <> remaining accounts mismatch. The number of remaining accounts must match the number of leaves.';
         },
         {
-            code: 6004;
+            code: 6003;
             name: 'InvalidNoopPubkey';
             msg: 'Provided noop program public key is invalid';
         },
         {
-            code: 6005;
+            code: 6004;
             name: 'NumberOfChangeLogIndicesMismatch';
             msg: 'Number of change log indices mismatch';
         },
         {
-            code: 6006;
+            code: 6005;
             name: 'NumberOfIndicesMismatch';
             msg: 'Number of indices mismatch';
         },
         {
-            code: 6007;
+            code: 6006;
             name: 'NumberOfProofsMismatch';
             msg: 'NumberOfProofsMismatch';
         },
         {
-            code: 6008;
+            code: 6007;
             name: 'InvalidMerkleProof';
             msg: 'InvalidMerkleProof';
         },
         {
-            code: 6009;
-            name: 'InvalidMerkleTree';
-            msg: 'InvalidMerkleTree';
-        },
-        {
-            code: 6010;
+            code: 6008;
             name: 'LeafNotFound';
             msg: 'Could not find the leaf in the queue';
         },
         {
-            code: 6011;
+            code: 6009;
             name: 'MerkleTreeAndQueueNotAssociated';
             msg: 'MerkleTreeAndQueueNotAssociated';
         },
         {
-            code: 6012;
+            code: 6010;
             name: 'MerkleTreeAlreadyRolledOver';
             msg: 'MerkleTreeAlreadyRolledOver';
         },
         {
-            code: 6013;
+            code: 6011;
             name: 'NotReadyForRollover';
             msg: 'NotReadyForRollover';
         },
         {
-            code: 6014;
+            code: 6012;
             name: 'RolloverNotConfigured';
             msg: 'RolloverNotConfigured';
         },
         {
-            code: 6015;
+            code: 6013;
             name: 'NotAllLeavesProcessed';
             msg: 'NotAllLeavesProcessed';
         },
         {
-            code: 6016;
+            code: 6014;
             name: 'InvalidQueueType';
             msg: 'InvalidQueueType';
         },
         {
-            code: 6017;
+            code: 6015;
             name: 'InputElementsEmpty';
             msg: 'InputElementsEmpty';
         },
         {
-            code: 6018;
+            code: 6016;
             name: 'NoLeavesForMerkleTree';
             msg: 'NoLeavesForMerkleTree';
         },
         {
-            code: 6019;
+            code: 6017;
             name: 'SizeMismatch';
             msg: 'SizeMismatch';
         },
         {
-            code: 6020;
+            code: 6018;
             name: 'InsufficientRolloverFee';
             msg: 'InsufficientRolloverFee';
         },
@@ -1381,7 +1372,8 @@ export const IDL: AccountCompression = {
         {
             name: 'initializeGroupAuthority',
             docs: [
-                'initialize group (a group can be used to give multiple programs access to the same Merkle trees by registering the programs to the group)',
+                'initialize group (a group can be used to give multiple programs access',
+                'to the same Merkle trees by registering the programs to the group)',
             ],
             accounts: [
                 {
@@ -1616,7 +1608,7 @@ export const IDL: AccountCompression = {
                     },
                 },
                 {
-                    name: 'indices',
+                    name: 'leafIndices',
                     type: {
                         vec: 'u64',
                     },
@@ -1718,22 +1710,6 @@ export const IDL: AccountCompression = {
     ],
     accounts: [
         {
-            name: 'groupAuthority',
-            type: {
-                kind: 'struct',
-                fields: [
-                    {
-                        name: 'authority',
-                        type: 'publicKey',
-                    },
-                    {
-                        name: 'seed',
-                        type: 'publicKey',
-                    },
-                ],
-            },
-        },
-        {
             name: 'registeredProgram',
             type: {
                 kind: 'struct',
@@ -1762,7 +1738,7 @@ export const IDL: AccountCompression = {
                     {
                         name: 'programOwner',
                         docs: [
-                            'Delegate of the Merkle tree. This will be used for program owned Merkle trees.',
+                            'Program owner of the Merkle tree. This will be used for program owned Merkle trees.',
                         ],
                         type: 'publicKey',
                     },
@@ -1779,6 +1755,22 @@ export const IDL: AccountCompression = {
                         type: {
                             defined: 'MerkleTreeMetadata',
                         },
+                    },
+                ],
+            },
+        },
+        {
+            name: 'groupAuthority',
+            type: {
+                kind: 'struct',
+                fields: [
+                    {
+                        name: 'authority',
+                        type: 'publicKey',
+                    },
+                    {
+                        name: 'seed',
+                        type: 'publicKey',
                     },
                 ],
             },
@@ -2072,96 +2064,86 @@ export const IDL: AccountCompression = {
         },
         {
             code: 6002,
-            name: 'InvalidVerifier',
-            msg: 'InvalidVerifier',
-        },
-        {
-            code: 6003,
             name: 'NumberOfLeavesMismatch',
             msg: 'Leaves <> remaining accounts mismatch. The number of remaining accounts must match the number of leaves.',
         },
         {
-            code: 6004,
+            code: 6003,
             name: 'InvalidNoopPubkey',
             msg: 'Provided noop program public key is invalid',
         },
         {
-            code: 6005,
+            code: 6004,
             name: 'NumberOfChangeLogIndicesMismatch',
             msg: 'Number of change log indices mismatch',
         },
         {
-            code: 6006,
+            code: 6005,
             name: 'NumberOfIndicesMismatch',
             msg: 'Number of indices mismatch',
         },
         {
-            code: 6007,
+            code: 6006,
             name: 'NumberOfProofsMismatch',
             msg: 'NumberOfProofsMismatch',
         },
         {
-            code: 6008,
+            code: 6007,
             name: 'InvalidMerkleProof',
             msg: 'InvalidMerkleProof',
         },
         {
-            code: 6009,
-            name: 'InvalidMerkleTree',
-            msg: 'InvalidMerkleTree',
-        },
-        {
-            code: 6010,
+            code: 6008,
             name: 'LeafNotFound',
             msg: 'Could not find the leaf in the queue',
         },
         {
-            code: 6011,
+            code: 6009,
             name: 'MerkleTreeAndQueueNotAssociated',
             msg: 'MerkleTreeAndQueueNotAssociated',
         },
         {
-            code: 6012,
+            code: 6010,
             name: 'MerkleTreeAlreadyRolledOver',
             msg: 'MerkleTreeAlreadyRolledOver',
         },
         {
-            code: 6013,
+            code: 6011,
             name: 'NotReadyForRollover',
             msg: 'NotReadyForRollover',
         },
         {
-            code: 6014,
+            code: 6012,
             name: 'RolloverNotConfigured',
             msg: 'RolloverNotConfigured',
         },
         {
-            code: 6015,
+            code: 6013,
             name: 'NotAllLeavesProcessed',
             msg: 'NotAllLeavesProcessed',
         },
         {
-            code: 6016,
+            code: 6014,
             name: 'InvalidQueueType',
             msg: 'InvalidQueueType',
         },
         {
-            code: 6017,
+            code: 6015,
             name: 'InputElementsEmpty',
             msg: 'InputElementsEmpty',
         },
         {
-            code: 6018,
+            code: 6016,
             name: 'NoLeavesForMerkleTree',
             msg: 'NoLeavesForMerkleTree',
         },
         {
-            code: 6019,
+            code: 6017,
             name: 'SizeMismatch',
             msg: 'SizeMismatch',
         },
         {
-            code: 6020,
+            code: 6018,
             name: 'InsufficientRolloverFee',
             msg: 'InsufficientRolloverFee',
         },

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -626,24 +626,6 @@ export type LightCompressedToken = {
             ];
         },
     ];
-    accounts: [
-        {
-            name: 'RegisteredProgram';
-            type: {
-                kind: 'struct';
-                fields: [
-                    {
-                        name: 'registeredProgramId';
-                        type: 'publicKey';
-                    },
-                    {
-                        name: 'groupAuthorityPda';
-                        type: 'publicKey';
-                    },
-                ];
-            };
-        },
-    ];
     types: [
         {
             name: 'AccessMetadata';
@@ -658,7 +640,7 @@ export type LightCompressedToken = {
                     {
                         name: 'programOwner';
                         docs: [
-                            'Delegate of the Merkle tree. This will be used for program owned Merkle trees.',
+                            'Program owner of the Merkle tree. This will be used for program owned Merkle trees.',
                         ];
                         type: 'publicKey';
                     },
@@ -1363,108 +1345,23 @@ export type LightCompressedToken = {
     errors: [
         {
             code: 6000;
-            name: 'PublicKeyAmountMissmatch';
-            msg: 'public keys and amounts must be of same length';
+            name: 'SignerCheckFailed';
+            msg: 'Signer check failed';
         },
         {
             code: 6001;
-            name: 'SignerCheckFailed';
-            msg: 'SignerCheckFailed';
+            name: 'CreateTransferInstructionFailed';
+            msg: 'Create transfer instruction failed';
         },
         {
             code: 6002;
-            name: 'ComputeInputSumFailed';
-            msg: 'ComputeInputSumFailed';
+            name: 'AccountNotFound';
+            msg: 'Account not found';
         },
         {
             code: 6003;
-            name: 'ComputeOutputSumFailed';
-            msg: 'ComputeOutputSumFailed';
-        },
-        {
-            code: 6004;
-            name: 'ComputeCompressSumFailed';
-            msg: 'ComputeCompressSumFailed';
-        },
-        {
-            code: 6005;
-            name: 'ComputeDecompressSumFailed';
-            msg: 'ComputeDecompressSumFailed';
-        },
-        {
-            code: 6006;
-            name: 'SumCheckFailed';
-            msg: 'SumCheckFailed';
-        },
-        {
-            code: 6007;
-            name: 'DecompressRecipientUndefinedForDecompress';
-            msg: 'DecompressRecipientUndefinedForDecompress';
-        },
-        {
-            code: 6008;
-            name: 'CompressedPdaUndefinedForDecompress';
-            msg: 'CompressedPdaUndefinedForDecompress';
-        },
-        {
-            code: 6009;
-            name: 'DeCompressAmountUndefinedForDecompress';
-            msg: 'DeCompressAmountUndefinedForDecompress';
-        },
-        {
-            code: 6010;
-            name: 'CompressedPdaUndefinedForCompress';
-            msg: 'CompressedPdaUndefinedForCompress';
-        },
-        {
-            code: 6011;
-            name: 'DeCompressAmountUndefinedForCompress';
-            msg: 'DeCompressAmountUndefinedForCompress';
-        },
-        {
-            code: 6012;
-            name: 'DelegateUndefined';
-            msg: 'DelegateUndefined while delegated amount is defined';
-        },
-        {
-            code: 6013;
-            name: 'DelegateSignerCheckFailed';
-            msg: 'DelegateSignerCheckFailed';
-        },
-        {
-            code: 6014;
-            name: 'SplTokenSupplyMismatch';
-            msg: 'SplTokenSupplyMismatch';
-        },
-        {
-            code: 6015;
-            name: 'HeapMemoryCheckFailed';
-            msg: 'HeapMemoryCheckFailed';
-        },
-        {
-            code: 6016;
-            name: 'InstructionNotCallable';
-            msg: 'The instruction is not callable';
-        },
-        {
-            code: 6017;
-            name: 'ArithmeticUnderflow';
-            msg: 'ArithmeticUnderflow';
-        },
-        {
-            code: 6018;
-            name: 'InvalidDelegate';
-            msg: 'InvalidDelegate';
-        },
-        {
-            code: 6019;
-            name: 'HashToFieldError';
-            msg: 'HashToFieldError';
-        },
-        {
-            code: 6020;
-            name: 'InvalidMint';
-            msg: 'InvalidMint';
+            name: 'SerializationError';
+            msg: 'Serialization error';
         },
     ];
 };
@@ -2096,24 +1993,6 @@ export const IDL: LightCompressedToken = {
             ],
         },
     ],
-    accounts: [
-        {
-            name: 'RegisteredProgram',
-            type: {
-                kind: 'struct',
-                fields: [
-                    {
-                        name: 'registeredProgramId',
-                        type: 'publicKey',
-                    },
-                    {
-                        name: 'groupAuthorityPda',
-                        type: 'publicKey',
-                    },
-                ],
-            },
-        },
-    ],
     types: [
         {
             name: 'AccessMetadata',
@@ -2128,7 +2007,7 @@ export const IDL: LightCompressedToken = {
                     {
                         name: 'programOwner',
                         docs: [
-                            'Delegate of the Merkle tree. This will be used for program owned Merkle trees.',
+                            'Program owner of the Merkle tree. This will be used for program owned Merkle trees.',
                         ],
                         type: 'publicKey',
                     },
@@ -2838,108 +2717,23 @@ export const IDL: LightCompressedToken = {
     errors: [
         {
             code: 6000,
-            name: 'PublicKeyAmountMissmatch',
-            msg: 'public keys and amounts must be of same length',
+            name: 'SignerCheckFailed',
+            msg: 'Signer check failed',
         },
         {
             code: 6001,
-            name: 'SignerCheckFailed',
-            msg: 'SignerCheckFailed',
+            name: 'CreateTransferInstructionFailed',
+            msg: 'Create transfer instruction failed',
         },
         {
             code: 6002,
-            name: 'ComputeInputSumFailed',
-            msg: 'ComputeInputSumFailed',
+            name: 'AccountNotFound',
+            msg: 'Account not found',
         },
         {
             code: 6003,
-            name: 'ComputeOutputSumFailed',
-            msg: 'ComputeOutputSumFailed',
-        },
-        {
-            code: 6004,
-            name: 'ComputeCompressSumFailed',
-            msg: 'ComputeCompressSumFailed',
-        },
-        {
-            code: 6005,
-            name: 'ComputeDecompressSumFailed',
-            msg: 'ComputeDecompressSumFailed',
-        },
-        {
-            code: 6006,
-            name: 'SumCheckFailed',
-            msg: 'SumCheckFailed',
-        },
-        {
-            code: 6007,
-            name: 'DecompressRecipientUndefinedForDecompress',
-            msg: 'DecompressRecipientUndefinedForDecompress',
-        },
-        {
-            code: 6008,
-            name: 'CompressedPdaUndefinedForDecompress',
-            msg: 'CompressedPdaUndefinedForDecompress',
-        },
-        {
-            code: 6009,
-            name: 'DeCompressAmountUndefinedForDecompress',
-            msg: 'DeCompressAmountUndefinedForDecompress',
-        },
-        {
-            code: 6010,
-            name: 'CompressedPdaUndefinedForCompress',
-            msg: 'CompressedPdaUndefinedForCompress',
-        },
-        {
-            code: 6011,
-            name: 'DeCompressAmountUndefinedForCompress',
-            msg: 'DeCompressAmountUndefinedForCompress',
-        },
-        {
-            code: 6012,
-            name: 'DelegateUndefined',
-            msg: 'DelegateUndefined while delegated amount is defined',
-        },
-        {
-            code: 6013,
-            name: 'DelegateSignerCheckFailed',
-            msg: 'DelegateSignerCheckFailed',
-        },
-        {
-            code: 6014,
-            name: 'SplTokenSupplyMismatch',
-            msg: 'SplTokenSupplyMismatch',
-        },
-        {
-            code: 6015,
-            name: 'HeapMemoryCheckFailed',
-            msg: 'HeapMemoryCheckFailed',
-        },
-        {
-            code: 6016,
-            name: 'InstructionNotCallable',
-            msg: 'The instruction is not callable',
-        },
-        {
-            code: 6017,
-            name: 'ArithmeticUnderflow',
-            msg: 'ArithmeticUnderflow',
-        },
-        {
-            code: 6018,
-            name: 'InvalidDelegate',
-            msg: 'InvalidDelegate',
-        },
-        {
-            code: 6019,
-            name: 'HashToFieldError',
-            msg: 'HashToFieldError',
-        },
-        {
-            code: 6020,
-            name: 'InvalidMint',
-            msg: 'InvalidMint',
+            name: 'SerializationError',
+            msg: 'Serialization error',
         },
     ],
 };

--- a/js/stateless.js/src/idls/light_system_program.ts
+++ b/js/stateless.js/src/idls/light_system_program.ts
@@ -42,6 +42,9 @@ export type LightSystemProgram = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: [
+                        'Fee payer needs to be mutable to pay rollover and protocol fees.',
+                    ];
                 },
                 {
                     name: 'authority';
@@ -62,23 +65,36 @@ export type LightSystemProgram = {
                     name: 'accountCompressionAuthority';
                     isMut: false;
                     isSigner: false;
+                    docs: [
+                        'This pda is used to invoke the account compression program.',
+                    ];
                 },
                 {
                     name: 'accountCompressionProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: ['Merkle trees.'];
                 },
                 {
                     name: 'solPoolPda';
                     isMut: true;
                     isSigner: false;
                     isOptional: true;
+                    docs: [
+                        'Sol pool pda is used to store compressed sol.',
+                        "It's only required when compressing or decompressing sol.",
+                    ];
                 },
                 {
                     name: 'decompressionRecipient';
                     isMut: true;
                     isSigner: false;
                     isOptional: true;
+                    docs: [
+                        'Only needs to be provided for decompression as a recipient for the',
+                        'decompressed sol.',
+                        'Compressed sol originate from authority.',
+                    ];
                 },
                 {
                     name: 'systemProgram';
@@ -100,6 +116,9 @@ export type LightSystemProgram = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: [
+                        'Fee payer needs to be mutable to pay rollover and protocol fees.',
+                    ];
                 },
                 {
                     name: 'authority';
@@ -174,6 +193,9 @@ export type LightSystemProgram = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: [
+                        'Fee payer needs to be mutable to pay rollover and protocol fees.',
+                    ];
                 },
                 {
                     name: 'authority';
@@ -194,23 +216,36 @@ export type LightSystemProgram = {
                     name: 'accountCompressionAuthority';
                     isMut: false;
                     isSigner: false;
+                    docs: [
+                        'This pda is used to invoke the account compression program.',
+                    ];
                 },
                 {
                     name: 'accountCompressionProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: ['Merkle trees.'];
                 },
                 {
                     name: 'solPoolPda';
                     isMut: true;
                     isSigner: false;
                     isOptional: true;
+                    docs: [
+                        'Sol pool pda is used to store compressed sol.',
+                        "It's only required when compressing or decompressing sol.",
+                    ];
                 },
                 {
                     name: 'decompressionRecipient';
                     isMut: true;
                     isSigner: false;
                     isOptional: true;
+                    docs: [
+                        'Only needs to be provided for decompression as a recipient for the',
+                        'decompressed sol.',
+                        'Compressed sol originate from authority.',
+                    ];
                 },
                 {
                     name: 'systemProgram';
@@ -241,22 +276,6 @@ export type LightSystemProgram = {
         },
     ];
     accounts: [
-        {
-            name: 'registeredProgram';
-            type: {
-                kind: 'struct';
-                fields: [
-                    {
-                        name: 'registeredProgramId';
-                        type: 'publicKey';
-                    },
-                    {
-                        name: 'groupAuthorityPda';
-                        type: 'publicKey';
-                    },
-                ];
-            };
-        },
         {
             name: 'stateMerkleTreeAccount';
             docs: [
@@ -321,7 +340,7 @@ export type LightSystemProgram = {
                     {
                         name: 'programOwner';
                         docs: [
-                            'Delegate of the Merkle tree. This will be used for program owned Merkle trees.',
+                            'Program owner of the Merkle tree. This will be used for program owned Merkle trees.',
                         ];
                         type: 'publicKey';
                     },
@@ -925,7 +944,7 @@ export type LightSystemProgram = {
         {
             code: 6019;
             name: 'ProofIsSome';
-            msg: 'ProofIsSome';
+            msg: 'Proof is some but no input compressed accounts or new addresses provided.';
         },
         {
             code: 6020;
@@ -939,43 +958,58 @@ export type LightSystemProgram = {
         },
         {
             code: 6022;
-            name: 'CpiContextProofMismatch';
-            msg: 'CpiContextMismatch';
-        },
-        {
-            code: 6023;
             name: 'CpiContextEmpty';
             msg: 'CpiContextEmpty';
         },
         {
-            code: 6024;
+            code: 6023;
             name: 'CpiContextMissing';
             msg: 'CpiContextMissing';
         },
         {
-            code: 6025;
+            code: 6024;
             name: 'DecompressionRecipienDefined';
             msg: 'DecompressionRecipienDefined';
         },
         {
-            code: 6026;
+            code: 6025;
             name: 'SolPoolPdaDefined';
             msg: 'SolPoolPdaDefined';
         },
         {
-            code: 6027;
+            code: 6026;
             name: 'AppendStateFailed';
             msg: 'AppendStateFailed';
         },
         {
-            code: 6028;
+            code: 6027;
             name: 'InstructionNotCallable';
             msg: 'The instruction is not callable';
         },
         {
-            code: 6029;
+            code: 6028;
             name: 'CpiContextFeePayerMismatch';
             msg: 'CpiContextFeePayerMismatch';
+        },
+        {
+            code: 6029;
+            name: 'CpiContextAssociatedMerkleTreeMismatch';
+            msg: 'CpiContextAssociatedMerkleTreeMismatch';
+        },
+        {
+            code: 6030;
+            name: 'NoInputs';
+            msg: 'NoInputs';
+        },
+        {
+            code: 6031;
+            name: 'InputMerkleTreeIndicesNotInOrder';
+            msg: 'Input merkle tree indices are not in ascending order.';
+        },
+        {
+            code: 6032;
+            name: 'OutputMerkleTreeIndicesNotInOrder';
+            msg: 'Output merkle tree indices are not in ascending order.';
         },
     ];
 };
@@ -1024,6 +1058,9 @@ export const IDL: LightSystemProgram = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: [
+                        'Fee payer needs to be mutable to pay rollover and protocol fees.',
+                    ],
                 },
                 {
                     name: 'authority',
@@ -1044,23 +1081,36 @@ export const IDL: LightSystemProgram = {
                     name: 'accountCompressionAuthority',
                     isMut: false,
                     isSigner: false,
+                    docs: [
+                        'This pda is used to invoke the account compression program.',
+                    ],
                 },
                 {
                     name: 'accountCompressionProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: ['Merkle trees.'],
                 },
                 {
                     name: 'solPoolPda',
                     isMut: true,
                     isSigner: false,
                     isOptional: true,
+                    docs: [
+                        'Sol pool pda is used to store compressed sol.',
+                        "It's only required when compressing or decompressing sol.",
+                    ],
                 },
                 {
                     name: 'decompressionRecipient',
                     isMut: true,
                     isSigner: false,
                     isOptional: true,
+                    docs: [
+                        'Only needs to be provided for decompression as a recipient for the',
+                        'decompressed sol.',
+                        'Compressed sol originate from authority.',
+                    ],
                 },
                 {
                     name: 'systemProgram',
@@ -1082,6 +1132,9 @@ export const IDL: LightSystemProgram = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: [
+                        'Fee payer needs to be mutable to pay rollover and protocol fees.',
+                    ],
                 },
                 {
                     name: 'authority',
@@ -1156,6 +1209,9 @@ export const IDL: LightSystemProgram = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: [
+                        'Fee payer needs to be mutable to pay rollover and protocol fees.',
+                    ],
                 },
                 {
                     name: 'authority',
@@ -1176,23 +1232,36 @@ export const IDL: LightSystemProgram = {
                     name: 'accountCompressionAuthority',
                     isMut: false,
                     isSigner: false,
+                    docs: [
+                        'This pda is used to invoke the account compression program.',
+                    ],
                 },
                 {
                     name: 'accountCompressionProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: ['Merkle trees.'],
                 },
                 {
                     name: 'solPoolPda',
                     isMut: true,
                     isSigner: false,
                     isOptional: true,
+                    docs: [
+                        'Sol pool pda is used to store compressed sol.',
+                        "It's only required when compressing or decompressing sol.",
+                    ],
                 },
                 {
                     name: 'decompressionRecipient',
                     isMut: true,
                     isSigner: false,
                     isOptional: true,
+                    docs: [
+                        'Only needs to be provided for decompression as a recipient for the',
+                        'decompressed sol.',
+                        'Compressed sol originate from authority.',
+                    ],
                 },
                 {
                     name: 'systemProgram',
@@ -1223,22 +1292,6 @@ export const IDL: LightSystemProgram = {
         },
     ],
     accounts: [
-        {
-            name: 'registeredProgram',
-            type: {
-                kind: 'struct',
-                fields: [
-                    {
-                        name: 'registeredProgramId',
-                        type: 'publicKey',
-                    },
-                    {
-                        name: 'groupAuthorityPda',
-                        type: 'publicKey',
-                    },
-                ],
-            },
-        },
         {
             name: 'stateMerkleTreeAccount',
             docs: [
@@ -1303,7 +1356,7 @@ export const IDL: LightSystemProgram = {
                     {
                         name: 'programOwner',
                         docs: [
-                            'Delegate of the Merkle tree. This will be used for program owned Merkle trees.',
+                            'Program owner of the Merkle tree. This will be used for program owned Merkle trees.',
                         ],
                         type: 'publicKey',
                     },
@@ -1912,7 +1965,7 @@ export const IDL: LightSystemProgram = {
         {
             code: 6019,
             name: 'ProofIsSome',
-            msg: 'ProofIsSome',
+            msg: 'Proof is some but no input compressed accounts or new addresses provided.',
         },
         {
             code: 6020,
@@ -1926,43 +1979,58 @@ export const IDL: LightSystemProgram = {
         },
         {
             code: 6022,
-            name: 'CpiContextProofMismatch',
-            msg: 'CpiContextMismatch',
-        },
-        {
-            code: 6023,
             name: 'CpiContextEmpty',
             msg: 'CpiContextEmpty',
         },
         {
-            code: 6024,
+            code: 6023,
             name: 'CpiContextMissing',
             msg: 'CpiContextMissing',
         },
         {
-            code: 6025,
+            code: 6024,
             name: 'DecompressionRecipienDefined',
             msg: 'DecompressionRecipienDefined',
         },
         {
-            code: 6026,
+            code: 6025,
             name: 'SolPoolPdaDefined',
             msg: 'SolPoolPdaDefined',
         },
         {
-            code: 6027,
+            code: 6026,
             name: 'AppendStateFailed',
             msg: 'AppendStateFailed',
         },
         {
-            code: 6028,
+            code: 6027,
             name: 'InstructionNotCallable',
             msg: 'The instruction is not callable',
         },
         {
-            code: 6029,
+            code: 6028,
             name: 'CpiContextFeePayerMismatch',
             msg: 'CpiContextFeePayerMismatch',
+        },
+        {
+            code: 6029,
+            name: 'CpiContextAssociatedMerkleTreeMismatch',
+            msg: 'CpiContextAssociatedMerkleTreeMismatch',
+        },
+        {
+            code: 6030,
+            name: 'NoInputs',
+            msg: 'NoInputs',
+        },
+        {
+            code: 6031,
+            name: 'InputMerkleTreeIndicesNotInOrder',
+            msg: 'Input merkle tree indices are not in ascending order.',
+        },
+        {
+            code: 6032,
+            name: 'OutputMerkleTreeIndicesNotInOrder',
+            msg: 'Output merkle tree indices are not in ascending order.',
         },
     ],
 };

--- a/programs/account-compression/src/errors.rs
+++ b/programs/account-compression/src/errors.rs
@@ -6,8 +6,6 @@ pub enum AccountCompressionErrorCode {
     IntegerOverflow,
     #[msg("InvalidAuthority")]
     InvalidAuthority,
-    #[msg("InvalidVerifier")]
-    InvalidVerifier,
     #[msg(
         "Leaves <> remaining accounts mismatch. The number of remaining accounts must match the number of leaves."
     )]
@@ -22,8 +20,6 @@ pub enum AccountCompressionErrorCode {
     NumberOfProofsMismatch,
     #[msg("InvalidMerkleProof")]
     InvalidMerkleProof,
-    #[msg("InvalidMerkleTree")]
-    InvalidMerkleTree,
     #[msg("Could not find the leaf in the queue")]
     LeafNotFound,
     #[msg("MerkleTreeAndQueueNotAssociated")]

--- a/programs/account-compression/src/instructions/insert_into_queues.rs
+++ b/programs/account-compression/src/instructions/insert_into_queues.rs
@@ -47,6 +47,9 @@ pub fn process_insert_into_queues<'a, 'b, 'c: 'info, 'info, MerkleTreeAccount: O
     light_heap::bench_sbf_start!("acp_create_queue_map");
 
     let mut queue_map = QueueMap::new();
+    // Deduplicate tree and queue pairs.
+    // So that we iterate over every pair only once,
+    // and pay rollover fees only once.
     for i in (0..ctx.remaining_accounts.len()).step_by(2) {
         let queue: &AccountInfo<'info> = ctx.remaining_accounts.get(i).unwrap();
         let merkle_tree = ctx.remaining_accounts.get(i + 1).unwrap();

--- a/programs/account-compression/src/instructions/nullify_leaves.rs
+++ b/programs/account-compression/src/instructions/nullify_leaves.rs
@@ -43,7 +43,7 @@ pub fn process_nullify_leaves<'a, 'b, 'c: 'info, 'info>(
     ctx: &'a Context<'a, 'b, 'c, 'info, NullifyLeaves<'info>>,
     change_log_indices: &'a [u64],
     leaves_queue_indices: &'a [u16],
-    indices: &'a [u64],
+    leaf_indices: &'a [u64],
     proofs: &'a [Vec<[u8; 32]>],
 ) -> Result<()> {
     if change_log_indices.len() != 1 {
@@ -54,7 +54,7 @@ pub fn process_nullify_leaves<'a, 'b, 'c: 'info, 'info>(
         msg!("only implemented for 1 nullifier update");
         return Err(AccountCompressionErrorCode::NumberOfLeavesMismatch.into());
     }
-    if indices.len() != change_log_indices.len() {
+    if leaf_indices.len() != change_log_indices.len() {
         msg!("only implemented for 1 nullifier update");
         return Err(AccountCompressionErrorCode::NumberOfIndicesMismatch.into());
     }
@@ -66,7 +66,7 @@ pub fn process_nullify_leaves<'a, 'b, 'c: 'info, 'info>(
         proofs,
         change_log_indices,
         leaves_queue_indices,
-        indices,
+        leaf_indices,
         ctx,
     )?;
 
@@ -78,7 +78,7 @@ fn insert_nullifier<'a, 'c: 'info, 'info>(
     proofs: &[Vec<[u8; 32]>],
     change_log_indices: &[u64],
     leaves_queue_indices: &[u16],
-    indices: &[u64],
+    leaf_indices: &[u64],
     ctx: &Context<'a, '_, 'c, 'info, NullifyLeaves<'info>>,
 ) -> Result<()> {
     {
@@ -131,7 +131,7 @@ fn insert_nullifier<'a, 'c: 'info, 'info>(
                 change_log_indices[i] as usize,
                 &leaf_cell.value_bytes(),
                 &ZERO_BYTES[0],
-                indices[i] as usize,
+                leaf_indices[i] as usize,
                 &mut proof,
             )
             .map_err(ProgramError::from)?;
@@ -142,7 +142,7 @@ fn insert_nullifier<'a, 'c: 'info, 'info>(
     }
     let nullify_event = NullifierEvent {
         id: ctx.accounts.merkle_tree.key().to_bytes(),
-        nullified_leaves_indices: indices.to_vec(),
+        nullified_leaves_indices: leaf_indices.to_vec(),
         seq,
     };
     let nullify_event = MerkleTreeEvent::V2(nullify_event);
@@ -168,7 +168,7 @@ pub mod sdk_nullify {
     pub fn create_nullify_instruction(
         change_log_indices: &[u64],
         leaves_queue_indices: &[u16],
-        indices: &[u64],
+        leaf_indices: &[u64],
         proofs: &[Vec<[u8; 32]>],
         payer: &Pubkey,
         merkle_tree_pubkey: &Pubkey,
@@ -176,7 +176,7 @@ pub mod sdk_nullify {
     ) -> Instruction {
         let instruction_data = crate::instruction::NullifyLeaves {
             leaves_queue_indices: leaves_queue_indices.to_vec(),
-            indices: indices.to_vec(),
+            leaf_indices: leaf_indices.to_vec(),
             change_log_indices: change_log_indices.to_vec(),
             proofs: proofs.to_vec(),
         };

--- a/programs/account-compression/src/instructions/register_program.rs
+++ b/programs/account-compression/src/instructions/register_program.rs
@@ -14,7 +14,7 @@ pub struct RegisteredProgram {
 #[derive(Accounts)]
 pub struct RegisterProgramToGroup<'info> {
     /// CHECK: Signer is checked according to authority pda in instruction.
-    #[account(mut, address=group_authority_pda.authority @AccountCompressionErrorCode::InvalidAuthority)]
+    #[account(mut, constraint= authority.key() == group_authority_pda.authority @AccountCompressionErrorCode::InvalidAuthority)]
     pub authority: Signer<'info>,
     pub program_to_be_registered: Signer<'info>,
     #[account(

--- a/programs/account-compression/src/lib.rs
+++ b/programs/account-compression/src/lib.rs
@@ -82,10 +82,10 @@ pub mod account_compression {
             changelog_index,
             indexed_changelog_index,
             value,
-            low_address_index,
             low_address_value,
             low_address_next_index,
             low_address_next_value,
+            low_address_index,
             low_address_proof,
         )
     }
@@ -96,7 +96,8 @@ pub mod account_compression {
         process_rollover_address_merkle_tree_and_queue(ctx)
     }
 
-    /// initialize group (a group can be used to give multiple programs access to the same Merkle trees by registering the programs to the group)
+    /// initialize group (a group can be used to give multiple programs access
+    /// to the same Merkle trees by registering the programs to the group)
     pub fn initialize_group_authority<'info>(
         ctx: Context<'_, '_, '_, 'info, InitializeGroupAuthority<'info>>,
         authority: Pubkey,
@@ -158,14 +159,14 @@ pub mod account_compression {
         ctx: Context<'a, 'b, 'c, 'info, NullifyLeaves<'info>>,
         change_log_indices: Vec<u64>,
         leaves_queue_indices: Vec<u16>,
-        indices: Vec<u64>,
+        leaf_indices: Vec<u64>,
         proofs: Vec<Vec<[u8; 32]>>,
     ) -> Result<()> {
         process_nullify_leaves(
             &ctx,
             &change_log_indices,
             &leaves_queue_indices,
-            &indices,
+            &leaf_indices,
             &proofs,
         )
     }

--- a/programs/system/src/errors.rs
+++ b/programs/system/src/errors.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 
+// TODO: check that all errors are used
 #[error_code]
 pub enum SystemProgramError {
     #[msg("Sum check failed")]
@@ -40,14 +41,12 @@ pub enum SystemProgramError {
     InvalidMerkleTreeOwner,
     #[msg("ProofIsNone")]
     ProofIsNone,
-    #[msg("ProofIsSome")]
+    #[msg("Proof is some but no input compressed accounts or new addresses provided.")]
     ProofIsSome,
     #[msg("EmptyInputs")]
     EmptyInputs,
     #[msg("CpiContextAccountUndefined")]
     CpiContextAccountUndefined,
-    #[msg("CpiContextMismatch")]
-    CpiContextProofMismatch,
     #[msg("CpiContextEmpty")]
     CpiContextEmpty,
     #[msg("CpiContextMissing")]
@@ -66,4 +65,8 @@ pub enum SystemProgramError {
     CpiContextAssociatedMerkleTreeMismatch,
     #[msg("NoInputs")]
     NoInputs,
+    #[msg("Input merkle tree indices are not in ascending order.")]
+    InputMerkleTreeIndicesNotInOrder,
+    #[msg("Output merkle tree indices are not in ascending order.")]
+    OutputMerkleTreeIndicesNotInOrder, // TODO: adapt failing tests
 }

--- a/programs/system/src/errors.rs
+++ b/programs/system/src/errors.rs
@@ -1,6 +1,5 @@
 use anchor_lang::prelude::*;
 
-// TODO: check that all errors are used
 #[error_code]
 pub enum SystemProgramError {
     #[msg("Sum check failed")]
@@ -68,5 +67,5 @@ pub enum SystemProgramError {
     #[msg("Input merkle tree indices are not in ascending order.")]
     InputMerkleTreeIndicesNotInOrder,
     #[msg("Output merkle tree indices are not in ascending order.")]
-    OutputMerkleTreeIndicesNotInOrder, // TODO: adapt failing tests
+    OutputMerkleTreeIndicesNotInOrder,
 }

--- a/programs/system/src/invoke/append_state.rs
+++ b/programs/system/src/invoke/append_state.rs
@@ -118,7 +118,7 @@ pub fn create_cpi_accounts_and_instruction_data<'a>(
     let num_leaves = output_compressed_account_hashes.len();
     let mut instruction_data = Vec::<u8>::with_capacity(12 + 33 * num_leaves);
     let mut hashed_merkle_tree = [0u8; 32];
-    let mut num_accounts = 0;
+    let mut index_merkle_tree_account = 0;
 
     // Anchor instruction signature.
     instruction_data.extend_from_slice(&[199, 144, 10, 82, 247, 142, 143, 7]);
@@ -162,7 +162,7 @@ pub fn create_cpi_accounts_and_instruction_data<'a>(
             account_infos.push(account_info);
 
             num_leaves_in_tree = 0;
-            num_accounts += 1;
+            index_merkle_tree_account += 1;
         } else {
             // Check 2.
             // Output Merkle tree indices must be in order since we use the
@@ -220,7 +220,7 @@ pub fn create_cpi_accounts_and_instruction_data<'a>(
                 &output_compressed_account_indices[j],
             )?;
         // - 1 since we want the index of the next account index.
-        instruction_data.extend_from_slice(&[num_accounts - 1]);
+        instruction_data.extend_from_slice(&[index_merkle_tree_account - 1]);
         instruction_data.extend_from_slice(&output_compressed_account_hashes[j]);
     }
     Ok(instruction_data)

--- a/programs/system/src/invoke/append_state.rs
+++ b/programs/system/src/invoke/append_state.rs
@@ -40,9 +40,9 @@ pub fn insert_output_compressed_accounts_into_state_merkle_tree<
 ) -> Result<()> {
     bench_sbf_start!("cpda_append_data_init");
     let mut account_infos = vec![
-        ctx.accounts.get_fee_payer().to_account_info(),
+        ctx.accounts.get_fee_payer().to_account_info(), // fee payer
         ctx.accounts
-            .get_account_compression_authority()
+            .get_account_compression_authority() // authority
             .to_account_info(),
         ctx.accounts.get_registered_program_pda().to_account_info(),
         ctx.accounts.get_system_program().to_account_info(),
@@ -112,12 +112,14 @@ pub fn create_cpi_accounts_and_instruction_data<'a>(
     account_infos: &mut Vec<AccountInfo<'a>>,
     accounts: &mut Vec<AccountMeta>,
 ) -> Result<Vec<u8>> {
-    let mut current_index: i8 = -1;
+    let mut current_index: i16 = -1;
     let mut num_leaves_in_tree: u32 = 0;
     let mut mt_next_index = 0;
     let num_leaves = output_compressed_account_hashes.len();
     let mut instruction_data = Vec::<u8>::with_capacity(12 + 33 * num_leaves);
     let mut hashed_merkle_tree = [0u8; 32];
+    let mut num_accounts = 0;
+
     // Anchor instruction signature.
     instruction_data.extend_from_slice(&[199, 144, 10, 82, 247, 142, 143, 7]);
     // leaves vector length (for borsh compat)
@@ -127,13 +129,10 @@ pub fn create_cpi_accounts_and_instruction_data<'a>(
         // if mt index == current index Merkle tree account info has already been added.
         // if mt index != current index, Merkle tree account info is new, add it.
         #[allow(clippy::comparison_chain)]
-        if account.merkle_tree_index as i8 == current_index {
+        if account.merkle_tree_index as i16 == current_index {
             // Do nothing, but it is the most common case.
-        } else if account.merkle_tree_index as i8 > current_index {
-            current_index = account.merkle_tree_index.try_into().map_err(|_| {
-                msg!("Merkle tree index is not in order.");
-                SystemProgramError::AppendStateFailed
-            })?;
+        } else if account.merkle_tree_index as i16 > current_index {
+            current_index = account.merkle_tree_index.into();
             let seq;
             // Check 1.
             (mt_next_index, _, seq) = check_program_owner_state_merkle_tree(
@@ -142,11 +141,7 @@ pub fn create_cpi_accounts_and_instruction_data<'a>(
             )?;
             let account_info =
                 remaining_accounts[account.merkle_tree_index as usize].to_account_info();
-            accounts.push(AccountMeta {
-                pubkey: account_info.key(),
-                is_signer: false,
-                is_writable: true,
-            });
+
             sequence_numbers.push(MerkleTreeSequenceNumber {
                 pubkey: account_info.key(),
                 seq,
@@ -159,16 +154,22 @@ pub fn create_cpi_accounts_and_instruction_data<'a>(
                         .0
                 }
             };
+            accounts.push(AccountMeta {
+                pubkey: account_info.key(),
+                is_signer: false,
+                is_writable: true,
+            });
             account_infos.push(account_info);
+
             num_leaves_in_tree = 0;
+            num_accounts += 1;
         } else {
             // Check 2.
             // Output Merkle tree indices must be in order since we use the
             // number of leaves in a Merkle tree to determine the correct leaf
             // index. Since the leaf index is part of the hash this is security
             // critical.
-            msg!("Merkle tree index is not in order.");
-            return err!(SystemProgramError::AppendStateFailed);
+            return err!(SystemProgramError::OutputMerkleTreeIndicesNotInOrder);
         }
 
         // Check 3.
@@ -218,8 +219,8 @@ pub fn create_cpi_accounts_and_instruction_data<'a>(
                 &hashed_merkle_tree,
                 &output_compressed_account_indices[j],
             )?;
-        let index_merkle_tree_account = (account_infos.len() - 5) as u8;
-        instruction_data.extend_from_slice(&[index_merkle_tree_account]);
+        // - 1 since we want the index of the next account index.
+        instruction_data.extend_from_slice(&[num_accounts - 1]);
         instruction_data.extend_from_slice(&output_compressed_account_hashes[j]);
     }
     Ok(instruction_data)

--- a/programs/system/src/invoke/instruction.rs
+++ b/programs/system/src/invoke/instruction.rs
@@ -24,18 +24,25 @@ pub struct InvokeInstruction<'info> {
     seeds = [&crate::ID.to_bytes()], bump, seeds::program = &account_compression::ID,
     )]
     pub registered_program_pda: AccountInfo<'info>,
-    /// CHECK: this account
+    /// CHECK: is checked when emitting the event.
     pub noop_program: UncheckedAccount<'info>,
-    /// CHECK: this account in psp account compression program
+    /// CHECK: this account in account compression program.
+    /// This pda is used to invoke the account compression program.
     #[account(seeds = [CPI_AUTHORITY_PDA_SEED], bump)]
     pub account_compression_authority: UncheckedAccount<'info>,
-    /// CHECK: this account in psp account compression program
+    /// CHECK: Account compression program is used to update state and address
+    /// Merkle trees.
     pub account_compression_program: Program<'info, AccountCompression>,
+    /// Sol pool pda is used to store compressed sol.
+    /// It's only required when compressing or decompressing sol.
     #[account(
         mut,
         seeds = [SOL_POOL_PDA_SEED], bump
     )]
     pub sol_pool_pda: Option<UncheckedAccount<'info>>,
+    /// Only needs to be provided for decompression as a recipient for the
+    /// decompressed sol.
+    /// Compressed sol originate from authority.
     #[account(mut)]
     pub decompression_recipient: Option<UncheckedAccount<'info>>,
     pub system_program: Program<'info, System>,
@@ -71,15 +78,16 @@ impl<'info> InvokeAccounts<'info> for InvokeInstruction<'info> {
     fn get_system_program(&self) -> &Program<'info, System> {
         &self.system_program
     }
+
     fn get_sol_pool_pda(&self) -> Option<&UncheckedAccount<'info>> {
         self.sol_pool_pda.as_ref()
     }
+
     fn get_decompression_recipient(&self) -> Option<&UncheckedAccount<'info>> {
         self.decompression_recipient.as_ref()
     }
 }
 
-// TODO; make all options
 #[derive(Debug, PartialEq, Default, Clone, AnchorSerialize, AnchorDeserialize)]
 pub struct InstructionDataInvoke {
     pub proof: Option<CompressedProof>,

--- a/programs/system/src/invoke/nullify_state.rs
+++ b/programs/system/src/invoke/nullify_state.rs
@@ -40,16 +40,8 @@ pub fn insert_nullifiers<
             is_signer: true,
             is_writable: true,
         },
-        AccountMeta {
-            pubkey: account_infos[1].key(),
-            is_signer: true,
-            is_writable: false,
-        },
-        AccountMeta {
-            pubkey: account_infos[2].key(),
-            is_signer: false,
-            is_writable: false,
-        },
+        AccountMeta::new_readonly(account_infos[1].key(), true),
+        AccountMeta::new_readonly(account_infos[2].key(), false),
         AccountMeta::new_readonly(account_infos[3].key(), false),
     ];
     // If the transaction contains at least one input compressed account a
@@ -78,17 +70,14 @@ pub fn insert_nullifiers<
                 network_fee.unwrap(),
             ));
         }
+        let account_info =
+            &ctx.remaining_accounts[account.merkle_context.merkle_tree_pubkey_index as usize];
         accounts.push(AccountMeta {
-            pubkey: ctx.remaining_accounts
-                [account.merkle_context.merkle_tree_pubkey_index as usize]
-                .key(),
+            pubkey: account_info.key(),
             is_signer: false,
             is_writable: false,
         });
-        account_infos.push(
-            ctx.remaining_accounts[account.merkle_context.merkle_tree_pubkey_index as usize]
-                .clone(),
-        );
+        account_infos.push(account_info.clone());
     }
 
     light_heap::bench_sbf_end!("cpda_insert_nullifiers_prep_accs");

--- a/programs/system/src/invoke/sol_compression.rs
+++ b/programs/system/src/invoke/sol_compression.rs
@@ -31,10 +31,8 @@ pub fn compress_or_decompress_lamports<
 ) -> Result<()> {
     if inputs.is_compress {
         compress_lamports(inputs, ctx)
-    } else if inputs.compress_or_decompress_lamports.is_some() {
-        decompress_lamports(inputs, ctx)
     } else {
-        Ok(())
+        decompress_lamports(inputs, ctx)
     }
 }
 
@@ -61,9 +59,7 @@ pub fn decompress_lamports<
         None => return err!(SystemProgramError::DeCompressLamportsUndefinedForDecompressSol),
     };
 
-    transfer_lamports(&sol_pool_pda, &recipient, lamports)?;
-
-    Ok(())
+    transfer_lamports(&sol_pool_pda, &recipient, lamports)
 }
 
 pub fn compress_lamports<

--- a/programs/system/src/invoke/verify_signer.rs
+++ b/programs/system/src/invoke/verify_signer.rs
@@ -17,7 +17,6 @@ pub fn input_compressed_accounts_signer_check(
         .try_for_each(
             |compressed_account_with_context: &PackedCompressedAccountWithMerkleContext| {
                 if compressed_account_with_context.compressed_account.owner == *authority {
-                    println!("ok");
                     Ok(())
                 } else {
                     msg!(

--- a/programs/system/src/invoke/verify_signer.rs
+++ b/programs/system/src/invoke/verify_signer.rs
@@ -6,27 +6,26 @@ use anchor_lang::{
 
 use crate::{
     errors::SystemProgramError, sdk::compressed_account::PackedCompressedAccountWithMerkleContext,
-    InstructionDataInvoke,
 };
 
 pub fn input_compressed_accounts_signer_check(
-    inputs: &InstructionDataInvoke,
+    input_compressed_accounts_with_merkle_context: &[PackedCompressedAccountWithMerkleContext],
     authority: &Pubkey,
 ) -> Result<()> {
-    inputs
-        .input_compressed_accounts_with_merkle_context
+    input_compressed_accounts_with_merkle_context
         .iter()
         .try_for_each(
             |compressed_account_with_context: &PackedCompressedAccountWithMerkleContext| {
-                if compressed_account_with_context.compressed_account.owner != *authority {
+                if compressed_account_with_context.compressed_account.owner == *authority {
+                    println!("ok");
+                    Ok(())
+                } else {
                     msg!(
                         "signer check failed compressed account owner {} != authority {}",
                         compressed_account_with_context.compressed_account.owner,
                         authority
                     );
                     err!(SystemProgramError::SignerCheckFailed)
-                } else {
-                    Ok(())
                 }
             },
         )
@@ -40,7 +39,7 @@ mod test {
     #[test]
     fn test_input_compressed_accounts_signer_check() {
         let authority = Pubkey::new_unique();
-        let mut compressed_account_with_context = PackedCompressedAccountWithMerkleContext {
+        let compressed_account_with_context = PackedCompressedAccountWithMerkleContext {
             compressed_account: CompressedAccount {
                 owner: authority,
                 ..CompressedAccount::default()
@@ -50,26 +49,24 @@ mod test {
 
         assert_eq!(
             input_compressed_accounts_signer_check(
-                &InstructionDataInvoke {
-                    input_compressed_accounts_with_merkle_context: vec![
-                        compressed_account_with_context.clone()
-                    ],
-                    ..InstructionDataInvoke::default()
-                },
+                &vec![compressed_account_with_context.clone()],
                 &authority
             ),
             Ok(())
         );
-
-        compressed_account_with_context.compressed_account.owner = Pubkey::new_unique();
+        let invalid_compressed_account_with_context = PackedCompressedAccountWithMerkleContext {
+            compressed_account: CompressedAccount {
+                owner: Pubkey::new_unique(),
+                ..CompressedAccount::default()
+            },
+            ..PackedCompressedAccountWithMerkleContext::default()
+        };
         assert_eq!(
             input_compressed_accounts_signer_check(
-                &InstructionDataInvoke {
-                    input_compressed_accounts_with_merkle_context: vec![
-                        compressed_account_with_context
-                    ],
-                    ..InstructionDataInvoke::default()
-                },
+                &vec![
+                    compressed_account_with_context,
+                    invalid_compressed_account_with_context
+                ],
                 &authority
             ),
             Err(SystemProgramError::SignerCheckFailed.into())

--- a/programs/system/src/invoke_cpi/process_cpi_context.rs
+++ b/programs/system/src/invoke_cpi/process_cpi_context.rs
@@ -78,6 +78,7 @@ pub fn process_cpi_context<'info>(
                 return err!(SystemProgramError::CpiContextFeePayerMismatch);
             }
             inputs.combine(&cpi_context_account.context);
+            // Reset cpi context account
             cpi_context_account.context = Vec::new();
             cpi_context_account.fee_payer = Pubkey::default();
         }

--- a/programs/system/src/invoke_cpi/verify_signer.rs
+++ b/programs/system/src/invoke_cpi/verify_signer.rs
@@ -42,6 +42,7 @@ pub fn cpi_signer_checks(
 
 /// Cpi signer check, validates that the provided invoking program
 /// is the actual invoking program.
+#[heap_neutral]
 pub fn cpi_signer_check(
     signer_seeds: &[Vec<u8>],
     invoking_program: &Pubkey,
@@ -74,7 +75,6 @@ pub fn input_compressed_accounts_signer_check(
         .iter()
         .try_for_each(
             |compressed_account_with_context: &PackedCompressedAccountWithMerkleContext| {
-                // CHECK 1
                 let invoking_program_id = invoking_program_id.key();
                 if invoking_program_id == compressed_account_with_context.compressed_account.owner {
                     Ok(())
@@ -96,7 +96,6 @@ pub fn input_compressed_accounts_signer_check(
 /// invoking_program.
 /// - outputs without data can be owned by any pubkey.
 #[inline(never)]
-#[heap_neutral]
 pub fn output_compressed_accounts_write_access_check(
     output_compressed_accounts: &[OutputCompressedAccountWithPackedContext],
     invoking_program_id: &Pubkey,

--- a/programs/system/src/lib.rs
+++ b/programs/system/src/lib.rs
@@ -33,15 +33,12 @@ pub mod light_system_program {
     };
     use super::*;
 
-    pub fn init_cpi_context_account(_ctx: Context<InitializeCpiContextAccount>) -> Result<()> {
-        use account_compression::state_merkle_tree_from_bytes_zero_copy_mut;
-
-        let merkle_tree_account = _ctx.accounts.associated_merkle_tree.to_account_info();
-        let mut data = merkle_tree_account.try_borrow_mut_data()?;
-        state_merkle_tree_from_bytes_zero_copy_mut(&mut data)?;
-        _ctx.accounts
+    pub fn init_cpi_context_account(ctx: Context<InitializeCpiContextAccount>) -> Result<()> {
+        // Check that Merkle tree is initialized.
+        ctx.accounts.associated_merkle_tree.load()?;
+        ctx.accounts
             .cpi_context_account
-            .init(_ctx.accounts.associated_merkle_tree.key());
+            .init(ctx.accounts.associated_merkle_tree.key());
         Ok(())
     }
 
@@ -52,7 +49,10 @@ pub mod light_system_program {
         let inputs: InstructionDataInvoke =
             InstructionDataInvoke::deserialize(&mut inputs.as_slice())?;
 
-        input_compressed_accounts_signer_check(&inputs, &ctx.accounts.authority.key())?;
+        input_compressed_accounts_signer_check(
+            &inputs.input_compressed_accounts_with_merkle_context,
+            &ctx.accounts.authority.key(),
+        )?;
         process(inputs, None, ctx, 0)
     }
 

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -346,8 +346,11 @@ async fn test_address_queue_and_tree_invalid_config() {
             queue_size,
         )
         .await;
+        println!("Invalid result: {}", result.as_ref().unwrap_err());
         assert_rpc_error(
-            result, 2, 6021, // AccountCompressionErrorCode::UnsupportedHeight
+            result,
+            2,
+            AccountCompressionErrorCode::UnsupportedHeight.into(),
         )
         .unwrap();
     }
@@ -366,7 +369,9 @@ async fn test_address_queue_and_tree_invalid_config() {
         )
         .await;
         assert_rpc_error(
-            result, 2, 6021, // AccountCompressionErrorCode::UnsupportedHeight
+            result,
+            2,
+            AccountCompressionErrorCode::UnsupportedHeight.into(),
         )
         .unwrap();
     }
@@ -385,7 +390,9 @@ async fn test_address_queue_and_tree_invalid_config() {
         )
         .await;
         assert_rpc_error(
-            result, 2, 6022, // AccountCompressionErrorCode::UnsupportedCanopyDepth
+            result,
+            2,
+            AccountCompressionErrorCode::UnsupportedCanopyDepth.into(),
         )
         .unwrap();
     }
@@ -404,7 +411,9 @@ async fn test_address_queue_and_tree_invalid_config() {
         )
         .await;
         assert_rpc_error(
-            result, 2, 6024, // AccountCompressionErrorCode::UnsupportedCloseThreshold
+            result,
+            2,
+            AccountCompressionErrorCode::UnsupportedCloseThreshold.into(),
         )
         .unwrap();
     }
@@ -425,7 +434,9 @@ async fn test_address_queue_and_tree_invalid_config() {
         )
         .await;
         assert_rpc_error(
-            result, 2, 6023, // AccountCompressionErrorCode::InvalidSequenceThreshold
+            result,
+            2,
+            AccountCompressionErrorCode::InvalidSequenceThreshold.into(),
         )
         .unwrap();
     }

--- a/test-programs/account-compression-test/tests/merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/merkle_tree_tests.rs
@@ -1647,7 +1647,9 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_confi
         )
         .await;
         assert_rpc_error(
-            result, 2, 6021, // AccountCompressionErrorCode::UnsupportedHeight
+            result,
+            2,
+            AccountCompressionErrorCode::UnsupportedHeight.into(),
         )
         .unwrap();
     }
@@ -1666,7 +1668,9 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_confi
         )
         .await;
         assert_rpc_error(
-            result, 2, 6021, // AccountCompressionErrorCode::UnsupportedHeight
+            result,
+            2,
+            AccountCompressionErrorCode::UnsupportedHeight.into(),
         )
         .unwrap();
     }
@@ -1685,7 +1689,9 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_confi
         )
         .await;
         assert_rpc_error(
-            result, 2, 6022, // AccountCompressionErrorCode::UnsupportedCanopyDepth
+            result,
+            2,
+            AccountCompressionErrorCode::UnsupportedCanopyDepth.into(),
         )
         .unwrap();
     }
@@ -1704,7 +1710,9 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_confi
         )
         .await;
         assert_rpc_error(
-            result, 2, 6024, // AccountCompressionErrorCode::UnsupportedCloseThreshold
+            result,
+            2,
+            AccountCompressionErrorCode::UnsupportedCloseThreshold.into(),
         )
         .unwrap();
     }
@@ -1725,7 +1733,9 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_confi
         )
         .await;
         assert_rpc_error(
-            result, 2, 6023, // AccountCompressionErrorCode::InvalidSequenceThreshold
+            result,
+            2,
+            AccountCompressionErrorCode::InvalidSequenceThreshold.into(),
         )
         .unwrap();
     }

--- a/test-programs/account-compression-test/tests/merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/merkle_tree_tests.rs
@@ -1865,7 +1865,6 @@ pub async fn functional_3_append_leaves_to_merkle_tree<R: RpcConnection>(
             .0
             .push(leaf.clone());
     }
-    println!("leaves len {}", leaves.len());
     let instruction = [create_insert_leaves_instruction(
         leaves.clone(),
         context.get_payer().pubkey(),

--- a/test-programs/account-compression-test/tests/merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/merkle_tree_tests.rs
@@ -973,7 +973,7 @@ async fn test_append_functional_and_failing(
     .unwrap();
 
     // CHECK: 4 append leaves to merkle tree
-    let leaves = (0u8..=140)
+    let leaves = (0u8..=139)
         .map(|i| {
             (
                 0,
@@ -1865,7 +1865,7 @@ pub async fn functional_3_append_leaves_to_merkle_tree<R: RpcConnection>(
             .0
             .push(leaf.clone());
     }
-
+    println!("leaves len {}", leaves.len());
     let instruction = [create_insert_leaves_instruction(
         leaves.clone(),
         context.get_payer().pubkey(),

--- a/test-utils/src/test_forester.rs
+++ b/test-utils/src/test_forester.rs
@@ -454,7 +454,7 @@ pub async fn empty_address_queue_test<const INDEXED_ARRAY_SIZE: usize, R: RpcCon
                     .unwrap()
                     .sequence_number()
                     .unwrap(),
-                old_sequence_number + address_queue.sequence_threshold
+                old_sequence_number + address_queue.sequence_threshold + 2 // We are doing two Merkle tree operations
             );
 
             relayer_merkle_tree


### PR DESCRIPTION
Changes:
- removed unused errors
- nullify leaves rename `indices` -> `leaf_indices`
- register program replace address constraint with constraint with same functionality because anchor 0.30. idl generation doesn't like address constraints
- update_address_merkle_tree - add comments, move address indexed element down, replace sequence_number with `merkle_tree.sequence_number` after it has been incremented
- append_state refactor index_merkle_tree_account to start at zero and be incremented with every iteration
- invoke/processor.rs - rename `roots` to `input_compressed_account_roots`
- invoke/processor.rs - remove deduplication of sequence numbers, its not needed anymore since we enforce ordered output Merkle trees
- rename `fetch_roots` -> `fetch_input_compressed_account_roots`
- `hash_input_compressed_accounts` -> enforce input ordering because we allow Merkle trees to be inserted into hashed_pubkeys without checking whether these exist already
-  merkle tree append performance has regressed by 1 from 141 to 140 for unknown reasons (no changes in append_leaves in account compression program)