### PR TITLE
fix: Rust compilation and clippy errors

### DIFF
--- a/.github/workflows/light-examples-tests.yml
+++ b/.github/workflows/light-examples-tests.yml
@@ -1,0 +1,63 @@
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "examples/**"
+  pull_request:
+    branches:
+      - "*"
+    paths:
+      - "examples/**"
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+name: examples-tests
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  system-programs:
+    name: system-programs
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        include:
+          - program: token-escrow-test
+            sub-tests: '[
+              "cargo test-sbf -p token-escrow -- --test-threads=1"
+            ]'
+          - program: name-service-test
+            sub-tests: '[
+              "cargo test-sbf -p name-service -- --test-threads=1"
+            ]'
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup and build
+        uses: ./.github/actions/setup-and-build
+
+      - name: build-programs
+        run: |
+          source ./scripts/devenv.sh
+          anchor build
+
+      - name: ${{ matrix.program }}
+        run: |
+          source ./scripts/devenv.sh
+          
+          IFS=',' read -r -a sub_tests <<< "${{ join(fromJSON(matrix['sub-tests']), ', ') }}"
+          for subtest in "${sub_tests[@]}"
+          do
+            echo "$subtest"
+            eval "RUSTFLAGS=\"-D warnings\" $subtest"
+          done

--- a/examples/name-service/programs/name-service/src/lib.rs
+++ b/examples/name-service/programs/name-service/src/lib.rs
@@ -2,7 +2,7 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 
 use anchor_lang::{prelude::*, solana_program::hash};
 use borsh::{BorshDeserialize, BorshSerialize};
-use light_hasher::{bytes::AsByteVec, errors::HasherError, DataHasher, Discriminator, Poseidon};
+use light_hasher::{bytes::AsByteVec, DataHasher, Discriminator, Poseidon};
 use light_sdk::{
     light_accounts,
     merkle_context::{PackedAddressMerkleContext, PackedMerkleContext, PackedMerkleOutputContext},
@@ -28,6 +28,7 @@ declare_id!("7yucc7fL3JGbyMwg4neUaenNSdySS39hbAk89Ao3t1Hz");
 pub mod name_service {
     use super::*;
 
+    #[allow(clippy::too_many_arguments)]
     pub fn create_record<'info>(
         ctx: Context<'_, '_, '_, 'info, NameService<'info>>,
         proof: CompressedProof,
@@ -71,6 +72,7 @@ pub mod name_service {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn update_record<'info>(
         ctx: Context<'_, '_, '_, 'info, NameService<'info>>,
         proof: CompressedProof,
@@ -127,6 +129,7 @@ pub mod name_service {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn delete_record<'info>(
         ctx: Context<'_, '_, '_, 'info, NameService<'info>>,
         proof: CompressedProof,

--- a/examples/name-service/programs/name-service/tests/test.rs
+++ b/examples/name-service/programs/name-service/tests/test.rs
@@ -137,7 +137,7 @@ async fn create_record<R: RpcConnection>(
         )
         .await;
 
-    let mut remaining_accounts = RemainingAccounts::new();
+    let mut remaining_accounts = RemainingAccounts::default();
 
     let merkle_output_context = MerkleOutputContext {
         merkle_tree_pubkey: env.merkle_tree_pubkey,
@@ -210,7 +210,7 @@ async fn update_record<R: RpcConnection>(
         )
         .await;
 
-    let mut remaining_accounts = RemainingAccounts::new();
+    let mut remaining_accounts = RemainingAccounts::default();
 
     let merkle_context =
         pack_merkle_context(compressed_account.merkle_context, &mut remaining_accounts);
@@ -273,7 +273,7 @@ async fn delete_record<R: RpcConnection>(
         )
         .await;
 
-    let mut remaining_accounts = RemainingAccounts::new();
+    let mut remaining_accounts = RemainingAccounts::default();
 
     let merkle_context =
         pack_merkle_context(compressed_account.merkle_context, &mut remaining_accounts);

--- a/sdk/src/merkle_context.rs
+++ b/sdk/src/merkle_context.rs
@@ -6,19 +6,13 @@ use anchor_lang::prelude::{AccountMeta, AnchorDeserialize, AnchorSerialize, Pubk
 pub use light_system_program::sdk::compressed_account::{MerkleContext, PackedMerkleContext};
 
 /// Collection of remaining accounts which are sent to the program.
+#[derive(Default)]
 pub struct RemainingAccounts {
     next_index: u8,
     map: HashMap<Pubkey, u8>,
 }
 
 impl RemainingAccounts {
-    pub fn new() -> Self {
-        Self {
-            next_index: 0,
-            map: HashMap::new(),
-        }
-    }
-
     /// Returns the index of the provided `pubkey` in the collection.
     ///
     /// If the provided `pubkey` is not a part of the collection, it gets


### PR DESCRIPTION
- Remove unused import (`errors::HasherError`).
- Allow `clippy::too_many_arguments`.
- Remove `RemainingAccounts::new()` - we can just `#[derive(Default)]` and instantiate with `RemainingAccounts::default()`.