### PR TITLE
chore: compressed token tests & cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,8 +62,6 @@
 **/*.iml
 
 /**/dump.rdb
-psp-examples/tmp-test-psp
-psp-examples/tmp-test-circom
 
 /**/package-lock.json
 qodana.yaml

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,8 +7,7 @@ macros/ @vadorovsky
 merkle-tree/ @ananas-block @vadorovsky
 programs/ @ananas-block @vadorovsky
 prover.js/ @sergeytimoshin
-psp-examples/ @ananas-block @sergeytimoshin
-psp-template/ @ananas-block @sergeytimoshin @vadorovsky
+examples/ @ananas-block @SwenSchaeferjohann
 rpc/ @sergeytimoshin @SwenSchaeferjohann
 scripts/ @vadorovsky
 third-party/ @vadorovsky

--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -15,6 +15,7 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'tokenPoolPda';
@@ -57,6 +58,7 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
@@ -77,6 +79,9 @@ export type LightCompressedToken = {
                     name: 'tokenPoolPda';
                     isMut: true;
                     isSigner: false;
+                    docs: [
+                        'account to a token account of a different mint will fail',
+                    ];
                 },
                 {
                     name: 'tokenProgram';
@@ -97,6 +102,7 @@ export type LightCompressedToken = {
                     name: 'noopProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: ['programs'];
                 },
                 {
                     name: 'accountCompressionAuthority';
@@ -146,11 +152,17 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
                     isMut: false;
                     isSigner: true;
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ];
                 },
                 {
                     name: 'cpiAuthorityPda';
@@ -186,6 +198,9 @@ export type LightCompressedToken = {
                     name: 'selfProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ];
                 },
                 {
                     name: 'tokenPoolPda';
@@ -225,11 +240,17 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
                     isMut: false;
                     isSigner: true;
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ];
                 },
                 {
                     name: 'cpiAuthorityPda';
@@ -265,6 +286,9 @@ export type LightCompressedToken = {
                     name: 'selfProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ];
                 },
                 {
                     name: 'systemProgram';
@@ -286,11 +310,17 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
                     isMut: false;
                     isSigner: true;
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ];
                 },
                 {
                     name: 'cpiAuthorityPda';
@@ -326,6 +356,9 @@ export type LightCompressedToken = {
                     name: 'selfProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ];
                 },
                 {
                     name: 'systemProgram';
@@ -347,6 +380,7 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
@@ -387,6 +421,9 @@ export type LightCompressedToken = {
                     name: 'selfProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ];
                 },
                 {
                     name: 'systemProgram';
@@ -413,6 +450,7 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
@@ -453,6 +491,9 @@ export type LightCompressedToken = {
                     name: 'selfProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ];
                 },
                 {
                     name: 'systemProgram';
@@ -479,11 +520,17 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
                     isMut: false;
                     isSigner: true;
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ];
                 },
                 {
                     name: 'cpiAuthorityPda';
@@ -519,6 +566,9 @@ export type LightCompressedToken = {
                     name: 'selfProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ];
                 },
                 {
                     name: 'systemProgram';
@@ -545,11 +595,17 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
                     isMut: false;
                     isSigner: true;
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ];
                 },
                 {
                     name: 'cpiAuthorityPda';
@@ -585,6 +641,9 @@ export type LightCompressedToken = {
                     name: 'selfProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ];
                 },
                 {
                     name: 'tokenPoolPda';
@@ -1412,6 +1471,7 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'tokenPoolPda',
@@ -1454,6 +1514,7 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
@@ -1474,6 +1535,9 @@ export const IDL: LightCompressedToken = {
                     name: 'tokenPoolPda',
                     isMut: true,
                     isSigner: false,
+                    docs: [
+                        'account to a token account of a different mint will fail',
+                    ],
                 },
                 {
                     name: 'tokenProgram',
@@ -1494,6 +1558,7 @@ export const IDL: LightCompressedToken = {
                     name: 'noopProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: ['programs'],
                 },
                 {
                     name: 'accountCompressionAuthority',
@@ -1543,11 +1608,17 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
                     isMut: false,
                     isSigner: true,
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ],
                 },
                 {
                     name: 'cpiAuthorityPda',
@@ -1583,6 +1654,9 @@ export const IDL: LightCompressedToken = {
                     name: 'selfProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ],
                 },
                 {
                     name: 'tokenPoolPda',
@@ -1622,11 +1696,17 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
                     isMut: false,
                     isSigner: true,
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ],
                 },
                 {
                     name: 'cpiAuthorityPda',
@@ -1662,6 +1742,9 @@ export const IDL: LightCompressedToken = {
                     name: 'selfProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ],
                 },
                 {
                     name: 'systemProgram',
@@ -1683,11 +1766,17 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
                     isMut: false,
                     isSigner: true,
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ],
                 },
                 {
                     name: 'cpiAuthorityPda',
@@ -1723,6 +1812,9 @@ export const IDL: LightCompressedToken = {
                     name: 'selfProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ],
                 },
                 {
                     name: 'systemProgram',
@@ -1744,6 +1836,7 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
@@ -1784,6 +1877,9 @@ export const IDL: LightCompressedToken = {
                     name: 'selfProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ],
                 },
                 {
                     name: 'systemProgram',
@@ -1810,6 +1906,7 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
@@ -1850,6 +1947,9 @@ export const IDL: LightCompressedToken = {
                     name: 'selfProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ],
                 },
                 {
                     name: 'systemProgram',
@@ -1876,11 +1976,17 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
                     isMut: false,
                     isSigner: true,
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ],
                 },
                 {
                     name: 'cpiAuthorityPda',
@@ -1916,6 +2022,9 @@ export const IDL: LightCompressedToken = {
                     name: 'selfProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ],
                 },
                 {
                     name: 'systemProgram',
@@ -1942,11 +2051,17 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
                     isMut: false,
                     isSigner: true,
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ],
                 },
                 {
                     name: 'cpiAuthorityPda',
@@ -1982,6 +2097,9 @@ export const IDL: LightCompressedToken = {
                     name: 'selfProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ],
                 },
                 {
                     name: 'tokenPoolPda',

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -15,6 +15,7 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'tokenPoolPda';
@@ -57,6 +58,7 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
@@ -77,6 +79,9 @@ export type LightCompressedToken = {
                     name: 'tokenPoolPda';
                     isMut: true;
                     isSigner: false;
+                    docs: [
+                        'account to a token account of a different mint will fail',
+                    ];
                 },
                 {
                     name: 'tokenProgram';
@@ -97,6 +102,7 @@ export type LightCompressedToken = {
                     name: 'noopProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: ['programs'];
                 },
                 {
                     name: 'accountCompressionAuthority';
@@ -146,11 +152,17 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
                     isMut: false;
                     isSigner: true;
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ];
                 },
                 {
                     name: 'cpiAuthorityPda';
@@ -186,6 +198,9 @@ export type LightCompressedToken = {
                     name: 'selfProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ];
                 },
                 {
                     name: 'tokenPoolPda';
@@ -225,11 +240,17 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
                     isMut: false;
                     isSigner: true;
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ];
                 },
                 {
                     name: 'cpiAuthorityPda';
@@ -265,6 +286,9 @@ export type LightCompressedToken = {
                     name: 'selfProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ];
                 },
                 {
                     name: 'systemProgram';
@@ -286,11 +310,17 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
                     isMut: false;
                     isSigner: true;
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ];
                 },
                 {
                     name: 'cpiAuthorityPda';
@@ -326,6 +356,9 @@ export type LightCompressedToken = {
                     name: 'selfProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ];
                 },
                 {
                     name: 'systemProgram';
@@ -347,6 +380,7 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
@@ -387,6 +421,9 @@ export type LightCompressedToken = {
                     name: 'selfProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ];
                 },
                 {
                     name: 'systemProgram';
@@ -413,6 +450,7 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
@@ -453,6 +491,9 @@ export type LightCompressedToken = {
                     name: 'selfProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ];
                 },
                 {
                     name: 'systemProgram';
@@ -479,11 +520,17 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
                     isMut: false;
                     isSigner: true;
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ];
                 },
                 {
                     name: 'cpiAuthorityPda';
@@ -519,6 +566,9 @@ export type LightCompressedToken = {
                     name: 'selfProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ];
                 },
                 {
                     name: 'systemProgram';
@@ -545,11 +595,17 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
                     isMut: false;
                     isSigner: true;
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ];
                 },
                 {
                     name: 'cpiAuthorityPda';
@@ -585,6 +641,9 @@ export type LightCompressedToken = {
                     name: 'selfProgram';
                     isMut: false;
                     isSigner: false;
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ];
                 },
                 {
                     name: 'tokenPoolPda';
@@ -1412,6 +1471,7 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'tokenPoolPda',
@@ -1454,6 +1514,7 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
@@ -1474,6 +1535,9 @@ export const IDL: LightCompressedToken = {
                     name: 'tokenPoolPda',
                     isMut: true,
                     isSigner: false,
+                    docs: [
+                        'account to a token account of a different mint will fail',
+                    ],
                 },
                 {
                     name: 'tokenProgram',
@@ -1494,6 +1558,7 @@ export const IDL: LightCompressedToken = {
                     name: 'noopProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: ['programs'],
                 },
                 {
                     name: 'accountCompressionAuthority',
@@ -1543,11 +1608,17 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
                     isMut: false,
                     isSigner: true,
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ],
                 },
                 {
                     name: 'cpiAuthorityPda',
@@ -1583,6 +1654,9 @@ export const IDL: LightCompressedToken = {
                     name: 'selfProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ],
                 },
                 {
                     name: 'tokenPoolPda',
@@ -1622,11 +1696,17 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
                     isMut: false,
                     isSigner: true,
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ],
                 },
                 {
                     name: 'cpiAuthorityPda',
@@ -1662,6 +1742,9 @@ export const IDL: LightCompressedToken = {
                     name: 'selfProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ],
                 },
                 {
                     name: 'systemProgram',
@@ -1683,11 +1766,17 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
                     isMut: false,
                     isSigner: true,
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ],
                 },
                 {
                     name: 'cpiAuthorityPda',
@@ -1723,6 +1812,9 @@ export const IDL: LightCompressedToken = {
                     name: 'selfProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ],
                 },
                 {
                     name: 'systemProgram',
@@ -1744,6 +1836,7 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
@@ -1784,6 +1877,9 @@ export const IDL: LightCompressedToken = {
                     name: 'selfProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ],
                 },
                 {
                     name: 'systemProgram',
@@ -1810,6 +1906,7 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
@@ -1850,6 +1947,9 @@ export const IDL: LightCompressedToken = {
                     name: 'selfProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ],
                 },
                 {
                     name: 'systemProgram',
@@ -1876,11 +1976,17 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
                     isMut: false,
                     isSigner: true,
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ],
                 },
                 {
                     name: 'cpiAuthorityPda',
@@ -1916,6 +2022,9 @@ export const IDL: LightCompressedToken = {
                     name: 'selfProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ],
                 },
                 {
                     name: 'systemProgram',
@@ -1942,11 +2051,17 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
                     isMut: false,
                     isSigner: true,
+                    docs: [
+                        'or delegate both are included in the token data hash, thus in the',
+                        'compressed data hash thus in the compressed account hash which is public',
+                        'input to the validity proof.',
+                    ],
                 },
                 {
                     name: 'cpiAuthorityPda',
@@ -1982,6 +2097,9 @@ export const IDL: LightCompressedToken = {
                     name: 'selfProgram',
                     isMut: false,
                     isSigner: false,
+                    docs: [
+                        'cpi_authority_pda and check that this program is the signer of the cpi.',
+                    ],
                 },
                 {
                     name: 'tokenPoolPda',

--- a/programs/compressed-token/src/delegation.rs
+++ b/programs/compressed-token/src/delegation.rs
@@ -59,8 +59,7 @@ pub fn process_approve<'a, 'b, 'c, 'info: 'b + 'c>(
         ctx.accounts.light_system_program.to_account_info(),
         ctx.accounts.self_program.to_account_info(),
         ctx.remaining_accounts,
-    )?;
-    Ok(())
+    )
 }
 
 pub fn create_input_and_output_accounts_approve(
@@ -71,8 +70,9 @@ pub fn create_input_and_output_accounts_approve(
     Vec<PackedCompressedAccountWithMerkleContext>,
     Vec<OutputCompressedAccountWithPackedContext>,
 )> {
+    const IS_FROZEN: bool = false;
     let (mut compressed_input_accounts, input_token_data) =
-        get_input_compressed_accounts_with_merkle_context_and_check_signer::<false>(
+        get_input_compressed_accounts_with_merkle_context_and_check_signer::<IS_FROZEN>(
             authority,
             &None,
             remaining_accounts,
@@ -105,7 +105,8 @@ pub fn create_input_and_output_accounts_approve(
             inputs.change_account_merkle_tree_index,
         ],
     )?;
-    add_token_data_to_input_compressed_accounts::<false>(
+    const FROZEN_INPUTS: bool = false;
+    add_token_data_to_input_compressed_accounts::<FROZEN_INPUTS>(
         &mut compressed_input_accounts,
         input_token_data.as_slice(),
         &hashed_mint,

--- a/programs/compressed-token/src/freeze.rs
+++ b/programs/compressed-token/src/freeze.rs
@@ -52,7 +52,6 @@ pub fn process_freeze_or_thaw<
             &ctx.accounts.mint.key(),
             ctx.remaining_accounts,
         )?;
-    // TODO: implement trait for TransferInstruction and FreezeInstruction
     cpi_execute_compressed_transaction_transfer(
         ctx.accounts,
         compressed_input_accounts,
@@ -63,8 +62,7 @@ pub fn process_freeze_or_thaw<
         ctx.accounts.light_system_program.to_account_info(),
         ctx.accounts.self_program.to_account_info(),
         ctx.remaining_accounts,
-    )?;
-    Ok(())
+    )
 }
 
 pub fn create_input_and_output_accounts_freeze_or_thaw<

--- a/programs/compressed-token/src/instructions/freeze.rs
+++ b/programs/compressed-token/src/instructions/freeze.rs
@@ -5,25 +5,27 @@ use light_system_program::sdk::accounts::{InvokeAccounts, SignerAccounts};
 
 #[derive(Accounts)]
 pub struct FreezeInstruction<'info> {
+    /// UNCHECKED: only pays fees.
     #[account(mut)]
     pub fee_payer: Signer<'info>,
     #[account(address= mint.freeze_authority.unwrap()
         @ crate::ErrorCode::InvalidFreezeAuthority)]
     pub authority: Signer<'info>,
-    /// CHECK: that mint authority is derived from signer
+    /// CHECK:
     #[account(seeds = [CPI_AUTHORITY_PDA_SEED], bump,)]
     pub cpi_authority_pda: UncheckedAccount<'info>,
     pub light_system_program: Program<'info, light_system_program::program::LightSystemProgram>,
-    /// CHECK: this account is checked in account compression program
+    /// CHECK: (different program) checked in account compression program
     pub registered_program_pda: AccountInfo<'info>,
-    /// CHECK: this account
+    /// CHECK: (different program) checked in system and account compression programs
     pub noop_program: UncheckedAccount<'info>,
-    /// CHECK: this account in psp account compression program
+    /// CHECK: (different program) is used to cpi account compression program from light system program.
     #[account(seeds = [CPI_AUTHORITY_PDA_SEED], bump, seeds::program = light_system_program::ID,)]
     pub account_compression_authority: UncheckedAccount<'info>,
-    /// CHECK: this account in psp account compression program
     pub account_compression_program:
         Program<'info, account_compression::program::AccountCompression>,
+    /// CHECK: (different program) checked in light system program to derive
+    /// cpi_authority_pda and check that this program is the signer of the cpi.
     pub self_program: Program<'info, crate::program::LightCompressedToken>,
     pub system_program: Program<'info, System>,
     pub mint: Account<'info, Mint>,

--- a/programs/compressed-token/src/instructions/generic.rs
+++ b/programs/compressed-token/src/instructions/generic.rs
@@ -4,23 +4,29 @@ use light_system_program::sdk::accounts::{InvokeAccounts, SignerAccounts};
 
 #[derive(Accounts)]
 pub struct GenericInstruction<'info> {
+    /// UNCHECKED: only pays fees.
     #[account(mut)]
     pub fee_payer: Signer<'info>,
+    /// CHECK: is checked by proof verification since authority is either owner
+    /// or delegate both are included in the token data hash, thus in the
+    /// compressed data hash thus in the compressed account hash which is public
+    /// input to the validity proof.
     pub authority: Signer<'info>,
-    /// CHECK: that mint authority is derived from signer
+    /// CHECK:
     #[account(seeds = [CPI_AUTHORITY_PDA_SEED], bump,)]
     pub cpi_authority_pda: UncheckedAccount<'info>,
     pub light_system_program: Program<'info, light_system_program::program::LightSystemProgram>,
-    /// CHECK: this account is checked in account compression program
+    /// CHECK: (different program) checked in account compression program
     pub registered_program_pda: AccountInfo<'info>,
-    /// CHECK: this account
+    /// CHECK: (different program) checked in system and account compression programs
     pub noop_program: UncheckedAccount<'info>,
-    /// CHECK: this account in psp account compression program
+    /// CHECK: (different program) is used to cpi account compression program from light system program.
     #[account(seeds = [CPI_AUTHORITY_PDA_SEED], bump, seeds::program = light_system_program::ID,)]
     pub account_compression_authority: UncheckedAccount<'info>,
-    /// CHECK: this account in psp account compression program
     pub account_compression_program:
         Program<'info, account_compression::program::AccountCompression>,
+    /// CHECK: (different program) checked in light system program to derive
+    /// cpi_authority_pda and check that this program is the signer of the cpi.
     pub self_program: Program<'info, crate::program::LightCompressedToken>,
     pub system_program: Program<'info, System>,
 }

--- a/programs/compressed-token/src/instructions/transfer.rs
+++ b/programs/compressed-token/src/instructions/transfer.rs
@@ -7,23 +7,29 @@ use light_system_program::{
 };
 #[derive(Accounts)]
 pub struct TransferInstruction<'info> {
+    /// UNCHECKED: only pays fees.
     #[account(mut)]
     pub fee_payer: Signer<'info>,
+    /// CHECK: is checked by proof verification since authority is either owner
+    /// or delegate both are included in the token data hash, thus in the
+    /// compressed data hash thus in the compressed account hash which is public
+    /// input to the validity proof.
     pub authority: Signer<'info>,
-    /// CHECK: that mint authority is derived from signer
+    /// CHECK:
     #[account(seeds = [CPI_AUTHORITY_PDA_SEED], bump,)]
     pub cpi_authority_pda: UncheckedAccount<'info>,
     pub light_system_program: Program<'info, light_system_program::program::LightSystemProgram>,
-    /// CHECK: this account
+    /// CHECK: (different program) checked in account compression program
     pub registered_program_pda: AccountInfo<'info>,
-    /// CHECK: this account
+    /// CHECK: (different program) checked in system and account compression programs
     pub noop_program: UncheckedAccount<'info>,
-    /// CHECK: this account in psp account compression program
+    /// CHECK: (different program) is used to cpi account compression program from light system program.
     #[account(seeds = [CPI_AUTHORITY_PDA_SEED], bump, seeds::program = light_system_program::ID,)]
     pub account_compression_authority: UncheckedAccount<'info>,
-    /// CHECK: this account in psp account compression program
     pub account_compression_program:
         Program<'info, account_compression::program::AccountCompression>,
+    /// CHECK: (different program) checked in light system program to derive
+    /// cpi_authority_pda and check that this program is the signer of the cpi.
     pub self_program: Program<'info, crate::program::LightCompressedToken>,
     #[account(mut)]
     pub token_pool_pda: Option<Account<'info, TokenAccount>>,

--- a/programs/compressed-token/src/process_mint.rs
+++ b/programs/compressed-token/src/process_mint.rs
@@ -16,6 +16,7 @@ pub const POOL_SEED: &[u8] = b"pool";
 /// creates a token pool account which is owned by the token authority pda
 #[derive(Accounts)]
 pub struct CreateTokenPoolInstruction<'info> {
+    /// UNCHECKED: only pays fees.
     #[account(mut)]
     pub fee_payer: Signer<'info>,
     #[account(
@@ -314,10 +315,12 @@ pub fn mint_spl_to_pool_pda<'info>(
 
 #[derive(Accounts)]
 pub struct MintToInstruction<'info> {
+    /// UNCHECKED: only pays fees.
     #[account(mut)]
     pub fee_payer: Signer<'info>,
+    /// CHECK: is checked by mint account macro.
     pub authority: Signer<'info>,
-    /// CHECK: that mint authority is derived from signer
+    /// CHECK:
     #[account(seeds = [CPI_AUTHORITY_PDA_SEED], bump)]
     pub cpi_authority_pda: UncheckedAccount<'info>,
     /// CHECK: that authority is mint authority
@@ -327,24 +330,27 @@ pub struct MintToInstruction<'info> {
             @ crate::ErrorCode::InvalidAuthorityMint
     )]
     pub mint: Account<'info, Mint>,
-    /// CHECK: this account
+    /// CHECK: this account is checked implictly since a mint to from a mint
+    /// account to a token account of a different mint will fail
     #[account(mut)]
     pub token_pool_pda: Account<'info, TokenAccount>,
     pub token_program: Program<'info, Token>,
     pub light_system_program: Program<'info, light_system_program::program::LightSystemProgram>,
-    /// CHECK: this account
+    /// CHECK: (different program) checked in account compression program
     pub registered_program_pda: UncheckedAccount<'info>,
-    /// CHECK: this account
+    /// CHECK: (different program) checked in system and account compression
+    /// programs
     pub noop_program: UncheckedAccount<'info>,
-    /// CHECK: this account in psp account compression program
+    /// CHECK: this account in account compression program
     #[account(seeds = [CPI_AUTHORITY_PDA_SEED], bump, seeds::program = light_system_program::ID)]
     pub account_compression_authority: UncheckedAccount<'info>,
-    /// CHECK: this account in psp account compression program
+    /// CHECK: this account in account compression program
     pub account_compression_program:
         Program<'info, account_compression::program::AccountCompression>,
-    /// CHECK: this account will be checked by psp compressed pda program
+    /// CHECK: (different program) will be checked by the system program
     #[account(mut)]
     pub merkle_tree: UncheckedAccount<'info>,
+    /// CHECK: (different program) will be checked by the system program
     pub self_program: Program<'info, crate::program::LightCompressedToken>,
     pub system_program: Program<'info, System>,
 }


### PR DESCRIPTION
Changes:
- updated instruction comments
- added tests with 8 inputs for `approve` and `revoke`
- replaced remaining `unwrap_err`s
- added failing tests:
  - Invalid delegate amount (too high)
  - freeze frozen compressed account
  - thaw non frozen compressed account
  - 