### PR TITLE
test: Failing tests for `mint_to` instruction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,6 +1310,7 @@ dependencies = [
  "light-verifier",
  "num-bigint 0.4.6",
  "num-traits",
+ "rand 0.8.5",
  "reqwest 0.11.26",
  "solana-program-test",
  "solana-sdk",

--- a/programs/compressed-token/src/lib.rs
+++ b/programs/compressed-token/src/lib.rs
@@ -137,6 +137,8 @@ pub enum ErrorCode {
     DelegateUndefined,
     #[msg("DelegateSignerCheckFailed")]
     DelegateSignerCheckFailed,
+    #[msg("Minted amount greater than u64::MAX")]
+    MintTooLarge,
     #[msg("SplTokenSupplyMismatch")]
     SplTokenSupplyMismatch,
     #[msg("HeapMemoryCheckFailed")]

--- a/programs/compressed-token/src/lib.rs
+++ b/programs/compressed-token/src/lib.rs
@@ -153,4 +153,6 @@ pub enum ErrorCode {
     HashToFieldError,
     #[msg("InvalidMint")]
     InvalidMint,
+    #[msg("Expected the authority to be also a mint authority")]
+    InvalidAuthorityMint,
 }

--- a/programs/compressed-token/src/process_mint.rs
+++ b/programs/compressed-token/src/process_mint.rs
@@ -282,7 +282,9 @@ pub fn mint_spl_to_pool_pda<'info>(
 ) -> Result<()> {
     let mut mint_amount: u64 = 0;
     for amount in amounts.iter() {
-        mint_amount = mint_amount.checked_add(*amount).unwrap();
+        mint_amount = mint_amount
+            .checked_add(*amount)
+            .ok_or(crate::ErrorCode::MintTooLarge)?;
     }
     let pre_token_balance = ctx.accounts.token_pool_pda.amount;
     let cpi_accounts = anchor_spl::token::MintTo {

--- a/programs/compressed-token/src/process_mint.rs
+++ b/programs/compressed-token/src/process_mint.rs
@@ -321,7 +321,11 @@ pub struct MintToInstruction<'info> {
     #[account(seeds = [CPI_AUTHORITY_PDA_SEED], bump)]
     pub cpi_authority_pda: UncheckedAccount<'info>,
     /// CHECK: that authority is mint authority
-    #[account(mut, constraint = mint.mint_authority.unwrap() == authority.key())]
+    #[account(
+        mut,
+        constraint = mint.mint_authority.unwrap() == authority.key()
+            @ crate::ErrorCode::InvalidAuthorityMint
+    )]
     pub mint: Account<'info, Mint>,
     /// CHECK: this account
     #[account(mut)]

--- a/test-programs/compressed-token-test/Cargo.toml
+++ b/test-programs/compressed-token-test/Cargo.toml
@@ -40,3 +40,4 @@ num-bigint = "0.4.6"
 num-traits = "0.2.18"
 spl-token = { workspace = true }
 anchor-spl = { workspace = true }
+rand = "0.8"

--- a/test-programs/compressed-token-test/tests/test.rs
+++ b/test-programs/compressed-token-test/tests/test.rs
@@ -292,6 +292,12 @@ async fn test_25_mint_to() {
     test_mint_to(amounts, 10).await
 }
 
+#[tokio::test]
+async fn test_25_mint_to_zeros() {
+    let amounts = vec![0; 25];
+    test_mint_to(amounts, 1).await
+}
+
 /// Failing tests:
 /// 1. Try to mint token from `mint_1` and sign the transaction with `mint_2`
 ///    authority.

--- a/test-programs/compressed-token-test/tests/test.rs
+++ b/test-programs/compressed-token-test/tests/test.rs
@@ -364,7 +364,7 @@ async fn test_mint_to_failing() {
         assert_rpc_error(
             result,
             0,
-            anchor_lang::error::ErrorCode::ConstraintRaw.into(),
+            light_compressed_token::ErrorCode::InvalidAuthorityMint.into(),
         )
         .unwrap();
     }
@@ -385,7 +385,7 @@ async fn test_mint_to_failing() {
         assert_rpc_error(
             result,
             0,
-            anchor_lang::error::ErrorCode::ConstraintRaw.into(),
+            light_compressed_token::ErrorCode::InvalidAuthorityMint.into(),
         )
         .unwrap();
     }

--- a/test-programs/compressed-token-test/tests/test.rs
+++ b/test-programs/compressed-token-test/tests/test.rs
@@ -42,7 +42,7 @@ use light_test_utils::{
 };
 use light_verifier::VerifierError;
 use rand::Rng;
-use spl_token::instruction::initialize_mint;
+use spl_token::{error::TokenError, instruction::initialize_mint};
 
 #[tokio::test]
 async fn test_create_mint() {
@@ -418,9 +418,10 @@ async fn test_mint_to_failing() {
             accounts: accounts.to_account_metas(Some(true)),
             data: instruction_data.data(),
         };
-        rpc.create_and_send_transaction(&[instruction], &payer_1.pubkey(), &[&payer_1])
-            .await
-            .unwrap_err();
+        let result = rpc
+            .create_and_send_transaction(&[instruction], &payer_1.pubkey(), &[&payer_1])
+            .await;
+        assert_rpc_error(result, 0, TokenError::MintMismatch as u32).unwrap();
     }
     // 4. Try to mint token from `mint_2` while using `mint_1` pool.
     {
@@ -451,9 +452,10 @@ async fn test_mint_to_failing() {
             accounts: accounts.to_account_metas(Some(true)),
             data: instruction_data.data(),
         };
-        rpc.create_and_send_transaction(&[instruction], &payer_2.pubkey(), &[&payer_2])
-            .await
-            .unwrap_err();
+        let result = rpc
+            .create_and_send_transaction(&[instruction], &payer_2.pubkey(), &[&payer_2])
+            .await;
+        assert_rpc_error(result, 0, TokenError::MintMismatch as u32).unwrap();
     }
     // 5. Invalid CPI authority.
     {
@@ -662,9 +664,10 @@ async fn test_mint_to_failing() {
             .await
             .unwrap();
         // The second mint should overflow.
-        rpc.create_and_send_transaction(&[instruction], &payer_1.pubkey(), &[&payer_1])
-            .await
-            .unwrap_err(); // No error code to catch, happens inside anchor-spl.
+        let result = rpc
+            .create_and_send_transaction(&[instruction], &payer_1.pubkey(), &[&payer_1])
+            .await;
+        assert_rpc_error(result, 0, TokenError::Overflow as u32).unwrap();
     }
 }
 


### PR DESCRIPTION
Test cases:

1. Try to mint token from `mint_1` and sign the transaction with `mint_2` authority.
2. Try to mint token from `mint_2` and sign the transaction with `mint_1` authority.
3. Try to mint token from `mint_1` while using `mint_2` pool.
4. Try to mint token from `mint_2` while using `mint_1` pool.
5. Invalid CPI authority.
6. Invalid registered program.
7. Invalid noop program.
8. Invalid account compression authority.
9. Invalid Merkle tree.
10. Mint more than `u64::MAX` tokens.
11. Multiple mints which overflow the token supply over `u64::MAX`.

Related fixes:

- Add `MintTooLarge` error when the sum of mint amounts exceeds `u64::MAX`.