### PR TITLE
fix: Pass only the value of new element to `update`

### DIFF
--- a/merkle-tree/indexed/src/errors.rs
+++ b/merkle-tree/indexed/src/errors.rs
@@ -31,8 +31,6 @@ pub enum IndexedMerkleTreeError {
     Utils(#[from] UtilsError),
     #[error("Bounded vector error: {0}")]
     BoundedVec(#[from] BoundedVecError),
-    #[error("Next index of new element should be next index of the low element.")]
-    NewElementNextIndexMismatch,
     #[error("Indexed array is full, cannot append more elements")]
     ArrayFull,
 }
@@ -51,8 +49,7 @@ impl From<IndexedMerkleTreeError> for u32 {
             IndexedMerkleTreeError::ElementAlreadyExists => 11006,
             IndexedMerkleTreeError::ElementDoesNotExist => 11007,
             IndexedMerkleTreeError::ChangelogBufferSize(_, _) => 11008,
-            IndexedMerkleTreeError::NewElementNextIndexMismatch => 11009,
-            IndexedMerkleTreeError::ArrayFull => 11010,
+            IndexedMerkleTreeError::ArrayFull => 11009,
             IndexedMerkleTreeError::Hasher(e) => e.into(),
             IndexedMerkleTreeError::ConcurrentMerkleTree(e) => e.into(),
             IndexedMerkleTreeError::Utils(e) => e.into(),

--- a/merkle-tree/indexed/src/lib.rs
+++ b/merkle-tree/indexed/src/lib.rs
@@ -338,11 +338,18 @@ where
         &mut self,
         mut changelog_index: usize,
         indexed_changelog_index: usize,
-        mut new_element: IndexedElement<I>,
+        new_element_value: BigUint,
         mut low_element: IndexedElement<I>,
         mut low_element_next_value: BigUint,
         low_leaf_proof: &mut BoundedVec<[u8; 32]>,
     ) -> Result<IndexedMerkleTreeUpdate<I>, IndexedMerkleTreeError> {
+        let mut new_element = IndexedElement {
+            index: I::try_from(self.merkle_tree.next_index())
+                .map_err(|_| IndexedMerkleTreeError::IntegerOverflow)?,
+            value: new_element_value,
+            next_index: low_element.next_index,
+        };
+
         self.patch_elements_and_proof(
             indexed_changelog_index,
             &mut changelog_index,
@@ -371,9 +378,6 @@ where
             if new_element.value >= low_element_next_value {
                 return Err(IndexedMerkleTreeError::NewElementGreaterOrEqualToNextElement);
             }
-        }
-        if new_element.next_index != low_element.next_index {
-            return Err(IndexedMerkleTreeError::NewElementNextIndexMismatch);
         }
         // Instantiate `new_low_element` - the low element with updated values.
         let new_low_element = IndexedElement {

--- a/programs/account-compression/src/instructions/update_address_merkle_tree.rs
+++ b/programs/account-compression/src/instructions/update_address_merkle_tree.rs
@@ -95,13 +95,6 @@ pub fn process_update_address_merkle_tree<'info>(
 
     let low_address_next_value = BigUint::from_bytes_be(&low_address_next_value);
 
-    // higher range
-    let address: IndexedElement<usize> = IndexedElement {
-        index: merkle_tree.next_index(),
-        value: value.clone(),
-        next_index: low_address_next_index as usize,
-    };
-
     let mut proof =
         from_vec(low_address_proof.as_slice(), merkle_tree.height).map_err(ProgramError::from)?;
 
@@ -116,7 +109,7 @@ pub fn process_update_address_merkle_tree<'info>(
         .update(
             usize::from(changelog_index),
             usize::from(indexed_changelog_index),
-            address,
+            value.clone(),
             low_address,
             low_address_next_value,
             &mut proof,


### PR DESCRIPTION
* Instead of consuming `new_element` as `IndexedElement`, take only a `BigUint` value, then instantiate an `IndexedElement` using the current `index` from Merkle tree (as `index`) and `next_index` from `low_element`.
* That manually instantiated `IndexedElement` is still a subject to change by `patch_elements_and_proof` to preserve concurrency.
* Remove the `NewElementNextIndexMismatch`, as we don't allow users to specify `next_index`.