### PR TITLE
fix: Update canopy after Merkle tree updates

### DIFF
--- a/merkle-tree/concurrent/src/lib.rs
+++ b/merkle-tree/concurrent/src/lib.rs
@@ -413,6 +413,10 @@ where
         }
         self.changelog.push(changelog_entry);
 
+        if self.canopy_depth > 0 {
+            self.update_canopy(self.changelog.last_index(), 1);
+        }
+
         Ok((self.changelog.last_index(), self.sequence_number()))
     }
 

--- a/merkle-tree/reference/src/lib.rs
+++ b/merkle-tree/reference/src/lib.rs
@@ -50,6 +50,11 @@ where
         }
     }
 
+    /// Number of nodes to include in canopy, based on `canopy_depth`.
+    pub fn canopy_size(&self) -> usize {
+        (1 << (self.canopy_depth + 1)) - 2
+    }
+
     fn update_upper_layers(&mut self, mut i: usize) -> Result<(), HasherError> {
         for level in 1..self.height {
             i /= 2;
@@ -183,6 +188,28 @@ where
         }
 
         Ok(proof)
+    }
+
+    pub fn get_canopy(&self) -> Result<BoundedVec<[u8; 32]>, BoundedVecError> {
+        if self.canopy_depth == 0 {
+            return Ok(BoundedVec::with_capacity(0));
+        }
+        let mut canopy = BoundedVec::with_capacity(self.canopy_size());
+
+        let mut num_nodes_in_level = 2;
+        for i in 0..self.canopy_depth {
+            let level = self.height - 1 - i;
+            for j in 0..num_nodes_in_level {
+                let node = self.layers[level]
+                    .get(j)
+                    .cloned()
+                    .unwrap_or(H::zero_bytes()[level]);
+                canopy.push(node)?;
+            }
+            num_nodes_in_level *= 2;
+        }
+
+        Ok(canopy)
     }
 
     pub fn leaf(&self, leaf_index: usize) -> [u8; 32] {


### PR DESCRIPTION
Before this change, we were updating canopy only after appends. Now we do it also for updates.

Add unit tests which assert the whole canopy.