### PR TITLE
chore: add memcp filter option to rpc, bump to photon 0.39.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightprotocol/zk-compression-cli",
-  "version": "0.5.1",
+  "version": "0.7.0",
   "description": "ZK Compression: Secure Scaling on Solana",
   "maintainers": [
     {

--- a/cli/src/utils/constants.ts
+++ b/cli/src/utils/constants.ts
@@ -21,7 +21,7 @@ export const LIGHT_PROVER_PROCESS_NAME = "light-prover";
 export const INDEXER_PROCESS_NAME = "photon";
 export const FORESTER_PROCESS_NAME = "forester";
 
-export const PHOTON_VERSION = "0.39.0";
+export const PHOTON_VERSION = "0.40.0";
 
 export const LIGHT_PROTOCOL_PROGRAMS_DIR_ENV = "LIGHT_PROTOCOL_PROGRAMS_DIR";
 export const BASE_PATH = "../../bin/";

--- a/cli/src/utils/constants.ts
+++ b/cli/src/utils/constants.ts
@@ -21,7 +21,7 @@ export const LIGHT_PROVER_PROCESS_NAME = "light-prover";
 export const INDEXER_PROCESS_NAME = "photon";
 export const FORESTER_PROCESS_NAME = "forester";
 
-export const PHOTON_VERSION = "0.38.0";
+export const PHOTON_VERSION = "0.39.0";
 
 export const LIGHT_PROTOCOL_PROGRAMS_DIR_ENV = "LIGHT_PROTOCOL_PROGRAMS_DIR";
 export const BASE_PATH = "../../bin/";

--- a/js/stateless.js/src/rpc-interface.ts
+++ b/js/stateless.js/src/rpc-interface.ts
@@ -1,4 +1,4 @@
-import { PublicKey, DataSizeFilter, MemcmpFilter } from '@solana/web3.js';
+import { PublicKey, MemcmpFilter, DataSlice } from '@solana/web3.js';
 import {
     type as pick,
     number,
@@ -35,6 +35,13 @@ export interface LatestNonVotingSignatures {
             error: string | null;
         }[];
     };
+}
+
+export interface GetCompressedAccountsByOwnerConfig {
+    filters?: GetCompressedAccountsFilter[];
+    dataSlice?: DataSlice;
+    cursor?: string;
+    limit?: BN;
 }
 
 export interface LatestNonVotingSignaturesPaginated {
@@ -107,14 +114,17 @@ export interface GetCompressedTokenAccountsByOwnerOrDelegateOptions {
     limit?: BN;
 }
 
-export type GetCompressedAccountsFilter = MemcmpFilter | DataSizeFilter;
+/**
+ * Note, DataSizeFilter is currently not available.
+ */
+export type GetCompressedAccountsFilter = MemcmpFilter; // | DataSizeFilter;
 
 export type GetCompressedAccountConfig = {
     encoding?: string;
 };
 
 export type GetCompressedAccountsConfig = {
-    encoding?: string;
+    dataSlice: DataSlice;
     filters?: GetCompressedAccountsFilter[];
 };
 
@@ -131,6 +141,7 @@ export type WithContext<T> = {
     /** response value */
     value: T;
 };
+
 export type WithCursor<T> = {
     /** context */
     cursor: string | null;
@@ -493,6 +504,7 @@ export interface CompressionApiInterface {
 
     getCompressedAccountsByOwner(
         owner: PublicKey,
+        config?: GetCompressedAccountsByOwnerConfig,
     ): Promise<WithCursor<CompressedAccountWithMerkleContext[]>>;
 
     getCompressedTokenAccountsByOwner(

--- a/js/stateless.js/src/rpc.ts
+++ b/js/stateless.js/src/rpc.ts
@@ -35,6 +35,7 @@ import {
     LatestNonVotingSignaturesResultPaginated,
     LatestNonVotingSignaturesPaginated,
     WithContext,
+    GetCompressedAccountsByOwnerConfig,
     WithCursor,
 } from './rpc-interface';
 import {
@@ -663,17 +664,25 @@ export class Rpc extends Connection implements CompressionApiInterface {
      */
     async getCompressedAccountsByOwner(
         owner: PublicKey,
+        config?: GetCompressedAccountsByOwnerConfig,
     ): Promise<WithCursor<CompressedAccountWithMerkleContext[]>> {
         const unsafeRes = await rpcRequest(
             this.compressionApiEndpoint,
             'getCompressedAccountsByOwner',
-            { owner: owner.toBase58() },
+            {
+                owner: owner.toBase58(),
+                filters: config?.filters || [],
+                dataSlice: config?.dataSlice,
+                cursor: config?.cursor,
+                limit: config?.limit?.toNumber(),
+            },
         );
 
         const res = create(
             unsafeRes,
             jsonRpcResultAndContext(CompressedAccountsByOwnerResult),
         );
+
         if ('error' in res) {
             throw new SolanaJSONRPCError(
                 res.error,

--- a/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
@@ -16,6 +16,7 @@ import { getParsedEvents } from './get-parsed-events';
 import { defaultTestStateTreeAccounts } from '../../constants';
 import {
     CompressedTransaction,
+    GetCompressedAccountsByOwnerConfig,
     LatestNonVotingSignatures,
     LatestNonVotingSignaturesPaginated,
     SignatureWithMetadata,
@@ -334,7 +335,14 @@ export class TestRpc extends Connection implements CompressionApiInterface {
      */
     async getCompressedAccountsByOwner(
         owner: PublicKey,
+        _config?: GetCompressedAccountsByOwnerConfig,
     ): Promise<WithCursor<CompressedAccountWithMerkleContext[]>> {
+        if (_config) {
+            throw new Error(
+                'dataSlice or filters are not supported in test-rpc. Please use rpc.ts instead.',
+            );
+        }
+
         const accounts = await getCompressedAccountsByOwnerTest(this, owner);
         return {
             items: accounts,

--- a/js/stateless.js/tests/e2e/rpc-interop.test.ts
+++ b/js/stateless.js/tests/e2e/rpc-interop.test.ts
@@ -40,7 +40,7 @@ describe('rpc-interop', () => {
     const transferAmount = 1e4;
     const numberOfTransfers = 15;
 
-    it('getCompressedAccountsByOnwer [noforester] filter should work', async () => {
+    it('getCompressedAccountsByOwner [noforester] filter should work', async () => {
         let accs = await rpc.getCompressedAccountsByOwner(payer.publicKey, {
             filters: [
                 {

--- a/js/stateless.js/tests/e2e/rpc-interop.test.ts
+++ b/js/stateless.js/tests/e2e/rpc-interop.test.ts
@@ -40,6 +40,25 @@ describe('rpc-interop', () => {
     const transferAmount = 1e4;
     const numberOfTransfers = 15;
 
+    it('getCompressedAccountsByOnwer [noforester] filter should work', async () => {
+        let accs = await rpc.getCompressedAccountsByOwner(payer.publicKey, {
+            filters: [
+                {
+                    memcmp: {
+                        offset: 1,
+                        bytes: '5Vf',
+                    },
+                },
+            ],
+        });
+        assert.equal(accs.items.length, 0);
+
+        accs = await rpc.getCompressedAccountsByOwner(payer.publicKey, {
+            dataSlice: { offset: 1, length: 2 },
+        });
+        /// TODO: DataSlice filter does not work in photon. Adapt once photon is fixed.
+        assert.equal(accs.items.length, 1);
+    });
     it('getValidityProof [noforester] (inclusion) should match', async () => {
         const senderAccounts = await rpc.getCompressedAccountsByOwner(
             payer.publicKey,

--- a/js/stateless.js/tests/e2e/rpc-interop.test.ts
+++ b/js/stateless.js/tests/e2e/rpc-interop.test.ts
@@ -56,7 +56,7 @@ describe('rpc-interop', () => {
         accs = await rpc.getCompressedAccountsByOwner(payer.publicKey, {
             dataSlice: { offset: 1, length: 2 },
         });
-        /// TODO: DataSlice filter does not work in photon. Adapt once photon is fixed.
+
         assert.equal(accs.items.length, 1);
     });
     it('getValidityProof [noforester] (inclusion) should match', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,6 +413,10 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@22.1.0)(@vitest/browser@1.6.0)(terser@5.31.0)
 
+  hasher.rs/src/main/wasm: {}
+
+  hasher.rs/src/main/wasm-simd: {}
+
   js/compressed-token:
     dependencies:
       '@coral-xyz/anchor':

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,6 +62,7 @@ get_version() {
     echo "unknown"
 }
 
+<<<<<<< HEAD
 get_suffix() {
     local key="${1}_${OS}_${ARCH}"
     for item in "${SUFFIXES[@]}"; do
@@ -73,6 +74,16 @@ get_suffix() {
     done
     echo "unknown"
 }
+=======
+GO_VERSION="1.21.7"
+NODE_VERSION="20.9.0"
+PNPM_VERSION="9.5.0"
+SOLANA_VERSION="1.18.11"
+ANCHOR_VERSION="anchor-v0.29.0"
+JQ_VERSION="jq-1.7.1"
+PHOTON_VERSION="0.39.0"
+PHOTON_BRANCH=""
+>>>>>>> 041775d08 (bump 1)
 
 download() {
     curl -sSL --retry 5 --retry-delay 10 -o "$2" "$1"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,7 +13,7 @@ VERSIONS=(
     "solana:1.18.17"
     "anchor:anchor-v0.29.0"
     "jq:jq-1.7.1"
-    "photon:0.38.0"
+    "photon:0.40.0"
 )
 
 # Architecture-specific suffixes

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,7 +62,6 @@ get_version() {
     echo "unknown"
 }
 
-<<<<<<< HEAD
 get_suffix() {
     local key="${1}_${OS}_${ARCH}"
     for item in "${SUFFIXES[@]}"; do
@@ -74,16 +73,6 @@ get_suffix() {
     done
     echo "unknown"
 }
-=======
-GO_VERSION="1.21.7"
-NODE_VERSION="20.9.0"
-PNPM_VERSION="9.5.0"
-SOLANA_VERSION="1.18.11"
-ANCHOR_VERSION="anchor-v0.29.0"
-JQ_VERSION="jq-1.7.1"
-PHOTON_VERSION="0.39.0"
-PHOTON_BRANCH=""
->>>>>>> 041775d08 (bump 1)
 
 download() {
     curl -sSL --retry 5 --retry-delay 10 -o "$2" "$1"


### PR DESCRIPTION
upd:
- 0.40.0
- bump to latest ts versions accordingly
- support filter config again in rpc endpoints
