### PR TITLE
style: Rename `sibling_index` to `level`

### DIFF
--- a/merkle-tree/concurrent/src/hash.rs
+++ b/merkle-tree/concurrent/src/hash.rs
@@ -9,12 +9,12 @@ pub fn compute_parent_node<H>(
     node: &[u8; 32],
     sibling: &[u8; 32],
     node_index: usize,
-    sibling_index: usize,
+    level: usize,
 ) -> Result<[u8; 32], ConcurrentMerkleTreeError>
 where
     H: Hasher,
 {
-    let is_left = (node_index >> sibling_index) & 1 == 0;
+    let is_left = (node_index >> level) & 1 == 0;
     let hash = if is_left {
         H::hashv(&[node, sibling])?
     } else {
@@ -34,8 +34,8 @@ where
     H: Hasher,
 {
     let mut node = *leaf;
-    for (j, sibling) in proof.iter().enumerate() {
-        node = compute_parent_node::<H>(&node, sibling, leaf_index, j)?;
+    for (level, sibling) in proof.iter().enumerate() {
+        node = compute_parent_node::<H>(&node, sibling, leaf_index, level)?;
     }
     Ok(node)
 }

--- a/merkle-tree/concurrent/src/lib.rs
+++ b/merkle-tree/concurrent/src/lib.rs
@@ -392,9 +392,9 @@ where
     ) -> Result<(usize, usize), ConcurrentMerkleTreeError> {
         let mut current_node = *new_leaf;
         let mut changelog_path = [[0u8; 32]; HEIGHT];
-        for (i, sibling) in proof.iter().enumerate() {
-            changelog_path[i] = current_node;
-            current_node = compute_parent_node::<H>(&current_node, sibling, leaf_index, i)?;
+        for (level, sibling) in proof.iter().enumerate() {
+            changelog_path[level] = current_node;
+            current_node = compute_parent_node::<H>(&current_node, sibling, leaf_index, level)?;
         }
 
         self.inc_sequence_number()?;


### PR DESCRIPTION
The latter is more clear and widely used in the rest of the code.