### PR TITLE
fix: Correct the `fillup_index`

### DIFF
--- a/merkle-tree/concurrent/tests/tests.rs
+++ b/merkle-tree/concurrent/tests/tests.rs
@@ -3181,6 +3181,6 @@ fn test_append_batch() {
     let path_0 = [leaf_0, Sha256::hashv(&[&leaf_0, &leaf_1]).unwrap()];
     let path_1 = [leaf_1, Sha256::hashv(&[&leaf_0, &leaf_1]).unwrap()];
 
-    assert_eq!(change_log_1, path_1); // Test Passes
-    assert_eq!(change_log_0, path_0); // Assets since change_log_0[1] != path_0[1]
+    assert_eq!(change_log_1, path_1);
+    assert_eq!(change_log_0, path_0);
 }

--- a/merkle-tree/concurrent/tests/tests.rs
+++ b/merkle-tree/concurrent/tests/tests.rs
@@ -3160,3 +3160,27 @@ fn test_update_changelog_wrap_around_sha256_26_256_512_0() {
     const CANOPY: usize = 0;
     update_changelog_wrap_around::<Sha256, HEIGHT, CHANGELOG, ROOTS, CANOPY>()
 }
+
+#[test]
+fn test_append_batch() {
+    let mut tree = ConcurrentMerkleTree::<Sha256, 2>::new(2, 2, 2, 1).unwrap();
+    tree.init().unwrap();
+    let leaf_0 = [0; 32];
+    let leaf_1 = [1; 32];
+    tree.append_batch(&[&leaf_0, &leaf_1]).unwrap();
+    let change_log_0 = tree
+        .changelog
+        .get(tree.changelog.first_index())
+        .unwrap()
+        .path;
+    let change_log_1 = tree
+        .changelog
+        .get(tree.changelog.last_index())
+        .unwrap()
+        .path;
+    let path_0 = [leaf_0, Sha256::hashv(&[&leaf_0, &leaf_1]).unwrap()];
+    let path_1 = [leaf_1, Sha256::hashv(&[&leaf_0, &leaf_1]).unwrap()];
+
+    assert_eq!(change_log_1, path_1); // Test Passes
+    assert_eq!(change_log_0, path_0); // Assets since change_log_0[1] != path_0[1]
+}


### PR DESCRIPTION
`fillup_index` used to be our limit of hashes computed for each non-terminal Merkle path in a batched update. However, it didn't work reliably.

`fillup_index` limited to `next_index().trailing_ones()` was resulting in `filled_subtrees` not being updated in case when `fillup_index` was 0.

Incrementing it by 1, which we used to do, was a workaround which worked for the most cases in a sense of producing correct roots, but the non-terminal Merkle paths were incorrect - they contained one node too many.

Here we are introducing a different approach where we always iterate in `0..self.height` range, but we break the loop as soon as we encounter a node on the left. Before breaking the loop, we update `filled_subtrees`. Therefore, both `filled_subtrees` and all Merkle paths are correct.