### PR TITLE
fix: unchecked token pool account

### DIFF
--- a/programs/compressed-token/src/instructions/transfer.rs
+++ b/programs/compressed-token/src/instructions/transfer.rs
@@ -5,6 +5,8 @@ use light_system_program::{
     self,
     sdk::accounts::{InvokeAccounts, SignerAccounts},
 };
+
+use crate::POOL_SEED;
 #[derive(Accounts)]
 pub struct TransferInstruction<'info> {
     /// UNCHECKED: only pays fees.
@@ -32,9 +34,9 @@ pub struct TransferInstruction<'info> {
     /// (different program) checked in light system program to derive
     /// cpi_authority_pda and check that this program is the signer of the cpi.
     pub self_program: Program<'info, crate::program::LightCompressedToken>,
-    #[account(mut)]
+    #[account(mut,  seeds = [POOL_SEED, &token_pool_pda.mint.key().to_bytes()],bump)]
     pub token_pool_pda: Option<Account<'info, TokenAccount>>,
-    #[account(mut)]
+    #[account(mut, constraint= if token_pool_pda.is_some() {Ok(token_pool_pda.as_ref().unwrap().key() != compress_or_decompress_token_account.key())}else {err!(crate::ErrorCode::TokenPoolPdaUndefined)}? @crate::ErrorCode::IsTokenPoolPda)]
     pub compress_or_decompress_token_account: Option<Account<'info, TokenAccount>>,
     pub token_program: Option<Program<'info, Token>>,
     pub system_program: Program<'info, System>,

--- a/programs/compressed-token/src/lib.rs
+++ b/programs/compressed-token/src/lib.rs
@@ -180,4 +180,7 @@ pub enum ErrorCode {
     #[msg("Provided authority is not the freeze authority")]
     InvalidFreezeAuthority,
     InvalidDelegateIndex,
+    TokenPoolPdaUndefined,
+    #[msg("Compress or decompress recipient is the same account as the token pool pda.")]
+    IsTokenPoolPda,
 }

--- a/programs/compressed-token/src/process_mint.rs
+++ b/programs/compressed-token/src/process_mint.rs
@@ -359,7 +359,7 @@ pub struct MintToInstruction<'info> {
     pub mint: Account<'info, Mint>,
     /// CHECK: this account is checked implictly since a mint to from a mint
     /// account to a token account of a different mint will fail
-    #[account(mut)]
+    #[account(mut, seeds = [POOL_SEED, &mint.key().to_bytes()],bump)]
     pub token_pool_pda: Account<'info, TokenAccount>,
     pub token_program: Program<'info, Token>,
     pub light_system_program: Program<'info, light_system_program::program::LightSystemProgram>,


### PR DESCRIPTION
Issues:
- unchecked token pool accounts allowed tokens to move to non-pool accounts during compression

Changes:
- check pool account seeds