### PR TITLE
fix: spend program owned account with program keypair

### DIFF
--- a/programs/system/src/errors.rs
+++ b/programs/system/src/errors.rs
@@ -69,4 +69,5 @@ pub enum SystemProgramError {
     #[msg("Output merkle tree indices are not in ascending order.")]
     OutputMerkleTreeIndicesNotInOrder,
     OutputMerkleTreeNotUnique,
+    DataFieldUndefined,
 }

--- a/programs/system/src/invoke/verify_signer.rs
+++ b/programs/system/src/invoke/verify_signer.rs
@@ -16,13 +16,19 @@ pub fn input_compressed_accounts_signer_check(
         .iter()
         .try_for_each(
             |compressed_account_with_context: &PackedCompressedAccountWithMerkleContext| {
-                if compressed_account_with_context.compressed_account.owner == *authority {
+                if compressed_account_with_context.compressed_account.owner == *authority
+                    && compressed_account_with_context
+                        .compressed_account
+                        .data
+                        .is_none()
+                {
                     Ok(())
                 } else {
                     msg!(
-                        "signer check failed compressed account owner {} != authority {}",
+                        "signer check failed compressed account owner {} != authority {} or data is not none {} (only programs can own compressed accounts with data)",
                         compressed_account_with_context.compressed_account.owner,
-                        authority
+                        authority,
+                        compressed_account_with_context.compressed_account.data.is_none()
                     );
                     err!(SystemProgramError::SignerCheckFailed)
                 }

--- a/programs/system/src/invoke_cpi/verify_signer.rs
+++ b/programs/system/src/invoke_cpi/verify_signer.rs
@@ -114,6 +114,13 @@ pub fn output_compressed_accounts_write_access_check(
             msg!("compressed_account: {:?}", compressed_account);
             return err!(SystemProgramError::WriteAccessCheckFailed);
         }
+        if compressed_account.compressed_account.data.is_none()
+            && compressed_account.compressed_account.owner == invoking_program_id.key()
+        {
+            msg!("For program owned compressed accounts the data field needs to be defined.");
+            msg!("compressed_account: {:?}", compressed_account);
+            return err!(SystemProgramError::DataFieldUndefined);
+        }
     }
     Ok(())
 }

--- a/test-programs/system-cpi-test/src/create_pda.rs
+++ b/test-programs/system-cpi-test/src/create_pda.rs
@@ -17,6 +17,7 @@ pub enum CreatePdaMode {
     InvalidSignerSeeds,
     InvalidInvokingProgram,
     WriteToAccountNotOwned,
+    NoData,
 }
 
 pub fn process_create_pda<'info>(
@@ -85,6 +86,17 @@ pub fn process_create_pda<'info>(
                 cpi_context,
                 bump,
                 CreatePdaMode::WriteToAccountNotOwned,
+            )?;
+        }
+        CreatePdaMode::NoData => {
+            cpi_compressed_pda_transfer_as_program(
+                &ctx,
+                proof,
+                new_address_params,
+                compressed_pda,
+                cpi_context,
+                bump,
+                CreatePdaMode::NoData,
             )?;
         }
     }
@@ -161,6 +173,12 @@ fn cpi_compressed_pda_transfer_as_program<'info>(
             // account with data needs to be owned by the program
             let mut compressed_pda = compressed_pda;
             compressed_pda.compressed_account.owner = ctx.accounts.signer.key();
+            compressed_pda
+        }
+        CreatePdaMode::NoData => {
+            let mut compressed_pda = compressed_pda;
+
+            compressed_pda.compressed_account.data = None;
             compressed_pda
         }
         _ => compressed_pda,

--- a/test-programs/system-test/tests/test.rs
+++ b/test-programs/system-test/tests/test.rs
@@ -444,7 +444,7 @@ pub async fn failing_transaction_inputs_inner(
             payer,
             inputs_struct,
             remaining_accounts.clone(),
-            VerifierError::ProofVerificationFailed.into(),
+            SystemProgramError::SignerCheckFailed.into(),
         )
         .await
         .unwrap();


### PR DESCRIPTION
 Issue:
 - program owned accounts can be spend by the program keypair with the `invoke` system program instruction

Solution:
 - add check to reject accounts with data as input accounts in `invoke`
 - add check to not allow program owned account creation without data 