### PR TITLE
feat: add Send trait for HashSet and HashSetCell

### DIFF
--- a/merkle-tree/hash-set/src/lib.rs
+++ b/merkle-tree/hash-set/src/lib.rs
@@ -4,6 +4,7 @@ use num_traits::{FromBytes, ToPrimitive};
 use std::{
     alloc::{self, handle_alloc_error, Layout},
     cmp::Ordering,
+    marker::Send,
     mem,
     ptr::NonNull,
 };
@@ -56,6 +57,8 @@ pub struct HashSetCell {
     pub value: [u8; 32],
     pub sequence_number: Option<usize>,
 }
+
+unsafe impl Send for HashSet {}
 
 impl HashSetCell {
     /// Returns the value as a byte array.
@@ -113,6 +116,8 @@ pub struct HashSet {
     /// elements.
     buckets: NonNull<Option<HashSetCell>>,
 }
+
+unsafe impl Send for HashSetCell {}
 
 impl HashSet {
     /// Size of the struct **without** dynamically sized fields.


### PR DESCRIPTION
The Send trait has been unsafely implemented for the HashSet and HashSetCell, making these types able to be sent between threads safely when used properly. 
This allows for potential multi-threading and concurrent usage of these data types.