### PR TITLE
feat: forester: do not retry on not eligible slots

### DIFF
--- a/forester/src/epoch_manager.rs
+++ b/forester/src/epoch_manager.rs
@@ -811,7 +811,7 @@ impl<R: RpcConnection, I: Indexer<R>> EpochManager<R, I> {
                                 );
                                 return Err(e);
                             }
-                            let delay = BASE_RETRY_DELAY * 2u32.pow(retries as u32);
+                            let delay = BASE_RETRY_DELAY.saturating_mul(2u32.saturating_pow(retries as u32));
                             let jitter = rand::thread_rng().gen_range(0..=50);
                             sleep(delay + Duration::from_millis(jitter)).await;
                             retries += 1;

--- a/forester/src/epoch_manager.rs
+++ b/forester/src/epoch_manager.rs
@@ -811,7 +811,8 @@ impl<R: RpcConnection, I: Indexer<R>> EpochManager<R, I> {
                                 );
                                 return Err(e);
                             }
-                            let delay = BASE_RETRY_DELAY.saturating_mul(2u32.saturating_pow(retries as u32));
+                            let delay = BASE_RETRY_DELAY
+                                .saturating_mul(2u32.saturating_pow(retries as u32));
                             let jitter = rand::thread_rng().gen_range(0..=50);
                             sleep(delay + Duration::from_millis(jitter)).await;
                             retries += 1;

--- a/forester/src/errors.rs
+++ b/forester/src/errors.rs
@@ -12,6 +12,8 @@ use tokio::task::JoinError;
 
 #[derive(Error, Debug)]
 pub enum ForesterError {
+    #[error("Element is not eligible for foresting")]
+    NotEligible,
     #[error("RPC Error: {0}")]
     RpcError(#[from] RpcError),
     #[error("failed to deserialize account data")]
@@ -55,6 +57,7 @@ pub enum ForesterError {
 impl Clone for ForesterError {
     fn clone(&self) -> Self {
         match self {
+            ForesterError::NotEligible => ForesterError::NotEligible,
             ForesterError::RpcError(_) => ForesterError::Custom("RPC Error".to_string()),
             ForesterError::DeserializeError(e) => ForesterError::DeserializeError(e.clone()),
             ForesterError::CopyMerkleTreeError(_) => {
@@ -89,6 +92,7 @@ impl Clone for ForesterError {
 impl ForesterError {
     pub fn to_owned(&self) -> Self {
         match self {
+            ForesterError::NotEligible => ForesterError::NotEligible,
             ForesterError::RpcError(e) => ForesterError::Custom(format!("RPC Error: {:?}", e)),
             ForesterError::DeserializeError(e) => {
                 ForesterError::Custom(format!("Deserialize Error: {:?}", e))


### PR DESCRIPTION
Introduced a new error variant `NotEligible` in `ForesterError`. 
Updated the eligibility check to return this error and handle it appropriately during the transaction processing loop.