### PR TITLE
chore: release 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3568,7 +3568,7 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-std",
- "borsh 0.9.3",
+ "borsh 0.10.3",
  "bytemuck",
  "color-eyre",
  "duct",
@@ -5877,8 +5877,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4185d569c062983fc2a618ae4ee6fe1a139b36bce7a25045647c49bf0020a53"
 dependencies = [
  "Inflector",
  "base64 0.21.7",
@@ -5901,8 +5902,9 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c156ddd42a2746e14fe267f85a2f802567dfa7c1702836b0ce69ea3be15a3c3"
 dependencies = [
  "arrayref",
  "bincode",
@@ -5961,8 +5963,9 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f5967c234aa8281f36999ded250403ddacb77863e2a1e157a3203884a13cfa"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -5981,8 +5984,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78204433cdb1945ef3622905f806423f5536cc91205dc8e325efe521394d3ca"
 dependencies = [
  "borsh 1.4.0",
  "futures 0.3.30",
@@ -5997,8 +6001,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f959539e11afaa554c0ae445bb3c726ad658aa33d8b577b76ab7e0ad6e313405"
 dependencies = [
  "serde",
  "solana-sdk",
@@ -6007,8 +6012,9 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5224477dc90857c98bec8ff746926facf525e0216fdfbde51e28d92d5b11b236"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -6026,8 +6032,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aadccb11676cb4f77d26a929293366048b2589e0ce135f29b4b1d4ac0a944e3"
 dependencies = [
  "bv",
  "fnv",
@@ -6044,8 +6051,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfab3aa028e4feac760f28e7fb24760813d451e7cff5a13584509ddab4a94311"
 dependencies = [
  "bincode",
  "byteorder",
@@ -6062,8 +6070,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06f781213cf76d8840e688d52fbc3876ae8522d2ac594c1c11ab9b982d7f0336"
 dependencies = [
  "bv",
  "bytemuck",
@@ -6079,8 +6088,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c817832e71886dbea877d1aa911c9ce2e984a39081bb56ee30d4c835567827a6"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -6095,8 +6105,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3d0ab58e2a883f36082c736fec6e6d5872dc902c3b2cc960ed67d8eaf8994d"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -6110,8 +6121,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a398964bb920e7606a8c4b2c01cb6d394ab9b5eb8a6f214fcdc7c5f90f470f36"
 dependencies = [
  "Inflector",
  "base64 0.21.7",
@@ -6136,8 +6148,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fa9cc6e8e59adf70acbf5cac21342ae8b5e41cbf05519fe5f6287e84ab40f63"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6168,8 +6181,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b176bad40620d1c443365daf24e19fbfccafe8daff60eb3ddd6cbd9cf0fbec58"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk",
@@ -6177,8 +6191,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d02fb29934427f1487d2149fe8bcb405306729b2f22a2ad616bb8ffd024cee7b"
 dependencies = [
  "bincode",
  "chrono",
@@ -6190,8 +6205,9 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e5a2e26448b3e04ce673794994ff27f3972ec8a806c224eccc02e09f751ca5"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6211,8 +6227,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4564996ef9f2983efeedb14a38315fa606d3d2cc0a2c8d899c507c5893fe79"
 dependencies = [
  "lazy_static",
  "log",
@@ -6234,8 +6251,9 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba386267f01dd5705cdefc5beb7130ec8e6c46d1f7b724010ef50d9f42310f7"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -6255,8 +6273,9 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9a4ff234ab4eb241f21b116400ffadd1499f292af1e3b9a09b508b4bd4f407e"
 dependencies = [
  "bincode",
  "byteorder",
@@ -6278,8 +6297,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a6ef2db80dceb124b7bf81cca3300804bf427d2711973fc3df450ed7dfb26d"
 dependencies = [
  "block-buffer 0.10.4",
  "bs58 0.4.0",
@@ -6302,8 +6322,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70088de7d4067d19a7455609e2b393e6086bd847bb39c4d2bf234fc14827ef9e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6313,8 +6334,9 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95395de72ae9e470b16bf532f95688ff366ed0b9a3f7c3cf839db8a9ce3cdc3f"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6362,8 +6384,9 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1979b6d6f8fbf865c5d3aa4b2f4e330ad8af3764bdc62ba7a6707ef11be7d02"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6428,8 +6451,9 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fde1ab49eb031882f4803bf5a8008dca84356717e120ba9276d229ff24633c"
 dependencies = [
  "log",
  "solana-measure",
@@ -6440,8 +6464,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b129da15193f26db62d62ae6bb9f72361f361bcdc36054be3ab8bc04cc7a4f31"
 dependencies = [
  "env_logger 0.9.3",
  "lazy_static",
@@ -6450,8 +6475,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d195b73093a4964ba6b5943418054a5fcbba23eafdd0842fd973fcceac1a967"
 dependencies = [
  "log",
  "solana-sdk",
@@ -6459,8 +6485,9 @@ dependencies = [
 
 [[package]]
 name = "solana-merkle-tree"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db1311f011af0e6f0fc738bc00a5a8752582c460a1a32a6644614525b568bda9"
 dependencies = [
  "fast-math",
  "solana-program",
@@ -6468,8 +6495,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7b06860ffbf4cf4714182e1b7eb00eb3ff0bcc9cff615d05e01e488923883c"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -6482,8 +6510,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9400b50b8439868a99b5fa2d961d74e37b7a6c1d5865759d0b1c906c2ad6b2a9"
 dependencies = [
  "bincode",
  "clap 3.2.25",
@@ -6509,8 +6538,9 @@ checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
 
 [[package]]
 name = "solana-perf"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b01a386e852df67031195094628851b8d239dd71fe17b721c3993277e68cb3ab"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -6537,8 +6567,9 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8ee2972639da87ad3190fb2bc28092260af5f1e3d6d58ac50df8486d774bce7"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -6554,8 +6585,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb2b2c8babfae4cace1a25b6efa00418f3acd852cf55d7cecc0360d3c5050479"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -6608,8 +6640,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0444f9440f4459d377c41470b2eb48b527def81f3052b7a121f6aa8c7350cc52"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -6635,8 +6668,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c76274336971f37dbbd3508aaaa4c98ca0061abd31fb309ad1c6ad132f0c6c0e"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -6664,8 +6698,9 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee4a39e41e789b6f100c97d9f40c1d08381bf6e3d0e351065e542091cddb039"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -6688,8 +6723,9 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baad755c76ee0aab8890f0ef873e61b8b3012c523d33bfa5b062fe9be8cef370"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -6714,8 +6750,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c2a0ccb0be7ca79e8ff0d7c786bce586433a5687ffbea522453d0b41c4bf4a"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -6723,8 +6760,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d042a812537e3507e1c163c7573fc04c96e12d3eba512e3fe74c7393229fa39"
 dependencies = [
  "console",
  "dialoguer",
@@ -6741,8 +6779,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9bf44b110c15790d97760875a4d97f05a7c0b183410c2899dcdff229ffe8f4c"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -6797,8 +6836,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c6f5560283bd0a6833d1bd816299785058a870fff51b0df399fdb3ce92c8484"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -6822,8 +6862,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4ca77f89caa9071acadb1eed19c28a6691fd63d0563ed927c96bf734cf1c9c"
 dependencies = [
  "base64 0.21.7",
  "bs58 0.4.0",
@@ -6843,8 +6884,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a6ea9ad81d63f18fb8b3a9b39643cc43eaf909199d67037e724562301d1df7"
 dependencies = [
  "clap 2.34.0",
  "solana-clap-utils",
@@ -6855,8 +6897,9 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b50b29b6f5938d2c9b151e9187d4687ca9c26be2c6ebe53ba34826283441"
 dependencies = [
  "aquamarine",
  "arrayref",
@@ -6931,8 +6974,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e0f0def5c5af07f53d321cea7b104487b522cfff77c3cae3da361bfe956e9e"
 dependencies = [
  "assert_matches",
  "base64 0.21.7",
@@ -6985,8 +7029,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55c196c8050834c391a34b58e3c9fd86b15452ef1feeeafa1dbeb9d2291dfec"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2",
@@ -7003,8 +7048,9 @@ checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c5fc9df712efd671a5a5b68e58a448dc13b70f59ef16bdd0e8d644813eb67a"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -7018,8 +7064,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624f6d0c84c19a17bf882259303e99e1ed2562a0316c989f847a067aa99d4940"
 dependencies = [
  "bincode",
  "log",
@@ -7032,8 +7079,9 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c7205397d7453c9a5a432a775d0a1da06f6affe8be69d0b7cacf0c2bf93be52"
 dependencies = [
  "backoff",
  "bincode",
@@ -7065,8 +7113,9 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c28da494fc80ee8506f6397ec5e49d84679cb76fdbc1897dc00c3c275210fd2"
 dependencies = [
  "bincode",
  "bs58 0.4.0",
@@ -7081,8 +7130,9 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "749720d82c5f31f7ec326da1e0baac098201de70f0874719172a55309433b449"
 dependencies = [
  "async-channel",
  "bytes",
@@ -7113,8 +7163,9 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a449f40a516a8e83dcc2ce07643bb3feec4da690f170d438849af06c503cc28"
 dependencies = [
  "bincode",
  "log",
@@ -7126,8 +7177,9 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84535de1253afb6ccc4ae6852eb013ca734c439a902ec5e4684b90ed649a37c2"
 dependencies = [
  "bincode",
  "log",
@@ -7140,8 +7192,9 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff514462bb715aaea9bc5c0ee60f83ab3f91e04279337c6b07d054153b616dc"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7163,8 +7216,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670e387049812d42bdc8fcc4ff75452ff3cb00657af979a90f55f6d37dba9dd9"
 dependencies = [
  "Inflector",
  "base64 0.21.7",
@@ -7187,8 +7241,9 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11183dae826f942ebd0401712c8a52367a4a6312f1cd325f304cd9551226fc8b"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -7201,8 +7256,9 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d518e61ce22c812df23d9c61ab9bcbef4df3e3d3dcaa74a999625f11bcf07"
 dependencies = [
  "log",
  "rustc_version",
@@ -7216,8 +7272,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae2a4908ac4df02a4adb78f09fe938b31c75f42ba64401b8ac88193eb446943"
 dependencies = [
  "crossbeam-channel",
  "itertools",
@@ -7234,8 +7291,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5743503143fb2259c41a973a78e9aeeb8e21f1b03543c3bb85449926ea692719"
 dependencies = [
  "bincode",
  "log",
@@ -7255,8 +7313,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5813dc267bea898ff40d3bd662a0a7659170dd19ae5e7c46e8dc0a414a205868"
 dependencies = [
  "bytemuck",
  "num-derive 0.4.2",
@@ -7268,8 +7327,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.18.17"
-source = "git+https://github.com/lightprotocol/agave?branch=v1.18.17-enforce-cpi-tracking#0263904bacd75b6e9d012346bf0f75fa8be8aaad"
+version = "1.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ee07fa523b4cfcff68de774db7aa87d2da2c4357155a90bacd9a0a0af70a99"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.7",
@@ -7296,9 +7356,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d457cc2ba742c120492a64b7fa60e22c575e891f6b55039f4d736568fb112a3"
+checksum = "da5d083187e3b3f453e140f292c09186881da8a02a7b5e27f645ee26de3d9cc5"
 dependencies = [
  "byteorder",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,15 +31,15 @@ overflow-checks = true
 opt-level = 2
 
 [workspace.dependencies]
-solana-banks-interface = "=1.18.17"
-solana-program = "=1.18.17"
-solana-sdk = "=1.18.17"
-solana-program-test = "=1.18.17"
-solana-client = "=1.18.17"
-solana-cli-output = "=1.18.17"
-solana-transaction-status = "=1.18.17"
-solana-account-decoder = "=1.18.17"
-solana-rpc = "=1.18.17"
+solana-banks-interface = "=1.18.22"
+solana-program = "=1.18.22"
+solana-sdk = "=1.18.22"
+solana-program-test = "=1.18.22"
+solana-client = "=1.18.22"
+solana-cli-output = "=1.18.22"
+solana-transaction-status = "=1.18.22"
+solana-account-decoder = "=1.18.22"
+solana-rpc = "=1.18.22"
 
 anchor-lang = "=0.29.0"
 anchor-spl = "=0.29.0"
@@ -51,25 +51,3 @@ quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
 
 tokio = { version = "1.39.1", features = ["rt", "macros", "rt-multi-thread"] }
-
-[patch.crates-io]
-"solana-account-decoder" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-accounts-db" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-banks-client" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-banks-interface" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-banks-server" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-program" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-cli-output" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-program-test" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-program-runtime" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-rpc" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-rpc-client" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-rpc-client-api" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-runtime" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-sdk" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-sdk-macro" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-client" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-zk-token-sdk" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-frozen-abi" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-frozen-abi-macro" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }
-"solana-transaction-status" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.17-enforce-cpi-tracking" }

--- a/examples/name-service/programs/name-service/Cargo.toml
+++ b/examples/name-service/programs/name-service/Cargo.toml
@@ -34,9 +34,9 @@ light-utils = { path = "../../../../utils", version = "0.4.2" }
 light-verifier = { path = "../../../../circuit-lib/verifier", version = "0.4.2" }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
-solana-sdk = "1.18.11"
+solana-sdk = { workspace = true }
 
 [dev-dependencies]
 light-test-utils = { path = "../../../../test-utils", version = "0.4.2" }
-solana-program-test = "1.18.11"
+solana-program-test = { workspace = true }
 tokio = "1.36.0"

--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -1,5 +1,5 @@
 export type LightCompressedToken = {
-    version: '0.5.0';
+    version: '0.6.2';
     name: 'light_compressed_token';
     instructions: [
         {
@@ -1555,28 +1555,133 @@ export type LightCompressedToken = {
     errors: [
         {
             code: 6000;
-            name: 'SignerCheckFailed';
-            msg: 'Signer check failed';
+            name: 'PublicKeyAmountMissmatch';
+            msg: 'public keys and amounts must be of same length';
         },
         {
             code: 6001;
-            name: 'CreateTransferInstructionFailed';
-            msg: 'Create transfer instruction failed';
+            name: 'ComputeInputSumFailed';
+            msg: 'ComputeInputSumFailed';
         },
         {
             code: 6002;
-            name: 'AccountNotFound';
-            msg: 'Account not found';
+            name: 'ComputeOutputSumFailed';
+            msg: 'ComputeOutputSumFailed';
         },
         {
             code: 6003;
-            name: 'SerializationError';
-            msg: 'Serialization error';
+            name: 'ComputeCompressSumFailed';
+            msg: 'ComputeCompressSumFailed';
+        },
+        {
+            code: 6004;
+            name: 'ComputeDecompressSumFailed';
+            msg: 'ComputeDecompressSumFailed';
+        },
+        {
+            code: 6005;
+            name: 'SumCheckFailed';
+            msg: 'SumCheckFailed';
+        },
+        {
+            code: 6006;
+            name: 'DecompressRecipientUndefinedForDecompress';
+            msg: 'DecompressRecipientUndefinedForDecompress';
+        },
+        {
+            code: 6007;
+            name: 'CompressedPdaUndefinedForDecompress';
+            msg: 'CompressedPdaUndefinedForDecompress';
+        },
+        {
+            code: 6008;
+            name: 'DeCompressAmountUndefinedForDecompress';
+            msg: 'DeCompressAmountUndefinedForDecompress';
+        },
+        {
+            code: 6009;
+            name: 'CompressedPdaUndefinedForCompress';
+            msg: 'CompressedPdaUndefinedForCompress';
+        },
+        {
+            code: 6010;
+            name: 'DeCompressAmountUndefinedForCompress';
+            msg: 'DeCompressAmountUndefinedForCompress';
+        },
+        {
+            code: 6011;
+            name: 'DelegateSignerCheckFailed';
+            msg: 'DelegateSignerCheckFailed';
+        },
+        {
+            code: 6012;
+            name: 'MintTooLarge';
+            msg: 'Minted amount greater than u64::MAX';
+        },
+        {
+            code: 6013;
+            name: 'SplTokenSupplyMismatch';
+            msg: 'SplTokenSupplyMismatch';
+        },
+        {
+            code: 6014;
+            name: 'HeapMemoryCheckFailed';
+            msg: 'HeapMemoryCheckFailed';
+        },
+        {
+            code: 6015;
+            name: 'InstructionNotCallable';
+            msg: 'The instruction is not callable';
+        },
+        {
+            code: 6016;
+            name: 'ArithmeticUnderflow';
+            msg: 'ArithmeticUnderflow';
+        },
+        {
+            code: 6017;
+            name: 'HashToFieldError';
+            msg: 'HashToFieldError';
+        },
+        {
+            code: 6018;
+            name: 'InvalidAuthorityMint';
+            msg: 'Expected the authority to be also a mint authority';
+        },
+        {
+            code: 6019;
+            name: 'InvalidFreezeAuthority';
+            msg: 'Provided authority is not the freeze authority';
+        },
+        {
+            code: 6020;
+            name: 'InvalidDelegateIndex';
+        },
+        {
+            code: 6021;
+            name: 'TokenPoolPdaUndefined';
+        },
+        {
+            code: 6022;
+            name: 'IsTokenPoolPda';
+            msg: 'Compress or decompress recipient is the same account as the token pool pda.';
+        },
+        {
+            code: 6023;
+            name: 'InvalidTokenPoolPda';
+        },
+        {
+            code: 6024;
+            name: 'NoInputTokenAccountsProvided';
+        },
+        {
+            code: 6025;
+            name: 'NoInputsProvided';
         },
     ];
 };
 export const IDL: LightCompressedToken = {
-    version: '0.5.0',
+    version: '0.6.2',
     name: 'light_compressed_token',
     instructions: [
         {
@@ -3137,23 +3242,128 @@ export const IDL: LightCompressedToken = {
     errors: [
         {
             code: 6000,
-            name: 'SignerCheckFailed',
-            msg: 'Signer check failed',
+            name: 'PublicKeyAmountMissmatch',
+            msg: 'public keys and amounts must be of same length',
         },
         {
             code: 6001,
-            name: 'CreateTransferInstructionFailed',
-            msg: 'Create transfer instruction failed',
+            name: 'ComputeInputSumFailed',
+            msg: 'ComputeInputSumFailed',
         },
         {
             code: 6002,
-            name: 'AccountNotFound',
-            msg: 'Account not found',
+            name: 'ComputeOutputSumFailed',
+            msg: 'ComputeOutputSumFailed',
         },
         {
             code: 6003,
-            name: 'SerializationError',
-            msg: 'Serialization error',
+            name: 'ComputeCompressSumFailed',
+            msg: 'ComputeCompressSumFailed',
+        },
+        {
+            code: 6004,
+            name: 'ComputeDecompressSumFailed',
+            msg: 'ComputeDecompressSumFailed',
+        },
+        {
+            code: 6005,
+            name: 'SumCheckFailed',
+            msg: 'SumCheckFailed',
+        },
+        {
+            code: 6006,
+            name: 'DecompressRecipientUndefinedForDecompress',
+            msg: 'DecompressRecipientUndefinedForDecompress',
+        },
+        {
+            code: 6007,
+            name: 'CompressedPdaUndefinedForDecompress',
+            msg: 'CompressedPdaUndefinedForDecompress',
+        },
+        {
+            code: 6008,
+            name: 'DeCompressAmountUndefinedForDecompress',
+            msg: 'DeCompressAmountUndefinedForDecompress',
+        },
+        {
+            code: 6009,
+            name: 'CompressedPdaUndefinedForCompress',
+            msg: 'CompressedPdaUndefinedForCompress',
+        },
+        {
+            code: 6010,
+            name: 'DeCompressAmountUndefinedForCompress',
+            msg: 'DeCompressAmountUndefinedForCompress',
+        },
+        {
+            code: 6011,
+            name: 'DelegateSignerCheckFailed',
+            msg: 'DelegateSignerCheckFailed',
+        },
+        {
+            code: 6012,
+            name: 'MintTooLarge',
+            msg: 'Minted amount greater than u64::MAX',
+        },
+        {
+            code: 6013,
+            name: 'SplTokenSupplyMismatch',
+            msg: 'SplTokenSupplyMismatch',
+        },
+        {
+            code: 6014,
+            name: 'HeapMemoryCheckFailed',
+            msg: 'HeapMemoryCheckFailed',
+        },
+        {
+            code: 6015,
+            name: 'InstructionNotCallable',
+            msg: 'The instruction is not callable',
+        },
+        {
+            code: 6016,
+            name: 'ArithmeticUnderflow',
+            msg: 'ArithmeticUnderflow',
+        },
+        {
+            code: 6017,
+            name: 'HashToFieldError',
+            msg: 'HashToFieldError',
+        },
+        {
+            code: 6018,
+            name: 'InvalidAuthorityMint',
+            msg: 'Expected the authority to be also a mint authority',
+        },
+        {
+            code: 6019,
+            name: 'InvalidFreezeAuthority',
+            msg: 'Provided authority is not the freeze authority',
+        },
+        {
+            code: 6020,
+            name: 'InvalidDelegateIndex',
+        },
+        {
+            code: 6021,
+            name: 'TokenPoolPdaUndefined',
+        },
+        {
+            code: 6022,
+            name: 'IsTokenPoolPda',
+            msg: 'Compress or decompress recipient is the same account as the token pool pda.',
+        },
+        {
+            code: 6023,
+            name: 'InvalidTokenPoolPda',
+        },
+        {
+            code: 6024,
+            name: 'NoInputTokenAccountsProvided',
+        },
+        {
+            code: 6025,
+            name: 'NoInputsProvided',
         },
     ],
 };

--- a/js/stateless.js/src/idls/account_compression.ts
+++ b/js/stateless.js/src/idls/account_compression.ts
@@ -1,5 +1,5 @@
 export type AccountCompression = {
-    version: '0.5.0';
+    version: '0.6.2';
     name: 'account_compression';
     constants: [
         {
@@ -1165,7 +1165,7 @@ export type AccountCompression = {
 };
 
 export const IDL: AccountCompression = {
-    version: '0.5.0',
+    version: '0.6.2',
     name: 'account_compression',
     constants: [
         {

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -1,5 +1,5 @@
 export type LightCompressedToken = {
-    version: '0.5.0';
+    version: '0.6.2';
     name: 'light_compressed_token';
     instructions: [
         {
@@ -1555,28 +1555,133 @@ export type LightCompressedToken = {
     errors: [
         {
             code: 6000;
-            name: 'SignerCheckFailed';
-            msg: 'Signer check failed';
+            name: 'PublicKeyAmountMissmatch';
+            msg: 'public keys and amounts must be of same length';
         },
         {
             code: 6001;
-            name: 'CreateTransferInstructionFailed';
-            msg: 'Create transfer instruction failed';
+            name: 'ComputeInputSumFailed';
+            msg: 'ComputeInputSumFailed';
         },
         {
             code: 6002;
-            name: 'AccountNotFound';
-            msg: 'Account not found';
+            name: 'ComputeOutputSumFailed';
+            msg: 'ComputeOutputSumFailed';
         },
         {
             code: 6003;
-            name: 'SerializationError';
-            msg: 'Serialization error';
+            name: 'ComputeCompressSumFailed';
+            msg: 'ComputeCompressSumFailed';
+        },
+        {
+            code: 6004;
+            name: 'ComputeDecompressSumFailed';
+            msg: 'ComputeDecompressSumFailed';
+        },
+        {
+            code: 6005;
+            name: 'SumCheckFailed';
+            msg: 'SumCheckFailed';
+        },
+        {
+            code: 6006;
+            name: 'DecompressRecipientUndefinedForDecompress';
+            msg: 'DecompressRecipientUndefinedForDecompress';
+        },
+        {
+            code: 6007;
+            name: 'CompressedPdaUndefinedForDecompress';
+            msg: 'CompressedPdaUndefinedForDecompress';
+        },
+        {
+            code: 6008;
+            name: 'DeCompressAmountUndefinedForDecompress';
+            msg: 'DeCompressAmountUndefinedForDecompress';
+        },
+        {
+            code: 6009;
+            name: 'CompressedPdaUndefinedForCompress';
+            msg: 'CompressedPdaUndefinedForCompress';
+        },
+        {
+            code: 6010;
+            name: 'DeCompressAmountUndefinedForCompress';
+            msg: 'DeCompressAmountUndefinedForCompress';
+        },
+        {
+            code: 6011;
+            name: 'DelegateSignerCheckFailed';
+            msg: 'DelegateSignerCheckFailed';
+        },
+        {
+            code: 6012;
+            name: 'MintTooLarge';
+            msg: 'Minted amount greater than u64::MAX';
+        },
+        {
+            code: 6013;
+            name: 'SplTokenSupplyMismatch';
+            msg: 'SplTokenSupplyMismatch';
+        },
+        {
+            code: 6014;
+            name: 'HeapMemoryCheckFailed';
+            msg: 'HeapMemoryCheckFailed';
+        },
+        {
+            code: 6015;
+            name: 'InstructionNotCallable';
+            msg: 'The instruction is not callable';
+        },
+        {
+            code: 6016;
+            name: 'ArithmeticUnderflow';
+            msg: 'ArithmeticUnderflow';
+        },
+        {
+            code: 6017;
+            name: 'HashToFieldError';
+            msg: 'HashToFieldError';
+        },
+        {
+            code: 6018;
+            name: 'InvalidAuthorityMint';
+            msg: 'Expected the authority to be also a mint authority';
+        },
+        {
+            code: 6019;
+            name: 'InvalidFreezeAuthority';
+            msg: 'Provided authority is not the freeze authority';
+        },
+        {
+            code: 6020;
+            name: 'InvalidDelegateIndex';
+        },
+        {
+            code: 6021;
+            name: 'TokenPoolPdaUndefined';
+        },
+        {
+            code: 6022;
+            name: 'IsTokenPoolPda';
+            msg: 'Compress or decompress recipient is the same account as the token pool pda.';
+        },
+        {
+            code: 6023;
+            name: 'InvalidTokenPoolPda';
+        },
+        {
+            code: 6024;
+            name: 'NoInputTokenAccountsProvided';
+        },
+        {
+            code: 6025;
+            name: 'NoInputsProvided';
         },
     ];
 };
 export const IDL: LightCompressedToken = {
-    version: '0.5.0',
+    version: '0.6.2',
     name: 'light_compressed_token',
     instructions: [
         {
@@ -3137,23 +3242,128 @@ export const IDL: LightCompressedToken = {
     errors: [
         {
             code: 6000,
-            name: 'SignerCheckFailed',
-            msg: 'Signer check failed',
+            name: 'PublicKeyAmountMissmatch',
+            msg: 'public keys and amounts must be of same length',
         },
         {
             code: 6001,
-            name: 'CreateTransferInstructionFailed',
-            msg: 'Create transfer instruction failed',
+            name: 'ComputeInputSumFailed',
+            msg: 'ComputeInputSumFailed',
         },
         {
             code: 6002,
-            name: 'AccountNotFound',
-            msg: 'Account not found',
+            name: 'ComputeOutputSumFailed',
+            msg: 'ComputeOutputSumFailed',
         },
         {
             code: 6003,
-            name: 'SerializationError',
-            msg: 'Serialization error',
+            name: 'ComputeCompressSumFailed',
+            msg: 'ComputeCompressSumFailed',
+        },
+        {
+            code: 6004,
+            name: 'ComputeDecompressSumFailed',
+            msg: 'ComputeDecompressSumFailed',
+        },
+        {
+            code: 6005,
+            name: 'SumCheckFailed',
+            msg: 'SumCheckFailed',
+        },
+        {
+            code: 6006,
+            name: 'DecompressRecipientUndefinedForDecompress',
+            msg: 'DecompressRecipientUndefinedForDecompress',
+        },
+        {
+            code: 6007,
+            name: 'CompressedPdaUndefinedForDecompress',
+            msg: 'CompressedPdaUndefinedForDecompress',
+        },
+        {
+            code: 6008,
+            name: 'DeCompressAmountUndefinedForDecompress',
+            msg: 'DeCompressAmountUndefinedForDecompress',
+        },
+        {
+            code: 6009,
+            name: 'CompressedPdaUndefinedForCompress',
+            msg: 'CompressedPdaUndefinedForCompress',
+        },
+        {
+            code: 6010,
+            name: 'DeCompressAmountUndefinedForCompress',
+            msg: 'DeCompressAmountUndefinedForCompress',
+        },
+        {
+            code: 6011,
+            name: 'DelegateSignerCheckFailed',
+            msg: 'DelegateSignerCheckFailed',
+        },
+        {
+            code: 6012,
+            name: 'MintTooLarge',
+            msg: 'Minted amount greater than u64::MAX',
+        },
+        {
+            code: 6013,
+            name: 'SplTokenSupplyMismatch',
+            msg: 'SplTokenSupplyMismatch',
+        },
+        {
+            code: 6014,
+            name: 'HeapMemoryCheckFailed',
+            msg: 'HeapMemoryCheckFailed',
+        },
+        {
+            code: 6015,
+            name: 'InstructionNotCallable',
+            msg: 'The instruction is not callable',
+        },
+        {
+            code: 6016,
+            name: 'ArithmeticUnderflow',
+            msg: 'ArithmeticUnderflow',
+        },
+        {
+            code: 6017,
+            name: 'HashToFieldError',
+            msg: 'HashToFieldError',
+        },
+        {
+            code: 6018,
+            name: 'InvalidAuthorityMint',
+            msg: 'Expected the authority to be also a mint authority',
+        },
+        {
+            code: 6019,
+            name: 'InvalidFreezeAuthority',
+            msg: 'Provided authority is not the freeze authority',
+        },
+        {
+            code: 6020,
+            name: 'InvalidDelegateIndex',
+        },
+        {
+            code: 6021,
+            name: 'TokenPoolPdaUndefined',
+        },
+        {
+            code: 6022,
+            name: 'IsTokenPoolPda',
+            msg: 'Compress or decompress recipient is the same account as the token pool pda.',
+        },
+        {
+            code: 6023,
+            name: 'InvalidTokenPoolPda',
+        },
+        {
+            code: 6024,
+            name: 'NoInputTokenAccountsProvided',
+        },
+        {
+            code: 6025,
+            name: 'NoInputsProvided',
         },
     ],
 };

--- a/js/stateless.js/src/idls/light_registry.ts
+++ b/js/stateless.js/src/idls/light_registry.ts
@@ -1,5 +1,5 @@
 export type LightRegistry = {
-    version: '0.5.0';
+    version: '0.6.2';
     name: 'light_registry';
     constants: [
         {
@@ -1296,7 +1296,7 @@ export type LightRegistry = {
 };
 
 export const IDL: LightRegistry = {
-    version: '0.5.0',
+    version: '0.6.2',
     name: 'light_registry',
     constants: [
         {

--- a/js/stateless.js/src/idls/light_system_program.ts
+++ b/js/stateless.js/src/idls/light_system_program.ts
@@ -1,5 +1,5 @@
 export type LightSystemProgram = {
-    version: '0.5.0';
+    version: '0.6.2';
     name: 'light_system_program';
     constants: [
         {
@@ -1070,7 +1070,7 @@ export type LightSystemProgram = {
 };
 
 export const IDL: LightSystemProgram = {
-    version: '0.5.0',
+    version: '0.6.2',
     name: 'light_system_program',
     constants: [
         {

--- a/scripts/release-all-rust-crates.sh
+++ b/scripts/release-all-rust-crates.sh
@@ -12,9 +12,9 @@ echo "Tagging and releasing all Rust projects..."
 echo "Logging in to crates.io..."
 cargo login "${CRATES_IO_TOKEN}"
 # TODO: allow dynamic releases, and add gh release workflow
-PACKAGES=("light-hash-set" "light-merkle-tree-reference" "light-concurrent-merkle-tree" "light-indexed-merkle-tree" "light-prover-client" "light-verifier" "account-compression" "light-system-program" "light-registry" "light-compressed-token" "photon-api" "light-test-utils" "light-sdk")
+# PACKAGES=("light-hash-set" "light-merkle-tree-reference" "light-concurrent-merkle-tree" "light-indexed-merkle-tree" "light-prover-client" "light-verifier" "account-compression" "light-system-program" "light-registry" "light-compressed-token" "photon-api" "light-test-utils" "light-sdk")
 # PACKAGES=("aligned-sized" "light-heap" "light-bounded-vec" "light-utils" "light-hasher" "light-macros" "light-hash-set" "light-merkle-tree-reference" "light-concurrent-merkle-tree" "light-indexed-merkle-tree" "light-prover-client" "light-verifier" "account-compression" "light-system-program" "light-registry" "light-compressed-token" "photon-api" "light-test-utils" "light-sdk")
-# PACKAGES=("photon-api" "light-test-utils" "light-sdk")
+PACKAGES=("light-sdk")
 for PACKAGE in "${PACKAGES[@]}"; do
     PKG_VERSION=$(cargo pkgid -p "$PACKAGE" | cut -d "#" -f2)
     VERSION=${PKG_VERSION#*@}

--- a/scripts/release-all-rust-crates.sh
+++ b/scripts/release-all-rust-crates.sh
@@ -12,8 +12,8 @@ echo "Tagging and releasing all Rust projects..."
 echo "Logging in to crates.io..."
 cargo login "${CRATES_IO_TOKEN}"
 # TODO: allow dynamic releases, and add gh release workflow
-# PACKAGES=("aligned-sized" "light-heap" "light-bounded-vec" "light-utils" "light-hasher" "light-macros" "light-hash-set" "light-merkle-tree-reference" "light-concurrent-merkle-tree" "light-indexed-merkle-tree" "light-prover-client" "light-verifier" "account-compression" "light-registry" "light-system-program" "light-compressed-token" "light-test-utils" "light-sdk")
-PACKAGES=("photon-api" "light-test-utils" "light-sdk")
+PACKAGES=("aligned-sized" "light-heap" "light-bounded-vec" "light-utils" "light-hasher" "light-macros" "light-hash-set" "light-merkle-tree-reference" "light-concurrent-merkle-tree" "light-indexed-merkle-tree" "light-prover-client" "light-verifier" "account-compression" "light-system-program" "light-registry" "light-compressed-token" "photon-api" "light-test-utils" "light-sdk")
+# PACKAGES=("photon-api" "light-test-utils" "light-sdk")
 for PACKAGE in "${PACKAGES[@]}"; do
     PKG_VERSION=$(cargo pkgid -p "$PACKAGE" | cut -d "#" -f2)
     VERSION=${PKG_VERSION#*@}
@@ -23,6 +23,6 @@ for PACKAGE in "${PACKAGES[@]}"; do
     for attempt in {1..3}; do
         echo "Attempt $attempt: Publishing $PACKAGE..."
         cargo release publish --package "$PACKAGE" --execute --no-confirm && break || echo "Attempt $attempt failed, retrying in 20..."
-        sleep 20
+        sleep 13
     done
 done

--- a/scripts/release-all-rust-crates.sh
+++ b/scripts/release-all-rust-crates.sh
@@ -12,7 +12,8 @@ echo "Tagging and releasing all Rust projects..."
 echo "Logging in to crates.io..."
 cargo login "${CRATES_IO_TOKEN}"
 # TODO: allow dynamic releases, and add gh release workflow
-PACKAGES=("aligned-sized" "light-heap" "light-bounded-vec" "light-utils" "light-hasher" "light-macros" "light-hash-set" "light-merkle-tree-reference" "light-concurrent-merkle-tree" "light-indexed-merkle-tree" "light-prover-client" "light-verifier" "account-compression" "light-system-program" "light-registry" "light-compressed-token" "photon-api" "light-test-utils" "light-sdk")
+PACKAGES=("light-hash-set" "light-merkle-tree-reference" "light-concurrent-merkle-tree" "light-indexed-merkle-tree" "light-prover-client" "light-verifier" "account-compression" "light-system-program" "light-registry" "light-compressed-token" "photon-api" "light-test-utils" "light-sdk")
+# PACKAGES=("aligned-sized" "light-heap" "light-bounded-vec" "light-utils" "light-hasher" "light-macros" "light-hash-set" "light-merkle-tree-reference" "light-concurrent-merkle-tree" "light-indexed-merkle-tree" "light-prover-client" "light-verifier" "account-compression" "light-system-program" "light-registry" "light-compressed-token" "photon-api" "light-test-utils" "light-sdk")
 # PACKAGES=("photon-api" "light-test-utils" "light-sdk")
 for PACKAGE in "${PACKAGES[@]}"; do
     PKG_VERSION=$(cargo pkgid -p "$PACKAGE" | cut -d "#" -f2)

--- a/scripts/release-all-rust-crates.sh
+++ b/scripts/release-all-rust-crates.sh
@@ -12,9 +12,8 @@ echo "Tagging and releasing all Rust projects..."
 echo "Logging in to crates.io..."
 cargo login "${CRATES_IO_TOKEN}"
 # TODO: allow dynamic releases, and add gh release workflow
-# PACKAGES=("light-hash-set" "light-merkle-tree-reference" "light-concurrent-merkle-tree" "light-indexed-merkle-tree" "light-prover-client" "light-verifier" "account-compression" "light-system-program" "light-registry" "light-compressed-token" "photon-api" "light-test-utils" "light-sdk")
-# PACKAGES=("aligned-sized" "light-heap" "light-bounded-vec" "light-utils" "light-hasher" "light-macros" "light-hash-set" "light-merkle-tree-reference" "light-concurrent-merkle-tree" "light-indexed-merkle-tree" "light-prover-client" "light-verifier" "account-compression" "light-system-program" "light-registry" "light-compressed-token" "photon-api" "light-test-utils" "light-sdk")
-PACKAGES=("light-sdk")
+PACKAGES=("aligned-sized" "light-heap" "light-bounded-vec" "light-utils" "light-hasher" "light-macros" "light-hash-set" "light-merkle-tree-reference" "light-concurrent-merkle-tree" "light-indexed-merkle-tree" "light-prover-client" "light-verifier" "account-compression" "light-system-program" "light-registry" "light-compressed-token" "photon-api" "light-test-utils" "light-sdk")
+
 for PACKAGE in "${PACKAGES[@]}"; do
     PKG_VERSION=$(cargo pkgid -p "$PACKAGE" | cut -d "#" -f2)
     VERSION=${PKG_VERSION#*@}


### PR DESCRIPTION
* rust crates have been released
* remove custom patch. `solana_rbpf` was yanked, therefore we cannot use 1.18.17 anymore.
* upgrade dependencies to v1.18.22. this is the earliest non-yanked version for v1.x compatibility.