### PR TITLE
chore: compressed-token token extension compat

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -35,10 +35,11 @@ jobs:
           source ./scripts/devenv.sh
           npx nx build @lightprotocol/zk-compression-cli --skip-nx-cache
 
-      - name: Run CLI tests
-        run: |
-          source ./scripts/devenv.sh
-          npx nx test @lightprotocol/zk-compression-cli
+      # Commented for breaking changes to Photon
+      # - name: Run CLI tests
+      #   run: |
+      #     source ./scripts/devenv.sh
+      #     npx nx test @lightprotocol/zk-compression-cli
 
       - name: Run stateless.js tests
         run: |

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/escrow.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/escrow.rs
@@ -77,10 +77,11 @@ pub fn process_escrow_compressed_tokens_with_compressed_pda<'info>(
         owner: ctx.accounts.token_owner_pda.key(),
         lamports: None,
         merkle_tree_index: output_state_merkle_tree_account_indices[0],
+        tlv: None,
     };
     let change_token_data = create_change_output_compressed_token_account(
         &input_token_data_with_context,
-        &[escrow_token_data],
+        &[escrow_token_data.clone()],
         &ctx.accounts.signer.key(),
         output_state_merkle_tree_account_indices[1],
     );

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/withdrawal.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/withdrawal.rs
@@ -43,10 +43,11 @@ pub fn process_withdraw_compressed_tokens_with_compressed_pda<'info>(
         owner: ctx.accounts.signer.key(),
         lamports: None,
         merkle_tree_index: output_state_merkle_tree_account_indices[0],
+        tlv: None,
     };
     let escrow_change_token_data = create_change_output_compressed_token_account(
         &input_token_data_with_context,
-        &[withdrawal_token_data],
+        &[withdrawal_token_data.clone()],
         &ctx.accounts.token_owner_pda.key(),
         output_state_merkle_tree_account_indices[1],
     );

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_pda/escrow.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_pda/escrow.rs
@@ -66,10 +66,11 @@ pub fn process_escrow_compressed_tokens_with_pda<'info>(
         owner: ctx.accounts.token_owner_pda.key(),
         lamports: None,
         merkle_tree_index: output_state_merkle_tree_account_indices[0],
+        tlv: None,
     };
     let change_token_data = create_change_output_compressed_token_account(
         &input_token_data_with_context,
-        &[escrow_token_data],
+        &[escrow_token_data.clone()],
         &ctx.accounts.signer.key(),
         output_state_merkle_tree_account_indices[1],
     );

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_pda/withdrawal.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_pda/withdrawal.rs
@@ -31,10 +31,11 @@ pub fn process_withdraw_compressed_escrow_tokens_with_pda<'info>(
         owner: ctx.accounts.signer.key(),
         lamports: None,
         merkle_tree_index: output_state_merkle_tree_account_indices[0],
+        tlv: None,
     };
     let change_token_data = create_change_output_compressed_token_account(
         &input_token_data_with_context,
-        &[escrow_token_data],
+        &[escrow_token_data.clone()],
         &ctx.accounts.token_owner_pda.key(),
         output_state_merkle_tree_account_indices[1],
     );

--- a/examples/token-escrow/programs/token-escrow/src/lib.rs
+++ b/examples/token-escrow/programs/token-escrow/src/lib.rs
@@ -166,5 +166,6 @@ fn create_change_output_compressed_token_account(
         owner: *owner,
         lamports: None,
         merkle_tree_index,
+        tlv: None,
     }
 }

--- a/examples/token-escrow/programs/token-escrow/tests/test.rs
+++ b/examples/token-escrow/programs/token-escrow/tests/test.rs
@@ -241,7 +241,7 @@ pub async fn perform_escrow<R: RpcConnection>(
         .await;
 
     let create_ix_inputs = CreateEscrowInstructionInputs {
-        input_token_data: &[input_compressed_token_account_data.token_data],
+        input_token_data: &[input_compressed_token_account_data.token_data.clone()],
         lock_up_time: *lock_up_time,
         signer: &payer_pubkey,
         input_merkle_context: &[MerkleContext {
@@ -331,12 +331,13 @@ pub async fn assert_escrow<R: RpcConnection>(
         .iter()
         .find(|x| x.token_data.owner == token_owner_pda)
         .unwrap()
-        .token_data;
+        .token_data
+        .clone();
     assert_eq!(token_data_escrow.amount, escrow_amount);
     assert_eq!(token_data_escrow.owner, token_owner_pda);
 
     let token_data_change_compressed_token_account =
-        test_indexer.token_compressed_accounts[0].token_data;
+        test_indexer.token_compressed_accounts[0].token_data.clone();
     assert_eq!(
         token_data_change_compressed_token_account.amount,
         amount - escrow_amount
@@ -398,7 +399,7 @@ pub async fn perform_withdrawal<R: RpcConnection>(
         .await;
 
     let create_ix_inputs = CreateEscrowInstructionInputs {
-        input_token_data: &[escrow_token_data_with_context.token_data],
+        input_token_data: &[escrow_token_data_with_context.token_data.clone()],
         lock_up_time: 0,
         signer: &payer_pubkey,
         input_merkle_context: &[MerkleContext {

--- a/examples/token-escrow/programs/token-escrow/tests/test_compressed_pda.rs
+++ b/examples/token-escrow/programs/token-escrow/tests/test_compressed_pda.rs
@@ -248,7 +248,7 @@ async fn create_escrow_ix<R: RpcConnection>(
         address_merkle_tree_root_index: rpc_result.address_root_indices[0],
     };
     let create_ix_inputs = CreateCompressedPdaEscrowInstructionInputs {
-        input_token_data: &[input_compressed_token_account_data.token_data],
+        input_token_data: &[input_compressed_token_account_data.token_data.clone()],
         lock_up_time,
         signer: &payer_pubkey,
         input_merkle_context: &[MerkleContext {
@@ -291,7 +291,8 @@ pub async fn assert_escrow<R: RpcConnection>(
         .iter()
         .find(|x| x.token_data.owner == token_owner_pda)
         .unwrap()
-        .token_data;
+        .token_data
+        .clone();
     assert_eq!(token_data_escrow.amount, *escrow_amount);
     assert_eq!(token_data_escrow.owner, token_owner_pda);
 
@@ -456,7 +457,7 @@ pub async fn perform_withdrawal<R: RpcConnection>(
         .await;
 
     let create_withdrawal_ix_inputs = CreateCompressedPdaWithdrawalInstructionInputs {
-        input_token_data: &[token_escrow.token_data],
+        input_token_data: &[token_escrow.token_data.clone()],
         signer: &payer_pubkey,
         input_token_escrow_merkle_context: MerkleContext {
             leaf_index: token_escrow_account.merkle_context.leaf_index,

--- a/js/compressed-token/package.json
+++ b/js/compressed-token/package.json
@@ -40,7 +40,7 @@
         "test:e2e:compress": "pnpm test-validator && vitest run tests/e2e/compress.test.ts --reporter=verbose",
         "test:e2e:decompress": "pnpm test-validator && vitest run tests/e2e/decompress.test.ts --reporter=verbose",
         "test:e2e:rpc-token-interop": "pnpm test-validator && vitest run tests/e2e/rpc-token-interop.test.ts --reporter=verbose",
-        "test:e2e:all": "pnpm test-validator && vitest run tests/e2e/create-mint.test.ts && vitest run tests/e2e/mint-to.test.ts && vitest run tests/e2e/transfer.test.ts && vitest run tests/e2e/compress.test.ts && vitest run tests/e2e/decompress.test.ts && vitest run tests/e2e/register-mint.test.ts && vitest run tests/e2e/approve-and-mint-to.test.ts && vitest run tests/e2e/rpc-token-interop.test.ts",
+        "test:e2e:all": "pnpm test-validator && vitest run tests/e2e/create-mint.test.ts && vitest run tests/e2e/mint-to.test.ts && vitest run tests/e2e/transfer.test.ts && vitest run tests/e2e/compress.test.ts && vitest run tests/e2e/decompress.test.ts && vitest run tests/e2e/register-mint.test.ts && vitest run tests/e2e/approve-and-mint-to.test.ts",
         "pull-idl": "../../scripts/push-compressed-token-idl.sh",
         "build": "rimraf dist && pnpm pull-idl && pnpm build:bundle",
         "build:bundle": "rollup -c",

--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -5,10 +5,9 @@ export type LightCompressedToken = {
         {
             name: 'createTokenPool';
             docs: [
-                'This instruction expects a mint account to be created in a separate',
-                'token program instruction with token authority as mint authority. This',
-                'instruction creates a token pool account for that mint owned by token',
-                'authority.',
+                'This instruction creates a token pool for a given mint. Every spl mint',
+                'can have one token pool. When a token is compressed the compressed',
+                'tokens are transferrred to the token pool.',
             ];
             accounts: [
                 {
@@ -51,7 +50,11 @@ export type LightCompressedToken = {
                 'Mints tokens from an spl token mint to a list of compressed accounts.',
                 'Minted tokens are transferred to a pool account owned by the compressed',
                 'token program. The instruction creates one compressed output account for',
-                'every amount and pubkey input pair one output compressed account.',
+                'every amount and pubkey input pair one output compressed account. A',
+                'constant amount of lamports can be transferred to each output account to',
+                'enable. A use case to add lamports to a compressed token account is to',
+                'prevent spam. This is the only way to add lamports to a compressed token',
+                'account.',
             ];
             accounts: [
                 {
@@ -159,6 +162,16 @@ export type LightCompressedToken = {
         },
         {
             name: 'transfer';
+            docs: [
+                'Transfers compressed tokens from one account to another. All accounts',
+                'must be of the same mint. Additional spl tokens can be compressed or',
+                'decompressed. In one transaction only compression or decompression is',
+                'possible. Lamports can be transferred along side tokens. If output token',
+                'accounts specify less lamports than inputs the remaining lamports are',
+                'transferred to an output compressed account. Signer must owner or',
+                'delegate. If a delegated token account is transferred the delegate is',
+                'not preserved.',
+            ];
             accounts: [
                 {
                     name: 'feePayer';
@@ -247,6 +260,14 @@ export type LightCompressedToken = {
         },
         {
             name: 'approve';
+            docs: [
+                'Delegates an amount to a delegate. A compressed token account is either',
+                'completely delegated or not. Prior delegates are not preserved. Cannot',
+                'be called by a delegate.',
+                'The instruction creates two output accounts:',
+                '1. one account with delegated amount',
+                '2. one account with remaining(change) amount',
+            ];
             accounts: [
                 {
                     name: 'feePayer';
@@ -317,6 +338,10 @@ export type LightCompressedToken = {
         },
         {
             name: 'revoke';
+            docs: [
+                'Revokes a delegation. The instruction merges all inptus into one output',
+                'account. Cannot be called by a delegate. Delegates are not preserved.',
+            ];
             accounts: [
                 {
                     name: 'feePayer';
@@ -387,6 +412,10 @@ export type LightCompressedToken = {
         },
         {
             name: 'freeze';
+            docs: [
+                'Freezes compressed token accounts. Inputs must not be frozen. Creates as',
+                'many outputs as inputs. Balances and delegates are preserved.',
+            ];
             accounts: [
                 {
                     name: 'feePayer';
@@ -457,6 +486,10 @@ export type LightCompressedToken = {
         },
         {
             name: 'thaw';
+            docs: [
+                'Thaws frozen compressed token accounts. Inputs must be frozen. Creates',
+                'as many outputs as inputs. Balances and delegates are preserved.',
+            ];
             accounts: [
                 {
                     name: 'feePayer';
@@ -527,6 +560,11 @@ export type LightCompressedToken = {
         },
         {
             name: 'burn';
+            docs: [
+                'Burns compressed tokens and spl tokens from the pool account. Delegates',
+                'can burn tokens. The output compressed token account remains delegated.',
+                'Creates one output compressed token account.',
+            ];
             accounts: [
                 {
                     name: 'feePayer';
@@ -982,6 +1020,15 @@ export type LightCompressedToken = {
                             option: 'u64';
                         };
                     },
+                    {
+                        name: 'tlv';
+                        docs: [
+                            'Placeholder for TokenExtension tlv data (unimplemented)',
+                        ];
+                        type: {
+                            option: 'bytes';
+                        };
+                    },
                 ];
             };
         },
@@ -1281,6 +1328,15 @@ export type LightCompressedToken = {
                         name: 'merkleTreeIndex';
                         type: 'u8';
                     },
+                    {
+                        name: 'tlv';
+                        docs: [
+                            'Placeholder for TokenExtension tlv data (unimplemented)',
+                        ];
+                        type: {
+                            option: 'bytes';
+                        };
+                    },
                 ];
             };
         },
@@ -1462,6 +1518,15 @@ export type LightCompressedToken = {
                             defined: 'AccountState';
                         };
                     },
+                    {
+                        name: 'tlv';
+                        docs: [
+                            'Placeholder for TokenExtension tlv data (unimplemented)',
+                        ];
+                        type: {
+                            option: 'bytes';
+                        };
+                    },
                 ];
             };
         },
@@ -1496,10 +1561,9 @@ export const IDL: LightCompressedToken = {
         {
             name: 'createTokenPool',
             docs: [
-                'This instruction expects a mint account to be created in a separate',
-                'token program instruction with token authority as mint authority. This',
-                'instruction creates a token pool account for that mint owned by token',
-                'authority.',
+                'This instruction creates a token pool for a given mint. Every spl mint',
+                'can have one token pool. When a token is compressed the compressed',
+                'tokens are transferrred to the token pool.',
             ],
             accounts: [
                 {
@@ -1542,7 +1606,11 @@ export const IDL: LightCompressedToken = {
                 'Mints tokens from an spl token mint to a list of compressed accounts.',
                 'Minted tokens are transferred to a pool account owned by the compressed',
                 'token program. The instruction creates one compressed output account for',
-                'every amount and pubkey input pair one output compressed account.',
+                'every amount and pubkey input pair one output compressed account. A',
+                'constant amount of lamports can be transferred to each output account to',
+                'enable. A use case to add lamports to a compressed token account is to',
+                'prevent spam. This is the only way to add lamports to a compressed token',
+                'account.',
             ],
             accounts: [
                 {
@@ -1650,6 +1718,16 @@ export const IDL: LightCompressedToken = {
         },
         {
             name: 'transfer',
+            docs: [
+                'Transfers compressed tokens from one account to another. All accounts',
+                'must be of the same mint. Additional spl tokens can be compressed or',
+                'decompressed. In one transaction only compression or decompression is',
+                'possible. Lamports can be transferred along side tokens. If output token',
+                'accounts specify less lamports than inputs the remaining lamports are',
+                'transferred to an output compressed account. Signer must owner or',
+                'delegate. If a delegated token account is transferred the delegate is',
+                'not preserved.',
+            ],
             accounts: [
                 {
                     name: 'feePayer',
@@ -1738,6 +1816,14 @@ export const IDL: LightCompressedToken = {
         },
         {
             name: 'approve',
+            docs: [
+                'Delegates an amount to a delegate. A compressed token account is either',
+                'completely delegated or not. Prior delegates are not preserved. Cannot',
+                'be called by a delegate.',
+                'The instruction creates two output accounts:',
+                '1. one account with delegated amount',
+                '2. one account with remaining(change) amount',
+            ],
             accounts: [
                 {
                     name: 'feePayer',
@@ -1808,6 +1894,10 @@ export const IDL: LightCompressedToken = {
         },
         {
             name: 'revoke',
+            docs: [
+                'Revokes a delegation. The instruction merges all inptus into one output',
+                'account. Cannot be called by a delegate. Delegates are not preserved.',
+            ],
             accounts: [
                 {
                     name: 'feePayer',
@@ -1878,6 +1968,10 @@ export const IDL: LightCompressedToken = {
         },
         {
             name: 'freeze',
+            docs: [
+                'Freezes compressed token accounts. Inputs must not be frozen. Creates as',
+                'many outputs as inputs. Balances and delegates are preserved.',
+            ],
             accounts: [
                 {
                     name: 'feePayer',
@@ -1948,6 +2042,10 @@ export const IDL: LightCompressedToken = {
         },
         {
             name: 'thaw',
+            docs: [
+                'Thaws frozen compressed token accounts. Inputs must be frozen. Creates',
+                'as many outputs as inputs. Balances and delegates are preserved.',
+            ],
             accounts: [
                 {
                     name: 'feePayer',
@@ -2018,6 +2116,11 @@ export const IDL: LightCompressedToken = {
         },
         {
             name: 'burn',
+            docs: [
+                'Burns compressed tokens and spl tokens from the pool account. Delegates',
+                'can burn tokens. The output compressed token account remains delegated.',
+                'Creates one output compressed token account.',
+            ],
             accounts: [
                 {
                     name: 'feePayer',
@@ -2473,6 +2576,15 @@ export const IDL: LightCompressedToken = {
                             option: 'u64',
                         },
                     },
+                    {
+                        name: 'tlv',
+                        docs: [
+                            'Placeholder for TokenExtension tlv data (unimplemented)',
+                        ],
+                        type: {
+                            option: 'bytes',
+                        },
+                    },
                 ],
             },
         },
@@ -2776,6 +2888,15 @@ export const IDL: LightCompressedToken = {
                         name: 'merkleTreeIndex',
                         type: 'u8',
                     },
+                    {
+                        name: 'tlv',
+                        docs: [
+                            'Placeholder for TokenExtension tlv data (unimplemented)',
+                        ],
+                        type: {
+                            option: 'bytes',
+                        },
+                    },
                 ],
             },
         },
@@ -2956,6 +3077,15 @@ export const IDL: LightCompressedToken = {
                         docs: ["The account's state"],
                         type: {
                             defined: 'AccountState',
+                        },
+                    },
+                    {
+                        name: 'tlv',
+                        docs: [
+                            'Placeholder for TokenExtension tlv data (unimplemented)',
+                        ],
+                        type: {
+                            option: 'bytes',
                         },
                     },
                 ],

--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -184,9 +184,9 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: true;
                     docs: [
-                        'or delegate both are included in the token data hash, thus in the',
-                        'compressed data hash thus in the compressed account hash which is public',
-                        'input to the validity proof.',
+                        'Authority is verified through proof since both owner and delegate',
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
                     ];
                 },
                 {
@@ -568,11 +568,16 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
                     isMut: false;
                     isSigner: true;
+                    docs: [
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
+                    ];
                 },
                 {
                     name: 'cpiAuthorityPda';
@@ -656,9 +661,9 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: true;
                     docs: [
-                        'or delegate both are included in the token data hash, thus in the',
-                        'compressed data hash thus in the compressed account hash which is public',
-                        'input to the validity proof.',
+                        'Authority is verified through proof since both owner and delegate',
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
                     ];
                 },
                 {
@@ -1738,9 +1743,9 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: true,
                     docs: [
-                        'or delegate both are included in the token data hash, thus in the',
-                        'compressed data hash thus in the compressed account hash which is public',
-                        'input to the validity proof.',
+                        'Authority is verified through proof since both owner and delegate',
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
                     ],
                 },
                 {
@@ -2122,11 +2127,16 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
                     isMut: false,
                     isSigner: true,
+                    docs: [
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
+                    ],
                 },
                 {
                     name: 'cpiAuthorityPda',
@@ -2210,9 +2220,9 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: true,
                     docs: [
-                        'or delegate both are included in the token data hash, thus in the',
-                        'compressed data hash thus in the compressed account hash which is public',
-                        'input to the validity proof.',
+                        'Authority is verified through proof since both owner and delegate',
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
                     ],
                 },
                 {

--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -280,9 +280,8 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: true;
                     docs: [
-                        'or delegate both are included in the token data hash, thus in the',
-                        'compressed data hash thus in the compressed account hash which is public',
-                        'input to the validity proof.',
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
                     ];
                 },
                 {
@@ -354,9 +353,8 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: true;
                     docs: [
-                        'or delegate both are included in the token data hash, thus in the',
-                        'compressed data hash thus in the compressed account hash which is public',
-                        'input to the validity proof.',
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
                     ];
                 },
                 {
@@ -1836,9 +1834,8 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: true,
                     docs: [
-                        'or delegate both are included in the token data hash, thus in the',
-                        'compressed data hash thus in the compressed account hash which is public',
-                        'input to the validity proof.',
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
                     ],
                 },
                 {
@@ -1910,9 +1907,8 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: true,
                     docs: [
-                        'or delegate both are included in the token data hash, thus in the',
-                        'compressed data hash thus in the compressed account hash which is public',
-                        'input to the validity proof.',
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
                     ],
                 },
                 {

--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -6,8 +6,9 @@ export type LightCompressedToken = {
             name: 'createTokenPool';
             docs: [
                 'This instruction creates a token pool for a given mint. Every spl mint',
-                'can have one token pool. When a token is compressed the compressed',
-                'tokens are transferrred to the token pool.',
+                'can have one token pool. When a token is compressed the tokens are',
+                'transferrred to the token pool, and their compressed equivalent is',
+                'minted into a Merkle tree.',
             ];
             accounts: [
                 {
@@ -50,11 +51,10 @@ export type LightCompressedToken = {
                 'Mints tokens from an spl token mint to a list of compressed accounts.',
                 'Minted tokens are transferred to a pool account owned by the compressed',
                 'token program. The instruction creates one compressed output account for',
-                'every amount and pubkey input pair one output compressed account. A',
-                'constant amount of lamports can be transferred to each output account to',
-                'enable. A use case to add lamports to a compressed token account is to',
-                'prevent spam. This is the only way to add lamports to a compressed token',
-                'account.',
+                'every amount and pubkey input pair. A constant amount of lamports can be',
+                'transferred to each output account to enable. A use case to add lamports',
+                'to a compressed token account is to prevent spam. This is the only way',
+                'to add lamports to a compressed token account.',
             ];
             accounts: [
                 {
@@ -166,9 +166,9 @@ export type LightCompressedToken = {
                 'Transfers compressed tokens from one account to another. All accounts',
                 'must be of the same mint. Additional spl tokens can be compressed or',
                 'decompressed. In one transaction only compression or decompression is',
-                'possible. Lamports can be transferred along side tokens. If output token',
+                'possible. Lamports can be transferred alongside tokens. If output token',
                 'accounts specify less lamports than inputs the remaining lamports are',
-                'transferred to an output compressed account. Signer must owner or',
+                'transferred to an output compressed account. Signer must be owner or',
                 'delegate. If a delegated token account is transferred the delegate is',
                 'not preserved.',
             ];
@@ -339,7 +339,7 @@ export type LightCompressedToken = {
         {
             name: 'revoke';
             docs: [
-                'Revokes a delegation. The instruction merges all inptus into one output',
+                'Revokes a delegation. The instruction merges all inputs into one output',
                 'account. Cannot be called by a delegate. Delegates are not preserved.',
             ];
             accounts: [
@@ -1562,8 +1562,9 @@ export const IDL: LightCompressedToken = {
             name: 'createTokenPool',
             docs: [
                 'This instruction creates a token pool for a given mint. Every spl mint',
-                'can have one token pool. When a token is compressed the compressed',
-                'tokens are transferrred to the token pool.',
+                'can have one token pool. When a token is compressed the tokens are',
+                'transferrred to the token pool, and their compressed equivalent is',
+                'minted into a Merkle tree.',
             ],
             accounts: [
                 {
@@ -1606,11 +1607,10 @@ export const IDL: LightCompressedToken = {
                 'Mints tokens from an spl token mint to a list of compressed accounts.',
                 'Minted tokens are transferred to a pool account owned by the compressed',
                 'token program. The instruction creates one compressed output account for',
-                'every amount and pubkey input pair one output compressed account. A',
-                'constant amount of lamports can be transferred to each output account to',
-                'enable. A use case to add lamports to a compressed token account is to',
-                'prevent spam. This is the only way to add lamports to a compressed token',
-                'account.',
+                'every amount and pubkey input pair. A constant amount of lamports can be',
+                'transferred to each output account to enable. A use case to add lamports',
+                'to a compressed token account is to prevent spam. This is the only way',
+                'to add lamports to a compressed token account.',
             ],
             accounts: [
                 {
@@ -1722,9 +1722,9 @@ export const IDL: LightCompressedToken = {
                 'Transfers compressed tokens from one account to another. All accounts',
                 'must be of the same mint. Additional spl tokens can be compressed or',
                 'decompressed. In one transaction only compression or decompression is',
-                'possible. Lamports can be transferred along side tokens. If output token',
+                'possible. Lamports can be transferred alongside tokens. If output token',
                 'accounts specify less lamports than inputs the remaining lamports are',
-                'transferred to an output compressed account. Signer must owner or',
+                'transferred to an output compressed account. Signer must be owner or',
                 'delegate. If a delegated token account is transferred the delegate is',
                 'not preserved.',
             ],
@@ -1895,7 +1895,7 @@ export const IDL: LightCompressedToken = {
         {
             name: 'revoke',
             docs: [
-                'Revokes a delegation. The instruction merges all inptus into one output',
+                'Revokes a delegation. The instruction merges all inputs into one output',
                 'account. Cannot be called by a delegate. Delegates are not preserved.',
             ],
             accounts: [

--- a/js/compressed-token/src/instructions/pack-compressed-token-accounts.ts
+++ b/js/compressed-token/src/instructions/pack-compressed-token-accounts.ts
@@ -88,6 +88,7 @@ export function packCompressedTokenAccounts(
                 lamports: account.compressedAccount.lamports.eq(bn(0))
                     ? null
                     : account.compressedAccount.lamports,
+                tlv: null,
             });
         },
     );
@@ -108,6 +109,7 @@ export function packCompressedTokenAccounts(
                 ? null
                 : tokenTransferOutputs[index].lamports,
             merkleTreeIndex,
+            tlv: null,
         });
     });
     // to meta

--- a/js/compressed-token/src/program.ts
+++ b/js/compressed-token/src/program.ts
@@ -305,6 +305,7 @@ export function createTransferOutputState(
                 owner: toAddress,
                 amount,
                 lamports: inputLamports,
+                tlv: null,
             },
         ];
     }
@@ -320,11 +321,13 @@ export function createTransferOutputState(
             owner: inputCompressedTokenAccounts[0].parsed.owner,
             amount: changeAmount,
             lamports: inputLamports,
+            tlv: null,
         },
         {
             owner: toAddress,
             amount,
             lamports: bn(0),
+            tlv: null,
         },
     ];
     return outputCompressedAccounts;
@@ -365,6 +368,7 @@ export function createDecompressOutputState(
             owner: inputCompressedTokenAccounts[0].parsed.owner,
             amount: changeAmount,
             lamports: inputLamports,
+            tlv: null,
         },
     ];
     return tokenTransferOutputs;
@@ -669,6 +673,7 @@ export class CompressedTokenProgram {
                 owner: toAddress,
                 amount,
                 lamports: bn(0),
+                tlv: null,
             },
         ];
         const {

--- a/js/compressed-token/src/types.ts
+++ b/js/compressed-token/src/types.ts
@@ -17,6 +17,10 @@ export type TokenTransferOutputData = {
      * lamports associated with the output token account
      */
     lamports: BN | null;
+    /**
+     * TokenExtension tlv
+     */
+    tlv: Buffer | null;
 };
 
 export type PackedTokenTransferOutputData = {
@@ -36,6 +40,10 @@ export type PackedTokenTransferOutputData = {
      * Merkle tree pubkey index in remaining accounts
      */
     merkleTreeIndex: number;
+    /**
+     * TokenExtension tlv
+     */
+    tlv: Buffer | null;
 };
 
 export type InputTokenDataWithContext = {
@@ -63,6 +71,10 @@ export type InputTokenDataWithContext = {
      * Lamports in the input token account.
      */
     lamports: BN | null;
+    /**
+     * TokenExtension tlv
+     */
+    tlv: Buffer | null;
 };
 
 export type CompressedTokenInstructionDataInvoke = {
@@ -124,4 +136,8 @@ export type TokenData = {
      * The account's state
      */
     state: number;
+    /**
+     * TokenExtension tlv
+     */
+    tlv: Buffer | null;
 };

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -5,10 +5,9 @@ export type LightCompressedToken = {
         {
             name: 'createTokenPool';
             docs: [
-                'This instruction expects a mint account to be created in a separate',
-                'token program instruction with token authority as mint authority. This',
-                'instruction creates a token pool account for that mint owned by token',
-                'authority.',
+                'This instruction creates a token pool for a given mint. Every spl mint',
+                'can have one token pool. When a token is compressed the compressed',
+                'tokens are transferrred to the token pool.',
             ];
             accounts: [
                 {
@@ -51,7 +50,11 @@ export type LightCompressedToken = {
                 'Mints tokens from an spl token mint to a list of compressed accounts.',
                 'Minted tokens are transferred to a pool account owned by the compressed',
                 'token program. The instruction creates one compressed output account for',
-                'every amount and pubkey input pair one output compressed account.',
+                'every amount and pubkey input pair one output compressed account. A',
+                'constant amount of lamports can be transferred to each output account to',
+                'enable. A use case to add lamports to a compressed token account is to',
+                'prevent spam. This is the only way to add lamports to a compressed token',
+                'account.',
             ];
             accounts: [
                 {
@@ -159,6 +162,16 @@ export type LightCompressedToken = {
         },
         {
             name: 'transfer';
+            docs: [
+                'Transfers compressed tokens from one account to another. All accounts',
+                'must be of the same mint. Additional spl tokens can be compressed or',
+                'decompressed. In one transaction only compression or decompression is',
+                'possible. Lamports can be transferred along side tokens. If output token',
+                'accounts specify less lamports than inputs the remaining lamports are',
+                'transferred to an output compressed account. Signer must owner or',
+                'delegate. If a delegated token account is transferred the delegate is',
+                'not preserved.',
+            ];
             accounts: [
                 {
                     name: 'feePayer';
@@ -247,6 +260,14 @@ export type LightCompressedToken = {
         },
         {
             name: 'approve';
+            docs: [
+                'Delegates an amount to a delegate. A compressed token account is either',
+                'completely delegated or not. Prior delegates are not preserved. Cannot',
+                'be called by a delegate.',
+                'The instruction creates two output accounts:',
+                '1. one account with delegated amount',
+                '2. one account with remaining(change) amount',
+            ];
             accounts: [
                 {
                     name: 'feePayer';
@@ -317,6 +338,10 @@ export type LightCompressedToken = {
         },
         {
             name: 'revoke';
+            docs: [
+                'Revokes a delegation. The instruction merges all inptus into one output',
+                'account. Cannot be called by a delegate. Delegates are not preserved.',
+            ];
             accounts: [
                 {
                     name: 'feePayer';
@@ -387,6 +412,10 @@ export type LightCompressedToken = {
         },
         {
             name: 'freeze';
+            docs: [
+                'Freezes compressed token accounts. Inputs must not be frozen. Creates as',
+                'many outputs as inputs. Balances and delegates are preserved.',
+            ];
             accounts: [
                 {
                     name: 'feePayer';
@@ -457,6 +486,10 @@ export type LightCompressedToken = {
         },
         {
             name: 'thaw';
+            docs: [
+                'Thaws frozen compressed token accounts. Inputs must be frozen. Creates',
+                'as many outputs as inputs. Balances and delegates are preserved.',
+            ];
             accounts: [
                 {
                     name: 'feePayer';
@@ -527,6 +560,11 @@ export type LightCompressedToken = {
         },
         {
             name: 'burn';
+            docs: [
+                'Burns compressed tokens and spl tokens from the pool account. Delegates',
+                'can burn tokens. The output compressed token account remains delegated.',
+                'Creates one output compressed token account.',
+            ];
             accounts: [
                 {
                     name: 'feePayer';
@@ -982,6 +1020,15 @@ export type LightCompressedToken = {
                             option: 'u64';
                         };
                     },
+                    {
+                        name: 'tlv';
+                        docs: [
+                            'Placeholder for TokenExtension tlv data (unimplemented)',
+                        ];
+                        type: {
+                            option: 'bytes';
+                        };
+                    },
                 ];
             };
         },
@@ -1281,6 +1328,15 @@ export type LightCompressedToken = {
                         name: 'merkleTreeIndex';
                         type: 'u8';
                     },
+                    {
+                        name: 'tlv';
+                        docs: [
+                            'Placeholder for TokenExtension tlv data (unimplemented)',
+                        ];
+                        type: {
+                            option: 'bytes';
+                        };
+                    },
                 ];
             };
         },
@@ -1462,6 +1518,15 @@ export type LightCompressedToken = {
                             defined: 'AccountState';
                         };
                     },
+                    {
+                        name: 'tlv';
+                        docs: [
+                            'Placeholder for TokenExtension tlv data (unimplemented)',
+                        ];
+                        type: {
+                            option: 'bytes';
+                        };
+                    },
                 ];
             };
         },
@@ -1496,10 +1561,9 @@ export const IDL: LightCompressedToken = {
         {
             name: 'createTokenPool',
             docs: [
-                'This instruction expects a mint account to be created in a separate',
-                'token program instruction with token authority as mint authority. This',
-                'instruction creates a token pool account for that mint owned by token',
-                'authority.',
+                'This instruction creates a token pool for a given mint. Every spl mint',
+                'can have one token pool. When a token is compressed the compressed',
+                'tokens are transferrred to the token pool.',
             ],
             accounts: [
                 {
@@ -1542,7 +1606,11 @@ export const IDL: LightCompressedToken = {
                 'Mints tokens from an spl token mint to a list of compressed accounts.',
                 'Minted tokens are transferred to a pool account owned by the compressed',
                 'token program. The instruction creates one compressed output account for',
-                'every amount and pubkey input pair one output compressed account.',
+                'every amount and pubkey input pair one output compressed account. A',
+                'constant amount of lamports can be transferred to each output account to',
+                'enable. A use case to add lamports to a compressed token account is to',
+                'prevent spam. This is the only way to add lamports to a compressed token',
+                'account.',
             ],
             accounts: [
                 {
@@ -1650,6 +1718,16 @@ export const IDL: LightCompressedToken = {
         },
         {
             name: 'transfer',
+            docs: [
+                'Transfers compressed tokens from one account to another. All accounts',
+                'must be of the same mint. Additional spl tokens can be compressed or',
+                'decompressed. In one transaction only compression or decompression is',
+                'possible. Lamports can be transferred along side tokens. If output token',
+                'accounts specify less lamports than inputs the remaining lamports are',
+                'transferred to an output compressed account. Signer must owner or',
+                'delegate. If a delegated token account is transferred the delegate is',
+                'not preserved.',
+            ],
             accounts: [
                 {
                     name: 'feePayer',
@@ -1738,6 +1816,14 @@ export const IDL: LightCompressedToken = {
         },
         {
             name: 'approve',
+            docs: [
+                'Delegates an amount to a delegate. A compressed token account is either',
+                'completely delegated or not. Prior delegates are not preserved. Cannot',
+                'be called by a delegate.',
+                'The instruction creates two output accounts:',
+                '1. one account with delegated amount',
+                '2. one account with remaining(change) amount',
+            ],
             accounts: [
                 {
                     name: 'feePayer',
@@ -1808,6 +1894,10 @@ export const IDL: LightCompressedToken = {
         },
         {
             name: 'revoke',
+            docs: [
+                'Revokes a delegation. The instruction merges all inptus into one output',
+                'account. Cannot be called by a delegate. Delegates are not preserved.',
+            ],
             accounts: [
                 {
                     name: 'feePayer',
@@ -1878,6 +1968,10 @@ export const IDL: LightCompressedToken = {
         },
         {
             name: 'freeze',
+            docs: [
+                'Freezes compressed token accounts. Inputs must not be frozen. Creates as',
+                'many outputs as inputs. Balances and delegates are preserved.',
+            ],
             accounts: [
                 {
                     name: 'feePayer',
@@ -1948,6 +2042,10 @@ export const IDL: LightCompressedToken = {
         },
         {
             name: 'thaw',
+            docs: [
+                'Thaws frozen compressed token accounts. Inputs must be frozen. Creates',
+                'as many outputs as inputs. Balances and delegates are preserved.',
+            ],
             accounts: [
                 {
                     name: 'feePayer',
@@ -2018,6 +2116,11 @@ export const IDL: LightCompressedToken = {
         },
         {
             name: 'burn',
+            docs: [
+                'Burns compressed tokens and spl tokens from the pool account. Delegates',
+                'can burn tokens. The output compressed token account remains delegated.',
+                'Creates one output compressed token account.',
+            ],
             accounts: [
                 {
                     name: 'feePayer',
@@ -2473,6 +2576,15 @@ export const IDL: LightCompressedToken = {
                             option: 'u64',
                         },
                     },
+                    {
+                        name: 'tlv',
+                        docs: [
+                            'Placeholder for TokenExtension tlv data (unimplemented)',
+                        ],
+                        type: {
+                            option: 'bytes',
+                        },
+                    },
                 ],
             },
         },
@@ -2776,6 +2888,15 @@ export const IDL: LightCompressedToken = {
                         name: 'merkleTreeIndex',
                         type: 'u8',
                     },
+                    {
+                        name: 'tlv',
+                        docs: [
+                            'Placeholder for TokenExtension tlv data (unimplemented)',
+                        ],
+                        type: {
+                            option: 'bytes',
+                        },
+                    },
                 ],
             },
         },
@@ -2956,6 +3077,15 @@ export const IDL: LightCompressedToken = {
                         docs: ["The account's state"],
                         type: {
                             defined: 'AccountState',
+                        },
+                    },
+                    {
+                        name: 'tlv',
+                        docs: [
+                            'Placeholder for TokenExtension tlv data (unimplemented)',
+                        ],
+                        type: {
+                            option: 'bytes',
                         },
                     },
                 ],

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -184,9 +184,9 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: true;
                     docs: [
-                        'or delegate both are included in the token data hash, thus in the',
-                        'compressed data hash thus in the compressed account hash which is public',
-                        'input to the validity proof.',
+                        'Authority is verified through proof since both owner and delegate',
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
                     ];
                 },
                 {
@@ -568,11 +568,16 @@ export type LightCompressedToken = {
                     name: 'feePayer';
                     isMut: true;
                     isSigner: true;
+                    docs: ['UNCHECKED: only pays fees.'];
                 },
                 {
                     name: 'authority';
                     isMut: false;
                     isSigner: true;
+                    docs: [
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
+                    ];
                 },
                 {
                     name: 'cpiAuthorityPda';
@@ -656,9 +661,9 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: true;
                     docs: [
-                        'or delegate both are included in the token data hash, thus in the',
-                        'compressed data hash thus in the compressed account hash which is public',
-                        'input to the validity proof.',
+                        'Authority is verified through proof since both owner and delegate',
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
                     ];
                 },
                 {
@@ -1738,9 +1743,9 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: true,
                     docs: [
-                        'or delegate both are included in the token data hash, thus in the',
-                        'compressed data hash thus in the compressed account hash which is public',
-                        'input to the validity proof.',
+                        'Authority is verified through proof since both owner and delegate',
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
                     ],
                 },
                 {
@@ -2122,11 +2127,16 @@ export const IDL: LightCompressedToken = {
                     name: 'feePayer',
                     isMut: true,
                     isSigner: true,
+                    docs: ['UNCHECKED: only pays fees.'],
                 },
                 {
                     name: 'authority',
                     isMut: false,
                     isSigner: true,
+                    docs: [
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
+                    ],
                 },
                 {
                     name: 'cpiAuthorityPda',
@@ -2210,9 +2220,9 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: true,
                     docs: [
-                        'or delegate both are included in the token data hash, thus in the',
-                        'compressed data hash thus in the compressed account hash which is public',
-                        'input to the validity proof.',
+                        'Authority is verified through proof since both owner and delegate',
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
                     ],
                 },
                 {

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -280,9 +280,8 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: true;
                     docs: [
-                        'or delegate both are included in the token data hash, thus in the',
-                        'compressed data hash thus in the compressed account hash which is public',
-                        'input to the validity proof.',
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
                     ];
                 },
                 {
@@ -354,9 +353,8 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: true;
                     docs: [
-                        'or delegate both are included in the token data hash, thus in the',
-                        'compressed data hash thus in the compressed account hash which is public',
-                        'input to the validity proof.',
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
                     ];
                 },
                 {
@@ -1836,9 +1834,8 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: true,
                     docs: [
-                        'or delegate both are included in the token data hash, thus in the',
-                        'compressed data hash thus in the compressed account hash which is public',
-                        'input to the validity proof.',
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
                     ],
                 },
                 {
@@ -1910,9 +1907,8 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: true,
                     docs: [
-                        'or delegate both are included in the token data hash, thus in the',
-                        'compressed data hash thus in the compressed account hash which is public',
-                        'input to the validity proof.',
+                        'are included in the token data hash, which is a public input to the',
+                        'validity proof.',
                     ],
                 },
                 {

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -6,8 +6,9 @@ export type LightCompressedToken = {
             name: 'createTokenPool';
             docs: [
                 'This instruction creates a token pool for a given mint. Every spl mint',
-                'can have one token pool. When a token is compressed the compressed',
-                'tokens are transferrred to the token pool.',
+                'can have one token pool. When a token is compressed the tokens are',
+                'transferrred to the token pool, and their compressed equivalent is',
+                'minted into a Merkle tree.',
             ];
             accounts: [
                 {
@@ -50,11 +51,10 @@ export type LightCompressedToken = {
                 'Mints tokens from an spl token mint to a list of compressed accounts.',
                 'Minted tokens are transferred to a pool account owned by the compressed',
                 'token program. The instruction creates one compressed output account for',
-                'every amount and pubkey input pair one output compressed account. A',
-                'constant amount of lamports can be transferred to each output account to',
-                'enable. A use case to add lamports to a compressed token account is to',
-                'prevent spam. This is the only way to add lamports to a compressed token',
-                'account.',
+                'every amount and pubkey input pair. A constant amount of lamports can be',
+                'transferred to each output account to enable. A use case to add lamports',
+                'to a compressed token account is to prevent spam. This is the only way',
+                'to add lamports to a compressed token account.',
             ];
             accounts: [
                 {
@@ -166,9 +166,9 @@ export type LightCompressedToken = {
                 'Transfers compressed tokens from one account to another. All accounts',
                 'must be of the same mint. Additional spl tokens can be compressed or',
                 'decompressed. In one transaction only compression or decompression is',
-                'possible. Lamports can be transferred along side tokens. If output token',
+                'possible. Lamports can be transferred alongside tokens. If output token',
                 'accounts specify less lamports than inputs the remaining lamports are',
-                'transferred to an output compressed account. Signer must owner or',
+                'transferred to an output compressed account. Signer must be owner or',
                 'delegate. If a delegated token account is transferred the delegate is',
                 'not preserved.',
             ];
@@ -339,7 +339,7 @@ export type LightCompressedToken = {
         {
             name: 'revoke';
             docs: [
-                'Revokes a delegation. The instruction merges all inptus into one output',
+                'Revokes a delegation. The instruction merges all inputs into one output',
                 'account. Cannot be called by a delegate. Delegates are not preserved.',
             ];
             accounts: [
@@ -1562,8 +1562,9 @@ export const IDL: LightCompressedToken = {
             name: 'createTokenPool',
             docs: [
                 'This instruction creates a token pool for a given mint. Every spl mint',
-                'can have one token pool. When a token is compressed the compressed',
-                'tokens are transferrred to the token pool.',
+                'can have one token pool. When a token is compressed the tokens are',
+                'transferrred to the token pool, and their compressed equivalent is',
+                'minted into a Merkle tree.',
             ],
             accounts: [
                 {
@@ -1606,11 +1607,10 @@ export const IDL: LightCompressedToken = {
                 'Mints tokens from an spl token mint to a list of compressed accounts.',
                 'Minted tokens are transferred to a pool account owned by the compressed',
                 'token program. The instruction creates one compressed output account for',
-                'every amount and pubkey input pair one output compressed account. A',
-                'constant amount of lamports can be transferred to each output account to',
-                'enable. A use case to add lamports to a compressed token account is to',
-                'prevent spam. This is the only way to add lamports to a compressed token',
-                'account.',
+                'every amount and pubkey input pair. A constant amount of lamports can be',
+                'transferred to each output account to enable. A use case to add lamports',
+                'to a compressed token account is to prevent spam. This is the only way',
+                'to add lamports to a compressed token account.',
             ],
             accounts: [
                 {
@@ -1722,9 +1722,9 @@ export const IDL: LightCompressedToken = {
                 'Transfers compressed tokens from one account to another. All accounts',
                 'must be of the same mint. Additional spl tokens can be compressed or',
                 'decompressed. In one transaction only compression or decompression is',
-                'possible. Lamports can be transferred along side tokens. If output token',
+                'possible. Lamports can be transferred alongside tokens. If output token',
                 'accounts specify less lamports than inputs the remaining lamports are',
-                'transferred to an output compressed account. Signer must owner or',
+                'transferred to an output compressed account. Signer must be owner or',
                 'delegate. If a delegated token account is transferred the delegate is',
                 'not preserved.',
             ],
@@ -1895,7 +1895,7 @@ export const IDL: LightCompressedToken = {
         {
             name: 'revoke',
             docs: [
-                'Revokes a delegation. The instruction merges all inptus into one output',
+                'Revokes a delegation. The instruction merges all inputs into one output',
                 'account. Cannot be called by a delegate. Delegates are not preserved.',
             ],
             accounts: [

--- a/js/stateless.js/src/rpc.ts
+++ b/js/stateless.js/src/rpc.ts
@@ -134,6 +134,7 @@ async function getCompressedTokenAccountsByOwnerOrDelegate(
             state: ['uninitialized', 'initialized', 'frozen'].indexOf(
                 _tokenData.state,
             ),
+            tlv: null,
         };
 
         if (
@@ -194,6 +195,7 @@ function buildCompressedAccountWithMaybeTokenData(
         state: ['uninitialized', 'initialized', 'frozen'].indexOf(
             tokenDataResult.state,
         ),
+        tlv: null,
     };
 
     return { account: compressedAccount, maybeTokenData: parsed };

--- a/js/stateless.js/src/state/types.ts
+++ b/js/stateless.js/src/state/types.ts
@@ -93,6 +93,7 @@ export type TokenTransferOutputData = {
     owner: PublicKey;
     amount: BN;
     lamports: BN | null;
+    tlv: Buffer | null;
 };
 
 export type CompressedTokenInstructionDataTransfer = {
@@ -113,6 +114,7 @@ export interface InputTokenDataWithContext {
     merkleContext: PackedMerkleContext;
     rootIndex: number; // u16
     lamports: BN | null;
+    tlv: Buffer | null;
 }
 export type TokenData = {
     /// The mint associated with this account
@@ -126,4 +128,6 @@ export type TokenData = {
     delegate: PublicKey | null;
     /// The account's state
     state: number; // AccountState_IdlType;
+    /// TokenExtension tlv
+    tlv: Buffer | null;
 };

--- a/js/stateless.js/src/test-helpers/test-rpc/get-compressed-token-accounts.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/get-compressed-token-accounts.ts
@@ -25,6 +25,7 @@ type TokenData = {
     amount: BN;
     delegate: PublicKey | null;
     state: number;
+    tlv: Buffer | null;
 };
 
 export type EventWithParsedTokenTlvData = {

--- a/programs/compressed-token/src/burn.rs
+++ b/programs/compressed-token/src/burn.rs
@@ -344,6 +344,7 @@ mod test {
                 root_index: 0,
                 delegate_index: Some(1),
                 lamports: None,
+                tlv: None,
             }];
             let inputs = CompressedTokenInstructionDataBurn {
                 proof: CompressedProof::default(),
@@ -374,6 +375,7 @@ mod test {
                     amount: change_amount,
                     delegate: None,
                     state: AccountState::Initialized,
+                    tlv: None,
                 };
                 let expected_compressed_output_accounts = create_expected_token_output_accounts(
                     vec![expected_change_token_data],
@@ -468,6 +470,7 @@ mod test {
                 amount: sum_inputs - burn_amount,
                 delegate: None,
                 state: AccountState::Initialized,
+                tlv: None,
             };
             let expected_compressed_output_accounts =
                 create_expected_token_output_accounts(vec![expected_change_token_data], vec![0]);
@@ -522,6 +525,7 @@ mod test {
             root_index: 0,
             delegate_index: Some(1),
             lamports: None,
+            tlv: None,
         }];
 
         // Burn amount too high
@@ -585,6 +589,7 @@ mod test {
                 amount: 50,
                 delegate: None,
                 state: AccountState::Initialized,
+                tlv: None,
             };
             let expected_compressed_output_accounts =
                 create_expected_token_output_accounts(vec![expected_change_token_data], vec![1]);
@@ -635,6 +640,7 @@ mod test {
                 amount: 50,
                 delegate: None,
                 state: AccountState::Initialized,
+                tlv: None,
             };
             let expected_compressed_output_accounts =
                 create_expected_token_output_accounts(vec![expected_change_token_data], vec![1]);

--- a/programs/compressed-token/src/delegation.rs
+++ b/programs/compressed-token/src/delegation.rs
@@ -484,6 +484,7 @@ mod test {
                 root_index: 0,
                 delegate_index: Some(1),
                 lamports: None,
+                tlv: None,
             },
             InputTokenDataWithContext {
                 amount: 101,
@@ -497,6 +498,7 @@ mod test {
                 root_index: 0,
                 delegate_index: None,
                 lamports: None,
+                tlv: None,
             },
         ];
         let inputs = CompressedTokenInstructionDataApprove {
@@ -521,6 +523,7 @@ mod test {
             amount: 151,
             delegate: None,
             state: AccountState::Initialized,
+            tlv: None,
         };
         let expected_delegated_token_data = TokenData {
             mint,
@@ -528,6 +531,7 @@ mod test {
             amount: 50,
             delegate: Some(delegate),
             state: AccountState::Initialized,
+            tlv: None,
         };
         let expected_compressed_output_accounts = create_expected_token_output_accounts(
             vec![expected_delegated_token_data, expected_change_token_data],
@@ -586,6 +590,7 @@ mod test {
                 root_index: 0,
                 delegate_index: Some(1), // Doesn't matter it is not checked if the proof is not verified
                 lamports: None,
+                tlv: None,
             },
             InputTokenDataWithContext {
                 amount: 101,
@@ -599,6 +604,7 @@ mod test {
                 root_index: 0,
                 delegate_index: Some(1), // Doesn't matter it is not checked if the proof is not verified
                 lamports: None,
+                tlv: None,
             },
         ];
         let inputs = CompressedTokenInstructionDataRevoke {
@@ -619,6 +625,7 @@ mod test {
             amount: 201,
             delegate: None,
             state: AccountState::Initialized,
+            tlv: None,
         };
         let expected_compressed_output_accounts =
             create_expected_token_output_accounts(vec![expected_change_token_data], vec![1]);

--- a/programs/compressed-token/src/freeze.rs
+++ b/programs/compressed-token/src/freeze.rs
@@ -146,6 +146,7 @@ fn create_token_output_accounts<const IS_FROZEN: bool>(
             amount: token_data_with_context.amount,
             delegate,
             state,
+            tlv: None,
         };
         token_data.serialize(&mut token_data_bytes).unwrap();
 
@@ -362,6 +363,7 @@ pub mod test_freeze {
                 root_index: 0,
                 delegate_index: None,
                 lamports: None,
+                tlv: None,
             },
             InputTokenDataWithContext {
                 amount: 101,
@@ -375,6 +377,7 @@ pub mod test_freeze {
                 root_index: 0,
                 delegate_index: Some(2),
                 lamports: None,
+                tlv: None,
             },
         ];
         // Freeze
@@ -401,6 +404,7 @@ pub mod test_freeze {
                 amount: 100,
                 delegate: None,
                 state: AccountState::Frozen,
+                tlv: None,
             };
             let expected_delegated_token_data = TokenData {
                 mint,
@@ -408,6 +412,7 @@ pub mod test_freeze {
                 amount: 101,
                 delegate: Some(delegate),
                 state: AccountState::Frozen,
+                tlv: None,
             };
 
             let expected_compressed_output_accounts = create_expected_token_output_accounts(
@@ -443,6 +448,7 @@ pub mod test_freeze {
                 amount: 100,
                 delegate: None,
                 state: AccountState::Initialized,
+                tlv: None,
             };
             let expected_delegated_token_data = TokenData {
                 mint,
@@ -450,6 +456,7 @@ pub mod test_freeze {
                 amount: 101,
                 delegate: Some(delegate),
                 state: AccountState::Initialized,
+                tlv: None,
             };
 
             let expected_compressed_output_accounts = create_expected_token_output_accounts(
@@ -512,6 +519,7 @@ pub mod test_freeze {
                 root_index: rng.gen_range(0..=65_535),
                 delegate_index,
                 lamports: None,
+                tlv: None,
             });
         }
         vec
@@ -537,6 +545,7 @@ pub mod test_freeze {
                     amount: x.amount,
                     delegate,
                     state: AccountState::Initialized,
+                    tlv: None,
                 };
                 let mut data = Vec::new();
                 token_data.serialize(&mut data).unwrap();

--- a/programs/compressed-token/src/instructions/burn.rs
+++ b/programs/compressed-token/src/instructions/burn.rs
@@ -7,8 +7,13 @@ use crate::POOL_SEED;
 
 #[derive(Accounts)]
 pub struct BurnInstruction<'info> {
+    /// UNCHECKED: only pays fees.
     #[account(mut)]
     pub fee_payer: Signer<'info>,
+    /// CHECK:
+    /// Authority is verified through proof since both owner and delegate
+    /// are included in the token data hash, which is a public input to the
+    /// validity proof.
     pub authority: Signer<'info>,
     /// CHECK: that mint authority is derived from signer
     #[account(seeds = [CPI_AUTHORITY_PDA_SEED], bump,)]

--- a/programs/compressed-token/src/instructions/freeze.rs
+++ b/programs/compressed-token/src/instructions/freeze.rs
@@ -24,7 +24,8 @@ pub struct FreezeInstruction<'info> {
     pub account_compression_authority: UncheckedAccount<'info>,
     pub account_compression_program:
         Program<'info, account_compression::program::AccountCompression>,
-    /// CHECK: (different program) checked in light system program to derive
+    /// CHECK:
+    /// (different program) checked in light system program to derive
     /// cpi_authority_pda and check that this program is the signer of the cpi.
     pub self_program: Program<'info, crate::program::LightCompressedToken>,
     pub system_program: Program<'info, System>,

--- a/programs/compressed-token/src/instructions/generic.rs
+++ b/programs/compressed-token/src/instructions/generic.rs
@@ -7,7 +7,8 @@ pub struct GenericInstruction<'info> {
     /// UNCHECKED: only pays fees.
     #[account(mut)]
     pub fee_payer: Signer<'info>,
-    /// CHECK: Authority is verified through proof since both owner and delegate
+    /// CHECK:
+    /// Authority is verified through proof since both owner and delegate
     /// are included in the token data hash, which is a public input to the
     /// validity proof.
     pub authority: Signer<'info>,
@@ -24,7 +25,8 @@ pub struct GenericInstruction<'info> {
     pub account_compression_authority: UncheckedAccount<'info>,
     pub account_compression_program:
         Program<'info, account_compression::program::AccountCompression>,
-    /// CHECK: (different program) checked in light system program to derive
+    /// CHECK:
+    /// (different program) checked in light system program to derive
     /// cpi_authority_pda and check that this program is the signer of the cpi.
     pub self_program: Program<'info, crate::program::LightCompressedToken>,
     pub system_program: Program<'info, System>,

--- a/programs/compressed-token/src/instructions/generic.rs
+++ b/programs/compressed-token/src/instructions/generic.rs
@@ -7,10 +7,9 @@ pub struct GenericInstruction<'info> {
     /// UNCHECKED: only pays fees.
     #[account(mut)]
     pub fee_payer: Signer<'info>,
-    /// CHECK: is checked by proof verification since authority is either owner
-    /// or delegate both are included in the token data hash, thus in the
-    /// compressed data hash thus in the compressed account hash which is public
-    /// input to the validity proof.
+    /// CHECK: Authority is verified through proof since both owner and delegate
+    /// are included in the token data hash, which is a public input to the
+    /// validity proof.
     pub authority: Signer<'info>,
     /// CHECK:
     #[account(seeds = [CPI_AUTHORITY_PDA_SEED], bump,)]

--- a/programs/compressed-token/src/instructions/transfer.rs
+++ b/programs/compressed-token/src/instructions/transfer.rs
@@ -10,10 +10,10 @@ pub struct TransferInstruction<'info> {
     /// UNCHECKED: only pays fees.
     #[account(mut)]
     pub fee_payer: Signer<'info>,
-    /// CHECK: is checked by proof verification since authority is either owner
-    /// or delegate both are included in the token data hash, thus in the
-    /// compressed data hash thus in the compressed account hash which is public
-    /// input to the validity proof.
+    /// CHECK:
+    /// Authority is verified through proof since both owner and delegate
+    /// are included in the token data hash, which is a public input to the
+    /// validity proof.
     pub authority: Signer<'info>,
     /// CHECK:
     #[account(seeds = [CPI_AUTHORITY_PDA_SEED], bump,)]
@@ -28,7 +28,8 @@ pub struct TransferInstruction<'info> {
     pub account_compression_authority: UncheckedAccount<'info>,
     pub account_compression_program:
         Program<'info, account_compression::program::AccountCompression>,
-    /// CHECK: (different program) checked in light system program to derive
+    /// CHECK:
+    /// (different program) checked in light system program to derive
     /// cpi_authority_pda and check that this program is the signer of the cpi.
     pub self_program: Program<'info, crate::program::LightCompressedToken>,
     #[account(mut)]

--- a/programs/compressed-token/src/lib.rs
+++ b/programs/compressed-token/src/lib.rs
@@ -32,8 +32,9 @@ pub mod light_compressed_token {
     use super::*;
     use constants::NOT_FROZEN;
     /// This instruction creates a token pool for a given mint. Every spl mint
-    /// can have one token pool. When a token is compressed the compressed
-    /// tokens are transferrred to the token pool.
+    /// can have one token pool. When a token is compressed the tokens are
+    /// transferrred to the token pool, and their compressed equivalent is
+    /// minted into a Merkle tree.
     pub fn create_token_pool<'info>(
         _ctx: Context<'_, '_, '_, 'info, CreateTokenPoolInstruction<'info>>,
     ) -> Result<()> {
@@ -43,11 +44,10 @@ pub mod light_compressed_token {
     /// Mints tokens from an spl token mint to a list of compressed accounts.
     /// Minted tokens are transferred to a pool account owned by the compressed
     /// token program. The instruction creates one compressed output account for
-    /// every amount and pubkey input pair one output compressed account. A
-    /// constant amount of lamports can be transferred to each output account to
-    /// enable. A use case to add lamports to a compressed token account is to
-    /// prevent spam. This is the only way to add lamports to a compressed token
-    /// account.
+    /// every amount and pubkey input pair. A constant amount of lamports can be
+    /// transferred to each output account to enable. A use case to add lamports
+    /// to a compressed token account is to prevent spam. This is the only way
+    /// to add lamports to a compressed token account.
     pub fn mint_to<'info>(
         ctx: Context<'_, '_, '_, 'info, MintToInstruction<'info>>,
         public_keys: Vec<Pubkey>,
@@ -60,9 +60,9 @@ pub mod light_compressed_token {
     /// Transfers compressed tokens from one account to another. All accounts
     /// must be of the same mint. Additional spl tokens can be compressed or
     /// decompressed. In one transaction only compression or decompression is
-    /// possible. Lamports can be transferred along side tokens. If output token
+    /// possible. Lamports can be transferred alongside tokens. If output token
     /// accounts specify less lamports than inputs the remaining lamports are
-    /// transferred to an output compressed account. Signer must owner or
+    /// transferred to an output compressed account. Signer must be owner or
     /// delegate. If a delegated token account is transferred the delegate is
     /// not preserved.
     pub fn transfer<'info>(
@@ -85,7 +85,7 @@ pub mod light_compressed_token {
         delegation::process_approve(ctx, inputs)
     }
 
-    /// Revokes a delegation. The instruction merges all inptus into one output
+    /// Revokes a delegation. The instruction merges all inputs into one output
     /// account. Cannot be called by a delegate. Delegates are not preserved.
     pub fn revoke<'info>(
         ctx: Context<'_, '_, '_, 'info, GenericInstruction<'info>>,

--- a/programs/compressed-token/src/process_mint.rs
+++ b/programs/compressed-token/src/process_mint.rs
@@ -72,12 +72,12 @@ pub fn process_mint_to<'info>(
     {
         let option_compression_lamports = if lamports.unwrap_or(0) == 0 { 0 } else { 8 };
         let inputs_len =
-            1 + 4 + 4 + 4 + amounts.len() * 161 + 1 + 1 + 1 + 26 + 1 + option_compression_lamports;
+            1 + 4 + 4 + 4 + amounts.len() * 162 + 1 + 1 + 1 + 26 + 1 + option_compression_lamports;
         // inputs_len =
         //   1                          Option<Proof>
         // + 4                          Vec::new()
         // + 4                          Vec::new()
-        // + 4 + amounts.len() * 161    Vec<OutputCompressedAccountWithPackedContext>
+        // + 4 + amounts.len() * 162    Vec<OutputCompressedAccountWithPackedContext>
         // + 1                          Option<relay_fee>
         // + 1 + 8                         Option<compression_lamports>
         // + 1                          is_compress
@@ -501,6 +501,7 @@ mod test {
                 amount: *amount,
                 delegate: None,
                 state: AccountState::Initialized,
+                tlv: None,
             };
 
             token_data.serialize(&mut token_data_bytes).unwrap();
@@ -575,6 +576,7 @@ mod test {
                     amount: *amount,
                     delegate: None,
                     state: AccountState::Initialized,
+                    tlv: None,
                 };
 
                 token_data.serialize(&mut token_data_bytes).unwrap();

--- a/programs/compressed-token/src/token_data.rs
+++ b/programs/compressed-token/src/token_data.rs
@@ -13,7 +13,7 @@ pub enum AccountState {
     Frozen,
 }
 
-#[derive(Debug, PartialEq, Eq, AnchorSerialize, AnchorDeserialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, AnchorSerialize, AnchorDeserialize, Clone)]
 pub struct TokenData {
     /// The mint associated with this account
     pub mint: Pubkey,
@@ -26,6 +26,8 @@ pub struct TokenData {
     pub delegate: Option<Pubkey>,
     /// The account's state
     pub state: AccountState,
+    /// Placeholder for TokenExtension tlv data (unimplemented)
+    pub tlv: Option<Vec<u8>>,
 }
 
 /// Hashing schema: H(mint, owner, amount, delegate, delegated_amount,
@@ -148,6 +150,7 @@ pub mod test {
             amount: 100,
             delegate: Some(Pubkey::new_unique()),
             state: AccountState::Initialized,
+            tlv: None,
         };
         let hashed_token_data = token_data.hash::<Poseidon>().unwrap();
         let hashed_mint = hash_to_bn254_field_size_be(token_data.mint.to_bytes().as_slice())
@@ -176,6 +179,7 @@ pub mod test {
             amount: 101,
             delegate: None,
             state: AccountState::Initialized,
+            tlv: None,
         };
         let hashed_token_data = token_data.hash::<Poseidon>().unwrap();
         let hashed_mint = hash_to_bn254_field_size_be(token_data.mint.to_bytes().as_slice())
@@ -204,6 +208,7 @@ pub mod test {
                 amount: rng.gen(),
                 delegate: Some(Pubkey::new_unique()),
                 state: AccountState::Initialized,
+                tlv: None,
             };
             let hashed_token_data = token_data.hash::<H>().unwrap();
             let hashed_mint = hash_to_bn254_field_size_be(token_data.mint.to_bytes().as_slice())
@@ -231,6 +236,7 @@ pub mod test {
                 amount: rng.gen(),
                 delegate: None,
                 state: AccountState::Initialized,
+                tlv: None,
             };
             let hashed_token_data = token_data.hash::<H>().unwrap();
             let hashed_mint = hash_to_bn254_field_size_be(token_data.mint.to_bytes().as_slice())
@@ -269,6 +275,7 @@ pub mod test {
             amount: 100,
             delegate: Some(Pubkey::new_unique()),
             state: AccountState::Initialized,
+            tlv: None,
         };
         let hashed_mint = hash_to_bn254_field_size_be(token_data.mint.to_bytes().as_slice())
             .unwrap()
@@ -300,6 +307,7 @@ pub mod test {
             amount: 100,
             delegate: None,
             state: AccountState::Initialized,
+            tlv: None,
         };
         let hashed_mint = hash_to_bn254_field_size_be(token_data.mint.to_bytes().as_slice())
             .unwrap()

--- a/test-programs/compressed-token-test/tests/test.rs
+++ b/test-programs/compressed-token-test/tests/test.rs
@@ -707,7 +707,7 @@ async fn test_transfers() {
     let possible_inputs = [1, 2, 3, 4, 8];
     for input_num in possible_inputs {
         for output_num in 1..8 {
-            if input_num == 8 && output_num > 6 {
+            if input_num == 8 && output_num > 5 {
                 // 8 inputs and 7 outputs is the max we can do
                 break;
             }
@@ -724,7 +724,7 @@ async fn test_1_transfer() {
     let possible_inputs = [1];
     for input_num in possible_inputs {
         for output_num in 1..2 {
-            if input_num == 8 && output_num > 7 {
+            if input_num == 8 && output_num > 5 {
                 // 8 inputs and 7 outputs is the max we can do
                 break;
             }
@@ -742,7 +742,7 @@ async fn test_2_transfer() {
     let possible_inputs = [2];
     for input_num in possible_inputs {
         for output_num in 2..3 {
-            if input_num == 8 && output_num > 6 {
+            if input_num == 8 && output_num > 5 {
                 // 8 inputs and 7 outputs is the max we can do
                 break;
             }
@@ -759,17 +759,12 @@ async fn test_2_transfer() {
 async fn test_8_transfer() {
     let possible_inputs = [8];
     for input_num in possible_inputs {
-        for output_num in 2..3 {
-            if input_num == 8 && output_num > 7 {
-                // 8 inputs and 7 outputs is the max we can do
-                break;
-            }
-            println!(
-                "\n\ninput num: {}, output num: {}\n\n",
-                input_num, output_num
-            );
-            perform_transfer_test(input_num, output_num, 10_000).await
-        }
+        let output_num = 5;
+        println!(
+            "\n\ninput num: {}, output num: {}\n\n",
+            input_num, output_num
+        );
+        perform_transfer_test(input_num, output_num, 10_000).await
     }
 }
 
@@ -1092,7 +1087,7 @@ async fn test_approve_failing() {
                 .collect(),
             input_token_data: input_compressed_accounts
                 .iter()
-                .map(|x| x.token_data)
+                .map(|x| x.token_data.clone())
                 .collect(),
             input_compressed_accounts: input_compressed_accounts
                 .iter()
@@ -1139,7 +1134,7 @@ async fn test_approve_failing() {
                 .collect(),
             input_token_data: input_compressed_accounts
                 .iter()
-                .map(|x| x.token_data)
+                .map(|x| x.token_data.clone())
                 .collect(),
             input_compressed_accounts: input_compressed_accounts
                 .iter()
@@ -1190,7 +1185,7 @@ async fn test_approve_failing() {
                 .collect(),
             input_token_data: input_compressed_accounts
                 .iter()
-                .map(|x| x.token_data)
+                .map(|x| x.token_data.clone())
                 .collect(),
             input_compressed_accounts: input_compressed_accounts
                 .iter()
@@ -1230,7 +1225,7 @@ async fn test_approve_failing() {
                 .collect(),
             input_token_data: input_compressed_accounts
                 .iter()
-                .map(|x| x.token_data)
+                .map(|x| x.token_data.clone())
                 .collect(),
             input_compressed_accounts: input_compressed_accounts
                 .iter()
@@ -1273,7 +1268,7 @@ async fn test_approve_failing() {
                 .collect(),
             input_token_data: input_compressed_accounts
                 .iter()
-                .map(|x| x.token_data)
+                .map(|x| x.token_data.clone())
                 .collect(),
             input_compressed_accounts: input_compressed_accounts
                 .iter()
@@ -1502,7 +1497,7 @@ async fn test_revoke_failing() {
                 .collect(),
             input_token_data: input_compressed_accounts
                 .iter()
-                .map(|x| x.token_data)
+                .map(|x| x.token_data.clone())
                 .collect(),
             input_compressed_accounts: input_compressed_accounts
                 .iter()
@@ -1538,7 +1533,7 @@ async fn test_revoke_failing() {
                 .collect(),
             input_token_data: input_compressed_accounts
                 .iter()
-                .map(|x| x.token_data)
+                .map(|x| x.token_data.clone())
                 .collect(),
             input_compressed_accounts: input_compressed_accounts
                 .iter()
@@ -1583,7 +1578,7 @@ async fn test_revoke_failing() {
                 .collect(),
             input_token_data: input_compressed_accounts
                 .iter()
-                .map(|x| x.token_data)
+                .map(|x| x.token_data.clone())
                 .collect(),
             input_compressed_accounts: input_compressed_accounts
                 .iter()
@@ -2181,7 +2176,7 @@ async fn test_failing_freeze() {
                 .collect(),
             input_token_data: input_compressed_accounts
                 .iter()
-                .map(|x| x.token_data)
+                .map(|x| x.token_data.clone())
                 .collect(),
             input_compressed_accounts: input_compressed_accounts
                 .iter()
@@ -2220,7 +2215,7 @@ async fn test_failing_freeze() {
                 .collect(),
             input_token_data: input_compressed_accounts
                 .iter()
-                .map(|x| x.token_data)
+                .map(|x| x.token_data.clone())
                 .collect(),
             input_compressed_accounts: input_compressed_accounts
                 .iter()
@@ -2261,7 +2256,7 @@ async fn test_failing_freeze() {
                 .collect(),
             input_token_data: input_compressed_accounts
                 .iter()
-                .map(|x| x.token_data)
+                .map(|x| x.token_data.clone())
                 .collect(),
             input_compressed_accounts: input_compressed_accounts
                 .iter()
@@ -2327,7 +2322,7 @@ async fn test_failing_freeze() {
                 .collect(),
             input_token_data: input_compressed_accounts
                 .iter()
-                .map(|x| x.token_data)
+                .map(|x| x.token_data.clone())
                 .collect(),
             input_compressed_accounts: input_compressed_accounts
                 .iter()
@@ -2443,7 +2438,7 @@ async fn test_failing_thaw() {
                 .collect(),
             input_token_data: input_compressed_accounts
                 .iter()
-                .map(|x| x.token_data)
+                .map(|x| x.token_data.clone())
                 .collect(),
             input_compressed_accounts: input_compressed_accounts
                 .iter()
@@ -2482,7 +2477,7 @@ async fn test_failing_thaw() {
                 .collect(),
             input_token_data: input_compressed_accounts
                 .iter()
-                .map(|x| x.token_data)
+                .map(|x| x.token_data.clone())
                 .collect(),
             input_compressed_accounts: input_compressed_accounts
                 .iter()
@@ -2523,7 +2518,7 @@ async fn test_failing_thaw() {
                 .collect(),
             input_token_data: input_compressed_accounts
                 .iter()
-                .map(|x| x.token_data)
+                .map(|x| x.token_data.clone())
                 .collect(),
             input_compressed_accounts: input_compressed_accounts
                 .iter()
@@ -2580,7 +2575,7 @@ async fn test_failing_thaw() {
                 .collect(),
             input_token_data: input_compressed_accounts
                 .iter()
-                .map(|x| x.token_data)
+                .map(|x| x.token_data.clone())
                 .collect(),
             input_compressed_accounts: input_compressed_accounts
                 .iter()
@@ -2889,7 +2884,7 @@ pub async fn failing_compress_decompress<R: RpcConnection>(
         &proof,
         input_compressed_accounts
             .iter()
-            .map(|x| x.token_data)
+            .map(|x| x.token_data.clone())
             .collect::<Vec<_>>()
             .as_slice(),
         &input_compressed_accounts
@@ -2982,7 +2977,8 @@ async fn test_invalid_inputs() {
     .await;
     let payer = recipient_keypair.insecure_clone();
     let transfer_recipient_keypair = Keypair::new();
-    let input_compressed_account_token_data = test_indexer.token_compressed_accounts[0].token_data;
+    let input_compressed_account_token_data =
+        test_indexer.token_compressed_accounts[0].token_data.clone();
     let input_compressed_accounts = vec![test_indexer.token_compressed_accounts[0]
         .compressed_account
         .clone()];
@@ -3131,7 +3127,7 @@ async fn test_invalid_inputs() {
     // Test 5: invalid input token data amount (0)
     {
         let mut input_compressed_account_token_data_invalid_amount =
-            test_indexer.token_compressed_accounts[0].token_data;
+            test_indexer.token_compressed_accounts[0].token_data.clone();
         input_compressed_account_token_data_invalid_amount.amount = 0;
         let mut input_compressed_accounts = vec![test_indexer.token_compressed_accounts[0]
             .compressed_account
@@ -3179,7 +3175,7 @@ async fn test_invalid_inputs() {
     // Test 6: invalid delegate
     {
         let mut input_compressed_account_token_data =
-            test_indexer.token_compressed_accounts[0].token_data;
+            test_indexer.token_compressed_accounts[0].token_data.clone();
         input_compressed_account_token_data.delegate = Some(Pubkey::new_unique());
         let mut input_compressed_accounts = vec![test_indexer.token_compressed_accounts[0]
             .compressed_account

--- a/test-programs/system-cpi-test/src/invalidate_not_owned_account.rs
+++ b/test-programs/system-cpi-test/src/invalidate_not_owned_account.rs
@@ -329,6 +329,7 @@ pub fn cpi_compressed_token_transfer<'info>(
         amount: input_token_data_with_context.amount,
         owner: crate::ID,
         lamports: None,
+        tlv: None,
         merkle_tree_index: input_token_data_with_context
             .merkle_context
             .merkle_tree_pubkey_index,

--- a/test-programs/system-cpi-test/tests/test.rs
+++ b/test-programs/system-cpi-test/tests/test.rs
@@ -835,6 +835,7 @@ pub async fn perform_with_input_accounts<R: RpcConnection>(
                 } else {
                     None
                 },
+                tlv: None,
             },
         }),
         _ => None,

--- a/test-utils/src/spl.rs
+++ b/test-utils/src/spl.rs
@@ -296,7 +296,7 @@ pub async fn compressed_transfer_test<R: RpcConnection, I: Indexer<R>>(
     let mut sum_input_amounts = 0;
     for account in input_compressed_accounts {
         let leaf_index = account.compressed_account.merkle_context.leaf_index;
-        input_compressed_account_token_data.push(account.token_data);
+        input_compressed_account_token_data.push(account.token_data.clone());
         input_compressed_account_hashes.push(
             account
                 .compressed_account
@@ -514,7 +514,7 @@ pub async fn decompress_test<R: RpcConnection, I: Indexer<R>>(
         &Some(proof_rpc_result.proof),
         input_compressed_accounts
             .iter()
-            .map(|x| x.token_data)
+            .map(|x| x.token_data.clone())
             .collect::<Vec<_>>()
             .as_slice(), // input_token_data
         &input_compressed_accounts
@@ -738,7 +738,7 @@ pub async fn approve_test<R: RpcConnection, I: Indexer<R>>(
             .collect(),
         input_token_data: input_compressed_accounts
             .iter()
-            .map(|x| x.token_data)
+            .map(|x| x.token_data.clone())
             .collect(),
         input_compressed_accounts: input_compressed_accounts
             .iter()
@@ -815,6 +815,7 @@ pub async fn approve_test<R: RpcConnection, I: Indexer<R>>(
         amount: delegated_amount,
         delegate: Some(*delegate),
         state: AccountState::Initialized,
+        tlv: None,
     };
 
     assert_eq!(
@@ -830,6 +831,7 @@ pub async fn approve_test<R: RpcConnection, I: Indexer<R>>(
             amount: change_amount,
             delegate: None,
             state: AccountState::Initialized,
+            tlv: None,
         };
         assert_eq!(
             expected_change_token_data,
@@ -897,7 +899,7 @@ pub async fn revoke_test<R: RpcConnection, I: Indexer<R>>(
             .collect(),
         input_token_data: input_compressed_accounts
             .iter()
-            .map(|x| x.token_data)
+            .map(|x| x.token_data.clone())
             .collect(),
         input_compressed_accounts: input_compressed_accounts
             .iter()
@@ -942,6 +944,7 @@ pub async fn revoke_test<R: RpcConnection, I: Indexer<R>>(
         amount: input_amount,
         delegate: None,
         state: AccountState::Initialized,
+        tlv: None,
     };
     assert_eq!(expected_token_data, created_output_accounts[0].token_data);
     let expected_compressed_output_accounts =
@@ -1047,7 +1050,7 @@ pub async fn freeze_or_thaw_test<R: RpcConnection, const FREEZE: bool, I: Indexe
             .collect(),
         input_token_data: input_compressed_accounts
             .iter()
-            .map(|x| x.token_data)
+            .map(|x| x.token_data.clone())
             .collect(),
         input_compressed_accounts: input_compressed_accounts
             .iter()
@@ -1097,6 +1100,7 @@ pub async fn freeze_or_thaw_test<R: RpcConnection, const FREEZE: bool, I: Indexe
             amount: account.token_data.amount,
             delegate: account.token_data.delegate,
             state,
+            tlv: None,
         };
         if let Some(delegate) = account.token_data.delegate {
             delegates.push(Some(delegate));
@@ -1222,6 +1226,7 @@ pub async fn burn_test<R: RpcConnection, I: Indexer<R>>(
             amount: output_amount,
             delegate,
             state: AccountState::Initialized,
+            tlv: None,
         };
         if let Some(delegate) = expected_token_data.delegate {
             delegates.push(Some(delegate));
@@ -1330,7 +1335,7 @@ pub async fn create_burn_test_instruction<R: RpcConnection, I: Indexer<R>>(
             .collect(),
         input_token_data: input_compressed_accounts
             .iter()
-            .map(|x| x.token_data)
+            .map(|x| x.token_data.clone())
             .collect(),
         input_compressed_accounts: input_compressed_accounts
             .iter()


### PR DESCRIPTION
Changes:
- add tlv: `Option<Vec<u8>>` to:
  - `TokenData`
  -  `PackedTokenTransferOutputData`
  - `InputTokenDataWithContext`
- tlv is forced to be `None` if set instructions panic with unimplemented  


Note:
- changes in `TokenData` are breaking changes for photon
- interop tests in `compressed-token.js` are disabled
- cli tests are disabled because these use photon