### PR TITLE
chore: update install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If you still want to setup dependencies manually, these are the requirements:
 If you are using Ubuntu and encounter errors during the build process, you may need to install additional dependencies. Use the following command:
 
 ```
-sudo apt-get install build-essential autoconf automake libtool zlib1g-dev
+sudo apt install build-essential autoconf automake libtool zlib1g-dev pkg-config libssl-dev
 ```
 
 ## Building

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -95,9 +95,9 @@ install_go() {
 install_rust() {
     if ! is_installed "rust"; then
         echo "Installing Rust..."
-        curl -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
         export RUSTUP_HOME="${PREFIX}/rustup"
         export CARGO_HOME="${PREFIX}/cargo"
+        curl --retry 5 --retry-delay 10 --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path        
         export PATH="${PREFIX}/cargo/bin:${PATH}"
         rustup component add clippy rustfmt
         cargo install cargo-expand wasm-pack


### PR DESCRIPTION
We should export RUSTUP_HOME & CARGO_HOME env vars before installation, otherwise cargo & rustup will be installed to the default path.