### PR TITLE
fix: add wide hash set steps

### DIFF
--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -1375,108 +1375,23 @@ export type LightCompressedToken = {
     errors: [
         {
             code: 6000;
-            name: 'PublicKeyAmountMissmatch';
-            msg: 'public keys and amounts must be of same length';
+            name: 'SignerCheckFailed';
+            msg: 'Signer check failed';
         },
         {
             code: 6001;
-            name: 'SignerCheckFailed';
-            msg: 'SignerCheckFailed';
+            name: 'CreateTransferInstructionFailed';
+            msg: 'Create transfer instruction failed';
         },
         {
             code: 6002;
-            name: 'ComputeInputSumFailed';
-            msg: 'ComputeInputSumFailed';
+            name: 'AccountNotFound';
+            msg: 'Account not found';
         },
         {
             code: 6003;
-            name: 'ComputeOutputSumFailed';
-            msg: 'ComputeOutputSumFailed';
-        },
-        {
-            code: 6004;
-            name: 'ComputeCompressSumFailed';
-            msg: 'ComputeCompressSumFailed';
-        },
-        {
-            code: 6005;
-            name: 'ComputeDecompressSumFailed';
-            msg: 'ComputeDecompressSumFailed';
-        },
-        {
-            code: 6006;
-            name: 'SumCheckFailed';
-            msg: 'SumCheckFailed';
-        },
-        {
-            code: 6007;
-            name: 'DecompressRecipientUndefinedForDecompress';
-            msg: 'DecompressRecipientUndefinedForDecompress';
-        },
-        {
-            code: 6008;
-            name: 'CompressedPdaUndefinedForDecompress';
-            msg: 'CompressedPdaUndefinedForDecompress';
-        },
-        {
-            code: 6009;
-            name: 'DeCompressAmountUndefinedForDecompress';
-            msg: 'DeCompressAmountUndefinedForDecompress';
-        },
-        {
-            code: 6010;
-            name: 'CompressedPdaUndefinedForCompress';
-            msg: 'CompressedPdaUndefinedForCompress';
-        },
-        {
-            code: 6011;
-            name: 'DeCompressAmountUndefinedForCompress';
-            msg: 'DeCompressAmountUndefinedForCompress';
-        },
-        {
-            code: 6012;
-            name: 'DelegateUndefined';
-            msg: 'DelegateUndefined while delegated amount is defined';
-        },
-        {
-            code: 6013;
-            name: 'DelegateSignerCheckFailed';
-            msg: 'DelegateSignerCheckFailed';
-        },
-        {
-            code: 6014;
-            name: 'SplTokenSupplyMismatch';
-            msg: 'SplTokenSupplyMismatch';
-        },
-        {
-            code: 6015;
-            name: 'HeapMemoryCheckFailed';
-            msg: 'HeapMemoryCheckFailed';
-        },
-        {
-            code: 6016;
-            name: 'InstructionNotCallable';
-            msg: 'The instruction is not callable';
-        },
-        {
-            code: 6017;
-            name: 'ArithmeticUnderflow';
-            msg: 'ArithmeticUnderflow';
-        },
-        {
-            code: 6018;
-            name: 'InvalidDelegate';
-            msg: 'InvalidDelegate';
-        },
-        {
-            code: 6019;
-            name: 'HashToFieldError';
-            msg: 'HashToFieldError';
-        },
-        {
-            code: 6020;
-            name: 'InvalidMint';
-            msg: 'InvalidMint';
+            name: 'SerializationError';
+            msg: 'Serialization error';
         },
     ];
 };
@@ -2862,108 +2777,23 @@ export const IDL: LightCompressedToken = {
     errors: [
         {
             code: 6000,
-            name: 'PublicKeyAmountMissmatch',
-            msg: 'public keys and amounts must be of same length',
+            name: 'SignerCheckFailed',
+            msg: 'Signer check failed',
         },
         {
             code: 6001,
-            name: 'SignerCheckFailed',
-            msg: 'SignerCheckFailed',
+            name: 'CreateTransferInstructionFailed',
+            msg: 'Create transfer instruction failed',
         },
         {
             code: 6002,
-            name: 'ComputeInputSumFailed',
-            msg: 'ComputeInputSumFailed',
+            name: 'AccountNotFound',
+            msg: 'Account not found',
         },
         {
             code: 6003,
-            name: 'ComputeOutputSumFailed',
-            msg: 'ComputeOutputSumFailed',
-        },
-        {
-            code: 6004,
-            name: 'ComputeCompressSumFailed',
-            msg: 'ComputeCompressSumFailed',
-        },
-        {
-            code: 6005,
-            name: 'ComputeDecompressSumFailed',
-            msg: 'ComputeDecompressSumFailed',
-        },
-        {
-            code: 6006,
-            name: 'SumCheckFailed',
-            msg: 'SumCheckFailed',
-        },
-        {
-            code: 6007,
-            name: 'DecompressRecipientUndefinedForDecompress',
-            msg: 'DecompressRecipientUndefinedForDecompress',
-        },
-        {
-            code: 6008,
-            name: 'CompressedPdaUndefinedForDecompress',
-            msg: 'CompressedPdaUndefinedForDecompress',
-        },
-        {
-            code: 6009,
-            name: 'DeCompressAmountUndefinedForDecompress',
-            msg: 'DeCompressAmountUndefinedForDecompress',
-        },
-        {
-            code: 6010,
-            name: 'CompressedPdaUndefinedForCompress',
-            msg: 'CompressedPdaUndefinedForCompress',
-        },
-        {
-            code: 6011,
-            name: 'DeCompressAmountUndefinedForCompress',
-            msg: 'DeCompressAmountUndefinedForCompress',
-        },
-        {
-            code: 6012,
-            name: 'DelegateUndefined',
-            msg: 'DelegateUndefined while delegated amount is defined',
-        },
-        {
-            code: 6013,
-            name: 'DelegateSignerCheckFailed',
-            msg: 'DelegateSignerCheckFailed',
-        },
-        {
-            code: 6014,
-            name: 'SplTokenSupplyMismatch',
-            msg: 'SplTokenSupplyMismatch',
-        },
-        {
-            code: 6015,
-            name: 'HeapMemoryCheckFailed',
-            msg: 'HeapMemoryCheckFailed',
-        },
-        {
-            code: 6016,
-            name: 'InstructionNotCallable',
-            msg: 'The instruction is not callable',
-        },
-        {
-            code: 6017,
-            name: 'ArithmeticUnderflow',
-            msg: 'ArithmeticUnderflow',
-        },
-        {
-            code: 6018,
-            name: 'InvalidDelegate',
-            msg: 'InvalidDelegate',
-        },
-        {
-            code: 6019,
-            name: 'HashToFieldError',
-            msg: 'HashToFieldError',
-        },
-        {
-            code: 6020,
-            name: 'InvalidMint',
-            msg: 'InvalidMint',
+            name: 'SerializationError',
+            msg: 'Serialization error',
         },
     ],
 };

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -1375,108 +1375,23 @@ export type LightCompressedToken = {
     errors: [
         {
             code: 6000;
-            name: 'PublicKeyAmountMissmatch';
-            msg: 'public keys and amounts must be of same length';
+            name: 'SignerCheckFailed';
+            msg: 'Signer check failed';
         },
         {
             code: 6001;
-            name: 'SignerCheckFailed';
-            msg: 'SignerCheckFailed';
+            name: 'CreateTransferInstructionFailed';
+            msg: 'Create transfer instruction failed';
         },
         {
             code: 6002;
-            name: 'ComputeInputSumFailed';
-            msg: 'ComputeInputSumFailed';
+            name: 'AccountNotFound';
+            msg: 'Account not found';
         },
         {
             code: 6003;
-            name: 'ComputeOutputSumFailed';
-            msg: 'ComputeOutputSumFailed';
-        },
-        {
-            code: 6004;
-            name: 'ComputeCompressSumFailed';
-            msg: 'ComputeCompressSumFailed';
-        },
-        {
-            code: 6005;
-            name: 'ComputeDecompressSumFailed';
-            msg: 'ComputeDecompressSumFailed';
-        },
-        {
-            code: 6006;
-            name: 'SumCheckFailed';
-            msg: 'SumCheckFailed';
-        },
-        {
-            code: 6007;
-            name: 'DecompressRecipientUndefinedForDecompress';
-            msg: 'DecompressRecipientUndefinedForDecompress';
-        },
-        {
-            code: 6008;
-            name: 'CompressedPdaUndefinedForDecompress';
-            msg: 'CompressedPdaUndefinedForDecompress';
-        },
-        {
-            code: 6009;
-            name: 'DeCompressAmountUndefinedForDecompress';
-            msg: 'DeCompressAmountUndefinedForDecompress';
-        },
-        {
-            code: 6010;
-            name: 'CompressedPdaUndefinedForCompress';
-            msg: 'CompressedPdaUndefinedForCompress';
-        },
-        {
-            code: 6011;
-            name: 'DeCompressAmountUndefinedForCompress';
-            msg: 'DeCompressAmountUndefinedForCompress';
-        },
-        {
-            code: 6012;
-            name: 'DelegateUndefined';
-            msg: 'DelegateUndefined while delegated amount is defined';
-        },
-        {
-            code: 6013;
-            name: 'DelegateSignerCheckFailed';
-            msg: 'DelegateSignerCheckFailed';
-        },
-        {
-            code: 6014;
-            name: 'SplTokenSupplyMismatch';
-            msg: 'SplTokenSupplyMismatch';
-        },
-        {
-            code: 6015;
-            name: 'HeapMemoryCheckFailed';
-            msg: 'HeapMemoryCheckFailed';
-        },
-        {
-            code: 6016;
-            name: 'InstructionNotCallable';
-            msg: 'The instruction is not callable';
-        },
-        {
-            code: 6017;
-            name: 'ArithmeticUnderflow';
-            msg: 'ArithmeticUnderflow';
-        },
-        {
-            code: 6018;
-            name: 'InvalidDelegate';
-            msg: 'InvalidDelegate';
-        },
-        {
-            code: 6019;
-            name: 'HashToFieldError';
-            msg: 'HashToFieldError';
-        },
-        {
-            code: 6020;
-            name: 'InvalidMint';
-            msg: 'InvalidMint';
+            name: 'SerializationError';
+            msg: 'Serialization error';
         },
     ];
 };
@@ -2862,108 +2777,23 @@ export const IDL: LightCompressedToken = {
     errors: [
         {
             code: 6000,
-            name: 'PublicKeyAmountMissmatch',
-            msg: 'public keys and amounts must be of same length',
+            name: 'SignerCheckFailed',
+            msg: 'Signer check failed',
         },
         {
             code: 6001,
-            name: 'SignerCheckFailed',
-            msg: 'SignerCheckFailed',
+            name: 'CreateTransferInstructionFailed',
+            msg: 'Create transfer instruction failed',
         },
         {
             code: 6002,
-            name: 'ComputeInputSumFailed',
-            msg: 'ComputeInputSumFailed',
+            name: 'AccountNotFound',
+            msg: 'Account not found',
         },
         {
             code: 6003,
-            name: 'ComputeOutputSumFailed',
-            msg: 'ComputeOutputSumFailed',
-        },
-        {
-            code: 6004,
-            name: 'ComputeCompressSumFailed',
-            msg: 'ComputeCompressSumFailed',
-        },
-        {
-            code: 6005,
-            name: 'ComputeDecompressSumFailed',
-            msg: 'ComputeDecompressSumFailed',
-        },
-        {
-            code: 6006,
-            name: 'SumCheckFailed',
-            msg: 'SumCheckFailed',
-        },
-        {
-            code: 6007,
-            name: 'DecompressRecipientUndefinedForDecompress',
-            msg: 'DecompressRecipientUndefinedForDecompress',
-        },
-        {
-            code: 6008,
-            name: 'CompressedPdaUndefinedForDecompress',
-            msg: 'CompressedPdaUndefinedForDecompress',
-        },
-        {
-            code: 6009,
-            name: 'DeCompressAmountUndefinedForDecompress',
-            msg: 'DeCompressAmountUndefinedForDecompress',
-        },
-        {
-            code: 6010,
-            name: 'CompressedPdaUndefinedForCompress',
-            msg: 'CompressedPdaUndefinedForCompress',
-        },
-        {
-            code: 6011,
-            name: 'DeCompressAmountUndefinedForCompress',
-            msg: 'DeCompressAmountUndefinedForCompress',
-        },
-        {
-            code: 6012,
-            name: 'DelegateUndefined',
-            msg: 'DelegateUndefined while delegated amount is defined',
-        },
-        {
-            code: 6013,
-            name: 'DelegateSignerCheckFailed',
-            msg: 'DelegateSignerCheckFailed',
-        },
-        {
-            code: 6014,
-            name: 'SplTokenSupplyMismatch',
-            msg: 'SplTokenSupplyMismatch',
-        },
-        {
-            code: 6015,
-            name: 'HeapMemoryCheckFailed',
-            msg: 'HeapMemoryCheckFailed',
-        },
-        {
-            code: 6016,
-            name: 'InstructionNotCallable',
-            msg: 'The instruction is not callable',
-        },
-        {
-            code: 6017,
-            name: 'ArithmeticUnderflow',
-            msg: 'ArithmeticUnderflow',
-        },
-        {
-            code: 6018,
-            name: 'InvalidDelegate',
-            msg: 'InvalidDelegate',
-        },
-        {
-            code: 6019,
-            name: 'HashToFieldError',
-            msg: 'HashToFieldError',
-        },
-        {
-            code: 6020,
-            name: 'InvalidMint',
-            msg: 'InvalidMint',
+            name: 'SerializationError',
+            msg: 'Serialization error',
         },
     ],
 };

--- a/merkle-tree/hash-set/src/lib.rs
+++ b/merkle-tree/hash-set/src/lib.rs
@@ -210,7 +210,9 @@ impl HashSet {
     }
 
     fn probe_index(&self, value: &BigUint, iteration: usize) -> usize {
-        let probe_index = (value.clone()
+        // Step at least 2 times over the entire array.
+        let iteration = iteration + self.capacity / 10;
+        let probe_index = (value
             + iteration.to_biguint().unwrap() * iteration.to_biguint().unwrap())
             % self.capacity.to_biguint().unwrap();
         probe_index.to_usize().unwrap()

--- a/merkle-tree/hash-set/src/lib.rs
+++ b/merkle-tree/hash-set/src/lib.rs
@@ -180,10 +180,6 @@ impl HashSet {
 
         let capacity = usize::from_ne_bytes(bytes[0..8].try_into().unwrap());
         let sequence_threshold = usize::from_ne_bytes(bytes[8..16].try_into().unwrap());
-        println!(
-            "capacity: {}, sequence_threshold: {}",
-            capacity, sequence_threshold
-        );
         let expected_size = Self::size_in_account(capacity);
         if bytes.len() != expected_size {
             return Err(HashSetError::BufferSize(expected_size, bytes.len()));
@@ -213,7 +209,7 @@ impl HashSet {
     }
 
     fn probe_index(&self, value: &BigUint, iteration: usize) -> usize {
-        // Step at least 2 times over the entire array.
+        // Increase stepsize over the capacity of the hash set.
         let iteration = iteration + self.capacity / 10;
         let probe_index = (value
             + iteration.to_biguint().unwrap() * iteration.to_biguint().unwrap())


### PR DESCRIPTION
Issue:
- the current hash-set seems to perform poorly in practice because it iterates only over a small part of the hash-set

Changes:
- increase step size relative to capacity

Note:
- some tests depend on linear filling which does not work anymore because of the increased step size this is expected
- adapted most tests, removed two which were just asserting linear filling