### PR TITLE
fix: compressed token program revoke test coverage with sol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4830,9 +4830,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -4848,9 +4848,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/programs/compressed-token/src/delegation.rs
+++ b/programs/compressed-token/src/delegation.rs
@@ -633,5 +633,67 @@ mod test {
             output_compressed_accounts,
             expected_compressed_output_accounts
         );
+
+        let lamports_amount = 2;
+
+        let input_token_data_with_context = vec![
+            InputTokenDataWithContext {
+                amount: 100,
+
+                merkle_context: PackedMerkleContext {
+                    merkle_tree_pubkey_index: 0,
+                    nullifier_queue_pubkey_index: 1,
+                    leaf_index: 1,
+                    queue_index: None,
+                },
+                root_index: 0,
+                delegate_index: Some(1), // Doesn't matter it is not checked if the proof is not verified
+                lamports: Some(lamports_amount / 2),
+                tlv: None,
+            },
+            InputTokenDataWithContext {
+                amount: 101,
+
+                merkle_context: PackedMerkleContext {
+                    merkle_tree_pubkey_index: 0,
+                    nullifier_queue_pubkey_index: 1,
+                    leaf_index: 2,
+                    queue_index: None,
+                },
+                root_index: 0,
+                delegate_index: Some(1), // Doesn't matter it is not checked if the proof is not verified
+                lamports: Some(lamports_amount / 2),
+                tlv: None,
+            },
+        ];
+        let inputs = CompressedTokenInstructionDataRevoke {
+            proof: CompressedProof::default(),
+            mint,
+            input_token_data_with_context,
+            cpi_context: None,
+            output_account_merkle_tree_index: 1,
+        };
+        let (compressed_input_accounts, output_compressed_accounts) =
+            create_input_and_output_accounts_revoke(&inputs, &authority, &remaining_accounts)
+                .unwrap();
+        assert_eq!(compressed_input_accounts.len(), 2);
+        assert_eq!(output_compressed_accounts.len(), 1);
+        let expected_change_token_data = TokenData {
+            mint,
+            owner: authority,
+            amount: 201,
+            delegate: None,
+            state: AccountState::Initialized,
+            tlv: None,
+        };
+        let mut expected_compressed_output_accounts =
+            create_expected_token_output_accounts(vec![expected_change_token_data], vec![1]);
+        expected_compressed_output_accounts[0]
+            .compressed_account
+            .lamports = lamports_amount;
+        assert_eq!(
+            output_compressed_accounts,
+            expected_compressed_output_accounts
+        );
     }
 }


### PR DESCRIPTION
Issue:
- compressed token program unit tests do not cover compressed token input accounts with SOL balance

Changes:
- add unit test with SOL balance