### PR TITLE
fix: (de)compression transfer ix token pool check

### DIFF
--- a/programs/compressed-token/src/instructions/transfer.rs
+++ b/programs/compressed-token/src/instructions/transfer.rs
@@ -6,7 +6,6 @@ use light_system_program::{
     sdk::accounts::{InvokeAccounts, SignerAccounts},
 };
 
-use crate::POOL_SEED;
 #[derive(Accounts)]
 pub struct TransferInstruction<'info> {
     /// UNCHECKED: only pays fees.
@@ -34,7 +33,7 @@ pub struct TransferInstruction<'info> {
     /// (different program) checked in light system program to derive
     /// cpi_authority_pda and check that this program is the signer of the cpi.
     pub self_program: Program<'info, crate::program::LightCompressedToken>,
-    #[account(mut,  seeds = [POOL_SEED, &token_pool_pda.mint.key().to_bytes()],bump)]
+    #[account(mut)]
     pub token_pool_pda: Option<Account<'info, TokenAccount>>,
     #[account(mut, constraint= if token_pool_pda.is_some() {Ok(token_pool_pda.as_ref().unwrap().key() != compress_or_decompress_token_account.key())}else {err!(crate::ErrorCode::TokenPoolPdaUndefined)}? @crate::ErrorCode::IsTokenPoolPda)]
     pub compress_or_decompress_token_account: Option<Account<'info, TokenAccount>>,

--- a/programs/compressed-token/src/lib.rs
+++ b/programs/compressed-token/src/lib.rs
@@ -183,4 +183,5 @@ pub enum ErrorCode {
     TokenPoolPdaUndefined,
     #[msg("Compress or decompress recipient is the same account as the token pool pda.")]
     IsTokenPoolPda,
+    InvalidTokenPoolPda,
 }

--- a/test-programs/compressed-token-test/tests/test.rs
+++ b/test-programs/compressed-token-test/tests/test.rs
@@ -2655,7 +2655,7 @@ async fn test_failing_decompression() {
             &mut context,
             &mut test_indexer,
             input_compressed_account.clone(),
-            decompress_amount, // need to be consistent with compression amount
+            decompress_amount, // needs to be consistent with compression amount
             &merkle_tree_pubkey,
             decompress_amount,
             false,
@@ -2678,7 +2678,7 @@ async fn test_failing_decompression() {
             &mut context,
             &mut test_indexer,
             input_compressed_account.clone(),
-            decompress_amount, // need to be consistent with compression amount
+            decompress_amount, // needs to be consistent with compression amount
             &merkle_tree_pubkey,
             decompress_amount,
             false,
@@ -2699,7 +2699,7 @@ async fn test_failing_decompression() {
             &mut context,
             &mut test_indexer,
             input_compressed_account.clone(),
-            0, // need to be consistent with compression amount
+            0, // needs to be consistent with compression amount
             &merkle_tree_pubkey,
             0,
             true,
@@ -2718,7 +2718,7 @@ async fn test_failing_decompression() {
             &mut context,
             &mut test_indexer,
             input_compressed_account.clone(),
-            decompress_amount, // need to be consistent with compression amount
+            decompress_amount, // needs to be consistent with compression amount
             &merkle_tree_pubkey,
             decompress_amount - 1,
             false,
@@ -2737,7 +2737,7 @@ async fn test_failing_decompression() {
             &mut context,
             &mut test_indexer,
             input_compressed_account.clone(),
-            decompress_amount, // need to be consistent with compression amount
+            decompress_amount, // needs to be consistent with compression amount
             &merkle_tree_pubkey,
             decompress_amount + 1,
             false,
@@ -2756,7 +2756,7 @@ async fn test_failing_decompression() {
             &mut context,
             &mut test_indexer,
             input_compressed_account.clone(),
-            decompress_amount, // need to be consistent with compression amount
+            decompress_amount, // needs to be consistent with compression amount
             &merkle_tree_pubkey,
             0,
             false,
@@ -2775,7 +2775,7 @@ async fn test_failing_decompression() {
             &mut context,
             &mut test_indexer,
             input_compressed_account.clone(),
-            decompress_amount, // need to be consistent with compression amount
+            decompress_amount, // needs to be consistent with compression amount
             &merkle_tree_pubkey,
             decompress_amount,
             false,
@@ -2808,7 +2808,7 @@ async fn test_failing_decompression() {
             &mut context,
             &mut test_indexer,
             Vec::new(),
-            compress_amount, // need to be consistent with compression amount
+            compress_amount, // needs to be consistent with compression amount
             &merkle_tree_pubkey,
             compress_amount - 1,
             true,
@@ -2827,7 +2827,7 @@ async fn test_failing_decompression() {
             &mut context,
             &mut test_indexer,
             Vec::new(),
-            compress_amount, // need to be consistent with compression amount
+            compress_amount, // needs to be consistent with compression amount
             &merkle_tree_pubkey,
             compress_amount + 1,
             true,
@@ -2846,7 +2846,7 @@ async fn test_failing_decompression() {
             &mut context,
             &mut test_indexer,
             Vec::new(),
-            compress_amount, // need to be consistent with compression amount
+            compress_amount, // needs to be consistent with compression amount
             &merkle_tree_pubkey,
             0,
             true,

--- a/test-programs/compressed-token-test/tests/test.rs
+++ b/test-programs/compressed-token-test/tests/test.rs
@@ -2667,7 +2667,7 @@ async fn test_failing_decompression() {
         .await
         .unwrap_err();
     }
-    // Test 2: invalid token pool pda
+    // Test 2: invalid token pool pda (compress and decompress)
     {
         let invalid_token_account_keypair = Keypair::new();
         create_token_account(&mut context, &mint, &invalid_token_account_keypair, &payer)
@@ -2680,12 +2680,33 @@ async fn test_failing_decompression() {
             input_compressed_account.clone(),
             decompress_amount, // need to be consistent with compression amount
             &merkle_tree_pubkey,
-            decompress_amount - 1,
+            decompress_amount,
             false,
             &token_account_keypair.pubkey(),
             Some(invalid_token_account_keypair.pubkey()),
             &mint,
-            anchor_lang::error::ErrorCode::ConstraintSeeds.into(),
+            ErrorCode::InvalidTokenPoolPda.into(),
+        )
+        .await
+        .unwrap();
+
+        let invalid_token_account_keypair = Keypair::new();
+        create_token_account(&mut context, &mint, &invalid_token_account_keypair, &payer)
+            .await
+            .unwrap();
+        failing_compress_decompress(
+            &sender,
+            &mut context,
+            &mut test_indexer,
+            input_compressed_account.clone(),
+            0, // need to be consistent with compression amount
+            &merkle_tree_pubkey,
+            0,
+            true,
+            &token_account_keypair.pubkey(),
+            Some(invalid_token_account_keypair.pubkey()),
+            &mint,
+            ErrorCode::InvalidTokenPoolPda.into(),
         )
         .await
         .unwrap();


### PR DESCRIPTION
Issue:
- prior token pool check in transfer instruction was insufficient

Changes:
- create a check token pool derivation function which checks derivation in the compress and decompress function instead of the instruction struct
- added failing test for invalid `token_pool_pda` for compressing tokens, adapted error for failing test with decompression