### PR TITLE
fix: Increment `first_index` correctly in `inc_first_index`

### DIFF
--- a/merkle-tree/bounded-vec/src/lib.rs
+++ b/merkle-tree/bounded-vec/src/lib.rs
@@ -748,7 +748,7 @@ where
     #[inline]
     fn inc_first_index(&self) {
         unsafe {
-            (*self.metadata).first_index = ((*self.metadata).last_index + 1) % self.capacity();
+            (*self.metadata).first_index = ((*self.metadata).first_index + 1) % self.capacity();
         }
     }
 


### PR DESCRIPTION
This was not resulting in any reproducable issue, because `inc_last_index` and `inc_first_index` are always called together. However, this could lead to issues in future code changes.