### PR TITLE
chore: Update `tokio` to workspace-wide specification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -3065,7 +3065,7 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-std",
- "borsh 0.9.3",
+ "borsh 0.10.3",
  "bytemuck",
  "color-eyre",
  "duct",
@@ -3378,13 +3378,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3613,7 +3614,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -7008,28 +7009,27 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "d040ac2b29ab03b09d4129c2f5bbd012a3ac2f79d38ff506a4bf8dd34b0eac8a"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.5",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ anchor-spl = "=0.29.0"
 
 spl-token = "=4.0.0"
 
-tokio = { version = "1.39.1", features = ["rt", "macros"] }
+tokio = { version = "1.39.1", features = ["rt", "macros", "rt-multi-thread"] }
 
 [patch.crates-io]
 "solana-account-decoder" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ anchor-spl = "=0.29.0"
 
 spl-token = "=4.0.0"
 
+tokio = { version = "1.39.1", features = ["rt", "macros"] }
+
 [patch.crates-io]
 "solana-account-decoder" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
 "solana-accounts-db" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }

--- a/circuit-lib/light-prover-client/Cargo.toml
+++ b/circuit-lib/light-prover-client/Cargo.toml
@@ -44,7 +44,7 @@ zeroize = "=1.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.60"
 num-traits = "0.2.18"
-tokio = { version = "1.38.0", features = ["rt", "macros"], optional = true }
+tokio = { workspace = true, optional = true }
 reqwest = {  version = "0.11.24", features = ["json", "rustls-tls"], optional = true  }
 sysinfo = "0.30"
 borsh = ">=0.9, <0.11"

--- a/circuit-lib/verifier/Cargo.toml
+++ b/circuit-lib/verifier/Cargo.toml
@@ -16,6 +16,6 @@ borsh = "0.10"
 solana-program = { workspace = true, optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.38.0", features = ["rt", "macros"] }
+tokio = { workspace = true }
 reqwest = {  version = "0.11.24", features = ["json", "rustls-tls"]  }
 light-prover-client = { path = "../light-prover-client", version = "0.3.0" }

--- a/examples/token-escrow/programs/token-escrow/Cargo.toml
+++ b/examples/token-escrow/programs/token-escrow/Cargo.toml
@@ -35,7 +35,7 @@ solana-sdk = { workspace = true }
 solana-program-test = { workspace = true }
 light-test-utils = { version = "0.3.0", path = "../../../../test-utils" }
 reqwest = "0.12"
-tokio = "1.38.0"
+tokio = { workspace = true }
 light-prover-client = { path = "../../../../circuit-lib/light-prover-client", version = "0.3.0" }
 num-bigint = "0.4.6"
 num-traits = "0.2.18"

--- a/merkle-tree/concurrent/Cargo.toml
+++ b/merkle-tree/concurrent/Cargo.toml
@@ -33,6 +33,6 @@ rand = "0.8"
 solana-program = {  workspace = true }
 spl-account-compression = { version = "0.3.0", default-features = false}
 spl-concurrent-merkle-tree = { version = "0.2.0", default-features = false}
-tokio = { version = "1.38", features = ["full"] }
+tokio = { workspace = true }
 num-bigint = "0.4"
 num-traits = "0.2"

--- a/programs/registry/Cargo.toml
+++ b/programs/registry/Cargo.toml
@@ -37,5 +37,5 @@ log = "0.4"
 [dev-dependencies]
 solana-program-test = { workspace = true }
 solana-sdk = { workspace = true }
-tokio = "1.38.0"
+tokio = { workspace = true }
 light-macros= { version = "0.5.0", path = "../../macros/light" }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -46,7 +46,7 @@ solana-program-test = { workspace = true }
 solana-sdk = { workspace = true }
 serde_json = "1.0.114"
 reqwest = "0.12"
-tokio = "1.38.0"
+tokio = { workspace = true }
 light-prover-client = { version = "0.3.0", path = "../circuit-lib/light-prover-client" }
 light-merkle-tree-reference = { version = "0.3.0", path = "../merkle-tree/reference/" }
 light-indexed-merkle-tree = { version = "0.3.0", path = "../merkle-tree/indexed/" }

--- a/test-programs/account-compression-test/Cargo.toml
+++ b/test-programs/account-compression-test/Cargo.toml
@@ -25,7 +25,7 @@ ark-ff = "0.4.0"
 solana-program-test =  { workspace = true}
 light-test-utils = { version = "0.3.0", path = "../../test-utils" }
 reqwest = "0.11.26"
-tokio = "1.38.0"
+tokio = { workspace = true }
 light-prover-client = {path = "../../circuit-lib/light-prover-client" }
 num-bigint = "0.4.6"
 num-traits = "0.2.18"

--- a/test-programs/compressed-token-test/Cargo.toml
+++ b/test-programs/compressed-token-test/Cargo.toml
@@ -34,7 +34,7 @@ solana-sdk = { workspace = true }
 solana-program-test = { workspace = true }
 light-test-utils = { version = "0.3.0", path = "../../test-utils" }
 reqwest = "0.11.26"
-tokio = "1.38.0"
+tokio = { workspace = true }
 light-prover-client = {path = "../../circuit-lib/light-prover-client" }
 num-bigint = "0.4.6"
 num-traits = "0.2.18"

--- a/test-programs/e2e-test/Cargo.toml
+++ b/test-programs/e2e-test/Cargo.toml
@@ -37,7 +37,7 @@ solana-client = { workspace = true }
 solana-program-test = { workspace = true }
 light-test-utils = { version = "0.3.0", path = "../../test-utils" }
 reqwest = "0.11.26"
-tokio = "1.38.0"
+tokio = { workspace = true }
 light-prover-client = {path = "../../circuit-lib/light-prover-client" }
 num-bigint = "0.4.6"
 num-traits = "0.2.18"

--- a/test-programs/registry-test/Cargo.toml
+++ b/test-programs/registry-test/Cargo.toml
@@ -24,7 +24,7 @@ default = ["custom-heap"]
 solana-program-test = { workspace = true }
 light-test-utils = { version = "0.3.0", path = "../../test-utils" }
 reqwest = "0.11.26"
-tokio = "1.38.0"
+tokio = { workspace = true }
 light-prover-client = {path = "../../circuit-lib/light-prover-client" }
 num-bigint = "0.4.6"
 num-traits = "0.2.18"

--- a/test-programs/system-cpi-test/Cargo.toml
+++ b/test-programs/system-cpi-test/Cargo.toml
@@ -36,7 +36,7 @@ solana-sdk = { workspace = true }
 solana-program-test = { workspace = true }
 light-test-utils = { version = "0.3.0", path = "../../test-utils" }
 reqwest = "0.11.26"
-tokio = "1.38.0"
+tokio = { workspace = true }
 light-prover-client = { path = "../../circuit-lib/light-prover-client", version = "0.3.0" }
 num-bigint = "0.4.6"
 num-traits = "0.2.18"

--- a/test-programs/system-test/Cargo.toml
+++ b/test-programs/system-test/Cargo.toml
@@ -24,7 +24,7 @@ default = ["custom-heap"]
 solana-program-test = { workspace = true }
 light-test-utils = { version = "0.3.0", path = "../../test-utils" }
 reqwest = "0.11.26"
-tokio = "1.38.0"
+tokio = { workspace = true }
 light-prover-client = {path = "../../circuit-lib/light-prover-client" }
 num-bigint = "0.4.6"
 num-traits = "0.2.18"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -28,7 +28,7 @@ light-system-program = { path = "../programs/system", version = "0.5.0", feature
 light-registry = { path = "../programs/registry", version = "0.5.0", features = ["cpi"] }
 spl-token = { workspace = true, features = ["no-entrypoint"] }
 solana-transaction-status = { workspace = true }
-tokio = "1.38"
+tokio = { workspace = true }
 light-prover-client = { path = "../circuit-lib/light-prover-client", version = "0.3.0" }
 reqwest = "0.11.26"
 light-hasher = { version = "0.3.0", path = "../merkle-tree/hasher" }


### PR DESCRIPTION
Replaced individual `tokio` versions with `tokio` specified at the workspace level for consistency across the project.