### PR TITLE
chore: switch to agave 1.18.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4673,9 +4673,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring 0.17.8",
@@ -5111,8 +5111,8 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "Inflector",
  "base64 0.21.7",
@@ -5135,8 +5135,8 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "arrayref",
  "bincode",
@@ -5195,8 +5195,8 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -5215,8 +5215,8 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "borsh 1.4.0",
  "futures",
@@ -5231,8 +5231,8 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "serde",
  "solana-sdk",
@@ -5241,8 +5241,8 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -5260,8 +5260,8 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "bincode",
  "byteorder",
@@ -5278,8 +5278,8 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "bv",
  "bytemuck",
@@ -5295,8 +5295,8 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -5311,8 +5311,8 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -5326,8 +5326,8 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "Inflector",
  "base64 0.21.7",
@@ -5352,8 +5352,8 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5384,8 +5384,8 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk",
@@ -5393,8 +5393,8 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "bincode",
  "chrono",
@@ -5406,8 +5406,8 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5427,8 +5427,8 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "lazy_static",
  "log",
@@ -5450,8 +5450,8 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "block-buffer 0.10.4",
  "bs58 0.4.0",
@@ -5474,8 +5474,8 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5485,8 +5485,8 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "log",
  "solana-measure",
@@ -5497,8 +5497,8 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "env_logger 0.9.3",
  "lazy_static",
@@ -5507,8 +5507,8 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "log",
  "solana-sdk",
@@ -5516,8 +5516,8 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -5530,8 +5530,8 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "bincode",
  "clap 3.2.25",
@@ -5557,8 +5557,8 @@ checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
 
 [[package]]
 name = "solana-perf"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -5585,8 +5585,8 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -5639,8 +5639,8 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -5666,8 +5666,8 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5695,8 +5695,8 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -5719,8 +5719,8 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -5745,8 +5745,8 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -5754,8 +5754,8 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "console",
  "dialoguer",
@@ -5772,8 +5772,8 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -5797,8 +5797,8 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "base64 0.21.7",
  "bs58 0.4.0",
@@ -5818,8 +5818,8 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "clap 2.34.0",
  "solana-clap-utils",
@@ -5830,8 +5830,8 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "aquamarine",
  "arrayref",
@@ -5906,8 +5906,8 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "assert_matches",
  "base64 0.21.7",
@@ -5960,8 +5960,8 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2",
@@ -5978,8 +5978,8 @@ checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -5993,8 +5993,8 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "bincode",
  "log",
@@ -6007,8 +6007,8 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "async-channel",
  "bytes",
@@ -6039,8 +6039,8 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "bincode",
  "log",
@@ -6052,8 +6052,8 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "bincode",
  "log",
@@ -6066,8 +6066,8 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6089,8 +6089,8 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "Inflector",
  "base64 0.21.7",
@@ -6113,8 +6113,8 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -6127,8 +6127,8 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "log",
  "rustc_version",
@@ -6142,8 +6142,8 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "crossbeam-channel",
  "itertools",
@@ -6160,8 +6160,8 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "bincode",
  "log",
@@ -6181,8 +6181,8 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "bytemuck",
  "num-derive 0.4.2",
@@ -6194,8 +6194,8 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.18.11"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07e25de696b4922ddde3e69877e8e9fa27"
+version = "1.18.17"
+source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.7",
@@ -7994,3 +7994,8 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "solana-rpc"
+version = "1.18.17"
+source = "git+https://github.com/sergeytimoshin/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,15 @@ overflow-checks = true
 opt-level = 2
 
 [workspace.dependencies]
-solana-banks-interface = "=1.18.11"
-solana-program = "=1.18.11"
-solana-sdk = "=1.18.11"
-solana-program-test = "=1.18.11"
-solana-client = "=1.18.11"
-solana-cli-output = "=1.18.11"
-solana-transaction-status = "=1.18.11"
+solana-banks-interface = "=1.18.17"
+solana-program = "=1.18.17"
+solana-sdk = "=1.18.17"
+solana-program-test = "=1.18.17"
+solana-client = "=1.18.17"
+solana-cli-output = "=1.18.17"
+solana-transaction-status = "=1.18.17"
+solana-account-decoder = "=1.18.17"
+solana-rpc = "=1.18.17"
 
 anchor-lang = "=0.29.0"
 anchor-spl = "=0.29.0"
@@ -45,22 +47,23 @@ spl-token = "=4.0.0"
 tokio = { version = "1.39.1", features = ["rt", "macros", "rt-multi-thread"] }
 
 [patch.crates-io]
-"solana-account-decoder" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-accounts-db" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-banks-client" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-banks-interface" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-banks-server" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-program" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-cli-output" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-program-test" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-program-runtime" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-rpc-client" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-rpc-client-api" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-runtime" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-sdk" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-sdk-macro" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-client" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-zk-token-sdk" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-frozen-abi" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-frozen-abi-macro" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
-"solana-transaction-status" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.11-enforce-cpi-tracking" }
+"solana-account-decoder" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-accounts-db" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-banks-client" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-banks-interface" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-banks-server" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-program" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-cli-output" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-program-test" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-program-runtime" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-rpc" = { git = "https://github.com/sergeytimoshin/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-rpc-client" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-rpc-client-api" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-runtime" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-sdk" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-sdk-macro" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-client" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-zk-token-sdk" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-frozen-abi" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-frozen-abi-macro" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
+"solana-transaction-status" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,6 +382,10 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@20.12.11)(@vitest/browser@1.6.0)(terser@5.31.0)
 
+  hasher.rs/src/main/wasm: {}
+
+  hasher.rs/src/main/wasm-simd: {}
+
   js/compressed-token:
     dependencies:
       '@coral-xyz/anchor':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,10 +382,6 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@20.12.11)(@vitest/browser@1.6.0)(terser@5.31.0)
 
-  hasher.rs/src/main/wasm: {}
-
-  hasher.rs/src/main/wasm-simd: {}
-
   js/compressed-token:
     dependencies:
       '@coral-xyz/anchor':


### PR DESCRIPTION
Motivation:

I use the pubsub client from the solana-rpc crate in forester. I switched to 1.18.17 because our 1.18.11 agave branch doesn't work well with this crate.
   ```
Compiling solana-rpc v1.18.11 (https://github.com/lightprotocol/agave?branch=v1.18.11-enforce-cpi-tracking#a24d3c07)
error[E0308]: mismatched types
    --> /Users/tsv/.cargo/git/checkouts/agave-f8c52564d46c9282/a24d3c0/rpc/src/rpc.rs:3677:29
     |
3677 | ...                   inner_instructions,
     |                       ^^^^^^^^^^^^^^^^^^ expected `Option<Vec<UiInnerInstructions>>`, found `Option<Vec<Vec<InnerInstruction>>>`
     |
     = note: expected enum `std::option::Option<Vec<UiInnerInstructions>>`
                found enum `std::option::Option<Vec<Vec<solana_sdk::inner_instruction::InnerInstruction>>>`
```