### PR TITLE
chore: add read only placeholder

### DIFF
--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/withdrawal.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/withdrawal.rs
@@ -98,6 +98,7 @@ fn create_compressed_pda_data_based_on_diff(
         compressed_account: old_compressed_account.compressed_account,
         merkle_context: input_compressed_pda.merkle_context,
         root_index: input_compressed_pda.root_index,
+        read_only: false,
     };
     let new_timelock_compressed_pda = EscrowTimeLock {
         slot: current_slot

--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -1276,6 +1276,13 @@ export type LightCompressedToken = {
                         ];
                         type: 'u16';
                     },
+                    {
+                        name: 'readOnly';
+                        docs: [
+                            'Placeholder to mark accounts read-only unimplemented set to false.',
+                        ];
+                        type: 'bool';
+                    },
                 ];
             };
         },
@@ -2849,6 +2856,13 @@ export const IDL: LightCompressedToken = {
                             'Index of root used in inclusion validity proof.',
                         ],
                         type: 'u16',
+                    },
+                    {
+                        name: 'readOnly',
+                        docs: [
+                            'Placeholder to mark accounts read-only unimplemented set to false.',
+                        ],
+                        type: 'bool',
                     },
                 ],
             },

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -1276,6 +1276,13 @@ export type LightCompressedToken = {
                         ];
                         type: 'u16';
                     },
+                    {
+                        name: 'readOnly';
+                        docs: [
+                            'Placeholder to mark accounts read-only unimplemented set to false.',
+                        ];
+                        type: 'bool';
+                    },
                 ];
             };
         },
@@ -2849,6 +2856,13 @@ export const IDL: LightCompressedToken = {
                             'Index of root used in inclusion validity proof.',
                         ],
                         type: 'u16',
+                    },
+                    {
+                        name: 'readOnly',
+                        docs: [
+                            'Placeholder to mark accounts read-only unimplemented set to false.',
+                        ],
+                        type: 'bool',
                     },
                 ],
             },

--- a/js/stateless.js/src/idls/light_system_program.ts
+++ b/js/stateless.js/src/idls/light_system_program.ts
@@ -746,6 +746,13 @@ export type LightSystemProgram = {
                         ];
                         type: 'u16';
                     },
+                    {
+                        name: 'readOnly';
+                        docs: [
+                            'Placeholder to mark accounts read-only unimplemented set to false.',
+                        ];
+                        type: 'bool';
+                    },
                 ];
             };
         },
@@ -1818,6 +1825,13 @@ export const IDL: LightSystemProgram = {
                             'Index of root used in inclusion validity proof.',
                         ],
                         type: 'u16',
+                    },
+                    {
+                        name: 'readOnly',
+                        docs: [
+                            'Placeholder to mark accounts read-only unimplemented set to false.',
+                        ],
+                        type: 'bool',
                     },
                 ],
             },

--- a/js/stateless.js/src/instruction/pack-compressed-accounts.ts
+++ b/js/stateless.js/src/instruction/pack-compressed-accounts.ts
@@ -138,6 +138,7 @@ export function packCompressedAccounts(
                 queueIndex: null,
             },
             rootIndex: inputStateRootIndices[index],
+            readOnly: false,
         });
     });
 

--- a/js/stateless.js/src/state/compressed-account.ts
+++ b/js/stateless.js/src/state/compressed-account.ts
@@ -9,7 +9,9 @@ import { BN254, bn } from './BN254';
 import { Buffer } from 'buffer';
 
 export type CompressedAccountWithMerkleContext = CompressedAccount &
-    MerkleContext;
+    MerkleContext & {
+        readOnly: boolean;
+    };
 
 /**
  * Context for compressed account inserted into a state Merkle tree
@@ -55,6 +57,7 @@ export const createCompressedAccountWithMerkleContext = (
 ): CompressedAccountWithMerkleContext => ({
     ...createCompressedAccount(owner, lamports, data, address),
     ...merkleContext,
+    readOnly: false,
 });
 
 export const createMerkleContext = (
@@ -134,6 +137,7 @@ if (import.meta.vitest) {
                 nullifierQueue,
                 hash,
                 leafIndex,
+                readOnly: false,
             });
         });
     });

--- a/js/stateless.js/src/state/types.ts
+++ b/js/stateless.js/src/state/types.ts
@@ -7,6 +7,7 @@ export interface PackedCompressedAccountWithMerkleContext {
     compressedAccount: CompressedAccount;
     merkleContext: PackedMerkleContext;
     rootIndex: number; // u16
+    readOnly: boolean;
 }
 
 export interface PackedMerkleContext {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,6 +382,10 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@22.1.0)(@vitest/browser@1.6.0)(terser@5.31.0)
 
+  hasher.rs/src/main/wasm: {}
+
+  hasher.rs/src/main/wasm-simd: {}
+
   js/compressed-token:
     dependencies:
       '@coral-xyz/anchor':

--- a/programs/compressed-token/src/freeze.rs
+++ b/programs/compressed-token/src/freeze.rs
@@ -563,6 +563,7 @@ pub mod test_freeze {
                     },
                     root_index: x.root_index,
                     merkle_context: x.merkle_context,
+                    read_only: false,
                 }
             })
             .collect()

--- a/programs/compressed-token/src/process_transfer.rs
+++ b/programs/compressed-token/src/process_transfer.rs
@@ -552,6 +552,7 @@ pub fn get_input_compressed_accounts_with_merkle_context_and_check_signer<const 
                 compressed_account,
                 merkle_context: input_token_data.merkle_context,
                 root_index: input_token_data.root_index,
+                read_only: false,
             },
         );
     }

--- a/programs/system/src/invoke/sum_check.rs
+++ b/programs/system/src/invoke/sum_check.rs
@@ -17,6 +17,9 @@ pub fn sum_check(
 ) -> Result<()> {
     let mut sum: u64 = 0;
     for compressed_account_with_context in input_compressed_accounts_with_merkle_context.iter() {
+        if compressed_account_with_context.read_only {
+            unimplemented!("read_only accounts are not supported. Set read_only to false.");
+        }
         sum = sum
             .checked_add(compressed_account_with_context.compressed_account.lamports)
             .ok_or(ProgramError::ArithmeticOverflow)
@@ -139,6 +142,7 @@ mod test {
                     queue_index: None,
                 },
                 root_index: 1,
+                read_only: false,
             });
         }
         let mut outputs = Vec::new();

--- a/programs/system/src/invoke_cpi/process_cpi_context.rs
+++ b/programs/system/src/invoke_cpi/process_cpi_context.rs
@@ -197,6 +197,7 @@ mod tests {
                         queue_index: None,
                     },
                     root_index: iter.into(),
+                    read_only: false,
                 },
             ],
             output_compressed_accounts: vec![OutputCompressedAccountWithPackedContext {

--- a/programs/system/src/sdk/compressed_account.rs
+++ b/programs/system/src/sdk/compressed_account.rs
@@ -10,6 +10,8 @@ pub struct PackedCompressedAccountWithMerkleContext {
     pub merkle_context: PackedMerkleContext,
     /// Index of root used in inclusion validity proof.
     pub root_index: u16,
+    /// Placeholder to mark accounts read-only unimplemented set to false.
+    pub read_only: bool,
 }
 
 #[derive(Debug, PartialEq, Default, Clone, AnchorSerialize, AnchorDeserialize)]

--- a/programs/system/src/sdk/invoke.rs
+++ b/programs/system/src/sdk/invoke.rs
@@ -123,6 +123,7 @@ pub fn create_invoke_instruction_data_and_remaining_accounts(
                 leaf_index: context.leaf_index,
                 queue_index: None,
             },
+            read_only: false,
             root_index: input_root_indices[i],
         });
     }

--- a/test-programs/system-cpi-test/tests/test.rs
+++ b/test-programs/system-cpi-test/tests/test.rs
@@ -908,6 +908,7 @@ pub async fn perform_with_input_accounts<R: RpcConnection>(
                 queue_index: None,
             },
             root_index: rpc_result.root_indices[0],
+            read_only: false,
         },
         token_transfer_data,
         invalid_fee_payer: &invalid_fee_payer.pubkey(),


### PR DESCRIPTION
Changes:
- add placeholder marker to mark input compressed accounts as readonly
- readonly needs to be false else panic with `unimplemented`