### PR TITLE
chore: update and add instruction comments,minor refactors

### DIFF
--- a/programs/compressed-token/src/burn.rs
+++ b/programs/compressed-token/src/burn.rs
@@ -105,7 +105,7 @@ pub fn create_input_and_output_accounts_burn(
     Vec<PackedCompressedAccountWithMerkleContext>,
     Vec<OutputCompressedAccountWithPackedContext>,
 )> {
-    let (mut compressed_input_accounts, input_token_data, _) =
+    let (mut compressed_input_accounts, input_token_data, sum_lamports) =
         get_input_compressed_accounts_with_merkle_context_and_check_signer::<NOT_FROZEN>(
             authority,
             &inputs.delegated_transfer,
@@ -118,11 +118,6 @@ pub fn create_input_and_output_accounts_burn(
         Some(change_amount) => change_amount,
         None => return err!(ErrorCode::ArithmeticUnderflow),
     };
-    let sum_lamports = inputs
-        .input_token_data_with_context
-        .iter()
-        .map(|x| x.lamports.unwrap_or(0))
-        .sum::<u64>();
 
     let hashed_mint = match hash_to_bn254_field_size_be(&mint.to_bytes()) {
         Some(hashed_mint) => hashed_mint.0,

--- a/programs/compressed-token/src/delegation.rs
+++ b/programs/compressed-token/src/delegation.rs
@@ -74,7 +74,7 @@ pub fn create_input_and_output_accounts_approve(
     Vec<PackedCompressedAccountWithMerkleContext>,
     Vec<OutputCompressedAccountWithPackedContext>,
 )> {
-    let (mut compressed_input_accounts, input_token_data, _) =
+    let (mut compressed_input_accounts, input_token_data, sum_lamports) =
         get_input_compressed_accounts_with_merkle_context_and_check_signer::<NOT_FROZEN>(
             authority,
             &None,
@@ -83,12 +83,6 @@ pub fn create_input_and_output_accounts_approve(
             &inputs.mint,
         )?;
     let sum_inputs = input_token_data.iter().map(|x| x.amount).sum::<u64>();
-    let sum_lamports = inputs
-        .input_token_data_with_context
-        .iter()
-        .map(|x| x.lamports.unwrap_or(0))
-        .sum::<u64>();
-
     let change_amount = match sum_inputs.checked_sub(inputs.delegated_amount) {
         Some(change_amount) => change_amount,
         None => return err!(ErrorCode::ArithmeticUnderflow),
@@ -207,7 +201,7 @@ pub fn create_input_and_output_accounts_revoke(
     Vec<PackedCompressedAccountWithMerkleContext>,
     Vec<OutputCompressedAccountWithPackedContext>,
 )> {
-    let (mut compressed_input_accounts, input_token_data, _) =
+    let (mut compressed_input_accounts, input_token_data, sum_lamports) =
         get_input_compressed_accounts_with_merkle_context_and_check_signer::<NOT_FROZEN>(
             authority,
             &None,
@@ -216,11 +210,6 @@ pub fn create_input_and_output_accounts_revoke(
             &inputs.mint,
         )?;
     let sum_inputs = input_token_data.iter().map(|x| x.amount).sum::<u64>();
-    let sum_lamports = inputs
-        .input_token_data_with_context
-        .iter()
-        .map(|x| x.lamports.unwrap_or(0))
-        .sum::<u64>();
     let lamports = if sum_lamports != 0 {
         Some(vec![Some(sum_lamports)])
     } else {

--- a/programs/compressed-token/src/freeze.rs
+++ b/programs/compressed-token/src/freeze.rs
@@ -108,7 +108,8 @@ pub fn create_input_and_output_accounts_freeze_or_thaw<
 }
 
 /// This is a separate function from create_output_compressed_accounts to allow
-/// for a flexible number of delegates.
+/// for a flexible number of delegates. create_output_compressed_accounts only
+/// supports one delegate.
 fn create_token_output_accounts<const IS_FROZEN: bool>(
     input_token_data_with_context: &[InputTokenDataWithContext],
     remaining_accounts: &[AccountInfo],


### PR DESCRIPTION
changes:
- add and update comments to all instructions in `lib.rs`
- remove duplicate code of manual lamports sum computations in multiple instructions
- adapt manual borsh unit test to explicitly cover case of `lamports=0` in addition to random amounts
- replace push additional lamports change compressed account with `resize` to avoid unnecessary heap memory allocations 