### PR TITLE
fix: improved retry logic on address tree foresting

### DIFF
--- a/forester/src/main.rs
+++ b/forester/src/main.rs
@@ -1,21 +1,22 @@
 use clap::Parser;
 use env_logger::Env;
 use forester::cli::{Cli, Commands};
+use forester::indexer::PhotonIndexer;
 use forester::nqmt::reindex_and_store;
 use forester::{
     init_config, init_rpc, nullify_addresses, nullify_state, subscribe_state, ForesterConfig,
 };
-use light_registry::sdk::get_group_pda;
-use light_test_utils::indexer::{AddressMerkleTreeAccounts, StateMerkleTreeAccounts, TestIndexer};
-use light_test_utils::rpc::SolanaRpcConnection;
-use light_test_utils::test_env::{GROUP_PDA_SEED_TEST_KEYPAIR, SIGNATURE_CPI_TEST_KEYPAIR};
 use log::{debug, error};
-use solana_sdk::signature::{Keypair, Signer};
 use std::sync::Arc;
+
+fn setup_logger() {
+    let env = Env::new().filter_or("RUST_LOG", "info,forester=debug");
+    env_logger::Builder::from_env(env).init();
+}
 
 #[tokio::main]
 async fn main() {
-    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+    setup_logger();
     let config: Arc<ForesterConfig> = Arc::new(init_config());
     let cli = Cli::parse();
     match &cli.command {
@@ -24,16 +25,16 @@ async fn main() {
                 "Subscribe to nullify compressed accounts for indexed array: {} and merkle tree: {}",
                 config.nullifier_queue_pubkey, config.state_merkle_tree_pubkey
             );
-            subscribe_state(config.clone()).await;
+            run_subscribe_state(config.clone()).await;
         }
         Some(Commands::NullifyState) => {
-            nullify_state(config).await;
+            run_nullify_state(config).await;
         }
         Some(Commands::NullifyAddresses) => {
             run_nullify_addresses(config).await;
         }
         Some(Commands::Nullify) => {
-            let state_nullifier = tokio::spawn(nullify_state(config.clone()));
+            let state_nullifier = tokio::spawn(run_nullify_state(config.clone()));
             let address_nullifier = tokio::spawn(run_nullify_addresses(config));
 
             // Wait for both nullifiers to complete
@@ -63,30 +64,19 @@ async fn main() {
     }
 }
 
+async fn run_subscribe_state(config: Arc<ForesterConfig>) {
+    subscribe_state(config.clone()).await;
+}
+
+async fn run_nullify_state(config: Arc<ForesterConfig>) {
+    nullify_state(config.clone()).await;
+}
+
 async fn run_nullify_addresses(config: Arc<ForesterConfig>) {
-    let rpc = init_rpc(&config).await;
+    let rpc = init_rpc(&config, false).await;
     let rpc = Arc::new(tokio::sync::Mutex::new(rpc));
-
-    let cpi_context_account_keypair = Keypair::from_bytes(&SIGNATURE_CPI_TEST_KEYPAIR).unwrap();
-    let group_seed_keypair = Keypair::from_bytes(&GROUP_PDA_SEED_TEST_KEYPAIR).unwrap();
-    let group_pda = get_group_pda(group_seed_keypair.pubkey());
-
-    let indexer: TestIndexer<200, SolanaRpcConnection> = TestIndexer::new(
-        vec![StateMerkleTreeAccounts {
-            merkle_tree: config.state_merkle_tree_pubkey,
-            nullifier_queue: config.nullifier_queue_pubkey,
-            cpi_context: cpi_context_account_keypair.pubkey(),
-        }],
-        vec![AddressMerkleTreeAccounts {
-            merkle_tree: config.address_merkle_tree_pubkey,
-            queue: config.address_merkle_tree_queue_pubkey,
-        }],
-        config.payer_keypair.insecure_clone(),
-        group_pda,
-        true,
-        true,
-    )
-    .await;
-    let indexer = Arc::new(tokio::sync::Mutex::new(indexer));
+    let indexer = Arc::new(tokio::sync::Mutex::new(PhotonIndexer::new(
+        config.external_services.indexer_url.to_string(),
+    )));
     nullify_addresses(config.clone(), rpc, indexer).await;
 }

--- a/forester/src/nullifier/address/processor.rs
+++ b/forester/src/nullifier/address/processor.rs
@@ -146,9 +146,9 @@ impl<T: Indexer, R: RpcConnection> AddressProcessor<T, R> {
             .map_err(|_| ForesterError::Custom("Failed to get address tree proof".to_string()))?;
         // TODO: use changelog array size from tree config
         let indexer_changelog = proof.root_seq % ADDRESS_MERKLE_TREE_CHANGELOG;
-        // TODO: 
+        // TODO:
         // 1. add index changelog current changelog index to the proof or we make them the same size
-        // 2. remove -1 after new zktestnet release 
+        // 2. remove -1 after new zktestnet release
         let indexer_index_changelog = (proof.root_seq - 1) % ADDRESS_MERKLE_TREE_INDEXED_CHANGELOG;
 
         debug!("changelog: {:?}", indexer_changelog);

--- a/forester/src/nullifier/pipeline_context.rs
+++ b/forester/src/nullifier/pipeline_context.rs
@@ -9,6 +9,7 @@ pub struct PipelineContext<T: Indexer, R: RpcConnection> {
     pub indexer: Arc<Mutex<T>>,
     pub rpc: Arc<Mutex<R>>,
     pub config: Arc<ForesterConfig>,
+    pub successful_nullifications: Arc<Mutex<usize>>,
 }
 
 impl<T: Indexer, R: RpcConnection> Clone for PipelineContext<T, R> {
@@ -17,6 +18,7 @@ impl<T: Indexer, R: RpcConnection> Clone for PipelineContext<T, R> {
             indexer: Arc::clone(&self.indexer),
             rpc: Arc::clone(&self.rpc),
             config: Arc::clone(&self.config),
+            successful_nullifications: Arc::clone(&self.successful_nullifications),
         }
     }
 }

--- a/forester/src/nullifier/state/pipeline.rs
+++ b/forester/src/nullifier/state/pipeline.rs
@@ -44,6 +44,7 @@ pub async fn setup_state_pipeline<T: Indexer, R: RpcConnection>(
         indexer: indexer.clone(),
         rpc: rpc.clone(),
         config: config.clone(),
+        successful_nullifications: Arc::new(Mutex::new(0)),
     };
 
     tokio::spawn(async move {

--- a/forester/src/nullifier/state/processor.rs
+++ b/forester/src/nullifier/state/processor.rs
@@ -141,6 +141,7 @@ impl<T: Indexer, R: RpcConnection> StateProcessor<T, R> {
             indexer: _,
             rpc,
             config,
+            ..
         } = &context;
 
         let accounts_to_nullify: Vec<ForesterQueueAccountData> = {
@@ -167,6 +168,7 @@ impl<T: Indexer, R: RpcConnection> StateProcessor<T, R> {
             indexer,
             rpc: _,
             config: _,
+            ..
         } = &context;
         debug!(
             "Fetching proofs for {} accounts",
@@ -226,6 +228,7 @@ impl<T: Indexer, R: RpcConnection> StateProcessor<T, R> {
             indexer: _,
             rpc,
             config,
+            ..
         } = &context;
 
         debug!("Nullifying account: {}", account_data.account.hash_string());
@@ -303,6 +306,7 @@ impl<T: Indexer, R: RpcConnection> StateProcessor<T, R> {
             indexer,
             rpc: _,
             config,
+            ..
         } = &context;
 
         debug!(

--- a/forester/src/operations.rs
+++ b/forester/src/operations.rs
@@ -59,7 +59,7 @@ pub async fn nullify_state(config: Arc<ForesterConfig>) {
         "Run state tree nullifier. Queue: {}. Merkle tree: {}",
         config.nullifier_queue_pubkey, config.state_merkle_tree_pubkey
     );
-    let rpc = init_rpc(&config).await;
+    let rpc = init_rpc(&config, false).await;
     let indexer = Arc::new(tokio::sync::Mutex::new(PhotonIndexer::new(
         config.external_services.indexer_url.to_string(),
     )));
@@ -107,7 +107,7 @@ pub async fn nullify_addresses<I: Indexer, R: RpcConnection>(
     tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
-pub async fn init_rpc(config: &Arc<ForesterConfig>) -> SolanaRpcConnection {
+pub async fn init_rpc(config: &Arc<ForesterConfig>, airdrop: bool) -> SolanaRpcConnection {
     let mut rpc = SolanaRpcConnection::new(
         config.external_services.rpc_url.clone(),
         Some(CommitmentConfig {
@@ -115,9 +115,11 @@ pub async fn init_rpc(config: &Arc<ForesterConfig>) -> SolanaRpcConnection {
         }),
     );
 
-    rpc.airdrop_lamports(&config.payer_keypair.pubkey(), 10_000_000_000)
-        .await
-        .unwrap();
+    if airdrop {
+        rpc.airdrop_lamports(&config.payer_keypair.pubkey(), 10_000_000_000)
+            .await
+            .unwrap();
+    }
 
     rpc
 }

--- a/forester/tests/empty_address_tree_test.rs
+++ b/forester/tests/empty_address_tree_test.rs
@@ -92,7 +92,7 @@ async fn empty_address_tree_test() {
     .await;
 
     let config = Arc::new(config.clone());
-    let rpc = init_rpc(&config).await;
+    let rpc = init_rpc(&config, true).await;
     let rpc = Arc::new(tokio::sync::Mutex::new(rpc));
 
     let indexer = Arc::new(tokio::sync::Mutex::new(env.indexer.clone()));

--- a/test-utils/src/indexer/mod.rs
+++ b/test-utils/src/indexer/mod.rs
@@ -41,7 +41,7 @@ pub trait Indexer: Sync + Send + Clone + Debug + 'static {
     fn address_tree_updated(
         &mut self,
         _merkle_tree_pubkey: [u8; 32],
-        _context: NewAddressProofWithContext,
+        _context: &NewAddressProofWithContext,
     ) {
     }
 }

--- a/test-utils/src/indexer/test_indexer.rs
+++ b/test-utils/src/indexer/test_indexer.rs
@@ -279,7 +279,7 @@ impl<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection + Send + Sync + 'static> 
     fn address_tree_updated(
         &mut self,
         merkle_tree_pubkey: [u8; 32],
-        context: NewAddressProofWithContext,
+        context: &NewAddressProofWithContext,
     ) {
         let pubkey = Pubkey::from(merkle_tree_pubkey);
         let mut address_tree_bundle: &mut AddressMerkleTreeBundle<{ INDEXED_ARRAY_SIZE }> = self
@@ -288,9 +288,9 @@ impl<const INDEXED_ARRAY_SIZE: usize, R: RpcConnection + Send + Sync + 'static> 
             .find(|x| x.accounts.merkle_tree == pubkey)
             .unwrap();
 
-        let new_low_element = context.new_low_element.unwrap();
-        let new_element = context.new_element.unwrap();
-        let new_element_next_value = context.new_element_next_value.unwrap();
+        let new_low_element = context.new_low_element.clone().unwrap();
+        let new_element = context.new_element.clone().unwrap();
+        let new_element_next_value = context.new_element_next_value.clone().unwrap();
         address_tree_bundle
             .merkle_tree
             .update(&new_low_element, &new_element, &new_element_next_value)


### PR DESCRIPTION
1. Improved retry logic on address tree foresting
2. Added more logs.
3. Introduced another magic number, it's needed for zktestnet forester until we upgrade to new release: `let indexer_index_changelog = (proof.root_seq - 1) % ADDRESS_MERKLE_TREE_INDEXED_CHANGELOG;`