### PR TITLE
feat: Add `LightDiscriminator` derive macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3034,6 +3034,7 @@ name = "light-macros"
 version = "0.5.0"
 dependencies = [
  "bs58 0.4.0",
+ "light-hasher",
  "proc-macro2",
  "quote",
  "syn 1.0.109",

--- a/macros/light/Cargo.toml
+++ b/macros/light/Cargo.toml
@@ -12,5 +12,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
 
+light-hasher = { path = "../../merkle-tree/hasher", version = "0.3.0" }
+
 [lib]
 proc-macro = true

--- a/macros/light/src/discriminator.rs
+++ b/macros/light/src/discriminator.rs
@@ -1,0 +1,44 @@
+use light_hasher::{Hasher, Sha256};
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{ItemStruct, Result};
+
+pub(crate) fn discriminator(input: ItemStruct) -> Result<TokenStream> {
+    let account_name = &input.ident;
+
+    let (impl_gen, type_gen, where_clause) = input.generics.split_for_impl();
+
+    let mut discriminator = [0u8; 8];
+    discriminator.copy_from_slice(&Sha256::hash(account_name.to_string().as_bytes()).unwrap()[..8]);
+    let discriminator: proc_macro2::TokenStream = format!("{discriminator:?}").parse().unwrap();
+
+    Ok(quote! {
+        impl #impl_gen light_hasher::Discriminator for #account_name #type_gen #where_clause {
+            const DISCRIMINATOR: [u8; 8] = #discriminator;
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use syn::parse_quote;
+
+    #[test]
+    fn test_discriminator() {
+        let input: ItemStruct = parse_quote! {
+            struct MyAccount {
+                a: u32,
+                b: i32,
+                c: u64,
+                d: i64,
+            }
+        };
+
+        let output = discriminator(input).unwrap();
+        let output = output.to_string();
+
+        assert!(output.contains("impl light_hasher :: Discriminator for MyAccount"));
+    }
+}

--- a/macros/light/src/discriminator.rs
+++ b/macros/light/src/discriminator.rs
@@ -40,5 +40,6 @@ mod tests {
         let output = output.to_string();
 
         assert!(output.contains("impl light_hasher :: Discriminator for MyAccount"));
+        assert!(output.contains("[181 , 255 , 112 , 42 , 17 , 188 , 66 , 199]"));
     }
 }

--- a/macros/light/src/lib.rs
+++ b/macros/light/src/lib.rs
@@ -2,9 +2,11 @@ extern crate proc_macro;
 use accounts::process_light_accounts;
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, parse_quote, DeriveInput, ItemFn};
+use syn::{parse_macro_input, parse_quote, DeriveInput, ItemFn, ItemStruct};
 use traits::process_light_traits;
+
 mod accounts;
+mod discriminator;
 mod pubkey;
 mod traits;
 
@@ -423,3 +425,11 @@ pub fn light_traits_derive(input: TokenStream) -> TokenStream {
 
 //     TokenStream::from(expanded)
 // }
+
+#[proc_macro_derive(LightDiscriminator)]
+pub fn light_discriminator(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemStruct);
+    discriminator::discriminator(input)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
+}

--- a/merkle-tree/hasher/src/lib.rs
+++ b/merkle-tree/hasher/src/lib.rs
@@ -26,3 +26,10 @@ pub trait Hasher {
 pub trait DataHasher {
     fn hash<H: crate::Hasher>(&self) -> Result<[u8; 32], HasherError>;
 }
+
+pub trait Discriminator {
+    const DISCRIMINATOR: [u8; 8];
+    fn discriminator() -> [u8; 8] {
+        Self::DISCRIMINATOR
+    }
+}


### PR DESCRIPTION
This macro generates discriminator for the annotated struct by using its name, hashing it with SHA256 and taking the first 8 bytes.