### PR TITLE
refactor: forester: unwraps & code structure

### DIFF
--- a/forester/src/pubsub_client.rs
+++ b/forester/src/pubsub_client.rs
@@ -1,0 +1,103 @@
+use crate::errors::ForesterError;
+use crate::queue_helpers::QueueUpdate;
+use crate::ForesterConfig;
+use crate::Result;
+use account_compression::initialize_address_merkle_tree::Pubkey;
+use futures::StreamExt;
+use log::{debug, error};
+use solana_account_decoder::UiAccountEncoding;
+use solana_client::nonblocking::pubsub_client::PubsubClient;
+use solana_client::rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig};
+use solana_sdk::commitment_config::CommitmentConfig;
+use std::str::FromStr;
+use std::thread;
+use tokio::runtime::Builder;
+use tokio::sync::mpsc;
+
+pub async fn setup_pubsub_client(
+    config: &ForesterConfig,
+    queue_pubkeys: std::collections::HashSet<Pubkey>,
+) -> Result<(mpsc::Receiver<QueueUpdate>, mpsc::Sender<()>)> {
+    let (update_tx, update_rx) = mpsc::channel(100);
+    let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+
+    let handle = spawn_pubsub_client(
+        config.external_services.ws_rpc_url.clone(),
+        queue_pubkeys,
+        update_tx,
+        shutdown_rx,
+    );
+
+    tokio::spawn(async move {
+        match handle.join() {
+            Ok(result) => {
+                if let Err(e) = result {
+                    error!("PubSub client error: {:?}", e);
+                }
+            }
+            Err(e) => error!("Failed to join PubSub client thread: {:?}", e),
+        }
+    });
+
+    Ok((update_rx, shutdown_tx))
+}
+
+fn spawn_pubsub_client(
+    ws_url: String,
+    queue_pubkeys: std::collections::HashSet<Pubkey>,
+    update_tx: mpsc::Sender<QueueUpdate>,
+    mut shutdown_rx: mpsc::Receiver<()>,
+) -> thread::JoinHandle<Result<()>> {
+    thread::spawn(move || {
+        let rt = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| ForesterError::Custom(format!("Failed to build runtime: {}", e)))?;
+
+        rt.block_on(async {
+            let pubsub_client = PubsubClient::new(&ws_url).await.map_err(|e| {
+                ForesterError::Custom(format!("Failed to create PubsubClient: {}", e))
+            })?;
+
+            let (mut subscription, _) = pubsub_client
+                .program_subscribe(
+                    &account_compression::id(),
+                    Some(RpcProgramAccountsConfig {
+                        filters: None,
+                        account_config: RpcAccountInfoConfig {
+                            encoding: Some(UiAccountEncoding::Base64),
+                            commitment: Some(CommitmentConfig::confirmed()),
+                            data_slice: None,
+                            min_context_slot: None,
+                        },
+                        with_context: Some(true),
+                    }),
+                )
+                .await
+                .map_err(|e| {
+                    ForesterError::Custom(format!("Failed to subscribe to program: {}", e))
+                })?;
+
+            loop {
+                tokio::select! {
+                    Some(update) = subscription.next() => {
+                        if let Ok(pubkey) = Pubkey::from_str(&update.value.pubkey) {
+                            if queue_pubkeys.contains(&pubkey) && update_tx.send(QueueUpdate {
+                                    pubkey,
+                                    slot: update.context.slot,
+                                }).await.is_err() {
+                                debug!("Failed to send update, receiver might have been dropped");
+                                break;
+                            }
+                        }
+                    }
+                    _ = shutdown_rx.recv() => {
+                        debug!("Received shutdown signal");
+                        break;
+                    }
+                }
+            }
+            Ok(())
+        })
+    })
+}

--- a/forester/src/queue_helpers.rs
+++ b/forester/src/queue_helpers.rs
@@ -1,0 +1,51 @@
+use crate::errors::ForesterError;
+use account_compression::initialize_address_merkle_tree::Pubkey;
+use account_compression::QueueAccount;
+use light_hash_set::HashSet;
+use light_test_utils::rpc::rpc_connection::RpcConnection;
+use log::debug;
+use std::mem;
+
+#[derive(Debug, Clone)]
+pub struct QueueItemData {
+    pub hash: [u8; 32],
+    pub index: usize,
+}
+
+pub async fn fetch_queue_item_data<R: RpcConnection>(
+    rpc: &mut R,
+    queue_pubkey: &Pubkey,
+) -> crate::Result<Vec<QueueItemData>> {
+    debug!("Fetching queue data for {:?}", queue_pubkey);
+    let mut account = rpc
+        .get_account(*queue_pubkey)
+        .await?
+        .ok_or_else(|| ForesterError::Custom("Queue account not found".to_string()))?;
+
+    let nullifier_queue: HashSet = unsafe {
+        HashSet::from_bytes_copy(&mut account.data[8 + mem::size_of::<QueueAccount>()..])?
+    };
+
+    Ok((0..nullifier_queue.capacity)
+        .filter_map(|i| {
+            nullifier_queue.get_bucket(i).and_then(|opt_cell| {
+                opt_cell.as_ref().and_then(|cell| {
+                    if cell.sequence_number.is_none() {
+                        Some(QueueItemData {
+                            hash: cell.value_bytes(),
+                            index: i,
+                        })
+                    } else {
+                        None
+                    }
+                })
+            })
+        })
+        .collect())
+}
+
+#[derive(Debug)]
+pub struct QueueUpdate {
+    pub(crate) pubkey: Pubkey,
+    pub(crate) slot: u64,
+}

--- a/forester/tests/e2e_test.rs
+++ b/forester/tests/e2e_test.rs
@@ -1,4 +1,4 @@
-use forester::epoch_manager::fetch_queue_item_data;
+use forester::queue_helpers::fetch_queue_item_data;
 use forester::rpc_pool::SolanaRpcPool;
 use forester::run_pipeline;
 use forester::utils::LightValidatorConfig;


### PR DESCRIPTION
* Introduced `setup_pubsub_client` for setting up a PubSub client and fetching queue item data. 
* Extracted queue-related logic into a new `queue_helpers` module. 
* Refactored slot waiting logic into utility functions.
* Removed most unwraps in epoch_manager.