### PR TITLE
feat: `#[derive(LightHasher)]` macro and `AsByteVec` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3488,6 +3488,7 @@ version = "0.3.0"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
+ "rand 0.8.5",
  "sha2 0.10.8",
  "sha3 0.10.8",
  "solana-program",
@@ -3526,6 +3527,7 @@ version = "0.5.0"
 dependencies = [
  "bs58 0.4.0",
  "light-hasher",
+ "light-utils",
  "proc-macro2",
  "quote",
  "syn 1.0.109",

--- a/macros/light/Cargo.toml
+++ b/macros/light/Cargo.toml
@@ -14,5 +14,8 @@ syn = { version = "1.0", features = ["full"] }
 
 light-hasher = { path = "../../merkle-tree/hasher", version = "0.3.0" }
 
+[dev-dependencies]
+light-utils = { path = "../../utils", version = "0.3.0" }
+
 [lib]
 proc-macro = true

--- a/macros/light/src/hasher.rs
+++ b/macros/light/src/hasher.rs
@@ -1,0 +1,107 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Error, Fields, ItemStruct, Result};
+
+pub(crate) fn hasher(input: ItemStruct) -> Result<TokenStream> {
+    let struct_name = &input.ident;
+
+    let (impl_gen, type_gen, where_clause) = input.generics.split_for_impl();
+
+    let fields = match input.fields {
+        Fields::Named(fields) => fields,
+        _ => {
+            return Err(Error::new_spanned(
+                input,
+                "Only structs with named fields are supported",
+            ))
+        }
+    };
+
+    let field_into_bytes_calls = fields
+        .named
+        .iter()
+        .filter(|field| {
+            !field.attrs.iter().any(|attr| {
+                if let Some(attr_ident) = attr.path.get_ident() {
+                    attr_ident == "skip"
+                } else {
+                    false
+                }
+            })
+        })
+        .map(|field| {
+            let field_name = &field.ident;
+            let truncate = field.attrs.iter().any(|attr| {
+                if let Some(attr_ident) = attr.path.get_ident() {
+                    attr_ident == "truncate"
+                } else {
+                    false
+                }
+            });
+            if truncate {
+                quote! {
+                    let truncated_bytes = self
+                        .#field_name
+                        .as_byte_vec()
+                        .iter()
+                        .map(|bytes| {
+                            let (bytes, _) = ::light_utils::hash_to_bn254_field_size_be(bytes).expect(
+                                "Could not truncate the field #field_name to the BN254 prime field"
+                            );
+                            bytes.to_vec()
+                        })
+                        .collect::<Vec<Vec<u8>>>();
+                    result.extend_from_slice(truncated_bytes.as_slice());
+                }
+            } else {
+                quote! {
+                    result.extend_from_slice(self.#field_name.as_byte_vec().as_slice());
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Ok(quote! {
+        impl #impl_gen ::light_hasher::bytes::AsByteVec for #struct_name #type_gen #where_clause {
+            fn as_byte_vec(&self) -> Vec<Vec<u8>> {
+                use ::light_hasher::bytes::AsByteVec;
+
+                let mut result: Vec<Vec<u8>> = Vec::new();
+                #(#field_into_bytes_calls)*
+                result
+            }
+        }
+
+        impl #impl_gen ::light_hasher::DataHasher for #struct_name #type_gen #where_clause {
+            fn hash<H: light_hasher::Hasher>(&self) -> ::std::result::Result<[u8; 32], ::light_hasher::errors::HasherError> {
+                use ::light_hasher::bytes::AsByteVec;
+
+                H::hashv(self.as_byte_vec().iter().map(|v| v.as_slice()).collect::<Vec<_>>().as_slice())
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use syn::parse_quote;
+
+    #[test]
+    fn test_light_hasher() {
+        let input: ItemStruct = parse_quote! {
+            struct MyAccount {
+                a: u32,
+                b: i32,
+                c: u64,
+                d: i64,
+            }
+        };
+
+        let output = hasher(input).unwrap();
+        let output = output.to_string();
+
+        println!("{output}");
+    }
+}

--- a/macros/light/src/lib.rs
+++ b/macros/light/src/lib.rs
@@ -163,6 +163,114 @@ pub fn light_discriminator(input: TokenStream) -> TokenStream {
         .into()
 }
 
+/// Makes the annotated struct hashable by implementing the following traits:
+///
+/// - [`AsByteVec`](light_hasher::bytes::AsByteVec), which makes the struct
+///   convertable to a 2D byte vector.
+/// - [`DataHasher`](light_hasher::DataHasher), which makes the struct hashable
+///   with the `hash()` method, based on the byte inputs from `AsByteVec`
+///   implementation.
+///
+/// This macro assumes that all the fields of the struct implement the
+/// `AsByteVec` trait. The trait is implemented by default for the most of
+/// standard Rust types (primitives, `String`, arrays and options carrying the
+/// former). If there is a field of a type not implementing the trait, there
+/// are two options:
+///
+/// 1. The most recommended one - annotating that type with the `light_hasher`
+///    macro as well.
+/// 2. Manually implementing the `AsByteVec` trait.
+///
+/// # Attributes
+///
+/// - `skip` - skips the given field, it doesn't get included neither in
+///   `AsByteVec` nor `DataHasher` implementation.
+/// - `truncate` - makes sure that the byte value does not exceed the BN254
+///   prime field modulus, by hashing it (with Keccak) and truncating it to 31
+///   bytes. It's generally a good idea to use it on any field which is
+///   expected to output more than 31 bytes.
+///
+/// # Examples
+///
+/// Compressed account with only primitive types as fields:
+///
+/// ```ignore
+/// #[derive(LightHasher)]
+/// pub struct MyCompressedAccount {
+///     a: i64,
+///     b: Option<u64>,
+/// }
+/// ```
+///
+/// Compressed account with fields which might exceed the BN254 prime field:
+///
+/// ```ignore
+/// #[derive(LightHasher)]
+/// pub struct MyCompressedAccount {
+///     a: i64
+///     b: Option<u64>,
+///     #[truncate]
+///     c: [u8; 32],
+///     #[truncate]
+///     d: String,
+/// }
+/// ```
+///
+/// Compressed account with fields we want to skip:
+///
+/// ```ignore
+/// #[derive(LightHasher)]
+/// pub struct MyCompressedAccount {
+///     a: i64
+///     b: Option<u64>,
+///     #[skip]
+///     c: [u8; 32],
+/// }
+/// ```
+///
+/// Compressed account with a nested struct:
+///
+/// ```ignore
+/// #[derive(LightHasher)]
+/// pub struct MyCompressedAccount {
+///     a: i64
+///     b: Option<u64>,
+///     c: MyStruct,
+/// }
+///
+/// #[derive(LightHasher)]
+/// pub struct MyStruct {
+///     a: i32
+///     b: u32,
+/// }
+/// ```
+///
+/// Compressed account with a type with a custom `AsByteVec` implementation:
+///
+/// ```ignore
+/// #[derive(LightHasher)]
+/// pub struct MyCompressedAccount {
+///     a: i64
+///     b: Option<u64>,
+///     c: RData,
+/// }
+///
+/// pub enum RData {
+///     A(Ipv4Addr),
+///     AAAA(Ipv6Addr),
+///     CName(String),
+/// }
+///
+/// impl AsByteVec for RData {
+///     fn as_byte_vec(&self) -> Vec<Vec<u8>> {
+///         match self {
+///             Self::A(ipv4_addr) => vec![ipv4_addr.octets().to_vec()],
+///             Self::AAAA(ipv6_addr) => vec![ipv6_addr.octets().to_vec()],
+///             Self::CName(cname) => cname.as_byte_vec(),
+///         }
+///     }
+/// }
+/// ```
 #[proc_macro_derive(LightHasher, attributes(skip, truncate))]
 pub fn light_hasher(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);

--- a/macros/light/src/lib.rs
+++ b/macros/light/src/lib.rs
@@ -7,6 +7,7 @@ use traits::process_light_traits;
 
 mod accounts;
 mod discriminator;
+mod hasher;
 mod pubkey;
 mod traits;
 
@@ -158,6 +159,14 @@ pub fn light_traits_derive(input: TokenStream) -> TokenStream {
 pub fn light_discriminator(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
     discriminator::discriminator(input)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
+}
+
+#[proc_macro_derive(LightHasher, attributes(skip, truncate))]
+pub fn light_hasher(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemStruct);
+    hasher::hasher(input)
         .unwrap_or_else(|err| err.to_compile_error())
         .into()
 }

--- a/macros/light/tests/hasher.rs
+++ b/macros/light/tests/hasher.rs
@@ -1,0 +1,78 @@
+use std::{cell::RefCell, marker::PhantomData, rc::Rc};
+
+use light_hasher::{DataHasher, Poseidon};
+use light_macros::LightHasher;
+
+#[derive(LightHasher)]
+pub struct MyAccount {
+    pub a: bool,
+    pub b: u64,
+    pub c: MyNestedStruct,
+    #[truncate]
+    pub d: [u8; 32],
+    #[skip]
+    pub e: MyNestedNonHashableStruct,
+    pub f: Option<usize>,
+}
+
+#[derive(LightHasher)]
+pub struct MyNestedStruct {
+    pub a: i32,
+    pub b: u32,
+    #[truncate]
+    pub c: String,
+}
+
+pub struct MyNestedNonHashableStruct {
+    pub a: PhantomData<()>,
+    pub b: Rc<RefCell<usize>>,
+}
+
+#[test]
+fn test_light_hasher() {
+    let my_account = MyAccount {
+        a: true,
+        b: u64::MAX,
+        c: MyNestedStruct {
+            a: i32::MIN,
+            b: u32::MAX,
+            c: "wao".to_string(),
+        },
+        d: [u8::MAX; 32],
+        e: MyNestedNonHashableStruct {
+            a: PhantomData,
+            b: Rc::new(RefCell::new(usize::MAX)),
+        },
+        f: None,
+    };
+    assert_eq!(
+        my_account.hash::<Poseidon>().unwrap(),
+        [
+            44, 62, 31, 169, 73, 125, 135, 126, 176, 7, 127, 96, 183, 224, 156, 140, 105, 77, 225,
+            230, 174, 196, 38, 92, 0, 44, 19, 25, 255, 109, 6, 168
+        ]
+    );
+
+    let my_account = MyAccount {
+        a: true,
+        b: u64::MAX,
+        c: MyNestedStruct {
+            a: i32::MIN,
+            b: u32::MAX,
+            c: "wao".to_string(),
+        },
+        d: [u8::MAX; 32],
+        e: MyNestedNonHashableStruct {
+            a: PhantomData,
+            b: Rc::new(RefCell::new(usize::MAX)),
+        },
+        f: Some(0),
+    };
+    assert_eq!(
+        my_account.hash::<Poseidon>().unwrap(),
+        [
+            32, 205, 141, 227, 236, 5, 28, 219, 24, 164, 215, 79, 151, 131, 162, 82, 224, 101, 171,
+            201, 4, 181, 26, 146, 6, 1, 95, 107, 239, 19, 233, 80
+        ]
+    );
+}

--- a/merkle-tree/hasher/Cargo.toml
+++ b/merkle-tree/hasher/Cargo.toml
@@ -18,3 +18,6 @@ thiserror = "1.0"
 ark-bn254 = "0.4.0"
 sha2 = "0.10"
 sha3 = "0.10"
+
+[dev-dependencies]
+rand = "0.8"

--- a/merkle-tree/hasher/src/bytes.rs
+++ b/merkle-tree/hasher/src/bytes.rs
@@ -210,7 +210,79 @@ mod test {
     }
 
     #[test]
+    fn test_as_byte_vec_option() {
+        // Very important property - `None` and `Some(0)` always have to be
+        // different and should produce different hashes!
+        let u8_none: Option<u8> = None;
+        let u8_none: &dyn AsByteVec = &u8_none;
+        assert_eq!(u8_none.as_byte_vec(), &[&[0]]);
+
+        let u8_some_zero: Option<u8> = Some(0);
+        let u8_some_zero: &dyn AsByteVec = &u8_some_zero;
+        assert_eq!(u8_some_zero.as_byte_vec(), &[&[1], &[0]]);
+
+        let u16_none: Option<u16> = None;
+        let u16_none: &dyn AsByteVec = &u16_none;
+        assert_eq!(u16_none.as_byte_vec(), &[&[0]]);
+
+        let u16_some_zero: Option<u16> = Some(0);
+        let u16_some_zero: &dyn AsByteVec = &u16_some_zero;
+        assert_eq!(u16_some_zero.as_byte_vec(), &[&[1][..], &[0, 0][..]]);
+
+        let u32_none: Option<u32> = None;
+        let u32_none: &dyn AsByteVec = &u32_none;
+        assert_eq!(u32_none.as_byte_vec(), &[&[0]]);
+
+        let u32_some_zero: Option<u32> = Some(0);
+        let u32_some_zero: &dyn AsByteVec = &u32_some_zero;
+        assert_eq!(u32_some_zero.as_byte_vec(), &[&[1][..], &[0, 0, 0, 0][..]]);
+
+        let u64_none: Option<u64> = None;
+        let u64_none: &dyn AsByteVec = &u64_none;
+        assert_eq!(u64_none.as_byte_vec(), &[&[0]]);
+
+        let u64_some_zero: Option<u64> = Some(0);
+        let u64_some_zero: &dyn AsByteVec = &u64_some_zero;
+        assert_eq!(
+            u64_some_zero.as_byte_vec(),
+            &[&[1][..], &[0, 0, 0, 0, 0, 0, 0, 0][..]]
+        );
+
+        let u128_none: Option<u128> = None;
+        let u128_none: &dyn AsByteVec = &u128_none;
+        assert_eq!(u128_none.as_byte_vec(), &[&[0]]);
+
+        let u128_some_zero: Option<u128> = Some(0);
+        let u128_some_zero: &dyn AsByteVec = &u128_some_zero;
+        assert_eq!(
+            u128_some_zero.as_byte_vec(),
+            &[
+                &[1][..],
+                &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0][..]
+            ]
+        );
+    }
+
+    #[test]
+    fn test_as_byte_vec_array() {
+        let arr: [u8; 0] = [];
+        let arr: &dyn AsByteVec = &arr;
+        assert_eq!(arr.as_byte_vec(), &[&[]]);
+
+        let arr: [u8; 1] = [255];
+        let arr: &dyn AsByteVec = &arr;
+        assert_eq!(arr.as_byte_vec(), &[&[255]]);
+
+        let arr: [u8; 4] = [255, 255, 255, 255];
+        let arr: &dyn AsByteVec = &arr;
+        assert_eq!(arr.as_byte_vec(), &[&[255, 255, 255, 255]]);
+    }
+
+    #[test]
     fn test_as_byte_vec_string() {
+        let s: &dyn AsByteVec = &"".to_string();
+        assert_eq!(s.as_byte_vec(), &[b""]);
+
         let s: &dyn AsByteVec = &"foobar".to_string();
         assert_eq!(s.as_byte_vec(), &[b"foobar"]);
     }

--- a/merkle-tree/hasher/src/bytes.rs
+++ b/merkle-tree/hasher/src/bytes.rs
@@ -1,0 +1,217 @@
+use std::{mem, slice};
+
+/// A trait providing [`as_byte_vec()`](AsByteVec::as_byte_vec) method for types which
+/// are used inside compressed accounts.
+pub trait AsByteVec {
+    fn as_byte_vec(&self) -> Vec<Vec<u8>>;
+}
+
+macro_rules! impl_as_byte_vec_for_integer_type {
+    ($int_ty:ty) => {
+        impl AsByteVec for $int_ty {
+            fn as_byte_vec(&self) -> Vec<Vec<u8>> {
+                vec![self.to_ne_bytes().to_vec()]
+            }
+        }
+    };
+}
+
+macro_rules! impl_as_byte_vec_for_primitive_type {
+    ($int_ty:ty) => {
+        impl AsByteVec for $int_ty {
+            fn as_byte_vec(&self) -> Vec<Vec<u8>> {
+                let len = mem::size_of_val(self);
+                let self_ptr: *const Self = self;
+                // SAFETY:
+                // - All the primitive types we implement this macro for have
+                //   an exact size (`len`). There is no chance of reads out of
+                //   bounds.
+                // - Casting Rust primitives to bytes works fine, there is no
+                //   chance of undefined behavior.
+                // - Unfortunately, there is no way to achieve the similar
+                //   result with fully safe code. If we tried to do anything
+                //   like `&self.to_ne_bytes()` or `self.to_ne_bytes().as_slice()`,
+                //   compiler would complain with "cannot return reference to
+                //   temporary value".
+                let self_byte_slice = unsafe { slice::from_raw_parts(self_ptr.cast::<u8>(), len) };
+                vec![self_byte_slice.to_vec()]
+            }
+        }
+    };
+}
+
+impl_as_byte_vec_for_integer_type!(i8);
+impl_as_byte_vec_for_integer_type!(u8);
+impl_as_byte_vec_for_integer_type!(i16);
+impl_as_byte_vec_for_integer_type!(u16);
+impl_as_byte_vec_for_integer_type!(i32);
+impl_as_byte_vec_for_integer_type!(u32);
+impl_as_byte_vec_for_integer_type!(i64);
+impl_as_byte_vec_for_integer_type!(u64);
+impl_as_byte_vec_for_integer_type!(isize);
+impl_as_byte_vec_for_integer_type!(usize);
+impl_as_byte_vec_for_integer_type!(i128);
+impl_as_byte_vec_for_integer_type!(u128);
+
+impl_as_byte_vec_for_primitive_type!(bool);
+
+impl<T> AsByteVec for Option<T>
+where
+    T: AsByteVec,
+{
+    fn as_byte_vec(&self) -> Vec<Vec<u8>> {
+        match self {
+            Some(hashable) => {
+                let mut bytes = hashable.as_byte_vec();
+                bytes.reserve(1);
+                bytes.insert(0, vec![1]);
+                bytes
+            }
+            None => vec![vec![0]],
+        }
+    }
+}
+
+impl<const N: usize> AsByteVec for [u8; N] {
+    fn as_byte_vec(&self) -> Vec<Vec<u8>> {
+        vec![self.to_vec()]
+    }
+}
+
+impl AsByteVec for String {
+    fn as_byte_vec(&self) -> Vec<Vec<u8>> {
+        vec![self.as_bytes().to_vec()]
+    }
+}
+
+#[cfg(feature = "solana")]
+impl AsByteVec for solana_program::pubkey::Pubkey {
+    fn as_byte_vec(&self) -> Vec<Vec<u8>> {
+        vec![self.to_bytes().to_vec()]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_as_byte_vec_integers() {
+        let i8_min: &dyn AsByteVec = &i8::MIN;
+        let i8_min_bytes = i8_min.as_byte_vec();
+        assert_eq!(i8_min_bytes, &[&[128]]);
+        assert_eq!(i8_min_bytes, &[i8::MIN.to_ne_bytes()]);
+        let i8_max: &dyn AsByteVec = &i8::MAX;
+        let i8_max_bytes = i8_max.as_byte_vec();
+        assert_eq!(i8_max_bytes, &[&[127]]);
+        assert_eq!(i8_max_bytes, &[i8::MAX.to_ne_bytes()]);
+
+        let u8_min: &dyn AsByteVec = &u8::MIN;
+        let u8_min_bytes = u8_min.as_byte_vec();
+        assert_eq!(u8_min_bytes, &[&[0]]);
+        assert_eq!(u8_min_bytes, &[u8::MIN.to_ne_bytes()]);
+        let u8_max: &dyn AsByteVec = &u8::MAX;
+        let u8_max_bytes = u8_max.as_byte_vec();
+        assert_eq!(u8_max_bytes, &[&[255]]);
+        assert_eq!(u8_max_bytes, &[u8::MAX.to_ne_bytes()]);
+
+        let i16_min: &dyn AsByteVec = &i16::MIN;
+        let i16_min_bytes = i16_min.as_byte_vec();
+        assert_eq!(i16_min_bytes, &[&[0, 128]]);
+        assert_eq!(i16_min_bytes, &[&i16::MIN.to_ne_bytes()]);
+        let i16_max: &dyn AsByteVec = &i16::MAX;
+        let i16_max_bytes = i16_max.as_byte_vec();
+        assert_eq!(i16_max_bytes, &[&[255, 127]]);
+        assert_eq!(i16_max_bytes, &[i16::MAX.to_ne_bytes()]);
+
+        let u16_min: &dyn AsByteVec = &u16::MIN;
+        let u16_min_bytes = u16_min.as_byte_vec();
+        assert_eq!(u16_min_bytes, &[&[0, 0]]);
+        assert_eq!(u16_min_bytes, &[u16::MIN.to_ne_bytes()]);
+        let u16_max: &dyn AsByteVec = &u16::MAX;
+        let u16_max_bytes = u16_max.as_byte_vec();
+        assert_eq!(u16_max_bytes, &[&[255, 255]]);
+        assert_eq!(u16_max_bytes, &[u16::MAX.to_ne_bytes()]);
+
+        let i32_min: &dyn AsByteVec = &i32::MIN;
+        let i32_min_bytes = i32_min.as_byte_vec();
+        assert_eq!(i32_min_bytes, &[&[0, 0, 0, 128]]);
+        assert_eq!(i32_min_bytes, &[i32::MIN.to_ne_bytes()]);
+        let i32_max: &dyn AsByteVec = &i32::MAX;
+        let i32_max_bytes = i32_max.as_byte_vec();
+        assert_eq!(i32_max_bytes, &[&[255, 255, 255, 127]]);
+        assert_eq!(i32_max_bytes, &[i32::MAX.to_ne_bytes()]);
+
+        let u32_min: &dyn AsByteVec = &u32::MIN;
+        let u32_min_bytes = u32_min.as_byte_vec();
+        assert_eq!(u32_min_bytes, &[&[0, 0, 0, 0]]);
+        assert_eq!(u32_min_bytes, &[u32::MIN.to_ne_bytes()]);
+        let u32_max: &dyn AsByteVec = &u32::MAX;
+        let u32_max_bytes = u32_max.as_byte_vec();
+        assert_eq!(u32_max_bytes, &[&[255, 255, 255, 255]]);
+        assert_eq!(u32_max_bytes, &[u32::MAX.to_ne_bytes()]);
+
+        let i64_min: &dyn AsByteVec = &i64::MIN;
+        let i64_min_bytes = i64_min.as_byte_vec();
+        assert_eq!(i64_min_bytes, &[&[0, 0, 0, 0, 0, 0, 0, 128]]);
+        assert_eq!(i64_min_bytes, &[i64::MIN.to_ne_bytes()]);
+        let i64_max: &dyn AsByteVec = &i64::MAX;
+        let i64_max_bytes = i64_max.as_byte_vec();
+        assert_eq!(i64_max_bytes, &[&[255, 255, 255, 255, 255, 255, 255, 127]]);
+        assert_eq!(i64_max_bytes, &[i64::MAX.to_ne_bytes()]);
+
+        let u64_min: &dyn AsByteVec = &u64::MIN;
+        let u64_min_bytes = u64_min.as_byte_vec();
+        assert_eq!(u64_min_bytes, &[[0, 0, 0, 0, 0, 0, 0, 0]]);
+        assert_eq!(i64_min_bytes, &[i64::MIN.to_ne_bytes()]);
+        let u64_max: &dyn AsByteVec = &u64::MAX;
+        let u64_max_bytes = u64_max.as_byte_vec();
+        assert_eq!(u64_max_bytes, &[&[255, 255, 255, 255, 255, 255, 255, 255]]);
+        assert_eq!(u64_max_bytes, &[u64::MAX.to_ne_bytes()]);
+
+        let i128_min: &dyn AsByteVec = &i128::MIN;
+        let i128_min_bytes = i128_min.as_byte_vec();
+        assert_eq!(
+            i128_min_bytes,
+            &[&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128]]
+        );
+        assert_eq!(i128_min_bytes, &[i128::MIN.to_ne_bytes()]);
+        let i128_max: &dyn AsByteVec = &i128::MAX;
+        let i128_max_bytes = i128_max.as_byte_vec();
+        assert_eq!(
+            i128_max_bytes,
+            &[&[255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 127]]
+        );
+        assert_eq!(i128_max_bytes, &[i128::MAX.to_ne_bytes()]);
+
+        let u128_min: &dyn AsByteVec = &u128::MIN;
+        let u128_min_bytes = u128_min.as_byte_vec();
+        assert_eq!(
+            u128_min_bytes,
+            &[&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]
+        );
+        assert_eq!(u128_min_bytes, &[u128::MIN.to_ne_bytes()]);
+        let u128_max: &dyn AsByteVec = &u128::MAX;
+        let u128_max_bytes = u128_max.as_byte_vec();
+        assert_eq!(
+            u128_max_bytes,
+            &[&[255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]]
+        );
+        assert_eq!(u128_max_bytes, &[u128::MAX.to_ne_bytes()]);
+    }
+
+    #[test]
+    fn test_as_byte_vec_primitives() {
+        let bool_false: &dyn AsByteVec = &false;
+        assert_eq!(bool_false.as_byte_vec(), &[&[0]]);
+
+        let bool_true: &dyn AsByteVec = &true;
+        assert_eq!(bool_true.as_byte_vec(), &[&[1]]);
+    }
+
+    #[test]
+    fn test_as_byte_vec_string() {
+        let s: &dyn AsByteVec = &"foobar".to_string();
+        assert_eq!(s.as_byte_vec(), &[b"foobar"]);
+    }
+}

--- a/merkle-tree/hasher/src/lib.rs
+++ b/merkle-tree/hasher/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bytes;
 pub mod errors;
 pub mod keccak;
 pub mod poseidon;


### PR DESCRIPTION
- `AsByteVec`, providing `as_byte_vec()` method, guarantees consistent way of serializing types to 2D byte vectors before hashing. We provide default implementations for primitives. More complex types need to implement `IntoBytes` themselves.
  - By using 2D vectors, we make it possible to represent structs with multiple fields. This way, we can handle struct fields (nested structs) the same way as primitive fields and deal with all types by using one trait.
  - The reason behing using vectors instead of slices is that in some cases, we cannot just cast the type without defining custom bytes. Vectors, although they might introduce copies, make sure we always own the bytes we are creating.
- `#[derive(LightHasher)]` implements `AsByteVec` and `DataHasher` traits. The `DataHasher` implementation takes bytes returned by `AsByteVec` as an input.