### PR TITLE
fix(macros): Don't include original type size when `size` attribute is used

### DIFF
--- a/macros/aligned-sized/src/expand.rs
+++ b/macros/aligned-sized/src/expand.rs
@@ -66,6 +66,7 @@ pub(crate) fn aligned_sized(args: AlignedSizedArgs, strct: ItemStruct) -> Result
         // consuming it.
         let mut attrs = Vec::with_capacity(field.attrs.len());
 
+        let mut include_type_size = true;
         // Iterate over attributes.
         for attr in field.attrs.iter() {
             // Check the type of attribute. We look for meta name attribute
@@ -77,6 +78,7 @@ pub(crate) fn aligned_sized(args: AlignedSizedArgs, strct: ItemStruct) -> Result
                     if name_value.path.is_ident("size") {
                         let value = name_value.value;
                         field_size_getters.push(quote! { #value });
+                        include_type_size = false;
 
                         // Go to the next attribute. Do not include this one.
                         continue;
@@ -89,8 +91,10 @@ pub(crate) fn aligned_sized(args: AlignedSizedArgs, strct: ItemStruct) -> Result
             }
         }
 
-        let ty = field.clone().ty;
-        field_size_getters.push(quote! { ::core::mem::size_of::<#ty>() });
+        if include_type_size {
+            let ty = field.clone().ty;
+            field_size_getters.push(quote! { ::core::mem::size_of::<#ty>() });
+        }
 
         let field = Field {
             attrs,

--- a/macros/aligned-sized/tests/test.rs
+++ b/macros/aligned-sized/tests/test.rs
@@ -1,0 +1,56 @@
+use std::mem;
+
+use aligned_sized::aligned_sized;
+
+#[aligned_sized]
+#[derive(Debug)]
+#[allow(dead_code)]
+struct TestStruct {
+    pub a: u64,
+    pub b: u32,
+    pub c: i32,
+    pub d: TestStructNested,
+}
+
+#[aligned_sized]
+#[derive(Debug)]
+#[allow(dead_code)]
+struct TestStructNested {
+    pub e: usize,
+    pub f: isize,
+}
+
+#[test]
+fn test_aligned_sized() {
+    let expected_size =
+        // a
+        mem::size_of::<u64>()
+        // b
+        + mem::size_of::<u32>()
+        // c
+        + mem::size_of::<i32>()
+        // e
+        + mem::size_of::<usize>()
+        // f
+        + mem::size_of::<isize>();
+    assert_eq!(TestStruct::LEN, expected_size);
+}
+
+#[aligned_sized]
+#[derive(Debug)]
+#[allow(dead_code)]
+struct TestStructWithDefinedSize {
+    pub a: u64,
+    #[size = 50]
+    pub b: Vec<u8>,
+}
+
+#[test]
+fn test_aligned_sized_defined_size() {
+    let expected_size =
+        // a
+        mem::size_of::<u64>()
+        // b
+        + 50;
+    assert_eq!(TestStructWithDefinedSize::LEN, expected_size);
+}


### PR DESCRIPTION
Before this change, `#[aligned_sized]` macro was still including the size of the original type even on fields using the `size` attribute.

That was an incorrect behavior. The intention of the `size` attribute is usage for vectors, or other heap-backed types, which we want to serialize in Solana accounts. Therefore, providing an arbitrary size is necessary.