### PR TITLE
fix(macros): Provide full import paths in `light_accounts` macro

### DIFF
--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/escrow.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/escrow.rs
@@ -1,5 +1,4 @@
 use crate::{create_change_output_compressed_token_account, program::TokenEscrow, EscrowTimeLock};
-use account_compression::{program::AccountCompression, RegisteredProgram};
 use anchor_lang::prelude::*;
 use light_compressed_token::{
     process_transfer::{
@@ -15,7 +14,6 @@ use light_sdk::{
 use light_system_program::{
     invoke::processor::CompressedProof,
     invoke_cpi::account::CpiContextAccount,
-    program::LightSystemProgram,
     sdk::{
         address::derive_address,
         compressed_account::{CompressedAccount, CompressedAccountData, PackedMerkleContext},
@@ -23,8 +21,6 @@ use light_system_program::{
     },
     NewAddressParamsPacked, OutputCompressedAccountWithPackedContext,
 };
-
-use light_sdk::traits::*;
 
 #[light_accounts]
 #[derive(Accounts, LightTraits)]

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_pda/escrow.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_pda/escrow.rs
@@ -1,5 +1,4 @@
 use crate::create_change_output_compressed_token_account;
-use account_compression::{program::AccountCompression, RegisteredProgram};
 use anchor_lang::prelude::*;
 use light_compressed_token::{
     process_transfer::{
@@ -8,13 +7,10 @@ use light_compressed_token::{
     },
     program::LightCompressedToken,
 };
-use light_sdk::traits::*;
-use light_sdk::LightTraits;
-use light_system_program::{
-    invoke::processor::CompressedProof, invoke_cpi::account::CpiContextAccount,
-    program::LightSystemProgram,
-};
+use light_sdk::{light_accounts, LightTraits};
+use light_system_program::invoke::processor::CompressedProof;
 
+#[light_accounts]
 #[derive(Accounts, LightTraits)]
 pub struct EscrowCompressedTokensWithPda<'info> {
     #[account(mut)]
@@ -26,19 +22,10 @@ pub struct EscrowCompressedTokensWithPda<'info> {
     pub token_owner_pda: AccountInfo<'info>,
     #[self_program]
     pub compressed_token_program: Program<'info, LightCompressedToken>,
-    pub light_system_program: Program<'info, LightSystemProgram>,
-    pub account_compression_program: Program<'info, AccountCompression>,
-    /// CHECK:
-    pub account_compression_authority: AccountInfo<'info>,
     /// CHECK:
     pub compressed_token_cpi_authority_pda: AccountInfo<'info>,
-    /// CHECK:
-    pub registered_program_pda: Account<'info, RegisteredProgram>,
-    /// CHECK:
-    pub noop_program: AccountInfo<'info>,
     #[account(init_if_needed, seeds = [b"timelock".as_slice(), signer.key.to_bytes().as_slice()],bump, payer = signer, space = 8 + 8)]
     pub timelock_pda: Account<'info, EscrowTimeLock>,
-    pub system_program: Program<'info, System>,
 }
 
 #[derive(Debug)]

--- a/macros/light/src/accounts.rs
+++ b/macros/light/src/accounts.rs
@@ -8,17 +8,20 @@ pub(crate) fn process_light_accounts(input: DeriveInput) -> Result<TokenStream> 
     if let Data::Struct(ref mut data_struct) = output.data {
         if let Fields::Named(ref mut fields) = data_struct.fields {
             let fields_to_add = [
-                ("light_system_program", "Program<'info, LightSystemProgram>"),
+                (
+                    "light_system_program",
+                    "Program<'info, ::light_system_program::program::LightSystemProgram>",
+                ),
                 ("system_program", "Program<'info, System>"),
                 (
                     "account_compression_program",
-                    "Program<'info, AccountCompression>",
+                    "Program<'info, ::account_compression::program::AccountCompression>",
                 ),
             ];
             let fields_to_add_check = [
                 (
                     "registered_program_pda",
-                    "Account<'info, RegisteredProgram>",
+                    "Account<'info, ::account_compression::RegisteredProgram>",
                 ),
                 ("noop_program", "AccountInfo<'info>"),
                 ("account_compression_authority", "AccountInfo<'info>"),

--- a/macros/light/src/traits.rs
+++ b/macros/light/src/traits.rs
@@ -198,46 +198,55 @@ fn process_fields_and_attributes(name: &Ident, fields: FieldsNamed) -> TokenStre
         }
     } else {
         let base_impls = quote! {
-            impl<'info> InvokeCpiAccounts<'info> for #name<'info> {
+            impl<'info> ::light_sdk::traits::InvokeCpiAccounts<'info> for #name<'info> {
                 fn get_invoking_program(&self) -> &AccountInfo<'info> {
                     &self.#self_program_field
                 }
             }
-            impl<'info> SignerAccounts<'info> for #name<'info> {
-                fn get_fee_payer(&self) -> &Signer<'info> {
+            impl<'info> ::light_sdk::traits::SignerAccounts<'info> for #name<'info> {
+                fn get_fee_payer(&self) -> &::anchor_lang::prelude::Signer<'info> {
                     &self.#fee_payer_field
                 }
-                fn get_authority(&self) -> &AccountInfo<'info> {
+                fn get_authority(&self) -> &::anchor_lang::prelude::AccountInfo<'info> {
                     &self.#authority_field
                 }
             }
-            impl<'info> LightSystemAccount<'info> for #name<'info> {
-                fn get_light_system_program(&self) -> &Program<'info, LightSystemProgram> {
+            impl<'info> ::light_sdk::traits::LightSystemAccount<'info> for #name<'info> {
+                fn get_light_system_program(&self) -> &::anchor_lang::prelude::Program<
+                    'info,
+                    ::light_system_program::program::LightSystemProgram
+                > {
                     &self.#light_system_program_field
                 }
             }
         };
         let invoke_accounts_impl = quote! {
-            impl<'info> InvokeAccounts<'info> for #name<'info> {
-                fn get_registered_program_pda(&self) -> &Account<'info, RegisteredProgram> {
+            impl<'info> ::light_sdk::traits::InvokeAccounts<'info> for #name<'info> {
+                fn get_registered_program_pda(&self) -> &::anchor_lang::prelude::Account<
+                    'info,
+                    ::account_compression::RegisteredProgram
+                > {
                     &self.#registered_program_pda_field
                 }
-                fn get_noop_program(&self) -> &AccountInfo<'info> {
+                fn get_noop_program(&self) -> &::anchor_lang::prelude::AccountInfo<'info> {
                     &self.#noop_program_field
                 }
-                fn get_account_compression_authority(&self) -> &AccountInfo<'info> {
+                fn get_account_compression_authority(&self) -> &::anchor_lang::prelude::AccountInfo<'info> {
                     &self.#account_compression_authority_field
                 }
-                fn get_account_compression_program(&self) -> &Program<'info, AccountCompression> {
+                fn get_account_compression_program(&self) -> &::anchor_lang::prelude::Program<
+                    'info,
+                    ::account_compression::program::AccountCompression
+                > {
                     &self.#account_compression_program_field
                 }
-                fn get_system_program(&self) -> &Program<'info, System> {
+                fn get_system_program(&self) -> &::anchor_lang::prelude::Program<'info, System> {
                     &self.#system_program_field
                 }
-                fn get_compressed_sol_pda(&self) -> Option<&UncheckedAccount<'info>> {
+                fn get_compressed_sol_pda(&self) -> Option<&::anchor_lang::prelude::UncheckedAccount<'info>> {
                     #compressed_sol_pda_field
                 }
-                fn get_compression_recipient(&self) -> Option<&UncheckedAccount<'info>> {
+                fn get_compression_recipient(&self) -> Option<&::anchor_lang::prelude::UncheckedAccount<'info>> {
                     #compression_recipient_field
                 }
             }
@@ -246,8 +255,13 @@ fn process_fields_and_attributes(name: &Ident, fields: FieldsNamed) -> TokenStre
             quote! {
                 #base_impls
                 #invoke_accounts_impl
-                impl<'info> InvokeCpiContextAccount<'info> for #name<'info> {
-                    fn get_cpi_context_account(&self) -> Option<&Account<'info, CpiContextAccount>> {
+                impl<'info> ::light_sdk::traits::InvokeCpiContextAccount<'info> for #name<'info> {
+                    fn get_cpi_context_account(&self) -> Option<
+                        &::anchor_lang::prelude::Account<
+                            'info,
+                            ::light_system_program::invoke_cpi::account::CpiContextAccount
+                        >
+                    > {
                         None
                     }
                 }
@@ -256,8 +270,13 @@ fn process_fields_and_attributes(name: &Ident, fields: FieldsNamed) -> TokenStre
             quote! {
                 #base_impls
                 #invoke_accounts_impl
-                impl<'info> InvokeCpiContextAccount<'info> for #name<'info> {
-                    fn get_cpi_context_account(&self) -> Option<&Account<'info, CpiContextAccount>> {
+                impl<'info> ::light_sdk::traits::InvokeCpiContextAccount<'info> for #name<'info> {
+                    fn get_cpi_context_account(&self) -> Option<
+                        &::anchor_lang::prelude::Account<
+                            'info,
+                            ::light_system_program::invoke_cpi::account::CpiContextAccount
+                        >
+                    > {
                         Some(&self.#cpi_context_account_field)
                     }
                 }

--- a/macros/light/src/traits.rs
+++ b/macros/light/src/traits.rs
@@ -243,10 +243,10 @@ fn process_fields_and_attributes(name: &Ident, fields: FieldsNamed) -> TokenStre
                 fn get_system_program(&self) -> &::anchor_lang::prelude::Program<'info, System> {
                     &self.#system_program_field
                 }
-                fn get_compressed_sol_pda(&self) -> Option<&::anchor_lang::prelude::UncheckedAccount<'info>> {
+                fn get_compressed_sol_pda(&self) -> Option<&::anchor_lang::prelude::AccountInfo<'info>> {
                     #compressed_sol_pda_field
                 }
-                fn get_compression_recipient(&self) -> Option<&::anchor_lang::prelude::UncheckedAccount<'info>> {
+                fn get_compression_recipient(&self) -> Option<&::anchor_lang::prelude::AccountInfo<'info>> {
                     #compression_recipient_field
                 }
             }

--- a/programs/compressed-token/src/instructions/burn.rs
+++ b/programs/compressed-token/src/instructions/burn.rs
@@ -60,11 +60,11 @@ impl<'info> InvokeAccounts<'info> for BurnInstruction<'info> {
         &self.system_program
     }
 
-    fn get_sol_pool_pda(&self) -> Option<&UncheckedAccount<'info>> {
+    fn get_sol_pool_pda(&self) -> Option<&AccountInfo<'info>> {
         None
     }
 
-    fn get_decompression_recipient(&self) -> Option<&UncheckedAccount<'info>> {
+    fn get_decompression_recipient(&self) -> Option<&AccountInfo<'info>> {
         None
     }
 }

--- a/programs/compressed-token/src/instructions/freeze.rs
+++ b/programs/compressed-token/src/instructions/freeze.rs
@@ -52,11 +52,11 @@ impl<'info> InvokeAccounts<'info> for FreezeInstruction<'info> {
         &self.system_program
     }
 
-    fn get_sol_pool_pda(&self) -> Option<&UncheckedAccount<'info>> {
+    fn get_sol_pool_pda(&self) -> Option<&AccountInfo<'info>> {
         None
     }
 
-    fn get_decompression_recipient(&self) -> Option<&UncheckedAccount<'info>> {
+    fn get_decompression_recipient(&self) -> Option<&AccountInfo<'info>> {
         None
     }
 }

--- a/programs/compressed-token/src/instructions/generic.rs
+++ b/programs/compressed-token/src/instructions/generic.rs
@@ -51,11 +51,11 @@ impl<'info> InvokeAccounts<'info> for GenericInstruction<'info> {
         &self.system_program
     }
 
-    fn get_sol_pool_pda(&self) -> Option<&UncheckedAccount<'info>> {
+    fn get_sol_pool_pda(&self) -> Option<&AccountInfo<'info>> {
         None
     }
 
-    fn get_decompression_recipient(&self) -> Option<&UncheckedAccount<'info>> {
+    fn get_decompression_recipient(&self) -> Option<&AccountInfo<'info>> {
         None
     }
 }

--- a/programs/compressed-token/src/instructions/transfer.rs
+++ b/programs/compressed-token/src/instructions/transfer.rs
@@ -61,11 +61,11 @@ impl<'info> InvokeAccounts<'info> for TransferInstruction<'info> {
         &self.system_program
     }
 
-    fn get_sol_pool_pda(&self) -> Option<&UncheckedAccount<'info>> {
+    fn get_sol_pool_pda(&self) -> Option<&AccountInfo<'info>> {
         None
     }
 
-    fn get_decompression_recipient(&self) -> Option<&UncheckedAccount<'info>> {
+    fn get_decompression_recipient(&self) -> Option<&AccountInfo<'info>> {
         None
     }
 }

--- a/programs/system/src/invoke/instruction.rs
+++ b/programs/system/src/invoke/instruction.rs
@@ -39,12 +39,12 @@ pub struct InvokeInstruction<'info> {
         mut,
         seeds = [SOL_POOL_PDA_SEED], bump
     )]
-    pub sol_pool_pda: Option<UncheckedAccount<'info>>,
+    pub sol_pool_pda: Option<AccountInfo<'info>>,
     /// Only needs to be provided for decompression as a recipient for the
     /// decompressed sol.
     /// Compressed sol originate from authority.
     #[account(mut)]
-    pub decompression_recipient: Option<UncheckedAccount<'info>>,
+    pub decompression_recipient: Option<AccountInfo<'info>>,
     pub system_program: Program<'info, System>,
 }
 
@@ -79,11 +79,11 @@ impl<'info> InvokeAccounts<'info> for InvokeInstruction<'info> {
         &self.system_program
     }
 
-    fn get_sol_pool_pda(&self) -> Option<&UncheckedAccount<'info>> {
+    fn get_sol_pool_pda(&self) -> Option<&AccountInfo<'info>> {
         self.sol_pool_pda.as_ref()
     }
 
-    fn get_decompression_recipient(&self) -> Option<&UncheckedAccount<'info>> {
+    fn get_decompression_recipient(&self) -> Option<&AccountInfo<'info>> {
         self.decompression_recipient.as_ref()
     }
 }

--- a/programs/system/src/invoke_cpi/instruction.rs
+++ b/programs/system/src/invoke_cpi/instruction.rs
@@ -39,9 +39,9 @@ pub struct InvokeCpiInstruction<'info> {
         mut,
         seeds = [SOL_POOL_PDA_SEED], bump
     )]
-    pub sol_pool_pda: Option<UncheckedAccount<'info>>,
+    pub sol_pool_pda: Option<AccountInfo<'info>>,
     #[account(mut)]
-    pub decompression_recipient: Option<UncheckedAccount<'info>>,
+    pub decompression_recipient: Option<AccountInfo<'info>>,
     pub system_program: Program<'info, System>,
     #[account(mut)]
     pub cpi_context_account: Option<Account<'info, CpiContextAccount>>,
@@ -74,11 +74,11 @@ impl<'info> InvokeAccounts<'info> for InvokeCpiInstruction<'info> {
         &self.account_compression_program
     }
 
-    fn get_sol_pool_pda(&self) -> Option<&UncheckedAccount<'info>> {
+    fn get_sol_pool_pda(&self) -> Option<&AccountInfo<'info>> {
         self.sol_pool_pda.as_ref()
     }
 
-    fn get_decompression_recipient(&self) -> Option<&UncheckedAccount<'info>> {
+    fn get_decompression_recipient(&self) -> Option<&AccountInfo<'info>> {
         self.decompression_recipient.as_ref()
     }
 

--- a/programs/system/src/sdk/accounts.rs
+++ b/programs/system/src/sdk/accounts.rs
@@ -7,8 +7,8 @@ pub trait InvokeAccounts<'info> {
     fn get_account_compression_authority(&self) -> &UncheckedAccount<'info>;
     fn get_account_compression_program(&self) -> &Program<'info, AccountCompression>;
     fn get_system_program(&self) -> &Program<'info, System>;
-    fn get_sol_pool_pda(&self) -> Option<&UncheckedAccount<'info>>;
-    fn get_decompression_recipient(&self) -> Option<&UncheckedAccount<'info>>;
+    fn get_sol_pool_pda(&self) -> Option<&AccountInfo<'info>>;
+    fn get_decompression_recipient(&self) -> Option<&AccountInfo<'info>>;
 }
 
 pub trait SignerAccounts<'info> {

--- a/sdk/src/traits.rs
+++ b/sdk/src/traits.rs
@@ -11,8 +11,8 @@ pub trait InvokeAccounts<'info> {
     fn get_account_compression_authority(&self) -> &AccountInfo<'info>;
     fn get_account_compression_program(&self) -> &Program<'info, AccountCompression>;
     fn get_system_program(&self) -> &Program<'info, System>;
-    fn get_compressed_sol_pda(&self) -> Option<&UncheckedAccount<'info>>;
-    fn get_compression_recipient(&self) -> Option<&UncheckedAccount<'info>>;
+    fn get_compressed_sol_pda(&self) -> Option<&AccountInfo<'info>>;
+    fn get_compression_recipient(&self) -> Option<&AccountInfo<'info>>;
 }
 
 pub trait LightSystemAccount<'info> {


### PR DESCRIPTION
Before this change, using `#[light_accounts]` macro required adding necessary imports manually, e.g.

```rust
use account_compression::program::AccountCompression;
use light_system_program::program::LightSystemProgram;
```

Which might've been annoying for developers.

This change uses full paths for all foregin types used inside macros, so no additional imports are needed.