### PR TITLE
fix: wait for photon slot to match rpc slot in confirmTx

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -36,15 +36,15 @@ jobs:
           npx nx build @lightprotocol/zk-compression-cli --skip-nx-cache
 
       # Commented for breaking changes to Photon
-      # - name: Run CLI tests
-      #   run: |
-      #     source ./scripts/devenv.sh
-      #     npx nx test @lightprotocol/zk-compression-cli
+      - name: Run CLI tests
+        run: |
+          source ./scripts/devenv.sh
+          npx nx test @lightprotocol/zk-compression-cli
 
       - name: Run stateless.js tests
         run: |
           source ./scripts/devenv.sh
-          npx nx test @lightprotocol/stateless.js          
+          npx nx test @lightprotocol/stateless.js
 
       - name: Run compressed-token tests
         run: |

--- a/cli/src/utils/constants.ts
+++ b/cli/src/utils/constants.ts
@@ -21,7 +21,7 @@ export const LIGHT_PROVER_PROCESS_NAME = "light-prover";
 export const INDEXER_PROCESS_NAME = "photon";
 export const FORESTER_PROCESS_NAME = "forester";
 
-export const PHOTON_VERSION = "0.35.0";
+export const PHOTON_VERSION = "0.36.0";
 
 export const LIGHT_PROTOCOL_PROGRAMS_DIR_ENV = "LIGHT_PROTOCOL_PROGRAMS_DIR";
 export const BASE_PATH = "../../bin/";

--- a/js/compressed-token/package.json
+++ b/js/compressed-token/package.json
@@ -40,7 +40,7 @@
         "test:e2e:compress": "pnpm test-validator && vitest run tests/e2e/compress.test.ts --reporter=verbose",
         "test:e2e:decompress": "pnpm test-validator && vitest run tests/e2e/decompress.test.ts --reporter=verbose",
         "test:e2e:rpc-token-interop": "pnpm test-validator && vitest run tests/e2e/rpc-token-interop.test.ts --reporter=verbose",
-        "test:e2e:all": "pnpm test-validator && vitest run tests/e2e/create-mint.test.ts && vitest run tests/e2e/mint-to.test.ts && vitest run tests/e2e/transfer.test.ts && vitest run tests/e2e/compress.test.ts && vitest run tests/e2e/decompress.test.ts && vitest run tests/e2e/register-mint.test.ts && vitest run tests/e2e/approve-and-mint-to.test.ts",
+        "test:e2e:all": "pnpm test-validator && vitest run tests/e2e/create-mint.test.ts && vitest run tests/e2e/mint-to.test.ts && vitest run tests/e2e/transfer.test.ts && vitest run tests/e2e/compress.test.ts && vitest run tests/e2e/decompress.test.ts && vitest run tests/e2e/register-mint.test.ts && vitest run tests/e2e/approve-and-mint-to.test.ts && vitest run tests/e2e/rpc-token-interop.test.ts",
         "pull-idl": "../../scripts/push-compressed-token-idl.sh",
         "build": "rimraf dist && pnpm pull-idl && pnpm build:bundle",
         "build:bundle": "rollup -c",

--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -224,6 +224,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: false;
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ];
                 },
@@ -280,6 +281,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: true;
                     docs: [
+                        'Authority is verified through proof since both owner and delegate',
                         'are included in the token data hash, which is a public input to the',
                         'validity proof.',
                     ];
@@ -319,6 +321,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: false;
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ];
                 },
@@ -353,6 +356,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: true;
                     docs: [
+                        'Authority is verified through proof since both owner and delegate',
                         'are included in the token data hash, which is a public input to the',
                         'validity proof.',
                     ];
@@ -392,6 +396,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: false;
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ];
                 },
@@ -461,6 +466,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: false;
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ];
                 },
@@ -535,6 +541,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: false;
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ];
                 },
@@ -575,6 +582,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: true;
                     docs: [
+                        'Authority is verified through proof since both owner and delegate',
                         'are included in the token data hash, which is a public input to the',
                         'validity proof.',
                     ];
@@ -701,6 +709,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: false;
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ];
                 },
@@ -1783,6 +1792,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: false,
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ],
                 },
@@ -1839,6 +1849,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: true,
                     docs: [
+                        'Authority is verified through proof since both owner and delegate',
                         'are included in the token data hash, which is a public input to the',
                         'validity proof.',
                     ],
@@ -1878,6 +1889,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: false,
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ],
                 },
@@ -1912,6 +1924,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: true,
                     docs: [
+                        'Authority is verified through proof since both owner and delegate',
                         'are included in the token data hash, which is a public input to the',
                         'validity proof.',
                     ],
@@ -1951,6 +1964,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: false,
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ],
                 },
@@ -2020,6 +2034,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: false,
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ],
                 },
@@ -2094,6 +2109,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: false,
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ],
                 },
@@ -2134,6 +2150,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: true,
                     docs: [
+                        'Authority is verified through proof since both owner and delegate',
                         'are included in the token data hash, which is a public input to the',
                         'validity proof.',
                     ],
@@ -2260,6 +2277,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: false,
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ],
                 },

--- a/js/compressed-token/tests/e2e/rpc-token-interop.test.ts
+++ b/js/compressed-token/tests/e2e/rpc-token-interop.test.ts
@@ -11,6 +11,10 @@ import {
 } from '@lightprotocol/stateless.js';
 import { WasmFactory } from '@lightprotocol/hasher.rs';
 import { createMint, mintTo, transfer } from '../../src/actions';
+import {
+    PublicTransactionEvent,
+    getParsedEvents,
+} from '../../../stateless.js/src';
 
 const TEST_TOKEN_DECIMALS = 2;
 
@@ -24,12 +28,13 @@ describe('rpc-interop token', () => {
     let mintAuthority: Keypair;
 
     beforeAll(async () => {
-        const lightWasm = await WasmFactory.getInstance();
         rpc = createRpc();
-        testRpc = await getTestRpc(lightWasm);
+        const lightWasm = await WasmFactory.getInstance();
         payer = await newAccountWithLamports(rpc, 1e9, 256);
         mintAuthority = Keypair.generate();
         const mintKeypair = Keypair.generate();
+
+        testRpc = await getTestRpc(lightWasm);
 
         mint = (
             await createMint(
@@ -45,8 +50,8 @@ describe('rpc-interop token', () => {
         charlie = await newAccountWithLamports(rpc, 1e9, 256);
 
         await mintTo(rpc, payer, mint, bob.publicKey, mintAuthority, bn(1000));
-        /// TODO: replace for Rpc once 'getValidityProof' in Photon is working.
-        await transfer(testRpc, payer, mint, bn(700), bob, charlie.publicKey);
+
+        await transfer(rpc, payer, mint, bn(700), bob, charlie.publicKey);
     });
 
     it('getCompressedTokenAccountsByOwner should match', async () => {
@@ -78,6 +83,7 @@ describe('rpc-interop token', () => {
             charlie.publicKey,
             { mint },
         );
+
         const receiverAccountsTest =
             await testRpc.getCompressedTokenAccountsByOwner(charlie.publicKey, {
                 mint,

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -224,6 +224,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: false;
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ];
                 },
@@ -280,6 +281,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: true;
                     docs: [
+                        'Authority is verified through proof since both owner and delegate',
                         'are included in the token data hash, which is a public input to the',
                         'validity proof.',
                     ];
@@ -319,6 +321,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: false;
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ];
                 },
@@ -353,6 +356,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: true;
                     docs: [
+                        'Authority is verified through proof since both owner and delegate',
                         'are included in the token data hash, which is a public input to the',
                         'validity proof.',
                     ];
@@ -392,6 +396,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: false;
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ];
                 },
@@ -461,6 +466,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: false;
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ];
                 },
@@ -535,6 +541,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: false;
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ];
                 },
@@ -575,6 +582,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: true;
                     docs: [
+                        'Authority is verified through proof since both owner and delegate',
                         'are included in the token data hash, which is a public input to the',
                         'validity proof.',
                     ];
@@ -701,6 +709,7 @@ export type LightCompressedToken = {
                     isMut: false;
                     isSigner: false;
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ];
                 },
@@ -1783,6 +1792,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: false,
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ],
                 },
@@ -1839,6 +1849,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: true,
                     docs: [
+                        'Authority is verified through proof since both owner and delegate',
                         'are included in the token data hash, which is a public input to the',
                         'validity proof.',
                     ],
@@ -1878,6 +1889,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: false,
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ],
                 },
@@ -1912,6 +1924,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: true,
                     docs: [
+                        'Authority is verified through proof since both owner and delegate',
                         'are included in the token data hash, which is a public input to the',
                         'validity proof.',
                     ],
@@ -1951,6 +1964,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: false,
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ],
                 },
@@ -2020,6 +2034,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: false,
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ],
                 },
@@ -2094,6 +2109,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: false,
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ],
                 },
@@ -2134,6 +2150,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: true,
                     docs: [
+                        'Authority is verified through proof since both owner and delegate',
                         'are included in the token data hash, which is a public input to the',
                         'validity proof.',
                     ],
@@ -2260,6 +2277,7 @@ export const IDL: LightCompressedToken = {
                     isMut: false,
                     isSigner: false,
                     docs: [
+                        '(different program) checked in light system program to derive',
                         'cpi_authority_pda and check that this program is the signer of the cpi.',
                     ],
                 },

--- a/js/stateless.js/src/rpc.ts
+++ b/js/stateless.js/src/rpc.ts
@@ -1011,6 +1011,7 @@ export class Rpc extends Connection implements CompressionApiInterface {
      */
     async confirmTransactionIndexed(slot: number): Promise<boolean> {
         const startTime = Date.now();
+        // eslint-disable-next-line no-constant-condition
         while (true) {
             const indexerSlot = await this.getIndexerSlot();
             if (indexerSlot >= slot) {

--- a/js/stateless.js/src/rpc.ts
+++ b/js/stateless.js/src/rpc.ts
@@ -1007,6 +1007,26 @@ export class Rpc extends Connection implements CompressionApiInterface {
     }
 
     /**
+     * Ensure that the Compression Indexer has already indexed the transaction
+     */
+    async confirmTransactionIndexed(slot: number): Promise<boolean> {
+        const startTime = Date.now();
+        while (true) {
+            const indexerSlot = await this.getIndexerSlot();
+            if (indexerSlot >= slot) {
+                return true;
+            }
+            if (Date.now() - startTime > 20000) {
+                // 20 seconds
+                throw new Error(
+                    'Timeout: Indexer slot did not reach the required slot within 20 seconds',
+                );
+            }
+            await new Promise(resolve => setTimeout(resolve, 400));
+        }
+    }
+
+    /**
      * Fetch the current slot that the node is processing
      */
     async getIndexerSlot(): Promise<number> {

--- a/js/stateless.js/src/test-helpers/test-rpc/get-compressed-token-accounts.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/get-compressed-token-accounts.ts
@@ -158,8 +158,11 @@ export async function getCompressedTokenAccountsByOwnerTest(
 
     const compressedTokenAccounts = await getCompressedTokenAccounts(events);
 
-    return compressedTokenAccounts.filter(
+    const accounts = compressedTokenAccounts.filter(
         acc => acc.parsed.owner.equals(owner) && acc.parsed.mint.equals(mint),
+    );
+    return accounts.sort(
+        (a, b) => b.compressedAccount.leafIndex - a.compressedAccount.leafIndex,
     );
 }
 

--- a/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
@@ -254,7 +254,12 @@ export class TestRpc extends Connection implements CompressionApiInterface {
     ): Promise<CompressedAccountWithMerkleContext[]> {
         return await getMultipleCompressedAccountsByHashTest(this, hashes);
     }
-
+    /**
+     * Ensure that the Compression Indexer has already indexed the transaction
+     */
+    async confirmTransactionIndexed(_slot: number): Promise<boolean> {
+        return true;
+    }
     /**
      * Fetch the latest merkle proofs for multiple compressed accounts specified
      * by an array account hashes

--- a/js/stateless.js/src/utils/send-and-confirm.ts
+++ b/js/stateless.js/src/utils/send-and-confirm.ts
@@ -61,10 +61,12 @@ export async function sendAndConfirmTx(
         lastValidBlockHeight: blockHashCtx.lastValidBlockHeight,
     };
 
-    await rpc.confirmTransaction(
+    const ctxAndRes = await rpc.confirmTransaction(
         transactionConfirmationStrategy0,
         confirmOptions?.commitment || rpc.commitment || 'confirmed',
     );
+    const slot = ctxAndRes.context.slot;
+    await rpc.confirmTransactionIndexed(slot);
     return txId;
 }
 
@@ -94,6 +96,8 @@ export async function confirmTx(
         transactionConfirmationStrategy,
         confirmOptions?.commitment || rpc.commitment || 'confirmed',
     );
+    const slot = res.context.slot;
+    await rpc.confirmTransactionIndexed(slot);
     return res;
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -189,7 +189,7 @@ echo "Downloading gnark keys"
 # run the light-prover/scripts/download_keys.sh script
 # this script will download the keys from IPFS and place them in the light-prover/proving-keys directory
 ROOT_DIR="$(git rev-parse --show-toplevel)"
-"$ROOT_DIR"/light-prover/scripts/downlopad_keys.sh
+"$ROOT_DIR"/light-prover/scripts/download_keys.sh
 
 echo "🦀 Installing Rust"
 export RUSTUP_HOME="${PREFIX}/rustup"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -114,7 +114,7 @@ PNPM_VERSION="9.5.0"
 SOLANA_VERSION="1.18.11"
 ANCHOR_VERSION="anchor-v0.29.0"
 JQ_VERSION="jq-1.7.1"
-PHOTON_VERSION="0.35.0"
+PHOTON_VERSION="0.36.0"
 PHOTON_BRANCH=""
 
 case "${OS}" in
@@ -189,7 +189,7 @@ echo "Downloading gnark keys"
 # run the light-prover/scripts/download_keys.sh script
 # this script will download the keys from IPFS and place them in the light-prover/proving-keys directory
 ROOT_DIR="$(git rev-parse --show-toplevel)"
-"$ROOT_DIR"/light-prover/scripts/download_keys.sh
+"$ROOT_DIR"/light-prover/scripts/downlopad_keys.sh
 
 echo "🦀 Installing Rust"
 export RUSTUP_HOME="${PREFIX}/rustup"


### PR DESCRIPTION
- also bumps to newest photon 0.36.0
- enables token-interop tests
- cli ci