### PR TITLE
chore: remove Playwright install

### DIFF
--- a/hasher.rs/package.json
+++ b/hasher.rs/package.json
@@ -34,7 +34,7 @@
     "build:wasm-simd-ci": "wasm-pack build -t web --out-name hasher_wasm_simd --out-dir ../main/wasm-simd src/wasm",
     "build:bundle": "rollup -c --bundleConfigAsCjs",
     "build": "rm -rf dist/ && pnpm build:wasm && pnpm build:wasm-simd && pnpm build:bundle",
-    "test": "pnpm test:native && pnpm test:browser",
+    "test": "pnpm test:native",
     "test:types": "tsc",
     "test:native": "vitest run --config vitest.node.config.ts --dir tests",
     "test:browser": "vitest run --config vitest.config.ts --browser.name=firefox --browser.provider=playwright --browser.headless --dir tests",

--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -1,5 +1,5 @@
 export type LightCompressedToken = {
-    version: '0.4.1';
+    version: '0.5.0';
     name: 'light_compressed_token';
     instructions: [
         {
@@ -1567,7 +1567,7 @@ export type LightCompressedToken = {
     ];
 };
 export const IDL: LightCompressedToken = {
-    version: '0.4.1',
+    version: '0.5.0',
     name: 'light_compressed_token',
     instructions: [
         {

--- a/js/stateless.js/src/idls/account_compression.ts
+++ b/js/stateless.js/src/idls/account_compression.ts
@@ -1,5 +1,5 @@
 export type AccountCompression = {
-    version: '0.4.1';
+    version: '0.5.0';
     name: 'account_compression';
     constants: [
         {
@@ -1125,7 +1125,7 @@ export type AccountCompression = {
 };
 
 export const IDL: AccountCompression = {
-    version: '0.4.1',
+    version: '0.5.0',
     name: 'account_compression',
     constants: [
         {

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -1,5 +1,5 @@
 export type LightCompressedToken = {
-    version: '0.4.1';
+    version: '0.5.0';
     name: 'light_compressed_token';
     instructions: [
         {
@@ -1567,7 +1567,7 @@ export type LightCompressedToken = {
     ];
 };
 export const IDL: LightCompressedToken = {
-    version: '0.4.1',
+    version: '0.5.0',
     name: 'light_compressed_token',
     instructions: [
         {

--- a/js/stateless.js/src/idls/light_registry.ts
+++ b/js/stateless.js/src/idls/light_registry.ts
@@ -1,5 +1,5 @@
 export type LightRegistry = {
-    version: '0.4.1';
+    version: '0.5.0';
     name: 'light_registry';
     constants: [
         {
@@ -671,7 +671,7 @@ export type LightRegistry = {
 };
 
 export const IDL: LightRegistry = {
-    version: '0.4.1',
+    version: '0.5.0',
     name: 'light_registry',
     constants: [
         {

--- a/js/stateless.js/src/idls/light_system_program.ts
+++ b/js/stateless.js/src/idls/light_system_program.ts
@@ -1,5 +1,5 @@
 export type LightSystemProgram = {
-    version: '0.4.1';
+    version: '0.5.0';
     name: 'light_system_program';
     constants: [
         {
@@ -1045,7 +1045,7 @@ export type LightSystemProgram = {
 };
 
 export const IDL: LightSystemProgram = {
-    version: '0.4.1',
+    version: '0.5.0',
     name: 'light_system_program',
     constants: [
         {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -270,8 +270,5 @@ download_file_github \
 echo "📦 Installing pnpm dependencies"
 pnpm install
 
-echo "📦 Installing Playwright"
-pnpm exec playwright install --with-deps
-
 echo "✨ Light Protocol development dependencies installed"
 


### PR DESCRIPTION
* Removed Playwright installation from `install.sh` and updated the `test` script to omit browser tests on hasher.rs. 
* Additionally, bumped the version for multiple IDLs from `0.4.1` to `0.5.0`.