### PR TITLE
test: More tests for `approve` method of token program

### DIFF
--- a/test-programs/compressed-token-test/tests/test.rs
+++ b/test-programs/compressed-token-test/tests/test.rs
@@ -436,9 +436,8 @@ async fn test_delegation(
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_delegation_0() {
-    test_delegation(0, 0, vec![0], vec![0]).await
+    test_delegation(0, 0, vec![0, 0], vec![0]).await
 }
 
 #[tokio::test]

--- a/test-utils/src/assert_token_tx.rs
+++ b/test-utils/src/assert_token_tx.rs
@@ -105,6 +105,7 @@ pub fn assert_compressed_token_accounts<R: RpcConnection, I: Indexer<R>>(
             .position(|x| {
                 x.token_data.owner == out_compressed_account.owner
                     && x.token_data.amount == out_compressed_account.amount
+                    && x.token_data.delegate == delegates[i]
             })
             .expect("transfer recipient compressed account not found in mock indexer");
         let transfer_recipient_token_compressed_account =


### PR DESCRIPTION
Successful tests:

- Delegating `u64::MAX`.

Failing tests:

1. Invalid delegated compressed account Merkle tree.
2. Invalid change compressed account Merkle tree.
3. Invalid proof.
4. Invalid mint.