### PR TITLE
feat: Burn SPL tokens from the pool when burning compressed tokens

### DIFF
--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -491,6 +491,21 @@ export type LightCompressedToken = {
                     isSigner: false;
                 },
                 {
+                    name: 'mint';
+                    isMut: true;
+                    isSigner: false;
+                },
+                {
+                    name: 'tokenPoolPda';
+                    isMut: true;
+                    isSigner: false;
+                },
+                {
+                    name: 'tokenProgram';
+                    isMut: false;
+                    isSigner: false;
+                },
+                {
                     name: 'lightSystemProgram';
                     isMut: false;
                     isSigner: false;
@@ -1884,6 +1899,21 @@ export const IDL: LightCompressedToken = {
                 },
                 {
                     name: 'cpiAuthorityPda',
+                    isMut: false,
+                    isSigner: false,
+                },
+                {
+                    name: 'mint',
+                    isMut: true,
+                    isSigner: false,
+                },
+                {
+                    name: 'tokenPoolPda',
+                    isMut: true,
+                    isSigner: false,
+                },
+                {
+                    name: 'tokenProgram',
                     isMut: false,
                     isSigner: false,
                 },

--- a/js/compressed-token/tests/e2e/mint-to.test.ts
+++ b/js/compressed-token/tests/e2e/mint-to.test.ts
@@ -76,7 +76,7 @@ describe('mintTo', () => {
         /// wrong authority
         await expect(
             mintTo(rpc, payer, mint, bob.publicKey, payer, amount),
-        ).rejects.toThrowError(/custom program error: 0x1786/);
+        ).rejects.toThrowError(/custom program error: 0x1782/);
 
         /// with output state merkle tree defined
         await mintTo(

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -491,6 +491,21 @@ export type LightCompressedToken = {
                     isSigner: false;
                 },
                 {
+                    name: 'mint';
+                    isMut: true;
+                    isSigner: false;
+                },
+                {
+                    name: 'tokenPoolPda';
+                    isMut: true;
+                    isSigner: false;
+                },
+                {
+                    name: 'tokenProgram';
+                    isMut: false;
+                    isSigner: false;
+                },
+                {
                     name: 'lightSystemProgram';
                     isMut: false;
                     isSigner: false;
@@ -1884,6 +1899,21 @@ export const IDL: LightCompressedToken = {
                 },
                 {
                     name: 'cpiAuthorityPda',
+                    isMut: false,
+                    isSigner: false,
+                },
+                {
+                    name: 'mint',
+                    isMut: true,
+                    isSigner: false,
+                },
+                {
+                    name: 'tokenPoolPda',
+                    isMut: true,
+                    isSigner: false,
+                },
+                {
+                    name: 'tokenProgram',
                     isMut: false,
                     isSigner: false,
                 },

--- a/programs/compressed-token/src/instructions/burn.rs
+++ b/programs/compressed-token/src/instructions/burn.rs
@@ -1,0 +1,76 @@
+use account_compression::{program::AccountCompression, utils::constants::CPI_AUTHORITY_PDA_SEED};
+use anchor_lang::prelude::*;
+use anchor_spl::token::{Mint, Token, TokenAccount};
+use light_system_program::sdk::accounts::{InvokeAccounts, SignerAccounts};
+
+use crate::POOL_SEED;
+
+#[derive(Accounts)]
+pub struct BurnInstruction<'info> {
+    #[account(mut)]
+    pub fee_payer: Signer<'info>,
+    pub authority: Signer<'info>,
+    /// CHECK: that mint authority is derived from signer
+    #[account(seeds = [CPI_AUTHORITY_PDA_SEED], bump,)]
+    pub cpi_authority_pda: UncheckedAccount<'info>,
+    /// CHECK: that authority is mint authority
+    #[account(mut)]
+    pub mint: Account<'info, Mint>,
+    /// CHECK: the seed of token pool
+    #[account(mut, seeds = [POOL_SEED, mint.key().as_ref()], bump)]
+    pub token_pool_pda: Account<'info, TokenAccount>,
+    pub token_program: Program<'info, Token>,
+    pub light_system_program: Program<'info, light_system_program::program::LightSystemProgram>,
+    /// CHECK: this account is checked in account compression program
+    pub registered_program_pda: AccountInfo<'info>,
+    /// CHECK: this account
+    pub noop_program: UncheckedAccount<'info>,
+    /// CHECK: this account in psp account compression program
+    #[account(seeds = [CPI_AUTHORITY_PDA_SEED], bump, seeds::program = light_system_program::ID,)]
+    pub account_compression_authority: UncheckedAccount<'info>,
+    /// CHECK: this account in psp account compression program
+    pub account_compression_program:
+        Program<'info, account_compression::program::AccountCompression>,
+    pub self_program: Program<'info, crate::program::LightCompressedToken>,
+    pub system_program: Program<'info, System>,
+}
+
+impl<'info> InvokeAccounts<'info> for BurnInstruction<'info> {
+    fn get_registered_program_pda(&self) -> &AccountInfo<'info> {
+        &self.registered_program_pda
+    }
+
+    fn get_noop_program(&self) -> &UncheckedAccount<'info> {
+        &self.noop_program
+    }
+
+    fn get_account_compression_authority(&self) -> &UncheckedAccount<'info> {
+        &self.account_compression_authority
+    }
+
+    fn get_account_compression_program(&self) -> &Program<'info, AccountCompression> {
+        &self.account_compression_program
+    }
+
+    fn get_system_program(&self) -> &Program<'info, System> {
+        &self.system_program
+    }
+
+    fn get_sol_pool_pda(&self) -> Option<&UncheckedAccount<'info>> {
+        None
+    }
+
+    fn get_decompression_recipient(&self) -> Option<&UncheckedAccount<'info>> {
+        None
+    }
+}
+
+impl<'info> SignerAccounts<'info> for BurnInstruction<'info> {
+    fn get_fee_payer(&self) -> &Signer<'info> {
+        &self.fee_payer
+    }
+
+    fn get_authority(&self) -> &Signer<'info> {
+        &self.authority
+    }
+}

--- a/programs/compressed-token/src/instructions/mod.rs
+++ b/programs/compressed-token/src/instructions/mod.rs
@@ -1,6 +1,8 @@
+pub mod burn;
 pub mod freeze;
 pub mod generic;
 pub mod transfer;
+pub use burn::*;
 pub use freeze::*;
 pub use generic::*;
 pub use transfer::*;

--- a/programs/compressed-token/src/lib.rs
+++ b/programs/compressed-token/src/lib.rs
@@ -12,6 +12,7 @@ pub mod freeze;
 pub mod instructions;
 pub use instructions::*;
 pub mod burn;
+pub use burn::*;
 
 use crate::process_transfer::CompressedTokenInstructionDataTransfer;
 declare_id!("HXVfQ44ATEi9WBKLSCCwM54KokdkzqXci9xCQ7ST9SYN");
@@ -88,7 +89,7 @@ pub mod light_compressed_token {
     }
 
     pub fn burn<'info>(
-        ctx: Context<'_, '_, '_, 'info, GenericInstruction<'info>>,
+        ctx: Context<'_, '_, '_, 'info, BurnInstruction<'info>>,
         inputs: Vec<u8>,
     ) -> Result<()> {
         burn::process_burn(ctx, inputs)

--- a/programs/compressed-token/src/lib.rs
+++ b/programs/compressed-token/src/lib.rs
@@ -112,8 +112,6 @@ pub mod light_compressed_token {
 pub enum ErrorCode {
     #[msg("public keys and amounts must be of same length")]
     PublicKeyAmountMissmatch,
-    #[msg("SignerCheckFailed")]
-    SignerCheckFailed,
     #[msg("ComputeInputSumFailed")]
     ComputeInputSumFailed,
     #[msg("ComputeOutputSumFailed")]
@@ -134,8 +132,6 @@ pub enum ErrorCode {
     CompressedPdaUndefinedForCompress,
     #[msg("DeCompressAmountUndefinedForCompress")]
     DeCompressAmountUndefinedForCompress,
-    #[msg("DelegateUndefined while delegated amount is defined")]
-    DelegateUndefined,
     #[msg("DelegateSignerCheckFailed")]
     DelegateSignerCheckFailed,
     #[msg("Minted amount greater than u64::MAX")]
@@ -148,12 +144,8 @@ pub enum ErrorCode {
     InstructionNotCallable,
     #[msg("ArithmeticUnderflow")]
     ArithmeticUnderflow,
-    #[msg("InvalidDelegate")]
-    InvalidDelegate,
     #[msg("HashToFieldError")]
     HashToFieldError,
-    #[msg("InvalidMint")]
-    InvalidMint,
     #[msg("Expected the authority to be also a mint authority")]
     InvalidAuthorityMint,
 }

--- a/programs/system/src/invoke_cpi/verify_signer.rs
+++ b/programs/system/src/invoke_cpi/verify_signer.rs
@@ -1,4 +1,7 @@
-use account_compression::{AddressMerkleTreeAccount, StateMerkleTreeAccount};
+use account_compression::{
+    utils::check_discrimininator::check_discriminator, AddressMerkleTreeAccount,
+    StateMerkleTreeAccount,
+};
 use anchor_lang::prelude::*;
 use light_concurrent_merkle_tree::zero_copy::ConcurrentMerkleTreeZeroCopy;
 use light_hasher::Poseidon;
@@ -121,6 +124,7 @@ pub fn check_program_owner_state_merkle_tree<'a, 'b: 'a>(
 ) -> Result<(u32, Option<u64>, u64)> {
     let (seq, next_index) = {
         let merkle_tree = merkle_tree_acc_info.try_borrow_data()?;
+        check_discriminator::<StateMerkleTreeAccount>(&merkle_tree).map_err(ProgramError::from)?;
         let merkle_tree = ConcurrentMerkleTreeZeroCopy::<Poseidon, 26>::from_bytes_zero_copy(
             &merkle_tree[8 + mem::size_of::<StateMerkleTreeAccount>()..],
         )

--- a/test-utils/src/spl.rs
+++ b/test-utils/src/spl.rs
@@ -1142,11 +1142,12 @@ pub enum BurnInstructionMode {
     InvalidMint,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn create_burn_test_instruction<R: RpcConnection>(
     authority: &Keypair,
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
-    input_compressed_accounts: &Vec<TokenDataWithContext>,
+    input_compressed_accounts: &[TokenDataWithContext],
     change_account_merkle_tree: &Pubkey,
     burn_amount: u64,
     signer_is_delegate: bool,
@@ -1170,9 +1171,6 @@ pub async fn create_burn_test_instruction<R: RpcConnection>(
         )
         .await;
     let mint = if mode == BurnInstructionMode::InvalidMint {
-        // let payer = rpc.get_payer().insecure_clone();
-        // let mint = create_mint_helper(rpc, &payer).await;
-        // mint
         Pubkey::new_unique()
     } else {
         input_compressed_accounts[0].token_data.mint

--- a/test-utils/src/spl.rs
+++ b/test-utils/src/spl.rs
@@ -1,4 +1,4 @@
-use anchor_spl::token::TokenAccount;
+use anchor_spl::token::{Mint, TokenAccount};
 use solana_program_test::BanksClientError;
 use solana_sdk::{
     instruction::Instruction,
@@ -7,7 +7,6 @@ use solana_sdk::{
     signature::{Keypair, Signature, Signer},
 };
 use spl_token::instruction::initialize_mint;
-use spl_token::state::Mint;
 
 use light_compressed_token::{
     burn::sdk::{create_burn_instruction, CreateBurnInstructionInputs},
@@ -25,7 +24,10 @@ use light_compressed_token::{
     TokenData,
 };
 use light_hasher::Poseidon;
-use light_system_program::sdk::{compressed_account::MerkleContext, event::PublicTransactionEvent};
+use light_system_program::{
+    invoke::processor::CompressedProof,
+    sdk::{compressed_account::MerkleContext, event::PublicTransactionEvent},
+};
 
 use crate::indexer::{Indexer, TestIndexer, TokenDataWithContext};
 use crate::rpc::rpc_connection::RpcConnection;
@@ -1024,48 +1026,23 @@ pub async fn burn_test<R: RpcConnection>(
     signer_is_delegate: bool,
     transaction_params: Option<TransactionParams>,
 ) {
-    let input_compressed_account_hashes = input_compressed_accounts
-        .iter()
-        .map(|x| x.compressed_account.hash().unwrap())
-        .collect::<Vec<_>>();
-    let input_merkle_tree_pubkeys = input_compressed_accounts
-        .iter()
-        .map(|x| x.compressed_account.merkle_context.merkle_tree_pubkey)
-        .collect::<Vec<_>>();
-    let proof_rpc_result = test_indexer
-        .create_proof_for_compressed_accounts(
-            Some(&input_compressed_account_hashes),
-            Some(&input_merkle_tree_pubkeys),
-            None,
-            None,
-            rpc,
-        )
-        .await;
-    let mint = input_compressed_accounts[0].token_data.mint;
-    let inputs = CreateBurnInstructionInputs {
-        fee_payer: rpc.get_payer().pubkey(),
-        authority: authority.pubkey(),
-        input_merkle_contexts: input_compressed_accounts
-            .iter()
-            .map(|x| x.compressed_account.merkle_context)
-            .collect(),
-        input_token_data: input_compressed_accounts
-            .iter()
-            .map(|x| x.token_data)
-            .collect(),
-        change_account_merkle_tree: *change_account_merkle_tree,
-        root_indices: proof_rpc_result.root_indices,
-        proof: proof_rpc_result.proof,
+    let (
+        input_compressed_account_hashes,
+        input_merkle_tree_pubkeys,
         mint,
-        signer_is_delegate,
+        output_amount,
+        instruction,
+    ) = create_burn_test_instruction(
+        authority,
+        rpc,
+        test_indexer,
+        &input_compressed_accounts,
+        change_account_merkle_tree,
         burn_amount,
-    };
-    let input_amount_sum = input_compressed_accounts
-        .iter()
-        .map(|x| x.token_data.amount)
-        .sum::<u64>();
-    let output_amount = input_amount_sum - burn_amount;
-    let instruction = create_burn_instruction(inputs).unwrap();
+        signer_is_delegate,
+        BurnInstructionMode::Normal,
+    )
+    .await;
     let output_merkle_tree_pubkeys = vec![*change_account_merkle_tree; 1];
     let output_merkle_tree_test_snapshots = if output_amount > 0 {
         let output_merkle_tree_accounts =
@@ -1076,11 +1053,22 @@ pub async fn burn_test<R: RpcConnection>(
         Vec::new()
     };
 
+    let token_pool_pda_address = get_token_pool_pda(&mint);
+    let pre_token_pool_account = rpc
+        .get_account(token_pool_pda_address)
+        .await
+        .unwrap()
+        .unwrap();
+    let pre_token_pool_balance = spl_token::state::Account::unpack(&pre_token_pool_account.data)
+        .unwrap()
+        .amount;
+
     let input_merkle_tree_accounts =
         test_indexer.get_state_merkle_tree_accounts(&input_merkle_tree_pubkeys);
     let input_merkle_tree_test_snapshots =
         get_merkle_tree_snapshots::<R>(rpc, input_merkle_tree_accounts.as_slice()).await;
     let context_payer = rpc.get_payer().insecure_clone();
+
     let (event, _signature) = rpc
         .create_and_send_transaction_with_event::<PublicTransactionEvent>(
             &[instruction],
@@ -1133,6 +1121,102 @@ pub async fn burn_test<R: RpcConnection>(
         Some(delegates),
     )
     .await;
+    let post_token_pool_account = rpc
+        .get_account(token_pool_pda_address)
+        .await
+        .unwrap()
+        .unwrap();
+    let post_token_pool_balance = spl_token::state::Account::unpack(&post_token_pool_account.data)
+        .unwrap()
+        .amount;
+    assert_eq!(
+        post_token_pool_balance,
+        pre_token_pool_balance - burn_amount
+    );
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum BurnInstructionMode {
+    Normal,
+    InvalidProof,
+    InvalidMint,
+}
+
+pub async fn create_burn_test_instruction<R: RpcConnection>(
+    authority: &Keypair,
+    rpc: &mut R,
+    test_indexer: &mut TestIndexer<R>,
+    input_compressed_accounts: &Vec<TokenDataWithContext>,
+    change_account_merkle_tree: &Pubkey,
+    burn_amount: u64,
+    signer_is_delegate: bool,
+    mode: BurnInstructionMode,
+) -> (Vec<[u8; 32]>, Vec<Pubkey>, Pubkey, u64, Instruction) {
+    let input_compressed_account_hashes = input_compressed_accounts
+        .iter()
+        .map(|x| x.compressed_account.hash().unwrap())
+        .collect::<Vec<_>>();
+    let input_merkle_tree_pubkeys = input_compressed_accounts
+        .iter()
+        .map(|x| x.compressed_account.merkle_context.merkle_tree_pubkey)
+        .collect::<Vec<_>>();
+    let proof_rpc_result = test_indexer
+        .create_proof_for_compressed_accounts(
+            Some(&input_compressed_account_hashes),
+            Some(&input_merkle_tree_pubkeys),
+            None,
+            None,
+            rpc,
+        )
+        .await;
+    let mint = if mode == BurnInstructionMode::InvalidMint {
+        // let payer = rpc.get_payer().insecure_clone();
+        // let mint = create_mint_helper(rpc, &payer).await;
+        // mint
+        Pubkey::new_unique()
+    } else {
+        input_compressed_accounts[0].token_data.mint
+    };
+    let proof = if mode == BurnInstructionMode::InvalidProof {
+        CompressedProof {
+            a: proof_rpc_result.proof.a,
+            b: proof_rpc_result.proof.b,
+            c: proof_rpc_result.proof.a, // flip c to make proof invalid but not run into decompress errors
+        }
+    } else {
+        proof_rpc_result.proof
+    };
+    let inputs = CreateBurnInstructionInputs {
+        fee_payer: rpc.get_payer().pubkey(),
+        authority: authority.pubkey(),
+        input_merkle_contexts: input_compressed_accounts
+            .iter()
+            .map(|x| x.compressed_account.merkle_context)
+            .collect(),
+        input_token_data: input_compressed_accounts
+            .iter()
+            .map(|x| x.token_data)
+            .collect(),
+        change_account_merkle_tree: *change_account_merkle_tree,
+        root_indices: proof_rpc_result.root_indices,
+        proof,
+        mint,
+        signer_is_delegate,
+        burn_amount,
+    };
+    let input_amount_sum = input_compressed_accounts
+        .iter()
+        .map(|x| x.token_data.amount)
+        .sum::<u64>();
+    let output_amount = input_amount_sum - burn_amount;
+    let instruction = create_burn_instruction(inputs).unwrap();
+    (
+        input_compressed_account_hashes,
+        input_merkle_tree_pubkeys,
+        mint,
+        output_amount,
+        instruction,
+    )
 }
 
 pub fn create_expected_token_output_data(


### PR DESCRIPTION
Similarly to the `mint` instruction, where we are minting SPL tokens, burn SPL tokens when calling `burn` instruction.