### PR TITLE
test: Add a simple test case for `read_cyclic_bounded_vec_at`

### DIFF
--- a/merkle-tree/bounded-vec/src/lib.rs
+++ b/merkle-tree/bounded-vec/src/lib.rs
@@ -159,6 +159,10 @@ where
         Self { metadata, data }
     }
 
+    pub fn metadata(&self) -> &BoundedVecMetadata {
+        unsafe { &*self.metadata }
+    }
+
     pub fn from_array<const N: usize>(array: &[T; N]) -> Self {
         let mut vec = Self::with_capacity(N);
         for element in array {
@@ -608,6 +612,10 @@ where
         let data = Self::data_with_capacity(capacity);
 
         Self { metadata, data }
+    }
+
+    pub fn metadata(&self) -> &CyclicBoundedVecMetadata {
+        unsafe { &*self.metadata }
     }
 
     /// Creates a `CyclicBoundedVec<T>` directly from a pointer, a capacity, and a length.


### PR DESCRIPTION
Ensure that the metadata are being restored correctly and that the new copy points to the correct `first_index`, `last_index`.