### PR TITLE
fix: deregister program

### DIFF
--- a/programs/account-compression/src/errors.rs
+++ b/programs/account-compression/src/errors.rs
@@ -53,4 +53,5 @@ pub enum AccountCompressionErrorCode {
     #[msg("InvalidAccountBalance")]
     InvalidAccountBalance,
     UnsupportedAdditionalBytes,
+    InvalidGroup,
 }

--- a/programs/account-compression/src/instructions/deregister_program.rs
+++ b/programs/account-compression/src/instructions/deregister_program.rs
@@ -11,6 +11,7 @@ pub struct DeregisterProgram<'info> {
         mut, close=close_recipient
     )]
     pub registered_program_pda: Account<'info, RegisteredProgram>,
+    #[account( constraint= group_authority_pda.key() == registered_program_pda.group_authority_pda @AccountCompressionErrorCode::InvalidGroup)]
     pub group_authority_pda: Account<'info, GroupAuthority>,
     /// CHECK: recipient is not checked.
     #[account(mut)]


### PR DESCRIPTION
Issue:
- anyone can deregister arbitrary programs
Changes:
- add constraint which checks that  `registered_program_pda` is registered with provided `group_authority_pda` 