### PR TITLE
test: Add more test cases for `freeze` instruction in token program

### DIFF
--- a/programs/compressed-token/src/instructions/freeze.rs
+++ b/programs/compressed-token/src/instructions/freeze.rs
@@ -7,7 +7,8 @@ use light_system_program::sdk::accounts::{InvokeAccounts, SignerAccounts};
 pub struct FreezeInstruction<'info> {
     #[account(mut)]
     pub fee_payer: Signer<'info>,
-    #[account(address= mint.freeze_authority.unwrap())]
+    #[account(address= mint.freeze_authority.unwrap()
+        @ crate::ErrorCode::InvalidFreezeAuthority)]
     pub authority: Signer<'info>,
     /// CHECK: that mint authority is derived from signer
     #[account(seeds = [CPI_AUTHORITY_PDA_SEED], bump,)]

--- a/programs/compressed-token/src/lib.rs
+++ b/programs/compressed-token/src/lib.rs
@@ -155,4 +155,6 @@ pub enum ErrorCode {
     InvalidMint,
     #[msg("Expected the authority to be also a mint authority")]
     InvalidAuthorityMint,
+    #[msg("Provided authority is not the freeze authority")]
+    InvalidFreezeAuthority,
 }


### PR DESCRIPTION
- Test freeze and thaw with zero values.
- Failing tests for `freeze`
  1. Invalid authority.
  2. Invalid Merkle tree.
  3. Invalid proof.
- Failing tests for `thaw`
  1. Invalid authority.
  2. Invalid Merkle tree.
  3. Invalid proof.