### PR TITLE
feat: Add `#[light_account]` macro

### DIFF
--- a/examples/name-service/programs/name-service/src/lib.rs
+++ b/examples/name-service/programs/name-service/src/lib.rs
@@ -4,11 +4,11 @@ use anchor_lang::{prelude::*, solana_program::hash};
 use borsh::{BorshDeserialize, BorshSerialize};
 use light_hasher::{bytes::AsByteVec, DataHasher, Discriminator, Poseidon};
 use light_sdk::{
-    light_accounts,
+    light_account, light_accounts,
     merkle_context::{PackedAddressMerkleContext, PackedMerkleContext, PackedMerkleOutputContext},
     utils::create_cpi_inputs_for_new_address,
     verify::verify,
-    LightDiscriminator, LightHasher, LightTraits,
+    LightTraits,
 };
 use light_system_program::{
     invoke::processor::CompressedProof,
@@ -193,7 +193,8 @@ impl AsByteVec for RData {
     }
 }
 
-#[derive(Debug, BorshDeserialize, BorshSerialize, LightDiscriminator, LightHasher)]
+#[light_account]
+#[derive(Debug)]
 pub struct NameRecord {
     #[truncate]
     pub owner: Pubkey,

--- a/macros/light/src/account.rs
+++ b/macros/light/src/account.rs
@@ -1,0 +1,15 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{ItemStruct, Result};
+
+pub(crate) fn account(input: ItemStruct) -> Result<TokenStream> {
+    Ok(quote! {
+        #[derive(
+            ::anchor_lang::AnchorDeserialize,
+            ::anchor_lang::AnchorSerialize,
+            ::light_sdk::LightDiscriminator,
+            ::light_sdk::LightHasher,
+        )]
+        #input
+    })
+}

--- a/macros/light/src/lib.rs
+++ b/macros/light/src/lib.rs
@@ -5,6 +5,7 @@ use quote::quote;
 use syn::{parse_macro_input, parse_quote, DeriveInput, ItemFn, ItemStruct};
 use traits::process_light_traits;
 
+mod account;
 mod accounts;
 mod discriminator;
 mod hasher;
@@ -275,6 +276,14 @@ pub fn light_discriminator(input: TokenStream) -> TokenStream {
 pub fn light_hasher(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
     hasher::hasher(input)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
+}
+
+#[proc_macro_attribute]
+pub fn light_account(_: TokenStream, input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemStruct);
+    account::account(input)
         .unwrap_or_else(|err| err.to_compile_error())
         .into()
 }


### PR DESCRIPTION
That macro implements all traits necessary for compressed accounts, which inclides:

- `AnchorDeserialize`
- `AnchorSerialize`
- `LightDiscriminator`
- `LightHasher`