### PR TITLE
fix: Handle invalid (zero) capacity of changelog and roots reliably

### DIFF
--- a/merkle-tree/concurrent/src/copy.rs
+++ b/merkle-tree/concurrent/src/copy.rs
@@ -92,6 +92,7 @@ where
 
     pub fn from_bytes_copy(bytes: &[u8]) -> Result<Self, ConcurrentMerkleTreeError> {
         let (merkle_tree, _) = Self::struct_from_bytes_copy(bytes)?;
+        merkle_tree.check_size_constraints()?;
         Ok(Self(merkle_tree))
     }
 }

--- a/merkle-tree/concurrent/src/errors.rs
+++ b/merkle-tree/concurrent/src/errors.rs
@@ -8,10 +8,14 @@ pub enum ConcurrentMerkleTreeError {
     IntegerOverflow,
     #[error("Invalid height, it has to be greater than 0")]
     HeightZero,
+    #[error("Invalud height, expected {0}")]
+    InvalidHeight(usize),
     #[error("Invalid changelog size, it has to be greater than 0. Changelog is used for storing Merkle paths during appends.")]
     ChangelogZero,
     #[error("Invalid number of roots, it has to be greater than 0")]
     RootsZero,
+    #[error("Canopy depth has to be lower than height")]
+    CanopyGeThanHeight,
     #[error("Merkle tree is full, cannot append more leaves.")]
     TreeFull,
     #[error("Number of leaves ({0}) exceeds the changelog capacity ({1}).")]
@@ -42,16 +46,18 @@ impl From<ConcurrentMerkleTreeError> for u32 {
         match e {
             ConcurrentMerkleTreeError::IntegerOverflow => 10001,
             ConcurrentMerkleTreeError::HeightZero => 10002,
-            ConcurrentMerkleTreeError::ChangelogZero => 10003,
-            ConcurrentMerkleTreeError::RootsZero => 10004,
-            ConcurrentMerkleTreeError::TreeFull => 10005,
-            ConcurrentMerkleTreeError::BatchGreaterThanChangelog(_, _) => 10006,
-            ConcurrentMerkleTreeError::InvalidProofLength(_, _) => 10007,
-            ConcurrentMerkleTreeError::InvalidProof(_, _) => 10008,
-            ConcurrentMerkleTreeError::CannotUpdateLeaf => 10009,
-            ConcurrentMerkleTreeError::CannotUpdateEmpty => 10010,
-            ConcurrentMerkleTreeError::EmptyLeaves => 10011,
-            ConcurrentMerkleTreeError::BufferSize(_, _) => 10012,
+            ConcurrentMerkleTreeError::InvalidHeight(_) => 10003,
+            ConcurrentMerkleTreeError::ChangelogZero => 10004,
+            ConcurrentMerkleTreeError::RootsZero => 10005,
+            ConcurrentMerkleTreeError::CanopyGeThanHeight => 10006,
+            ConcurrentMerkleTreeError::TreeFull => 10007,
+            ConcurrentMerkleTreeError::BatchGreaterThanChangelog(_, _) => 10008,
+            ConcurrentMerkleTreeError::InvalidProofLength(_, _) => 10009,
+            ConcurrentMerkleTreeError::InvalidProof(_, _) => 10010,
+            ConcurrentMerkleTreeError::CannotUpdateLeaf => 10011,
+            ConcurrentMerkleTreeError::CannotUpdateEmpty => 10012,
+            ConcurrentMerkleTreeError::EmptyLeaves => 10013,
+            ConcurrentMerkleTreeError::BufferSize(_, _) => 10014,
             ConcurrentMerkleTreeError::Hasher(e) => e.into(),
             ConcurrentMerkleTreeError::BoundedVec(e) => e.into(),
         }

--- a/merkle-tree/concurrent/src/lib.rs
+++ b/merkle-tree/concurrent/src/lib.rs
@@ -125,9 +125,16 @@ where
         height: usize,
         changelog_size: usize,
         roots_size: usize,
+        canopy_depth: usize,
     ) -> Result<(), ConcurrentMerkleTreeError> {
         if height == 0 || HEIGHT == 0 {
             return Err(ConcurrentMerkleTreeError::HeightZero);
+        }
+        if height != HEIGHT {
+            return Err(ConcurrentMerkleTreeError::InvalidHeight(HEIGHT));
+        }
+        if canopy_depth > height {
+            return Err(ConcurrentMerkleTreeError::CanopyGeThanHeight);
         }
         // Changelog needs to be at least 1, because it's used for storing
         // Merkle paths in `append`/`append_batch`.
@@ -145,6 +152,7 @@ where
             self.height,
             self.changelog.capacity(),
             self.roots.capacity(),
+            self.canopy_depth,
         )
     }
 
@@ -154,7 +162,7 @@ where
         roots_size: usize,
         canopy_depth: usize,
     ) -> Result<Self, ConcurrentMerkleTreeError> {
-        Self::check_size_constraints_new(height, changelog_size, roots_size)?;
+        Self::check_size_constraints_new(height, changelog_size, roots_size, canopy_depth)?;
 
         let layout = Layout::new::<usize>();
         let next_index = unsafe { alloc::alloc(layout) as *mut usize };

--- a/merkle-tree/concurrent/src/lib.rs
+++ b/merkle-tree/concurrent/src/lib.rs
@@ -121,12 +121,11 @@ where
         + mem::size_of::<[u8; 32]>() * Self::canopy_size(canopy_depth)
     }
 
-    pub fn new(
+    fn check_size_constraints_new(
         height: usize,
         changelog_size: usize,
         roots_size: usize,
-        canopy_depth: usize,
-    ) -> Result<Self, ConcurrentMerkleTreeError> {
+    ) -> Result<(), ConcurrentMerkleTreeError> {
         if height == 0 || HEIGHT == 0 {
             return Err(ConcurrentMerkleTreeError::HeightZero);
         }
@@ -138,6 +137,24 @@ where
         if roots_size == 0 {
             return Err(ConcurrentMerkleTreeError::RootsZero);
         }
+        Ok(())
+    }
+
+    fn check_size_constraints(&self) -> Result<(), ConcurrentMerkleTreeError> {
+        Self::check_size_constraints_new(
+            self.height,
+            self.changelog.capacity(),
+            self.roots.capacity(),
+        )
+    }
+
+    pub fn new(
+        height: usize,
+        changelog_size: usize,
+        roots_size: usize,
+        canopy_depth: usize,
+    ) -> Result<Self, ConcurrentMerkleTreeError> {
+        Self::check_size_constraints_new(height, changelog_size, roots_size)?;
 
         let layout = Layout::new::<usize>();
         let next_index = unsafe { alloc::alloc(layout) as *mut usize };
@@ -179,6 +196,8 @@ where
 
     /// Initializes the Merkle tree.
     pub fn init(&mut self) -> Result<(), ConcurrentMerkleTreeError> {
+        self.check_size_constraints()?;
+
         // Initialize root.
         let root = H::zero_bytes()[self.height];
         self.roots.push(root);

--- a/merkle-tree/concurrent/src/zero_copy.rs
+++ b/merkle-tree/concurrent/src/zero_copy.rs
@@ -100,25 +100,26 @@ where
             )
         };
 
-        Ok((
-            ConcurrentMerkleTree {
-                height,
-                canopy_depth,
-                next_index,
-                sequence_number,
-                rightmost_leaf,
-                filled_subtrees,
-                changelog,
-                roots,
-                canopy,
-                _hasher: PhantomData,
-            },
-            offset,
-        ))
+        let merkle_tree = ConcurrentMerkleTree {
+            height,
+            canopy_depth,
+            next_index,
+            sequence_number,
+            rightmost_leaf,
+            filled_subtrees,
+            changelog,
+            roots,
+            canopy,
+            _hasher: PhantomData,
+        };
+        merkle_tree.check_size_constraints()?;
+
+        Ok((merkle_tree, offset))
     }
 
     pub fn from_bytes_zero_copy(bytes: &'a [u8]) -> Result<Self, ConcurrentMerkleTreeError> {
         let (merkle_tree, _) = Self::struct_from_bytes_zero_copy(bytes)?;
+        merkle_tree.check_size_constraints()?;
 
         Ok(Self {
             merkle_tree: mem::ManuallyDrop::new(merkle_tree),

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -420,7 +420,7 @@ async fn test_address_queue_and_tree_invalid_config() {
         )
         .await;
         assert_rpc_error(
-            result, 3, 10003, // ConcurrentMerkleTree::ChangelogZero
+            result, 2, 10003, // ConcurrentMerkleTree::ChangelogZero
         )
         .unwrap();
     }
@@ -439,7 +439,7 @@ async fn test_address_queue_and_tree_invalid_config() {
         )
         .await;
         assert_rpc_error(
-            result, 3, 10004, // ConcurrentMerkleTree::RootsSize
+            result, 2, 10004, // ConcurrentMerkleTree::RootsSize
         )
         .unwrap();
     }

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -975,36 +975,6 @@ async fn update_address_merkle_tree_failing_tests_default() {
     .await
 }
 
-#[tokio::test]
-async fn update_address_merkle_tree_failing_tests_custom() {
-    for changelog_size in (1..=5000).step_by(1000) {
-        for roots_size in (changelog_size..=5000).step_by(1000) {
-            for queue_capacity in [5003, 6857, 7901] {
-                for address_changelog_size in (250..1000).step_by(250) {
-                    update_address_merkle_tree_failing_tests(
-                        &AddressMerkleTreeConfig {
-                            height: ADDRESS_MERKLE_TREE_HEIGHT as u32,
-                            changelog_size,
-                            roots_size,
-                            canopy_depth: ADDRESS_MERKLE_TREE_CANOPY_DEPTH,
-                            address_changelog_size,
-                            network_fee: Some(5000),
-                            rollover_threshold: Some(95),
-                            close_threshold: None,
-                        },
-                        &AddressQueueConfig {
-                            capacity: queue_capacity,
-                            sequence_threshold: roots_size + SAFETY_MARGIN,
-                            network_fee: None,
-                        },
-                    )
-                    .await;
-                }
-            }
-        }
-    }
-}
-
 async fn update_address_merkle_tree_wrap_around(
     merkle_tree_config: &AddressMerkleTreeConfig,
     queue_config: &AddressQueueConfig,
@@ -1362,7 +1332,7 @@ async fn test_address_merkle_tree_and_queue_rollover_custom() {
                             canopy_depth: ADDRESS_MERKLE_TREE_CANOPY_DEPTH,
                             address_changelog_size,
                             network_fee: Some(5000),
-                            rollover_threshold: Some(95),
+                            rollover_threshold: Some(0),
                             close_threshold: None,
                         },
                         &AddressQueueConfig {

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -11,6 +11,8 @@ use account_compression::{
 use anchor_lang::error::ErrorCode;
 use ark_bn254::Fr;
 use ark_ff::{BigInteger, PrimeField, UniformRand};
+use light_bounded_vec::BoundedVecError;
+use light_concurrent_merkle_tree::errors::ConcurrentMerkleTreeError;
 use light_hash_set::{HashSet, HashSetError};
 use light_hasher::Poseidon;
 use light_indexed_merkle_tree::{array::IndexedArray, errors::IndexedMerkleTreeError, reference};
@@ -259,7 +261,9 @@ async fn test_address_queue_and_tree_invalid_sizes() {
             )
             .await;
             assert_rpc_error(
-                result, 2, 9006, // HashSetError::BufferSize
+                result,
+                2,
+                HashSetError::BufferSize(valid_queue_size, queue_size).into(),
             )
             .unwrap()
         }
@@ -281,7 +285,9 @@ async fn test_address_queue_and_tree_invalid_sizes() {
         )
         .await;
         assert_rpc_error(
-            result, 2, 10012, // ConcurrentMerkleTreeError::BufferSize
+            result,
+            2,
+            ConcurrentMerkleTreeError::BufferSize(valid_tree_size, tree_size).into(),
         )
         .unwrap()
     }
@@ -302,7 +308,9 @@ async fn test_address_queue_and_tree_invalid_sizes() {
         )
         .await;
         assert_rpc_error(
-            result, 2, 9006, // HashSetError::BufferSize
+            result,
+            2,
+            HashSetError::BufferSize(valid_queue_size, queue_size).into(),
         )
         .unwrap()
     }
@@ -422,10 +430,7 @@ async fn test_address_queue_and_tree_invalid_config() {
             queue_size,
         )
         .await;
-        assert_rpc_error(
-            result, 2, 10003, // ConcurrentMerkleTree::ChangelogZero
-        )
-        .unwrap();
+        assert_rpc_error(result, 2, ConcurrentMerkleTreeError::ChangelogZero.into()).unwrap();
     }
     {
         let mut merkle_tree_config = merkle_tree_config.clone();
@@ -441,10 +446,7 @@ async fn test_address_queue_and_tree_invalid_config() {
             queue_size,
         )
         .await;
-        assert_rpc_error(
-            result, 2, 10004, // ConcurrentMerkleTree::RootsSize
-        )
-        .unwrap();
+        assert_rpc_error(result, 2, ConcurrentMerkleTreeError::RootsZero.into()).unwrap();
     }
     for invalid_close_threshold in (0..100).step_by(20) {
         let mut merkle_tree_config = merkle_tree_config.clone();
@@ -680,7 +682,7 @@ async fn update_address_merkle_tree_failing_tests(
     assert_rpc_error(
         error_invalid_low_element_index,
         0,
-        10008, // ConcurrentMerkleTreeError::InvalidProof
+        ConcurrentMerkleTreeError::InvalidProof([0; 32], [0; 32]).into(),
     )
     .unwrap();
 
@@ -705,7 +707,7 @@ async fn update_address_merkle_tree_failing_tests(
     assert_rpc_error(
         error_invalid_low_element_value,
         0,
-        10008, // ConcurrentMerkleTreeError::InvalidProof
+        ConcurrentMerkleTreeError::InvalidProof([0; 32], [0; 32]).into(),
     )
     .unwrap();
 
@@ -730,7 +732,7 @@ async fn update_address_merkle_tree_failing_tests(
     assert_rpc_error(
         error_invalid_low_element_next_index,
         0,
-        10008, // ConcurrentMerkleTreeError::InvalidProof
+        ConcurrentMerkleTreeError::InvalidProof([0; 32], [0; 32]).into(),
     )
     .unwrap();
 
@@ -755,7 +757,7 @@ async fn update_address_merkle_tree_failing_tests(
     assert_rpc_error(
         error_invalid_low_element_next_value,
         0,
-        10008, // ConcurrentMerkleTreeError::InvalidProof
+        ConcurrentMerkleTreeError::InvalidProof([0; 32], [0; 32]).into(),
     )
     .unwrap();
 
@@ -781,7 +783,7 @@ async fn update_address_merkle_tree_failing_tests(
     assert_rpc_error(
         error_invalid_low_element_proof,
         0,
-        10008, // ConcurrentMerkleTreeError::InvalidProof
+        ConcurrentMerkleTreeError::InvalidProof([0; 32], [0; 32]).into(),
     )
     .unwrap();
     let address_merkle_tree = get_indexed_merkle_tree::<
@@ -818,7 +820,7 @@ async fn update_address_merkle_tree_failing_tests(
         assert_rpc_error(
             error_invalid_changelog_index_low,
             0,
-            10009, // ConcurrentMerkleTreeError::InvalidProof
+            ConcurrentMerkleTreeError::CannotUpdateLeaf.into(),
         )
         .unwrap();
 
@@ -843,7 +845,7 @@ async fn update_address_merkle_tree_failing_tests(
         assert_rpc_error(
             error_invalid_changelog_index_high,
             0,
-            8003, // BoundedVecError::IterFromOutOfBounds
+            BoundedVecError::IterFromOutOfBounds.into(),
         )
         .unwrap();
     }
@@ -872,7 +874,7 @@ async fn update_address_merkle_tree_failing_tests(
         assert_rpc_error(
             error_invalid_indexed_changelog_index_high,
             0,
-            8003, // BoundedVecError::IterFromOutOfBounds
+            BoundedVecError::IterFromOutOfBounds.into(),
         )
         .unwrap();
     }
@@ -1064,7 +1066,9 @@ async fn update_address_merkle_tree_wrap_around(
     )
     .await;
     assert_rpc_error(
-        error, 0, 10008, // ConcurrentMerkleTreeError::InvalidProof
+        error,
+        0,
+        ConcurrentMerkleTreeError::InvalidProof([0; 32], [0; 32]).into(),
     )
     .unwrap();
 }

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -122,8 +122,11 @@ async fn test_address_queue_and_tree_functional_default() {
 
 #[tokio::test]
 async fn test_address_queue_and_tree_functional_custom() {
-    for changelog_size in (1..=5000).step_by(1000) {
-        for roots_size in (changelog_size..=5000).step_by(1000) {
+    for changelog_size in [1, 1000, 2000] {
+        for roots_size in [1, 1000, 2000] {
+            if roots_size < changelog_size {
+                continue;
+            }
             for queue_capacity in [5003, 6857, 7901] {
                 for address_changelog_size in (250..1000).step_by(250) {
                     address_queue_and_tree_functional(
@@ -1320,8 +1323,11 @@ async fn test_address_merkle_tree_and_queue_rollover_default() {
 
 #[tokio::test]
 async fn test_address_merkle_tree_and_queue_rollover_custom() {
-    for changelog_size in (1..=5000).step_by(1000) {
-        for roots_size in (changelog_size..=5000).step_by(1000) {
+    for changelog_size in [1, 1000, 2000] {
+        for roots_size in [1, 1000, 2000] {
+            if roots_size < changelog_size {
+                continue;
+            }
             for queue_capacity in [5003, 6857, 7901] {
                 for address_changelog_size in (250..1000).step_by(250) {
                     address_merkle_tree_and_queue_rollover(

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -1332,7 +1332,7 @@ async fn test_address_merkle_tree_and_queue_rollover_custom() {
                             canopy_depth: ADDRESS_MERKLE_TREE_CANOPY_DEPTH,
                             address_changelog_size,
                             network_fee: Some(5000),
-                            rollover_threshold: Some(0),
+                            rollover_threshold: Some(95),
                             close_threshold: None,
                         },
                         &AddressQueueConfig {

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -793,82 +793,86 @@ async fn update_address_merkle_tree_failing_tests(
 
     let changelog_index = address_merkle_tree.changelog_index();
 
-    // CHECK: 9 invalid changelog index (lower)
-    let invalid_changelog_index_low = changelog_index - 2;
-    let error_invalid_changelog_index_low = update_merkle_tree(
-        &mut context,
-        &payer,
-        address_queue_pubkey,
-        address_merkle_tree_pubkey,
-        value_index,
-        low_element.index as u64,
-        bigint_to_be_bytes_array(&low_element.value).unwrap(),
-        low_element.next_index as u64,
-        bigint_to_be_bytes_array(&low_element_next_value).unwrap(),
-        low_element_proof.to_array().unwrap(),
-        Some(invalid_changelog_index_low as u16),
-        None,
-        true,
-    )
-    .await;
-    assert_rpc_error(
-        error_invalid_changelog_index_low,
-        0,
-        10009, // ConcurrentMerkleTreeError::InvalidProof
-    )
-    .unwrap();
+    if merkle_tree_config.changelog_size >= 2 {
+        // CHECK: 9 invalid changelog index (lower)
+        let invalid_changelog_index_low = changelog_index - 2;
+        let error_invalid_changelog_index_low = update_merkle_tree(
+            &mut context,
+            &payer,
+            address_queue_pubkey,
+            address_merkle_tree_pubkey,
+            value_index,
+            low_element.index as u64,
+            bigint_to_be_bytes_array(&low_element.value).unwrap(),
+            low_element.next_index as u64,
+            bigint_to_be_bytes_array(&low_element_next_value).unwrap(),
+            low_element_proof.to_array().unwrap(),
+            Some(invalid_changelog_index_low as u16),
+            None,
+            true,
+        )
+        .await;
+        assert_rpc_error(
+            error_invalid_changelog_index_low,
+            0,
+            10009, // ConcurrentMerkleTreeError::InvalidProof
+        )
+        .unwrap();
 
-    // CHECK: 10 invalid changelog index (higher)
-    let invalid_changelog_index_high = changelog_index + 2;
-    let error_invalid_changelog_index_high = update_merkle_tree(
-        &mut context,
-        &payer,
-        address_queue_pubkey,
-        address_merkle_tree_pubkey,
-        value_index,
-        low_element.index as u64,
-        bigint_to_be_bytes_array(&low_element.value).unwrap(),
-        low_element.next_index as u64,
-        bigint_to_be_bytes_array(&low_element_next_value).unwrap(),
-        low_element_proof.to_array().unwrap(),
-        Some(invalid_changelog_index_high as u16),
-        None,
-        true,
-    )
-    .await;
-    assert_rpc_error(
-        error_invalid_changelog_index_high,
-        0,
-        8003, // BoundedVecError::IterFromOutOfBounds
-    )
-    .unwrap();
+        // CHECK: 10 invalid changelog index (higher)
+        let invalid_changelog_index_high = changelog_index + 2;
+        let error_invalid_changelog_index_high = update_merkle_tree(
+            &mut context,
+            &payer,
+            address_queue_pubkey,
+            address_merkle_tree_pubkey,
+            value_index,
+            low_element.index as u64,
+            bigint_to_be_bytes_array(&low_element.value).unwrap(),
+            low_element.next_index as u64,
+            bigint_to_be_bytes_array(&low_element_next_value).unwrap(),
+            low_element_proof.to_array().unwrap(),
+            Some(invalid_changelog_index_high as u16),
+            None,
+            true,
+        )
+        .await;
+        assert_rpc_error(
+            error_invalid_changelog_index_high,
+            0,
+            8003, // BoundedVecError::IterFromOutOfBounds
+        )
+        .unwrap();
+    }
 
     let indexed_changelog_index = address_merkle_tree.indexed_changelog_index();
 
-    // CHECK: 11 invalid indexed changelog index (higher)
-    let invalid_indexed_changelog_index_high = indexed_changelog_index + 1;
-    let error_invalid_indexed_changelog_index_high = update_merkle_tree(
-        &mut context,
-        &payer,
-        address_queue_pubkey,
-        address_merkle_tree_pubkey,
-        value_index,
-        low_element.index as u64,
-        bigint_to_be_bytes_array(&low_element.value).unwrap(),
-        low_element.next_index as u64,
-        bigint_to_be_bytes_array(&low_element_next_value).unwrap(),
-        low_element_proof.to_array().unwrap(),
-        None,
-        Some(invalid_indexed_changelog_index_high as u16),
-        true,
-    )
-    .await;
-    assert_rpc_error(
-        error_invalid_indexed_changelog_index_high,
-        0,
-        8003, // BoundedVecError::IterFromOutOfBounds
-    )
-    .unwrap();
+    if merkle_tree_config.address_changelog_size >= 2 {
+        // CHECK: 11 invalid indexed changelog index (higher)
+        let invalid_indexed_changelog_index_high = indexed_changelog_index + 1;
+        let error_invalid_indexed_changelog_index_high = update_merkle_tree(
+            &mut context,
+            &payer,
+            address_queue_pubkey,
+            address_merkle_tree_pubkey,
+            value_index,
+            low_element.index as u64,
+            bigint_to_be_bytes_array(&low_element.value).unwrap(),
+            low_element.next_index as u64,
+            bigint_to_be_bytes_array(&low_element_next_value).unwrap(),
+            low_element_proof.to_array().unwrap(),
+            None,
+            Some(invalid_indexed_changelog_index_high as u16),
+            true,
+        )
+        .await;
+        assert_rpc_error(
+            error_invalid_indexed_changelog_index_high,
+            0,
+            8003, // BoundedVecError::IterFromOutOfBounds
+        )
+        .unwrap();
+    }
 
     // CHECK: 12 invalid queue account
     let invalid_queue = address_merkle_tree_pubkey;

--- a/test-programs/account-compression-test/tests/merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/merkle_tree_tests.rs
@@ -1135,7 +1135,9 @@ async fn test_nullify_leaves(
     )
     .await;
     assert_rpc_error(
-        result, 0, 10008, // Invalid proof
+        result,
+        0,
+        ConcurrentMerkleTreeError::InvalidProof([0; 32], [0; 32]).into(),
     )
     .unwrap();
 
@@ -1507,7 +1509,9 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_sizes
             )
             .await;
             assert_rpc_error(
-                result, 2, 10012, // ConcurrentMerkleTreeError::BufferSize
+                result,
+                2,
+                ConcurrentMerkleTreeError::BufferSize(valid_tree_size, invalid_tree_size).into(),
             )
             .unwrap();
         }
@@ -1618,10 +1622,7 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_confi
             queue_size,
         )
         .await;
-        assert_rpc_error(
-            result, 2, 10003, // ConcurrentMerkleTree::ChangelogZero
-        )
-        .unwrap();
+        assert_rpc_error(result, 2, ConcurrentMerkleTreeError::ChangelogZero.into()).unwrap();
     }
     {
         let mut merkle_tree_config = merkle_tree_config.clone();
@@ -1637,10 +1638,7 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_confi
             queue_size,
         )
         .await;
-        assert_rpc_error(
-            result, 2, 10004, // ConcurrentMerkleTree::RootsSize
-        )
-        .unwrap();
+        assert_rpc_error(result, 2, ConcurrentMerkleTreeError::RootsZero.into()).unwrap();
     }
     for invalid_close_threshold in (0..100).step_by(20) {
         let mut merkle_tree_config = merkle_tree_config.clone();

--- a/test-programs/account-compression-test/tests/merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/merkle_tree_tests.rs
@@ -192,8 +192,11 @@ async fn test_init_and_insert_into_nullifier_queue_default() {
 
 #[tokio::test]
 async fn test_init_and_insert_into_nullifier_queue_custom() {
-    for changelog_size in (1..=5000).step_by(1000) {
-        for roots_size in (changelog_size..=5000).step_by(1000) {
+    for changelog_size in [1, 1000, 2000] {
+        for roots_size in [1, 1000, 2000] {
+            if roots_size < changelog_size {
+                continue;
+            }
             for queue_capacity in [5003, 6857, 7901] {
                 test_init_and_insert_into_nullifier_queue(
                     &StateMerkleTreeConfig {
@@ -831,26 +834,30 @@ async fn test_init_and_rollover_state_merkle_tree_default() {
 
 #[tokio::test]
 async fn test_init_and_rollover_state_merkle_tree_custom() {
-    for changelog_size in (1000..5000).step_by(1000) {
-        for queue_capacity in [5003, 6857, 7901] {
-            let roots_size = changelog_size * 2;
-            test_init_and_rollover_state_merkle_tree(
-                &StateMerkleTreeConfig {
-                    height: STATE_MERKLE_TREE_HEIGHT as u32,
-                    changelog_size,
-                    roots_size,
-                    canopy_depth: STATE_MERKLE_TREE_CANOPY_DEPTH,
-                    network_fee: Some(5000),
-                    rollover_threshold: Some(95),
-                    close_threshold: None,
-                },
-                &NullifierQueueConfig {
-                    capacity: queue_capacity,
-                    sequence_threshold: roots_size + SAFETY_MARGIN,
-                    network_fee: None,
-                },
-            )
-            .await;
+    for changelog_size in [1, 1000, 2000] {
+        for roots_size in [1, 1000, 2000] {
+            if roots_size < changelog_size {
+                continue;
+            }
+            for queue_capacity in [5003, 6857, 7901] {
+                test_init_and_rollover_state_merkle_tree(
+                    &StateMerkleTreeConfig {
+                        height: STATE_MERKLE_TREE_HEIGHT as u32,
+                        changelog_size,
+                        roots_size,
+                        canopy_depth: STATE_MERKLE_TREE_CANOPY_DEPTH,
+                        network_fee: Some(5000),
+                        rollover_threshold: Some(95),
+                        close_threshold: None,
+                    },
+                    &NullifierQueueConfig {
+                        capacity: queue_capacity,
+                        sequence_threshold: roots_size + SAFETY_MARGIN,
+                        network_fee: None,
+                    },
+                )
+                .await;
+            }
         }
     }
 }

--- a/test-programs/account-compression-test/tests/merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/merkle_tree_tests.rs
@@ -412,32 +412,6 @@ async fn test_full_nullifier_queue_default() {
     .await
 }
 
-#[tokio::test]
-async fn test_full_nullifier_queue_custom() {
-    for changelog_size in (1000..5000).step_by(1000) {
-        for queue_capacity in [5003, 6857, 7901] {
-            let roots_size = changelog_size * 2;
-            test_full_nullifier_queue(
-                &StateMerkleTreeConfig {
-                    height: STATE_MERKLE_TREE_HEIGHT as u32,
-                    changelog_size,
-                    roots_size,
-                    canopy_depth: STATE_MERKLE_TREE_CANOPY_DEPTH,
-                    network_fee: Some(5000),
-                    rollover_threshold: Some(95),
-                    close_threshold: None,
-                },
-                &NullifierQueueConfig {
-                    capacity: queue_capacity,
-                    sequence_threshold: roots_size + SAFETY_MARGIN,
-                    network_fee: None,
-                },
-            )
-            .await;
-        }
-    }
-}
-
 /// Insert nullifiers failing tests
 /// Test:
 /// 1. no nullifiers
@@ -625,32 +599,6 @@ async fn test_failing_queue_default() {
         &NullifierQueueConfig::default(),
     )
     .await
-}
-
-#[tokio::test]
-async fn test_failing_queue_custom() {
-    for changelog_size in (1000..5000).step_by(1000) {
-        for queue_capacity in [5003, 6857, 7901] {
-            let roots_size = changelog_size * 2;
-            failing_queue(
-                &StateMerkleTreeConfig {
-                    height: STATE_MERKLE_TREE_HEIGHT as u32,
-                    changelog_size,
-                    roots_size,
-                    canopy_depth: STATE_MERKLE_TREE_CANOPY_DEPTH,
-                    network_fee: Some(5000),
-                    rollover_threshold: Some(95),
-                    close_threshold: None,
-                },
-                &NullifierQueueConfig {
-                    capacity: queue_capacity,
-                    sequence_threshold: roots_size + SAFETY_MARGIN,
-                    network_fee: None,
-                },
-            )
-            .await;
-        }
-    }
 }
 
 /// Tests:
@@ -1034,32 +982,6 @@ async fn test_append_functional_and_failing_default() {
     .await
 }
 
-#[tokio::test]
-async fn test_append_functional_and_failing_custom() {
-    for changelog_size in (1000..5000).step_by(1000) {
-        for queue_capacity in [5003, 6857, 7901] {
-            let roots_size = changelog_size * 2;
-            test_append_functional_and_failing(
-                &StateMerkleTreeConfig {
-                    height: STATE_MERKLE_TREE_HEIGHT as u32,
-                    changelog_size,
-                    roots_size,
-                    canopy_depth: STATE_MERKLE_TREE_CANOPY_DEPTH,
-                    network_fee: Some(5000),
-                    rollover_threshold: Some(95),
-                    close_threshold: None,
-                },
-                &NullifierQueueConfig {
-                    capacity: queue_capacity,
-                    sequence_threshold: roots_size + SAFETY_MARGIN,
-                    network_fee: None,
-                },
-            )
-            .await;
-        }
-    }
-}
-
 /// Tests:
 /// 1. Functional: nullify leaf
 /// 2. Failing: nullify leaf with invalid leaf index
@@ -1292,32 +1214,6 @@ async fn test_nullify_leaves_default() {
         &NullifierQueueConfig::default(),
     )
     .await
-}
-
-#[tokio::test]
-async fn test_nullify_leaves_custom() {
-    for changelog_size in (1000..5000).step_by(1000) {
-        for queue_capacity in [5003, 6857, 7901] {
-            let roots_size = changelog_size * 2;
-            test_nullify_leaves(
-                &StateMerkleTreeConfig {
-                    height: STATE_MERKLE_TREE_HEIGHT as u32,
-                    changelog_size,
-                    roots_size,
-                    canopy_depth: STATE_MERKLE_TREE_CANOPY_DEPTH,
-                    network_fee: Some(5000),
-                    rollover_threshold: Some(95),
-                    close_threshold: None,
-                },
-                &NullifierQueueConfig {
-                    capacity: queue_capacity,
-                    sequence_threshold: roots_size + SAFETY_MARGIN,
-                    network_fee: None,
-                },
-            )
-            .await;
-        }
-    }
 }
 
 async fn functional_2_test_insert_into_nullifier_queues<R: RpcConnection>(

--- a/test-utils/src/assert_address_merkle_tree.rs
+++ b/test-utils/src/assert_address_merkle_tree.rs
@@ -113,7 +113,7 @@ pub async fn assert_address_merkle_tree_initialized<R: RpcConnection>(
     );
     assert_eq!(merkle_tree.next_index(), expected_next_index);
     assert_eq!(
-        merkle_tree.sequence_number(),
+        merkle_tree.sequence_number() % merkle_tree_config.roots_size as usize,
         expected_roots_length.saturating_sub(1)
     );
     assert_eq!(&merkle_tree.rightmost_leaf(), expected_rightmost_leaf);

--- a/test-utils/src/test_env.rs
+++ b/test-utils/src/test_env.rs
@@ -1,3 +1,5 @@
+use std::cmp;
+
 use crate::assert_address_merkle_tree::assert_address_merkle_tree_initialized;
 use crate::assert_queue::assert_address_queue_initialized;
 use crate::create_account_instruction;
@@ -521,9 +523,11 @@ pub async fn create_address_merkle_tree_and_queue_account<R: RpcConnection>(
     // we appended two values this the expected next index is 2;
     // The right most leaf is the hash of the indexed array element with value FIELD_SIZE - 1
     // index 1, next_index: 0
-    let expected_change_log_length = 4;
-    let expected_roots_length = 4;
+    let expected_change_log_length = cmp::min(4, merkle_tree_config.changelog_size as usize);
+    let expected_roots_length = cmp::min(4, merkle_tree_config.roots_size as usize);
     let expected_next_index = 2;
+    let expected_indexed_change_log_length =
+        cmp::min(4, merkle_tree_config.address_changelog_size as usize);
     let mut reference_tree =
         light_indexed_merkle_tree::reference::IndexedMerkleTree::<Poseidon, usize>::new(
             account_compression::utils::constants::ADDRESS_MERKLE_TREE_HEIGHT as usize,
@@ -561,8 +565,8 @@ pub async fn create_address_merkle_tree_and_queue_account<R: RpcConnection>(
         expected_roots_length,
         expected_next_index,
         &expected_right_most_leaf,
-        &owner,
-        expected_change_log_length,
+        owner,
+        expected_indexed_change_log_length,
     )
     .await;
 

--- a/test-utils/src/test_env.rs
+++ b/test-utils/src/test_env.rs
@@ -565,7 +565,7 @@ pub async fn create_address_merkle_tree_and_queue_account<R: RpcConnection>(
         expected_roots_length,
         expected_next_index,
         &expected_right_most_leaf,
-        owner,
+        &owner,
         expected_indexed_change_log_length,
     )
     .await;


### PR DESCRIPTION
* Validate changelog and roots size not only in `new()` method, but also in `init()` and all wrapper types (zero-copy and copy).
* Add SBF tests which initialize trees with zero capacities and expect an error.
* Add SBF tests with changelog and root capacity 1. They are expected to succeed.