### PR TITLE
fix: noop program account check

### DIFF
--- a/programs/account-compression/src/state/change_log_event.rs
+++ b/programs/account-compression/src/state/change_log_event.rs
@@ -7,7 +7,7 @@ use crate::{errors::AccountCompressionErrorCode, utils::constants::NOOP_PUBKEY};
 
 #[inline(never)]
 pub fn emit_indexer_event(data: Vec<u8>, noop_program: &AccountInfo) -> Result<()> {
-    if noop_program.key() != Pubkey::new_from_array(NOOP_PUBKEY) && noop_program.executable {
+    if noop_program.key() != Pubkey::new_from_array(NOOP_PUBKEY) && !noop_program.executable {
         return err!(AccountCompressionErrorCode::InvalidNoopPubkey);
     }
     let instruction = Instruction {


### PR DESCRIPTION
Before this change, non-executable programs could pass the noop program check.