### PR TITLE
perf: Use index as an argument in `HashSet::mark_with_sequence_number`

### DIFF
--- a/merkle-tree/hash-set/src/zero_copy.rs
+++ b/merkle-tree/hash-set/src/zero_copy.rs
@@ -190,8 +190,8 @@ mod test {
             }
 
             for (seq, nullifier) in nullifiers.iter().enumerate() {
-                hs.insert(&nullifier, seq).unwrap();
-                hs.mark_with_sequence_number(&nullifier, seq).unwrap();
+                let index = hs.insert(&nullifier, seq).unwrap();
+                hs.mark_with_sequence_number(index, seq).unwrap();
             }
         }
 

--- a/merkle-tree/indexed/tests/tests.rs
+++ b/merkle-tree/indexed/tests/tests.rs
@@ -92,7 +92,7 @@ where
 
     // Mark the nullifier.
     queue
-        .mark_with_sequence_number(&nullifier.value_biguint(), merkle_tree.sequence_number())
+        .mark_with_sequence_number(queue_index as usize, merkle_tree.sequence_number())
         .unwrap();
 
     Ok(update)

--- a/programs/account-compression/src/instructions/nullify_leaves.rs
+++ b/programs/account-compression/src/instructions/nullify_leaves.rs
@@ -137,7 +137,7 @@ fn insert_nullifier<'a, 'c: 'info, 'info>(
             .map_err(ProgramError::from)?;
 
         nullifier_queue
-            .mark_with_sequence_number(&leaf_cell.value_biguint(), merkle_tree.sequence_number())
+            .mark_with_sequence_number(*leaf_queue_index as usize, merkle_tree.sequence_number())
             .map_err(ProgramError::from)?;
     }
     let nullify_event = NullifierEvent {

--- a/programs/account-compression/src/instructions/update_address_merkle_tree.rs
+++ b/programs/account-compression/src/instructions/update_address_merkle_tree.rs
@@ -118,7 +118,7 @@ pub fn process_update_address_merkle_tree<'info>(
 
     // Mark the address with the current sequence number.
     address_queue
-        .mark_with_sequence_number(&value, merkle_tree.sequence_number())
+        .mark_with_sequence_number(value_index as usize, merkle_tree.sequence_number())
         .map_err(ProgramError::from)?;
 
     let address_event = MerkleTreeEvent::V3(IndexedMerkleTreeEvent {

--- a/xtask/src/hash_set.rs
+++ b/xtask/src/hash_set.rs
@@ -70,11 +70,13 @@ fn bench(opts: BenchOptions) -> anyhow::Result<()> {
 
             for element_i in 0..capacity_with_load_factor {
                 let value = BigUint::from(Fr::rand(&mut rng));
-                if hs.insert(&value, sequence_number).is_err() {
-                    successful_insertions = element_i;
-                    break;
+                match hs.insert(&value, sequence_number) {
+                    Ok(index) => hs.mark_with_sequence_number(index, sequence_number)?,
+                    Err(_) => {
+                        successful_insertions = element_i;
+                        break;
+                    }
                 }
-                hs.mark_with_sequence_number(&value, sequence_number)?;
             }
 
             let bench_data = BenchData {


### PR DESCRIPTION
* Using a value was a bad choice, because it caused `mark_with_sequence_number` to search for the element. In all cases, where we use that method, we usually have the index available.
* Return the index in `HashSet::insert`, for easier testing.