### PR TITLE
fix: assert account sizes at init and unify rollover account size check

### DIFF
--- a/js/stateless.js/src/idls/account_compression.ts
+++ b/js/stateless.js/src/idls/account_compression.ts
@@ -1088,8 +1088,8 @@ export type AccountCompression = {
         },
         {
             code: 6017;
-            name: 'SizeMismatch';
-            msg: 'SizeMismatch';
+            name: 'InvalidAccountSize';
+            msg: 'InvalidAccountSize';
         },
         {
             code: 6018;
@@ -2214,8 +2214,8 @@ export const IDL: AccountCompression = {
         },
         {
             code: 6017,
-            name: 'SizeMismatch',
-            msg: 'SizeMismatch',
+            name: 'InvalidAccountSize',
+            msg: 'InvalidAccountSize',
         },
         {
             code: 6018,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,6 +376,10 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@20.12.11)(@vitest/browser@1.6.0)(terser@5.31.0)
 
+  hasher.rs/src/main/wasm: {}
+
+  hasher.rs/src/main/wasm-simd: {}
+
   js/compressed-token:
     dependencies:
       '@coral-xyz/anchor':

--- a/programs/account-compression/src/errors.rs
+++ b/programs/account-compression/src/errors.rs
@@ -38,8 +38,8 @@ pub enum AccountCompressionErrorCode {
     InputElementsEmpty,
     #[msg("NoLeavesForMerkleTree")]
     NoLeavesForMerkleTree,
-    #[msg("SizeMismatch")]
-    SizeMismatch,
+    #[msg("InvalidAccountSize")]
+    InvalidAccountSize,
     #[msg("InsufficientRolloverFee")]
     InsufficientRolloverFee,
     #[msg("Unsupported Merkle tree height")]

--- a/programs/account-compression/src/instructions/initialize_address_merkle_tree_and_queue.rs
+++ b/programs/account-compression/src/instructions/initialize_address_merkle_tree_and_queue.rs
@@ -123,9 +123,22 @@ pub fn process_initialize_address_merkle_tree_and_queue<'info>(
         }
         None => ctx.accounts.authority.key(),
     };
-    let merkle_tree_rent =
-        check_account_balance_is_rent_exempt(&ctx.accounts.merkle_tree.to_account_info())?;
-    check_account_balance_is_rent_exempt(&ctx.accounts.queue.to_account_info())?;
+    let merkle_tree_expected_size = AddressMerkleTreeAccount::size(
+        merkle_tree_config.height as usize,
+        merkle_tree_config.changelog_size as usize,
+        merkle_tree_config.roots_size as usize,
+        merkle_tree_config.canopy_depth as usize,
+        merkle_tree_config.address_changelog_size as usize,
+    );
+    let queue_expected_size = QueueAccount::size(queue_config.capacity as usize)?;
+    let merkle_tree_rent = check_account_balance_is_rent_exempt(
+        &ctx.accounts.merkle_tree.to_account_info(),
+        merkle_tree_expected_size,
+    )?;
+    check_account_balance_is_rent_exempt(
+        &ctx.accounts.queue.to_account_info(),
+        queue_expected_size,
+    )?;
     process_initialize_address_queue(
         &ctx.accounts.queue.to_account_info(),
         &ctx.accounts.queue,

--- a/programs/account-compression/src/instructions/initialize_state_merkle_tree_and_nullifier_queue.rs
+++ b/programs/account-compression/src/instructions/initialize_state_merkle_tree_and_nullifier_queue.rs
@@ -118,11 +118,21 @@ pub fn process_initialize_state_merkle_tree_and_nullifier_queue<'info>(
         );
         return err!(AccountCompressionErrorCode::InvalidSequenceThreshold);
     }
-
-    let merkle_tree_rent =
-        check_account_balance_is_rent_exempt(&ctx.accounts.merkle_tree.to_account_info())?;
-    let queue_rent =
-        check_account_balance_is_rent_exempt(&ctx.accounts.nullifier_queue.to_account_info())?;
+    let merkle_tree_expected_size = StateMerkleTreeAccount::size(
+        state_merkle_tree_config.height as usize,
+        state_merkle_tree_config.changelog_size as usize,
+        state_merkle_tree_config.roots_size as usize,
+        state_merkle_tree_config.canopy_depth as usize,
+    );
+    let queue_expected_size = QueueAccount::size(nullifier_queue_config.capacity as usize)?;
+    let merkle_tree_rent = check_account_balance_is_rent_exempt(
+        &ctx.accounts.merkle_tree.to_account_info(),
+        merkle_tree_expected_size,
+    )?;
+    let queue_rent = check_account_balance_is_rent_exempt(
+        &ctx.accounts.nullifier_queue.to_account_info(),
+        queue_expected_size,
+    )?;
     let owner = match ctx.accounts.registered_program_pda.as_ref() {
         Some(registered_program_pda) => {
             check_signer_is_registered_or_authority::<

--- a/programs/account-compression/src/instructions/rollover_address_merkle_tree_and_queue.rs
+++ b/programs/account-compression/src/instructions/rollover_address_merkle_tree_and_queue.rs
@@ -52,18 +52,17 @@ pub fn process_rollover_address_merkle_tree_and_queue<'a, 'b, 'c: 'info, 'info>(
     ctx: Context<'a, 'b, 'c, 'info, RolloverAddressMerkleTreeAndQueue<'info>>,
 ) -> Result<()> {
     let new_merkle_tree_account_info = ctx.accounts.new_address_merkle_tree.to_account_info();
-    let merkle_tree_rent = check_account_balance_is_rent_exempt(&new_merkle_tree_account_info)?;
-    let new_queue_account_info = ctx.accounts.new_queue.to_account_info();
-    let queue_rent = check_account_balance_is_rent_exempt(&new_queue_account_info)?;
-    assert_size_equal(
-        &ctx.accounts.old_queue.to_account_info(),
-        &new_queue_account_info,
-        "Queue size mismatch",
-    )?;
-    assert_size_equal(
-        &ctx.accounts.old_address_merkle_tree.to_account_info(),
+    let merkle_tree_rent = check_account_balance_is_rent_exempt(
         &new_merkle_tree_account_info,
-        "Merkle tree size mismatch",
+        ctx.accounts
+            .old_address_merkle_tree
+            .to_account_info()
+            .data_len(),
+    )?;
+    let new_queue_account_info = ctx.accounts.new_queue.to_account_info();
+    let queue_rent = check_account_balance_is_rent_exempt(
+        &new_queue_account_info,
+        ctx.accounts.old_queue.to_account_info().data_len(),
     )?;
 
     let (queue_metadata, height) = {
@@ -148,15 +147,5 @@ pub fn process_rollover_address_merkle_tree_and_queue<'a, 'b, 'c: 'info, 'info>(
         lamports,
     )?;
 
-    Ok(())
-}
-
-pub fn assert_size_equal(a: &AccountInfo, b: &AccountInfo, err_str: &str) -> Result<()> {
-    if a.data_len() != b.data_len() {
-        msg!("a: {}", a.data_len());
-        msg!("b: {}", b.data_len());
-        msg!("{}", err_str);
-        return err!(crate::errors::AccountCompressionErrorCode::SizeMismatch);
-    }
     Ok(())
 }

--- a/programs/account-compression/src/instructions/rollover_state_merkle_tree_and_queue.rs
+++ b/programs/account-compression/src/instructions/rollover_state_merkle_tree_and_queue.rs
@@ -1,5 +1,4 @@
 use crate::{
-    assert_size_equal,
     processor::{
         initialize_concurrent_merkle_tree::process_initialize_state_merkle_tree,
         initialize_nullifier_queue::process_initialize_nullifier_queue,
@@ -58,19 +57,22 @@ pub fn process_rollover_state_merkle_tree_nullifier_queue_pair<'a, 'b, 'c: 'info
 ) -> Result<()> {
     // TODO: rollover additional rent as well. (need to add a field to the metadata for this)
     let new_merkle_tree_account_info = ctx.accounts.new_state_merkle_tree.to_account_info();
-    let merkle_tree_rent = check_account_balance_is_rent_exempt(&new_merkle_tree_account_info)?;
-    let new_queue_account_info = ctx.accounts.new_nullifier_queue.to_account_info();
-    let queue_rent = check_account_balance_is_rent_exempt(&new_queue_account_info)?;
-    assert_size_equal(
-        &ctx.accounts.old_nullifier_queue.to_account_info(),
-        &new_queue_account_info,
-        "Queue size mismatch",
-    )?;
-    assert_size_equal(
-        &ctx.accounts.old_state_merkle_tree.to_account_info(),
+    let merkle_tree_rent = check_account_balance_is_rent_exempt(
         &new_merkle_tree_account_info,
-        "Merkle tree size mismatch",
+        ctx.accounts
+            .old_state_merkle_tree
+            .to_account_info()
+            .data_len(),
     )?;
+    let new_queue_account_info = ctx.accounts.new_nullifier_queue.to_account_info();
+    let queue_rent = check_account_balance_is_rent_exempt(
+        &new_queue_account_info,
+        ctx.accounts
+            .old_nullifier_queue
+            .to_account_info()
+            .data_len(),
+    )?;
+
     let queue_metadata = {
         let (merkle_tree_metadata, queue_metadata) = {
             let mut merkle_tree_account_loaded = ctx.accounts.old_state_merkle_tree.load_mut()?;

--- a/programs/account-compression/src/utils/check_account.rs
+++ b/programs/account-compression/src/utils/check_account.rs
@@ -1,15 +1,27 @@
+use crate::errors::AccountCompressionErrorCode;
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::{account_info::AccountInfo, msg, rent::Rent};
 
-use crate::errors::AccountCompressionErrorCode;
-
 /// Checks that the account balance is equal to rent exemption.
-pub fn check_account_balance_is_rent_exempt(account_info: &AccountInfo) -> Result<u64> {
+pub fn check_account_balance_is_rent_exempt(
+    account_info: &AccountInfo,
+    expected_size: usize,
+) -> Result<u64> {
+    let account_size = account_info.data_len();
+    if account_size != expected_size {
+        msg!(
+            "Account {:?} size not equal to expected size. size: {}, expected size {}",
+            account_info.key(),
+            account_size,
+            expected_size
+        );
+        return err!(AccountCompressionErrorCode::InvalidAccountSize);
+    }
     let lamports = account_info.lamports();
-    let rent_exemption = (Rent::get()?).minimum_balance(account_info.data_len());
+    let rent_exemption = (Rent::get()?).minimum_balance(expected_size);
     if lamports != rent_exemption {
         msg!(
-            "Account {:?} lamports is not equal to rentexemption: {} != {}",
+            "Account {:?} lamports is not equal to rentexemption: lamports {}, rent exemption {}",
             account_info.key(),
             lamports,
             rent_exemption

--- a/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -259,7 +259,7 @@ async fn test_address_queue_and_tree_invalid_sizes() {
             assert_rpc_error(
                 result,
                 2,
-                HashSetError::BufferSize(valid_queue_size, queue_size).into(),
+                AccountCompressionErrorCode::InvalidAccountSize.into(),
             )
             .unwrap()
         }
@@ -282,7 +282,7 @@ async fn test_address_queue_and_tree_invalid_sizes() {
         assert_rpc_error(
             result,
             2,
-            ConcurrentMerkleTreeError::BufferSize(valid_tree_size, tree_size).into(),
+            AccountCompressionErrorCode::InvalidAccountSize.into(),
         )
         .unwrap()
     }
@@ -302,7 +302,7 @@ async fn test_address_queue_and_tree_invalid_sizes() {
         assert_rpc_error(
             result,
             2,
-            HashSetError::BufferSize(valid_queue_size, queue_size).into(),
+            AccountCompressionErrorCode::InvalidAccountSize.into(),
         )
         .unwrap()
     }
@@ -410,6 +410,13 @@ async fn test_address_queue_and_tree_invalid_config() {
     {
         let mut merkle_tree_config = merkle_tree_config.clone();
         merkle_tree_config.changelog_size = 0;
+        let tree_size = AddressMerkleTreeAccount::size(
+            merkle_tree_config.height as usize,
+            merkle_tree_config.changelog_size as usize,
+            merkle_tree_config.roots_size as usize,
+            merkle_tree_config.canopy_depth as usize,
+            merkle_tree_config.address_changelog_size as usize,
+        );
         let result = initialize_address_merkle_tree_and_queue(
             &mut context,
             &payer,
@@ -426,6 +433,13 @@ async fn test_address_queue_and_tree_invalid_config() {
     {
         let mut merkle_tree_config = merkle_tree_config.clone();
         merkle_tree_config.roots_size = 0;
+        let tree_size = AddressMerkleTreeAccount::size(
+            merkle_tree_config.height as usize,
+            merkle_tree_config.changelog_size as usize,
+            merkle_tree_config.roots_size as usize,
+            merkle_tree_config.canopy_depth as usize,
+            merkle_tree_config.address_changelog_size as usize,
+        );
         let result = initialize_address_merkle_tree_and_queue(
             &mut context,
             &payer,

--- a/test-programs/account-compression-test/tests/merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/merkle_tree_tests.rs
@@ -709,7 +709,12 @@ async fn test_init_and_rollover_state_merkle_tree(
     )
     .await;
 
-    assert_rpc_error(result, 2, AccountCompressionErrorCode::SizeMismatch.into()).unwrap();
+    assert_rpc_error(
+        result,
+        2,
+        AccountCompressionErrorCode::InvalidAccountSize.into(),
+    )
+    .unwrap();
     let result = perform_state_merkle_tree_roll_over(
         &mut context,
         &new_nullifier_queue_keypair,
@@ -722,7 +727,12 @@ async fn test_init_and_rollover_state_merkle_tree(
     )
     .await;
 
-    assert_rpc_error(result, 2, AccountCompressionErrorCode::SizeMismatch.into()).unwrap();
+    assert_rpc_error(
+        result,
+        2,
+        AccountCompressionErrorCode::InvalidAccountSize.into(),
+    )
+    .unwrap();
 
     set_state_merkle_tree_next_index(
         &mut context,

--- a/test-programs/account-compression-test/tests/merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/merkle_tree_tests.rs
@@ -1522,7 +1522,7 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_sizes
             assert_rpc_error(
                 result,
                 2,
-                ConcurrentMerkleTreeError::BufferSize(valid_tree_size, invalid_tree_size).into(),
+                AccountCompressionErrorCode::InvalidAccountSize.into(),
             )
             .unwrap();
         }
@@ -1622,6 +1622,12 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_confi
     {
         let mut merkle_tree_config = merkle_tree_config.clone();
         merkle_tree_config.changelog_size = 0;
+        let merkle_tree_size = StateMerkleTreeAccount::size(
+            merkle_tree_config.height as usize,
+            merkle_tree_config.changelog_size as usize,
+            merkle_tree_config.roots_size as usize,
+            merkle_tree_config.canopy_depth as usize,
+        );
         let result = initialize_state_merkle_tree_and_nullifier_queue(
             rpc,
             payer_pubkey,
@@ -1638,6 +1644,12 @@ pub async fn fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_confi
     {
         let mut merkle_tree_config = merkle_tree_config.clone();
         merkle_tree_config.roots_size = 0;
+        let merkle_tree_size = StateMerkleTreeAccount::size(
+            merkle_tree_config.height as usize,
+            merkle_tree_config.changelog_size as usize,
+            merkle_tree_config.roots_size as usize,
+            merkle_tree_config.canopy_depth as usize,
+        );
         let result = initialize_state_merkle_tree_and_nullifier_queue(
             rpc,
             payer_pubkey,


### PR DESCRIPTION
Changes:
- introduce expected size check in `process_initialize_address_merkle_tree_and_queue` `process_initialize_state_merkle_tree_and_nullifier_queue`
- in rollover instructions unify `assert_size_equal` with `check_account_balance_is_rent_exempt`