### PR TITLE
chore: RPC patch

### DIFF
--- a/cli/src/commands/balance/index.ts
+++ b/cli/src/commands/balance/index.ts
@@ -37,12 +37,12 @@ class BalanceCommand extends Command {
 
       loader.stop(false);
 
-      if (tokenAccounts.length === 0) {
+      if (tokenAccounts.items.length === 0) {
         console.log("No token accounts found");
         return;
       }
 
-      const compressedTokenAccount = tokenAccounts.find((acc) =>
+      const compressedTokenAccount = tokenAccounts.items.find((acc) =>
         acc.parsed.mint.equals(refMint),
       );
       if (compressedTokenAccount === undefined) {

--- a/js/compressed-token/package.json
+++ b/js/compressed-token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightprotocol/compressed-token",
-    "version": "0.4.1",
+    "version": "0.7.0",
     "description": "JS client to interact with the compressed-token program",
     "sideEffects": false,
     "main": "dist/cjs/node/index.cjs",

--- a/js/compressed-token/package.json
+++ b/js/compressed-token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightprotocol/compressed-token",
-    "version": "0.8.0",
+    "version": "0.10.1",
     "description": "JS client to interact with the compressed-token program",
     "sideEffects": false,
     "main": "dist/cjs/node/index.cjs",

--- a/js/compressed-token/package.json
+++ b/js/compressed-token/package.json
@@ -3,26 +3,21 @@
     "version": "0.4.1",
     "description": "JS client to interact with the compressed-token program",
     "sideEffects": false,
-    "type": "module",
     "main": "dist/cjs/node/index.cjs",
-    "module": "dist/es/node/index.js",
-    "browser": {
-        "./dist/cjs/node/index.cjs": "./dist/cjs/browser/index.cjs",
-        "./dist/es/node/index.js": "./dist/es/browser/index.js"
-    },
-    "types": "dist/types/index.d.ts",
+    "type": "module",
     "exports": {
         ".": {
-            "import": "./dist/es/node/index.js",
             "require": "./dist/cjs/node/index.cjs",
-            "browser": {
-                "import": "./dist/es/browser/index.js",
-                "require": "./dist/cjs/browser/index.cjs"
-            },
             "types": "./dist/types/index.d.ts",
             "default": "./dist/cjs/node/index.cjs"
+        },
+        "./browser": {
+            "import": "./dist/es/browser/index.js",
+            "require": "./dist/cjs/browser/index.cjs",
+            "types": "./dist/types/index.d.ts"
         }
     },
+    "types": "./dist/types/index.d.ts",
     "files": [
         "dist"
     ],

--- a/js/compressed-token/package.json
+++ b/js/compressed-token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightprotocol/compressed-token",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "description": "JS client to interact with the compressed-token program",
     "sideEffects": false,
     "main": "dist/cjs/node/index.cjs",

--- a/js/compressed-token/src/actions/decompress.ts
+++ b/js/compressed-token/src/actions/decompress.ts
@@ -58,7 +58,7 @@ export async function decompress(
 
     /// TODO: consider using a different selection algorithm
     const [inputAccounts] = selectMinCompressedTokenAccountsForTransfer(
-        compressedTokenAccounts,
+        compressedTokenAccounts.items,
         amount,
     );
 

--- a/js/compressed-token/src/actions/transfer.ts
+++ b/js/compressed-token/src/actions/transfer.ts
@@ -55,7 +55,7 @@ export async function transfer(
     );
 
     const [inputAccounts] = selectMinCompressedTokenAccountsForTransfer(
-        compressedTokenAccounts,
+        compressedTokenAccounts.items,
         amount,
     );
 

--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -1555,23 +1555,120 @@ export type LightCompressedToken = {
     errors: [
         {
             code: 6000;
-            name: 'SignerCheckFailed';
-            msg: 'Signer check failed';
+            name: 'PublicKeyAmountMissmatch';
+            msg: 'public keys and amounts must be of same length';
         },
         {
             code: 6001;
-            name: 'CreateTransferInstructionFailed';
-            msg: 'Create transfer instruction failed';
+            name: 'ComputeInputSumFailed';
+            msg: 'ComputeInputSumFailed';
         },
         {
             code: 6002;
-            name: 'AccountNotFound';
-            msg: 'Account not found';
+            name: 'ComputeOutputSumFailed';
+            msg: 'ComputeOutputSumFailed';
         },
         {
             code: 6003;
-            name: 'SerializationError';
-            msg: 'Serialization error';
+            name: 'ComputeCompressSumFailed';
+            msg: 'ComputeCompressSumFailed';
+        },
+        {
+            code: 6004;
+            name: 'ComputeDecompressSumFailed';
+            msg: 'ComputeDecompressSumFailed';
+        },
+        {
+            code: 6005;
+            name: 'SumCheckFailed';
+            msg: 'SumCheckFailed';
+        },
+        {
+            code: 6006;
+            name: 'DecompressRecipientUndefinedForDecompress';
+            msg: 'DecompressRecipientUndefinedForDecompress';
+        },
+        {
+            code: 6007;
+            name: 'CompressedPdaUndefinedForDecompress';
+            msg: 'CompressedPdaUndefinedForDecompress';
+        },
+        {
+            code: 6008;
+            name: 'DeCompressAmountUndefinedForDecompress';
+            msg: 'DeCompressAmountUndefinedForDecompress';
+        },
+        {
+            code: 6009;
+            name: 'CompressedPdaUndefinedForCompress';
+            msg: 'CompressedPdaUndefinedForCompress';
+        },
+        {
+            code: 6010;
+            name: 'DeCompressAmountUndefinedForCompress';
+            msg: 'DeCompressAmountUndefinedForCompress';
+        },
+        {
+            code: 6011;
+            name: 'DelegateSignerCheckFailed';
+            msg: 'DelegateSignerCheckFailed';
+        },
+        {
+            code: 6012;
+            name: 'MintTooLarge';
+            msg: 'Minted amount greater than u64::MAX';
+        },
+        {
+            code: 6013;
+            name: 'SplTokenSupplyMismatch';
+            msg: 'SplTokenSupplyMismatch';
+        },
+        {
+            code: 6014;
+            name: 'HeapMemoryCheckFailed';
+            msg: 'HeapMemoryCheckFailed';
+        },
+        {
+            code: 6015;
+            name: 'InstructionNotCallable';
+            msg: 'The instruction is not callable';
+        },
+        {
+            code: 6016;
+            name: 'ArithmeticUnderflow';
+            msg: 'ArithmeticUnderflow';
+        },
+        {
+            code: 6017;
+            name: 'HashToFieldError';
+            msg: 'HashToFieldError';
+        },
+        {
+            code: 6018;
+            name: 'InvalidAuthorityMint';
+            msg: 'Expected the authority to be also a mint authority';
+        },
+        {
+            code: 6019;
+            name: 'InvalidFreezeAuthority';
+            msg: 'Provided authority is not the freeze authority';
+        },
+        {
+            code: 6020;
+            name: 'InvalidDelegateIndex';
+        },
+        {
+            code: 6021;
+            name: 'TokenPoolPdaUndefined';
+        },
+        {
+            code: 6022;
+            name: 'IsTokenPoolPda';
+            msg: 'Compress or decompress recipient is the same account as the token pool pda.';
+        },
+        {
+            code: 6023;
+            name: 'InvalidTokenPoolPda';
         },
     ];
 };
@@ -3137,23 +3234,120 @@ export const IDL: LightCompressedToken = {
     errors: [
         {
             code: 6000,
-            name: 'SignerCheckFailed',
-            msg: 'Signer check failed',
+            name: 'PublicKeyAmountMissmatch',
+            msg: 'public keys and amounts must be of same length',
         },
         {
             code: 6001,
-            name: 'CreateTransferInstructionFailed',
-            msg: 'Create transfer instruction failed',
+            name: 'ComputeInputSumFailed',
+            msg: 'ComputeInputSumFailed',
         },
         {
             code: 6002,
-            name: 'AccountNotFound',
-            msg: 'Account not found',
+            name: 'ComputeOutputSumFailed',
+            msg: 'ComputeOutputSumFailed',
         },
         {
             code: 6003,
-            name: 'SerializationError',
-            msg: 'Serialization error',
+            name: 'ComputeCompressSumFailed',
+            msg: 'ComputeCompressSumFailed',
+        },
+        {
+            code: 6004,
+            name: 'ComputeDecompressSumFailed',
+            msg: 'ComputeDecompressSumFailed',
+        },
+        {
+            code: 6005,
+            name: 'SumCheckFailed',
+            msg: 'SumCheckFailed',
+        },
+        {
+            code: 6006,
+            name: 'DecompressRecipientUndefinedForDecompress',
+            msg: 'DecompressRecipientUndefinedForDecompress',
+        },
+        {
+            code: 6007,
+            name: 'CompressedPdaUndefinedForDecompress',
+            msg: 'CompressedPdaUndefinedForDecompress',
+        },
+        {
+            code: 6008,
+            name: 'DeCompressAmountUndefinedForDecompress',
+            msg: 'DeCompressAmountUndefinedForDecompress',
+        },
+        {
+            code: 6009,
+            name: 'CompressedPdaUndefinedForCompress',
+            msg: 'CompressedPdaUndefinedForCompress',
+        },
+        {
+            code: 6010,
+            name: 'DeCompressAmountUndefinedForCompress',
+            msg: 'DeCompressAmountUndefinedForCompress',
+        },
+        {
+            code: 6011,
+            name: 'DelegateSignerCheckFailed',
+            msg: 'DelegateSignerCheckFailed',
+        },
+        {
+            code: 6012,
+            name: 'MintTooLarge',
+            msg: 'Minted amount greater than u64::MAX',
+        },
+        {
+            code: 6013,
+            name: 'SplTokenSupplyMismatch',
+            msg: 'SplTokenSupplyMismatch',
+        },
+        {
+            code: 6014,
+            name: 'HeapMemoryCheckFailed',
+            msg: 'HeapMemoryCheckFailed',
+        },
+        {
+            code: 6015,
+            name: 'InstructionNotCallable',
+            msg: 'The instruction is not callable',
+        },
+        {
+            code: 6016,
+            name: 'ArithmeticUnderflow',
+            msg: 'ArithmeticUnderflow',
+        },
+        {
+            code: 6017,
+            name: 'HashToFieldError',
+            msg: 'HashToFieldError',
+        },
+        {
+            code: 6018,
+            name: 'InvalidAuthorityMint',
+            msg: 'Expected the authority to be also a mint authority',
+        },
+        {
+            code: 6019,
+            name: 'InvalidFreezeAuthority',
+            msg: 'Provided authority is not the freeze authority',
+        },
+        {
+            code: 6020,
+            name: 'InvalidDelegateIndex',
+        },
+        {
+            code: 6021,
+            name: 'TokenPoolPdaUndefined',
+        },
+        {
+            code: 6022,
+            name: 'IsTokenPoolPda',
+            msg: 'Compress or decompress recipient is the same account as the token pool pda.',
+        },
+        {
+            code: 6023,
+            name: 'InvalidTokenPoolPda',
         },
     ],
 };

--- a/js/compressed-token/tests/e2e/approve-and-mint-to.test.ts
+++ b/js/compressed-token/tests/e2e/approve-and-mint-to.test.ts
@@ -110,7 +110,7 @@ async function assertApproveAndMintTo(
         },
     );
 
-    const compressedTokenAccount = compressedTokenAccounts[0];
+    const compressedTokenAccount = compressedTokenAccounts.items[0];
     expect(compressedTokenAccount.parsed.mint.toBase58()).toBe(
         refMint.toBase58(),
     );

--- a/js/compressed-token/tests/e2e/compress.test.ts
+++ b/js/compressed-token/tests/e2e/compress.test.ts
@@ -34,7 +34,7 @@ async function assertCompress(
             mint: refMint,
         });
 
-    const recipientSumPost = recipientCompressedTokenBalanceAfter.reduce(
+    const recipientSumPost = recipientCompressedTokenBalanceAfter.items.reduce(
         (acc, curr) => bn(acc).add(curr.parsed.amount),
         bn(0),
     );
@@ -121,7 +121,7 @@ describe('compress', () => {
             mint,
             bn(700),
             charlie.publicKey,
-            recipientCompressedTokenBalanceBefore,
+            recipientCompressedTokenBalanceBefore.items,
         );
     });
 });

--- a/js/compressed-token/tests/e2e/decompress.test.ts
+++ b/js/compressed-token/tests/e2e/decompress.test.ts
@@ -29,10 +29,11 @@ async function assertDecompress(
     const refRecipientAtaBalanceAfter =
         await rpc.getTokenAccountBalance(refRecipientAta);
 
-    const senderCompressedTokenBalanceAfter =
+    const senderCompressedTokenBalanceAfter = (
         await rpc.getCompressedTokenAccountsByOwner(refSender, {
             mint: refMint,
-        });
+        })
+    ).items;
 
     const senderSumPost = senderCompressedTokenBalanceAfter.reduce(
         (acc, curr) => bn(acc).add(curr.parsed.amount),
@@ -126,7 +127,7 @@ describe('decompress', () => {
                 mint,
                 bn(5),
                 bob.publicKey,
-                senderCompressedTokenBalanceBefore,
+                senderCompressedTokenBalanceBefore.items,
             );
         }
     });

--- a/js/compressed-token/tests/e2e/mint-to.test.ts
+++ b/js/compressed-token/tests/e2e/mint-to.test.ts
@@ -29,7 +29,7 @@ async function assertMintTo(
         },
     );
 
-    const compressedTokenAccount = compressedTokenAccounts[0];
+    const compressedTokenAccount = compressedTokenAccounts.items[0];
     expect(compressedTokenAccount.parsed.mint.toBase58()).toBe(
         refMint.toBase58(),
     );

--- a/js/compressed-token/tests/e2e/transfer.test.ts
+++ b/js/compressed-token/tests/e2e/transfer.test.ts
@@ -28,10 +28,11 @@ async function assertTransfer(
     expectedAccountCountRecipientPost?: number,
 ) {
     /// Transfer can merge input compressed accounts therefore we need to pass all as ref
-    const senderPostCompressedTokenAccounts =
+    const senderPostCompressedTokenAccounts = (
         await rpc.getCompressedTokenAccountsByOwner(refSender, {
             mint: refMint,
-        });
+        })
+    ).items;
     /// pre = post-amount
     const sumPre = senderPreCompressedTokenAccounts.reduce(
         (acc, curr) => bn(acc).add(curr.parsed.amount),
@@ -50,10 +51,11 @@ async function assertTransfer(
 
     expect(sumPre.sub(refAmount).eq(sumPost)).toBe(true);
 
-    const recipientCompressedTokenAccounts =
+    const recipientCompressedTokenAccounts = (
         await rpc.getCompressedTokenAccountsByOwner(refRecipient, {
             mint: refMint,
-        });
+        })
+    ).items;
 
     if (expectedAccountCountRecipientPost) {
         expect(recipientCompressedTokenAccounts.length).toBe(
@@ -108,10 +110,11 @@ describe('transfer', () => {
     it('should transfer from bob -> charlie', async () => {
         /// send 700 from bob -> charlie
         /// bob: 300, charlie: 700
-        const bobPreCompressedTokenAccounts =
+        const bobPreCompressedTokenAccounts = (
             await rpc.getCompressedTokenAccountsByOwner(bob.publicKey, {
                 mint,
-            });
+            })
+        ).items;
 
         await transfer(
             rpc,
@@ -152,7 +155,7 @@ describe('transfer', () => {
 
         await assertTransfer(
             rpc,
-            bobPreCompressedTokenAccounts2,
+            bobPreCompressedTokenAccounts2.items,
             mint,
             bn(200),
             bob.publicKey,
@@ -180,7 +183,7 @@ describe('transfer', () => {
 
         await assertTransfer(
             rpc,
-            charliePreCompressedTokenAccounts3,
+            charliePreCompressedTokenAccounts3.items,
             mint,
             bn(5),
             charlie.publicKey,
@@ -199,7 +202,7 @@ describe('transfer', () => {
 
         await assertTransfer(
             rpc,
-            charliePreCompressedTokenAccounts4,
+            charliePreCompressedTokenAccounts4.items,
             mint,
             bn(700),
             charlie.publicKey,

--- a/js/stateless.js/package.json
+++ b/js/stateless.js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightprotocol/stateless.js",
-    "version": "0.5.1",
+    "version": "0.8.0",
     "description": "JavaScript API for Light and ZK Compression",
     "sideEffects": false,
     "main": "dist/cjs/node/index.cjs",

--- a/js/stateless.js/package.json
+++ b/js/stateless.js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightprotocol/stateless.js",
-    "version": "0.9.0",
+    "version": "0.10.1",
     "description": "JavaScript API for Light and ZK Compression",
     "sideEffects": false,
     "main": "dist/cjs/node/index.cjs",

--- a/js/stateless.js/package.json
+++ b/js/stateless.js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightprotocol/stateless.js",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "description": "JavaScript API for Light and ZK Compression",
     "sideEffects": false,
     "main": "dist/cjs/node/index.cjs",

--- a/js/stateless.js/src/actions/create-account.ts
+++ b/js/stateless.js/src/actions/create-account.ts
@@ -126,7 +126,7 @@ export async function createAccountWithLamports(
     );
 
     const [inputAccounts] = selectMinCompressedSolAccountsForTransfer(
-        compressedAccounts,
+        compressedAccounts.items,
         lamports,
     );
 

--- a/js/stateless.js/src/actions/decompress.ts
+++ b/js/stateless.js/src/actions/decompress.ts
@@ -36,7 +36,7 @@ export async function decompress(
     /// TODO: use dynamic state tree and nullifier queue
 
     const userCompressedAccountsWithMerkleContext: CompressedAccountWithMerkleContext[] =
-        await rpc.getCompressedAccountsByOwner(payer.publicKey);
+        (await rpc.getCompressedAccountsByOwner(payer.publicKey)).items;
 
     lamports = bn(lamports);
 

--- a/js/stateless.js/src/actions/transfer.ts
+++ b/js/stateless.js/src/actions/transfer.ts
@@ -47,7 +47,7 @@ export async function transfer(
     );
 
     const [inputAccounts] = selectMinCompressedSolAccountsForTransfer(
-        compressedAccounts,
+        compressedAccounts.items,
         lamports,
     );
 

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -1555,23 +1555,120 @@ export type LightCompressedToken = {
     errors: [
         {
             code: 6000;
-            name: 'SignerCheckFailed';
-            msg: 'Signer check failed';
+            name: 'PublicKeyAmountMissmatch';
+            msg: 'public keys and amounts must be of same length';
         },
         {
             code: 6001;
-            name: 'CreateTransferInstructionFailed';
-            msg: 'Create transfer instruction failed';
+            name: 'ComputeInputSumFailed';
+            msg: 'ComputeInputSumFailed';
         },
         {
             code: 6002;
-            name: 'AccountNotFound';
-            msg: 'Account not found';
+            name: 'ComputeOutputSumFailed';
+            msg: 'ComputeOutputSumFailed';
         },
         {
             code: 6003;
-            name: 'SerializationError';
-            msg: 'Serialization error';
+            name: 'ComputeCompressSumFailed';
+            msg: 'ComputeCompressSumFailed';
+        },
+        {
+            code: 6004;
+            name: 'ComputeDecompressSumFailed';
+            msg: 'ComputeDecompressSumFailed';
+        },
+        {
+            code: 6005;
+            name: 'SumCheckFailed';
+            msg: 'SumCheckFailed';
+        },
+        {
+            code: 6006;
+            name: 'DecompressRecipientUndefinedForDecompress';
+            msg: 'DecompressRecipientUndefinedForDecompress';
+        },
+        {
+            code: 6007;
+            name: 'CompressedPdaUndefinedForDecompress';
+            msg: 'CompressedPdaUndefinedForDecompress';
+        },
+        {
+            code: 6008;
+            name: 'DeCompressAmountUndefinedForDecompress';
+            msg: 'DeCompressAmountUndefinedForDecompress';
+        },
+        {
+            code: 6009;
+            name: 'CompressedPdaUndefinedForCompress';
+            msg: 'CompressedPdaUndefinedForCompress';
+        },
+        {
+            code: 6010;
+            name: 'DeCompressAmountUndefinedForCompress';
+            msg: 'DeCompressAmountUndefinedForCompress';
+        },
+        {
+            code: 6011;
+            name: 'DelegateSignerCheckFailed';
+            msg: 'DelegateSignerCheckFailed';
+        },
+        {
+            code: 6012;
+            name: 'MintTooLarge';
+            msg: 'Minted amount greater than u64::MAX';
+        },
+        {
+            code: 6013;
+            name: 'SplTokenSupplyMismatch';
+            msg: 'SplTokenSupplyMismatch';
+        },
+        {
+            code: 6014;
+            name: 'HeapMemoryCheckFailed';
+            msg: 'HeapMemoryCheckFailed';
+        },
+        {
+            code: 6015;
+            name: 'InstructionNotCallable';
+            msg: 'The instruction is not callable';
+        },
+        {
+            code: 6016;
+            name: 'ArithmeticUnderflow';
+            msg: 'ArithmeticUnderflow';
+        },
+        {
+            code: 6017;
+            name: 'HashToFieldError';
+            msg: 'HashToFieldError';
+        },
+        {
+            code: 6018;
+            name: 'InvalidAuthorityMint';
+            msg: 'Expected the authority to be also a mint authority';
+        },
+        {
+            code: 6019;
+            name: 'InvalidFreezeAuthority';
+            msg: 'Provided authority is not the freeze authority';
+        },
+        {
+            code: 6020;
+            name: 'InvalidDelegateIndex';
+        },
+        {
+            code: 6021;
+            name: 'TokenPoolPdaUndefined';
+        },
+        {
+            code: 6022;
+            name: 'IsTokenPoolPda';
+            msg: 'Compress or decompress recipient is the same account as the token pool pda.';
+        },
+        {
+            code: 6023;
+            name: 'InvalidTokenPoolPda';
         },
     ];
 };
@@ -3137,23 +3234,120 @@ export const IDL: LightCompressedToken = {
     errors: [
         {
             code: 6000,
-            name: 'SignerCheckFailed',
-            msg: 'Signer check failed',
+            name: 'PublicKeyAmountMissmatch',
+            msg: 'public keys and amounts must be of same length',
         },
         {
             code: 6001,
-            name: 'CreateTransferInstructionFailed',
-            msg: 'Create transfer instruction failed',
+            name: 'ComputeInputSumFailed',
+            msg: 'ComputeInputSumFailed',
         },
         {
             code: 6002,
-            name: 'AccountNotFound',
-            msg: 'Account not found',
+            name: 'ComputeOutputSumFailed',
+            msg: 'ComputeOutputSumFailed',
         },
         {
             code: 6003,
-            name: 'SerializationError',
-            msg: 'Serialization error',
+            name: 'ComputeCompressSumFailed',
+            msg: 'ComputeCompressSumFailed',
+        },
+        {
+            code: 6004,
+            name: 'ComputeDecompressSumFailed',
+            msg: 'ComputeDecompressSumFailed',
+        },
+        {
+            code: 6005,
+            name: 'SumCheckFailed',
+            msg: 'SumCheckFailed',
+        },
+        {
+            code: 6006,
+            name: 'DecompressRecipientUndefinedForDecompress',
+            msg: 'DecompressRecipientUndefinedForDecompress',
+        },
+        {
+            code: 6007,
+            name: 'CompressedPdaUndefinedForDecompress',
+            msg: 'CompressedPdaUndefinedForDecompress',
+        },
+        {
+            code: 6008,
+            name: 'DeCompressAmountUndefinedForDecompress',
+            msg: 'DeCompressAmountUndefinedForDecompress',
+        },
+        {
+            code: 6009,
+            name: 'CompressedPdaUndefinedForCompress',
+            msg: 'CompressedPdaUndefinedForCompress',
+        },
+        {
+            code: 6010,
+            name: 'DeCompressAmountUndefinedForCompress',
+            msg: 'DeCompressAmountUndefinedForCompress',
+        },
+        {
+            code: 6011,
+            name: 'DelegateSignerCheckFailed',
+            msg: 'DelegateSignerCheckFailed',
+        },
+        {
+            code: 6012,
+            name: 'MintTooLarge',
+            msg: 'Minted amount greater than u64::MAX',
+        },
+        {
+            code: 6013,
+            name: 'SplTokenSupplyMismatch',
+            msg: 'SplTokenSupplyMismatch',
+        },
+        {
+            code: 6014,
+            name: 'HeapMemoryCheckFailed',
+            msg: 'HeapMemoryCheckFailed',
+        },
+        {
+            code: 6015,
+            name: 'InstructionNotCallable',
+            msg: 'The instruction is not callable',
+        },
+        {
+            code: 6016,
+            name: 'ArithmeticUnderflow',
+            msg: 'ArithmeticUnderflow',
+        },
+        {
+            code: 6017,
+            name: 'HashToFieldError',
+            msg: 'HashToFieldError',
+        },
+        {
+            code: 6018,
+            name: 'InvalidAuthorityMint',
+            msg: 'Expected the authority to be also a mint authority',
+        },
+        {
+            code: 6019,
+            name: 'InvalidFreezeAuthority',
+            msg: 'Provided authority is not the freeze authority',
+        },
+        {
+            code: 6020,
+            name: 'InvalidDelegateIndex',
+        },
+        {
+            code: 6021,
+            name: 'TokenPoolPdaUndefined',
+        },
+        {
+            code: 6022,
+            name: 'IsTokenPoolPda',
+            msg: 'Compress or decompress recipient is the same account as the token pool pda.',
+        },
+        {
+            code: 6023,
+            name: 'InvalidTokenPoolPda',
         },
     ],
 };

--- a/js/stateless.js/src/rpc-interface.ts
+++ b/js/stateless.js/src/rpc-interface.ts
@@ -131,6 +131,12 @@ export type WithContext<T> = {
     /** response value */
     value: T;
 };
+export type WithCursor<T> = {
+    /** context */
+    cursor: string | null;
+    /** response value */
+    items: T;
+};
 
 /**
  * @internal
@@ -279,7 +285,7 @@ export const MultipleCompressedAccountsResult = pick({
  */
 export const CompressedAccountsByOwnerResult = pick({
     items: array(CompressedAccountResult),
-    cursor: nullable(PublicKeyFromString),
+    cursor: nullable(string()),
 });
 
 /**
@@ -287,7 +293,7 @@ export const CompressedAccountsByOwnerResult = pick({
  */
 export const CompressedTokenAccountsByOwnerOrDelegateResult = pick({
     items: array(CompressedTokenAccountResult),
-    cursor: nullable(PublicKeyFromString),
+    cursor: nullable(string()),
 });
 
 /**
@@ -399,7 +405,7 @@ export const TokenBalanceResult = pick({
 
 export const TokenBalanceListResult = pick({
     tokenBalances: array(TokenBalanceResult),
-    cursor: nullable(PublicKeyFromString),
+    cursor: nullable(string()),
 });
 
 export const AccountProofResult = pick({
@@ -430,7 +436,7 @@ export const SignatureListWithCursorResult = pick({
             slot: number(),
         }),
     ),
-    cursor: nullable(PublicKeyFromString),
+    cursor: nullable(string()),
 });
 
 export const CompressedTransactionResult = pick({
@@ -487,24 +493,24 @@ export interface CompressionApiInterface {
 
     getCompressedAccountsByOwner(
         owner: PublicKey,
-    ): Promise<CompressedAccountWithMerkleContext[]>;
+    ): Promise<WithCursor<CompressedAccountWithMerkleContext[]>>;
 
     getCompressedTokenAccountsByOwner(
         publicKey: PublicKey,
         options: GetCompressedTokenAccountsByOwnerOrDelegateOptions,
-    ): Promise<ParsedTokenAccount[]>;
+    ): Promise<WithCursor<ParsedTokenAccount[]>>;
 
     getCompressedTokenAccountsByDelegate(
         delegate: PublicKey,
         options: GetCompressedTokenAccountsByOwnerOrDelegateOptions,
-    ): Promise<ParsedTokenAccount[]>;
+    ): Promise<WithCursor<ParsedTokenAccount[]>>;
 
     getCompressedTokenAccountBalance(hash: BN254): Promise<{ amount: BN }>;
 
     getCompressedTokenBalancesByOwner(
         publicKey: PublicKey,
         options: GetCompressedTokenAccountsByOwnerOrDelegateOptions,
-    ): Promise<{ balance: BN; mint: PublicKey }[]>;
+    ): Promise<WithCursor<{ balance: BN; mint: PublicKey }[]>>;
 
     getTransactionWithCompressionInfo(
         signature: string,
@@ -516,15 +522,15 @@ export interface CompressionApiInterface {
 
     getCompressionSignaturesForAddress(
         address: PublicKey,
-    ): Promise<SignatureWithMetadata[]>;
+    ): Promise<WithCursor<SignatureWithMetadata[]>>;
 
     getCompressionSignaturesForOwner(
         owner: PublicKey,
-    ): Promise<SignatureWithMetadata[]>;
+    ): Promise<WithCursor<SignatureWithMetadata[]>>;
 
     getCompressionSignaturesForTokenOwner(
         owner: PublicKey,
-    ): Promise<SignatureWithMetadata[]>;
+    ): Promise<WithCursor<SignatureWithMetadata[]>>;
 
     getLatestNonVotingSignatures(
         limit?: number,

--- a/js/stateless.js/src/rpc-interface.ts
+++ b/js/stateless.js/src/rpc-interface.ts
@@ -65,6 +65,16 @@ export interface CompressedTransaction {
             account: CompressedAccountWithMerkleContext;
             maybeTokenData: TokenData | null;
         }[];
+        preTokenBalances?: {
+            owner: PublicKey;
+            mint: PublicKey;
+            amount: BN;
+        }[];
+        postTokenBalances?: {
+            owner: PublicKey;
+            mint: PublicKey;
+            amount: BN;
+        }[];
     };
     transaction: any;
 }

--- a/js/stateless.js/src/rpc.ts
+++ b/js/stateless.js/src/rpc.ts
@@ -918,8 +918,8 @@ export class Rpc extends Connection implements CompressionApiInterface {
             return balances.length > 0 ? balances : undefined;
         };
 
-        let preTokenBalances = calculateTokenBalances(closedAccounts);
-        let postTokenBalances = calculateTokenBalances(openedAccounts);
+        const preTokenBalances = calculateTokenBalances(closedAccounts);
+        const postTokenBalances = calculateTokenBalances(openedAccounts);
 
         return {
             compressionInfo: {

--- a/js/stateless.js/src/test-helpers/test-rpc/get-compressed-token-accounts.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/get-compressed-token-accounts.ts
@@ -5,7 +5,7 @@ import { BN, BorshCoder } from '@coral-xyz/anchor';
 import { IDL } from '../../idls/light_compressed_token';
 import { defaultTestStateTreeAccounts } from '../../constants';
 import { Rpc } from '../../rpc';
-import { ParsedTokenAccount } from '../../rpc-interface';
+import { ParsedTokenAccount, WithCursor } from '../../rpc-interface';
 import {
     CompressedAccount,
     PublicTransactionEvent,
@@ -153,7 +153,7 @@ export async function getCompressedTokenAccountsByOwnerTest(
     rpc: Rpc,
     owner: PublicKey,
     mint: PublicKey,
-): Promise<ParsedTokenAccount[]> {
+): Promise<WithCursor<ParsedTokenAccount[]>> {
     const events = await getParsedEvents(rpc);
 
     const compressedTokenAccounts = await getCompressedTokenAccounts(events);
@@ -161,25 +161,31 @@ export async function getCompressedTokenAccountsByOwnerTest(
     const accounts = compressedTokenAccounts.filter(
         acc => acc.parsed.owner.equals(owner) && acc.parsed.mint.equals(mint),
     );
-    return accounts.sort(
-        (a, b) => b.compressedAccount.leafIndex - a.compressedAccount.leafIndex,
-    );
+    return {
+        items: accounts.sort(
+            (a, b) =>
+                b.compressedAccount.leafIndex - a.compressedAccount.leafIndex,
+        ),
+        cursor: null,
+    };
 }
 
 export async function getCompressedTokenAccountsByDelegateTest(
     rpc: Rpc,
     delegate: PublicKey,
     mint: PublicKey,
-): Promise<ParsedTokenAccount[]> {
+): Promise<WithCursor<ParsedTokenAccount[]>> {
     const events = await getParsedEvents(rpc);
 
     const compressedTokenAccounts = await getCompressedTokenAccounts(events);
-
-    return compressedTokenAccounts.filter(
-        acc =>
-            acc.parsed.delegate?.equals(delegate) &&
-            acc.parsed.mint.equals(mint),
-    );
+    return {
+        items: compressedTokenAccounts.filter(
+            acc =>
+                acc.parsed.delegate?.equals(delegate) &&
+                acc.parsed.mint.equals(mint),
+        ),
+        cursor: null,
+    };
 }
 
 export async function getCompressedTokenAccountByHashTest(

--- a/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
@@ -20,6 +20,7 @@ import {
     LatestNonVotingSignaturesPaginated,
     SignatureWithMetadata,
     WithContext,
+    WithCursor,
 } from '../../rpc-interface';
 import {
     CompressedProofWithContext,
@@ -229,7 +230,7 @@ export class TestRpc extends Connection implements CompressionApiInterface {
      */
     async getCompressedBalanceByOwner(owner: PublicKey): Promise<BN> {
         const accounts = await this.getCompressedAccountsByOwner(owner);
-        return accounts.reduce(
+        return accounts.items.reduce(
             (acc, account) => acc.add(account.lamports),
             bn(0),
         );
@@ -333,9 +334,12 @@ export class TestRpc extends Connection implements CompressionApiInterface {
      */
     async getCompressedAccountsByOwner(
         owner: PublicKey,
-    ): Promise<CompressedAccountWithMerkleContext[]> {
+    ): Promise<WithCursor<CompressedAccountWithMerkleContext[]>> {
         const accounts = await getCompressedAccountsByOwnerTest(this, owner);
-        return accounts;
+        return {
+            items: accounts,
+            cursor: null,
+        };
     }
 
     /**
@@ -368,7 +372,7 @@ export class TestRpc extends Connection implements CompressionApiInterface {
     async getCompressedTokenAccountsByOwner(
         owner: PublicKey,
         options: GetCompressedTokenAccountsByOwnerOrDelegateOptions,
-    ): Promise<ParsedTokenAccount[]> {
+    ): Promise<WithCursor<ParsedTokenAccount[]>> {
         return await getCompressedTokenAccountsByOwnerTest(
             this,
             owner,
@@ -382,7 +386,7 @@ export class TestRpc extends Connection implements CompressionApiInterface {
     async getCompressedTokenAccountsByDelegate(
         delegate: PublicKey,
         options: GetCompressedTokenAccountsByOwnerOrDelegateOptions,
-    ): Promise<ParsedTokenAccount[]> {
+    ): Promise<WithCursor<ParsedTokenAccount[]>> {
         return await getCompressedTokenAccountsByDelegateTest(
             this,
             delegate,
@@ -407,16 +411,19 @@ export class TestRpc extends Connection implements CompressionApiInterface {
     async getCompressedTokenBalancesByOwner(
         publicKey: PublicKey,
         options: GetCompressedTokenAccountsByOwnerOrDelegateOptions,
-    ): Promise<{ balance: BN; mint: PublicKey }[]> {
+    ): Promise<WithCursor<{ balance: BN; mint: PublicKey }[]>> {
         const accounts = await getCompressedTokenAccountsByOwnerTest(
             this,
             publicKey,
             options.mint!,
         );
-        return accounts.map(account => ({
-            balance: bn(account.parsed.amount),
-            mint: account.parsed.mint,
-        }));
+        return {
+            items: accounts.items.map(account => ({
+                balance: bn(account.parsed.amount),
+                mint: account.parsed.mint,
+            })),
+            cursor: null,
+        };
     }
 
     /**
@@ -453,7 +460,7 @@ export class TestRpc extends Connection implements CompressionApiInterface {
      */
     async getCompressionSignaturesForAddress(
         _address: PublicKey,
-    ): Promise<SignatureWithMetadata[]> {
+    ): Promise<WithCursor<SignatureWithMetadata[]>> {
         throw new Error('getSignaturesForAddress3 not implemented');
     }
 
@@ -466,7 +473,7 @@ export class TestRpc extends Connection implements CompressionApiInterface {
      */
     async getCompressionSignaturesForOwner(
         owner: PublicKey,
-    ): Promise<SignatureWithMetadata[]> {
+    ): Promise<WithCursor<SignatureWithMetadata[]>> {
         throw new Error('getSignaturesForOwner not implemented');
     }
 
@@ -477,7 +484,7 @@ export class TestRpc extends Connection implements CompressionApiInterface {
      */
     async getCompressionSignaturesForTokenOwner(
         owner: PublicKey,
-    ): Promise<SignatureWithMetadata[]> {
+    ): Promise<WithCursor<SignatureWithMetadata[]>> {
         throw new Error('getSignaturesForTokenOwner not implemented');
     }
 

--- a/js/stateless.js/tests/e2e/compress.test.ts
+++ b/js/stateless.js/tests/e2e/compress.test.ts
@@ -150,13 +150,13 @@ describe('compress', () => {
         const compressedAccounts = await rpc.getCompressedAccountsByOwner(
             payer.publicKey,
         );
-        assert.equal(compressedAccounts.length, 1);
+        assert.equal(compressedAccounts.items.length, 1);
         assert.equal(
-            Number(compressedAccounts[0].lamports),
+            Number(compressedAccounts.items[0].lamports),
             compressLamportsAmount,
         );
 
-        assert.equal(compressedAccounts[0].data, null);
+        assert.equal(compressedAccounts.items[0].data, null);
         const postCompressBalance = await rpc.getBalance(payer.publicKey);
         assert.equal(
             postCompressBalance,
@@ -201,13 +201,13 @@ describe('compress', () => {
         const compressedAccounts = await rpc.getCompressedAccountsByOwner(
             payer.publicKey,
         );
-        assert.equal(compressedAccounts.length, 1);
+        assert.equal(compressedAccounts.items.length, 1);
         assert.equal(
-            Number(compressedAccounts[0].lamports),
+            Number(compressedAccounts.items[0].lamports),
             compressLamportsAmount,
         );
 
-        assert.equal(compressedAccounts[0].data, null);
+        assert.equal(compressedAccounts.items[0].data, null);
         const postCompressBalance = await rpc.getBalance(payer.publicKey);
         assert.equal(
             postCompressBalance,
@@ -230,9 +230,9 @@ describe('compress', () => {
         const compressedAccounts2 = await rpc.getCompressedAccountsByOwner(
             payer.publicKey,
         );
-        assert.equal(compressedAccounts2.length, 1);
+        assert.equal(compressedAccounts2.items.length, 1);
         assert.equal(
-            Number(compressedAccounts2[0].lamports),
+            Number(compressedAccounts2.items[0].lamports),
             compressLamportsAmount - decompressLamportsAmount,
         );
         await decompress(rpc, payer, 1, decompressRecipient, merkleTree);

--- a/js/stateless.js/tests/e2e/rpc-interop.test.ts
+++ b/js/stateless.js/tests/e2e/rpc-interop.test.ts
@@ -48,8 +48,8 @@ describe('rpc-interop', () => {
             payer.publicKey,
         );
 
-        const hash = bn(senderAccounts[0].hash);
-        const hashTest = bn(senderAccountsTest[0].hash);
+        const hash = bn(senderAccounts.items[0].hash);
+        const hashTest = bn(senderAccountsTest.items[0].hash);
 
         // accounts are the same
         assert.isTrue(hash.eq(hashTest));
@@ -158,8 +158,8 @@ describe('rpc-interop', () => {
         const senderAccounts = await rpc.getCompressedAccountsByOwner(
             payer.publicKey,
         );
-        const hashTest = bn(senderAccountsTest[0].hash);
-        const hash = bn(senderAccounts[0].hash);
+        const hashTest = bn(senderAccountsTest.items[0].hash);
+        const hash = bn(senderAccounts.items[0].hash);
 
         // accounts are the same
         assert.isTrue(hash.eq(hashTest));
@@ -336,7 +336,7 @@ describe('rpc-interop', () => {
             const prePayerAccounts = await rpc.getCompressedAccountsByOwner(
                 payer.publicKey,
             );
-            const preSenderBalance = prePayerAccounts.reduce(
+            const preSenderBalance = prePayerAccounts.items.reduce(
                 (acc, account) => acc.add(account.lamports),
                 bn(0),
             );
@@ -344,19 +344,19 @@ describe('rpc-interop', () => {
             const preReceiverAccounts = await rpc.getCompressedAccountsByOwner(
                 bob.publicKey,
             );
-            const preReceiverBalance = preReceiverAccounts.reduce(
+            const preReceiverBalance = preReceiverAccounts.items.reduce(
                 (acc, account) => acc.add(account.lamports),
                 bn(0),
             );
 
             /// get reference proofs for sender
             const testProofs = await testRpc.getMultipleCompressedAccountProofs(
-                prePayerAccounts.map(account => bn(account.hash)),
+                prePayerAccounts.items.map(account => bn(account.hash)),
             );
 
             /// get photon proofs for sender
             const proofs = await rpc.getMultipleCompressedAccountProofs(
-                prePayerAccounts.map(account => bn(account.hash)),
+                prePayerAccounts.items.map(account => bn(account.hash)),
             );
 
             /// compare each proof by node and root
@@ -382,11 +382,11 @@ describe('rpc-interop', () => {
                 bob.publicKey,
             );
 
-            const postSenderBalance = postSenderAccs.reduce(
+            const postSenderBalance = postSenderAccs.items.reduce(
                 (acc, account) => acc.add(account.lamports),
                 bn(0),
             );
-            const postReceiverBalance = postReceiverAccs.reduce(
+            const postReceiverBalance = postReceiverAccs.items.reduce(
                 (acc, account) => acc.add(account.lamports),
                 bn(0),
             );
@@ -413,15 +413,18 @@ describe('rpc-interop', () => {
             payer.publicKey,
         );
 
-        assert.equal(senderAccounts.length, senderAccountsTest.length);
+        assert.equal(
+            senderAccounts.items.length,
+            senderAccountsTest.items.length,
+        );
 
-        senderAccounts.forEach((account, index) => {
+        senderAccounts.items.forEach((account, index) => {
             assert.equal(
                 account.owner.toBase58(),
-                senderAccountsTest[index].owner.toBase58(),
+                senderAccountsTest.items[index].owner.toBase58(),
             );
             assert.isTrue(
-                account.lamports.eq(senderAccountsTest[index].lamports),
+                account.lamports.eq(senderAccountsTest.items[index].lamports),
             );
         });
 
@@ -432,20 +435,25 @@ describe('rpc-interop', () => {
             bob.publicKey,
         );
 
-        assert.equal(receiverAccounts.length, receiverAccountsTest.length);
+        assert.equal(
+            receiverAccounts.items.length,
+            receiverAccountsTest.items.length,
+        );
 
-        receiverAccounts.sort((a, b) => a.lamports.sub(b.lamports).toNumber());
-        receiverAccountsTest.sort((a, b) =>
+        receiverAccounts.items.sort((a, b) =>
+            a.lamports.sub(b.lamports).toNumber(),
+        );
+        receiverAccountsTest.items.sort((a, b) =>
             a.lamports.sub(b.lamports).toNumber(),
         );
 
-        receiverAccounts.forEach((account, index) => {
+        receiverAccounts.items.forEach((account, index) => {
             assert.equal(
                 account.owner.toBase58(),
-                receiverAccountsTest[index].owner.toBase58(),
+                receiverAccountsTest.items[index].owner.toBase58(),
             );
             assert.isTrue(
-                account.lamports.eq(receiverAccountsTest[index].lamports),
+                account.lamports.eq(receiverAccountsTest.items[index].lamports),
             );
         });
     });
@@ -457,11 +465,11 @@ describe('rpc-interop', () => {
 
         const compressedAccount = await rpc.getCompressedAccount(
             undefined,
-            bn(senderAccounts[0].hash),
+            bn(senderAccounts.items[0].hash),
         );
         const compressedAccountTest = await testRpc.getCompressedAccount(
             undefined,
-            bn(senderAccounts[0].hash),
+            bn(senderAccounts.items[0].hash),
         );
 
         assert.isTrue(
@@ -483,11 +491,11 @@ describe('rpc-interop', () => {
         );
 
         const compressedAccounts = await rpc.getMultipleCompressedAccounts(
-            senderAccounts.map(account => bn(account.hash)),
+            senderAccounts.items.map(account => bn(account.hash)),
         );
         const compressedAccountsTest =
             await testRpc.getMultipleCompressedAccounts(
-                senderAccounts.map(account => bn(account.hash)),
+                senderAccounts.items.map(account => bn(account.hash)),
             );
 
         assert.equal(compressedAccounts.length, compressedAccountsTest.length);
@@ -510,14 +518,14 @@ describe('rpc-interop', () => {
             payer.publicKey,
         );
         const signaturesUnspent = await rpc.getCompressionSignaturesForAccount(
-            bn(senderAccounts[0].hash),
+            bn(senderAccounts.items[0].hash),
         );
 
         /// most recent therefore unspent account
         assert.equal(signaturesUnspent.length, 1);
 
         /// Note: assumes largest-first selection mechanism
-        const largestAccount = senderAccounts.reduce((acc, account) =>
+        const largestAccount = senderAccounts.items.reduce((acc, account) =>
             account.lamports.gt(acc.lamports) ? account : acc,
         );
 
@@ -536,7 +544,7 @@ describe('rpc-interop', () => {
         const signatures = await rpc.getCompressionSignaturesForOwner(
             payer.publicKey,
         );
-        assert.equal(signatures.length, executedTxs);
+        assert.equal(signatures.items.length, executedTxs);
     });
 
     it('[test-rpc missing] getLatestNonVotingSignatures should match', async () => {
@@ -579,7 +587,7 @@ describe('rpc-interop', () => {
         );
 
         const compressedTx = await rpc.getTransactionWithCompressionInfo(
-            signatures[0].signature,
+            signatures.items[0].signature,
         );
 
         /// is transfer
@@ -598,7 +606,7 @@ describe('rpc-interop', () => {
         const accounts = await rpc.getCompressedAccountsByOwner(
             payer.publicKey,
         );
-        const latestAccount = accounts[0];
+        const latestAccount = accounts.items[0];
 
         // assert the address was indexed
         assert.isTrue(new PublicKey(latestAccount.address!).equals(address));
@@ -608,7 +616,7 @@ describe('rpc-interop', () => {
         );
 
         /// most recent therefore unspent account
-        assert.equal(signaturesUnspent.length, 1);
+        assert.equal(signaturesUnspent.items.length, 1);
     });
 
     it('getCompressedAccount with address param should work ', async () => {
@@ -622,7 +630,7 @@ describe('rpc-interop', () => {
         const accounts = await rpc.getCompressedAccountsByOwner(
             payer.publicKey,
         );
-        const latestAccount = accounts[0];
+        const latestAccount = accounts.items[0];
 
         assert.isTrue(new PublicKey(latestAccount.address!).equals(address));
 

--- a/js/stateless.js/tests/e2e/test-rpc.test.ts
+++ b/js/stateless.js/tests/e2e/test-rpc.test.ts
@@ -58,8 +58,8 @@ describe('test-rpc', () => {
             payer.publicKey,
         );
 
-        compressedTestAccount = compressedAccounts[0];
-        assert.equal(compressedAccounts.length, 1);
+        compressedTestAccount = compressedAccounts.items[0];
+        assert.equal(compressedAccounts.items.length, 1);
         assert.equal(
             Number(compressedTestAccount.lamports),
             compressLamportsAmount,
@@ -84,7 +84,7 @@ describe('test-rpc', () => {
         const compressedAccounts = await rpc.getCompressedAccountsByOwner(
             payer.publicKey,
         );
-        const refHash = compressedAccounts[0].hash;
+        const refHash = compressedAccounts.items[0].hash;
         const compressedAccountProof = await rpc.getCompressedAccountProof(
             bn(refHash),
         );
@@ -93,7 +93,7 @@ describe('test-rpc', () => {
         expect(proof.length).toStrictEqual(26);
         expect(compressedAccountProof.hash).toStrictEqual(refHash);
         expect(compressedAccountProof.leafIndex).toStrictEqual(
-            compressedAccounts[0].leafIndex,
+            compressedAccounts.items[0].leafIndex,
         );
         expect(compressedAccountProof.rootIndex).toStrictEqual(2);
         preCompressBalance = await rpc.getBalance(payer.publicKey);
@@ -109,7 +109,7 @@ describe('test-rpc', () => {
         const compressedAccounts1 = await rpc.getCompressedAccountsByOwner(
             payer.publicKey,
         );
-        expect(compressedAccounts1?.length).toStrictEqual(1);
+        expect(compressedAccounts1.items.length).toStrictEqual(1);
         postCompressBalance = await rpc.getBalance(payer.publicKey);
         assert.equal(
             postCompressBalance,
@@ -123,7 +123,7 @@ describe('test-rpc', () => {
         const compressedAccounts2 = await rpc.getCompressedAccountsByOwner(
             payer.publicKey,
         );
-        expect(compressedAccounts2?.length).toStrictEqual(2);
+        expect(compressedAccounts2.items.length).toStrictEqual(2);
     });
 
     it('getCompressedAccountProof: get many valid proofs (10)', async () => {
@@ -148,7 +148,7 @@ describe('test-rpc', () => {
         const compressedAccounts = await rpc.getCompressedAccountsByOwner(
             payer.publicKey,
         );
-        const refHash = compressedAccounts[0].hash;
+        const refHash = compressedAccounts.items[0].hash;
         /// getCompressedAccount
         const compressedAccount = await rpc.getCompressedAccount(
             undefined,
@@ -166,7 +166,7 @@ describe('test-rpc', () => {
         const compressedAccounts = await rpc.getCompressedAccountsByOwner(
             refPayer.publicKey,
         );
-        const refHash = compressedAccounts[0].hash;
+        const refHash = compressedAccounts.items[0].hash;
         /// getCompressedBalance
         await expect(rpc.getCompressedBalance(bn(refHash))).rejects.toThrow(
             'address is not supported in test-rpc',

--- a/js/stateless.js/tests/e2e/testnet.test.ts
+++ b/js/stateless.js/tests/e2e/testnet.test.ts
@@ -29,11 +29,11 @@ describe('testnet transfer', () => {
         for (let i = 0; i < numberOfTransfers; i++) {
             const preSenderBalance = (
                 await rpc.getCompressedAccountsByOwner(payer.publicKey)
-            ).reduce((acc, account) => acc.add(account.lamports), bn(0));
+            ).items.reduce((acc, account) => acc.add(account.lamports), bn(0));
 
             const preReceiverBalance = (
                 await rpc.getCompressedAccountsByOwner(bob.publicKey)
-            ).reduce((acc, account) => acc.add(account.lamports), bn(0));
+            ).items.reduce((acc, account) => acc.add(account.lamports), bn(0));
 
             await transfer(rpc, payer, transferAmount, payer, bob.publicKey);
 
@@ -44,11 +44,11 @@ describe('testnet transfer', () => {
                 bob.publicKey,
             );
 
-            const postSenderBalance = postSenderAccs.reduce(
+            const postSenderBalance = postSenderAccs.items.reduce(
                 (acc, account) => acc.add(account.lamports),
                 bn(0),
             );
-            const postReceiverBalance = postReceiverAccs.reduce(
+            const postReceiverBalance = postReceiverAccs.items.reduce(
                 (acc, account) => acc.add(account.lamports),
                 bn(0),
             );

--- a/js/stateless.js/tests/e2e/transfer.test.ts
+++ b/js/stateless.js/tests/e2e/transfer.test.ts
@@ -27,11 +27,11 @@ describe('transfer', () => {
         for (let i = 0; i < numberOfTransfers; i++) {
             const preSenderBalance = (
                 await rpc.getCompressedAccountsByOwner(payer.publicKey)
-            ).reduce((acc, account) => acc.add(account.lamports), bn(0));
+            ).items.reduce((acc, account) => acc.add(account.lamports), bn(0));
 
             const preReceiverBalance = (
                 await rpc.getCompressedAccountsByOwner(bob.publicKey)
-            ).reduce((acc, account) => acc.add(account.lamports), bn(0));
+            ).items.reduce((acc, account) => acc.add(account.lamports), bn(0));
 
             await transfer(rpc, payer, transferAmount, payer, bob.publicKey);
 
@@ -42,11 +42,11 @@ describe('transfer', () => {
                 bob.publicKey,
             );
 
-            const postSenderBalance = postSenderAccs.reduce(
+            const postSenderBalance = postSenderAccs.items.reduce(
                 (acc, account) => acc.add(account.lamports),
                 bn(0),
             );
-            const postReceiverBalance = postReceiverAccs.reduce(
+            const postReceiverBalance = postReceiverAccs.items.reduce(
                 (acc, account) => acc.add(account.lamports),
                 bn(0),
             );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,6 +382,10 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@22.1.0)(@vitest/browser@1.6.0)(terser@5.31.0)
 
+  hasher.rs/src/main/wasm: {}
+
+  hasher.rs/src/main/wasm-simd: {}
+
   js/compressed-token:
     dependencies:
       '@coral-xyz/anchor':


### PR DESCRIPTION
* bump versions to latest NPM releases
* changes the JS RPC return type for endpoints with cursors. Wraps inside WithCursor<{items, cursor}>, so values need to be accessed like e.g. compressedAccounts.items[0]