### PR TITLE
feat: Add macros for compressed PDAs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -32,7 +32,7 @@ rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+rustflags = ["-C", "link-arg=-fuse-ld=ld"]
 
 
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -32,7 +32,7 @@ rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=ld"]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ spl-token = "=4.0.0"
 
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2.0", features = ["full"] }
+syn = { version = "2.0", features = ["visit-mut", "full"] }
 
 tokio = { version = "1.39.1", features = ["rt", "macros", "rt-multi-thread"] }
 

--- a/examples/name-service/programs/name-service/src/lib.rs
+++ b/examples/name-service/programs/name-service/src/lib.rs
@@ -4,200 +4,42 @@ use anchor_lang::prelude::*;
 use borsh::{BorshDeserialize, BorshSerialize};
 use light_hasher::bytes::AsByteVec;
 use light_sdk::{
-    light_account, light_accounts,
-    merkle_context::{PackedAddressMerkleContext, PackedMerkleContext, PackedMerkleOutputContext},
-    utils::{create_cpi_inputs_for_account_deletion, create_cpi_inputs_for_new_account},
-    verify::verify,
-    LightTraits,
+    compressed_account::LightAccount,
+    light_account, light_accounts, light_program,
+    merkle_context::{PackedAddressMerkleContext, PackedMerkleContext},
 };
-use light_system_program::{invoke::processor::CompressedProof, sdk::CompressedCpiContext};
+use light_system_program::invoke::processor::CompressedProof;
 
 declare_id!("7yucc7fL3JGbyMwg4neUaenNSdySS39hbAk89Ao3t1Hz");
 
-#[program]
+#[light_program]
 pub mod name_service {
-    use account_compression::utils::constants::CPI_AUTHORITY_PDA_SEED;
-    use light_sdk::{
-        address::derive_address_seed,
-        compressed_account::{
-            input_compressed_account, new_compressed_account, output_compressed_account,
-        },
-        merkle_context::unpack_address_merkle_context,
-        utils::create_cpi_inputs_for_account_update,
-    };
-
     use super::*;
 
-    #[allow(clippy::too_many_arguments)]
     pub fn create_record<'info>(
-        ctx: Context<'_, '_, '_, 'info, NameService<'info>>,
-        proof: CompressedProof,
-        merkle_output_context: PackedMerkleOutputContext,
-        address_merkle_context: PackedAddressMerkleContext,
-        address_merkle_tree_root_index: u16,
+        ctx: LightContext<'_, '_, '_, 'info, CreateRecord<'info>>,
         name: String,
         rdata: RData,
-        cpi_context: Option<CompressedCpiContext>,
     ) -> Result<()> {
-        let unpacked_address_merkle_context =
-            unpack_address_merkle_context(address_merkle_context, ctx.remaining_accounts);
-        let address_seed = derive_address_seed(
-            &[
-                ctx.accounts.signer.key.to_bytes().as_slice(),
-                name.as_bytes(),
-            ],
-            &crate::ID,
-            &unpacked_address_merkle_context,
-        );
-
-        let record = NameRecord {
-            owner: ctx.accounts.signer.key(),
-            name,
-            rdata,
-        };
-        let (compressed_account, new_address_params) = new_compressed_account(
-            &record,
-            &address_seed,
-            &crate::ID,
-            &merkle_output_context,
-            &address_merkle_context,
-            address_merkle_tree_root_index,
-            ctx.remaining_accounts,
-        )?;
-
-        let signer_seed = CPI_AUTHORITY_PDA_SEED;
-        let bump = Pubkey::find_program_address(&[signer_seed], &ctx.accounts.self_program.key()).1;
-        let signer_seeds = [signer_seed, &[bump]];
-
-        let inputs = create_cpi_inputs_for_new_account(
-            proof,
-            new_address_params,
-            compressed_account,
-            cpi_context,
-        );
-
-        verify(ctx, &inputs, &[&signer_seeds])?;
+        ctx.light_accounts.record.owner = ctx.accounts.signer.key();
+        ctx.light_accounts.record.name = name;
+        ctx.light_accounts.record.rdata = rdata;
 
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn update_record<'info>(
-        ctx: Context<'_, '_, '_, 'info, NameService<'info>>,
-        proof: CompressedProof,
-        merkle_context: PackedMerkleContext,
-        merkle_tree_root_index: u16,
-        address_merkle_context: PackedAddressMerkleContext,
-        name: String,
-        old_rdata: RData,
+        ctx: LightContext<'_, '_, '_, 'info, UpdateRecord<'info>>,
         new_rdata: RData,
-        cpi_context: Option<CompressedCpiContext>,
     ) -> Result<()> {
-        let unpacked_address_merkle_context =
-            unpack_address_merkle_context(address_merkle_context, ctx.remaining_accounts);
-        let address_seed = derive_address_seed(
-            &[
-                ctx.accounts.signer.key.to_bytes().as_slice(),
-                name.as_bytes(),
-            ],
-            &crate::ID,
-            &unpacked_address_merkle_context,
-        );
-
-        let owner = ctx.accounts.signer.key();
-
-        // Re-create the old compressed account. It's needed as an input for
-        // validation and nullification.
-        let old_record = NameRecord {
-            owner,
-            name: name.clone(),
-            rdata: old_rdata,
-        };
-        let old_compressed_account = input_compressed_account(
-            &old_record,
-            &address_seed,
-            &crate::ID,
-            &merkle_context,
-            merkle_tree_root_index,
-            &address_merkle_context,
-            ctx.remaining_accounts,
-        )?;
-
-        let new_record = NameRecord {
-            owner,
-            name,
-            rdata: new_rdata,
-        };
-        let new_compressed_account = output_compressed_account(
-            &new_record,
-            &address_seed,
-            &crate::ID,
-            &merkle_context,
-            &address_merkle_context,
-            ctx.remaining_accounts,
-        )?;
-
-        let signer_seed = CPI_AUTHORITY_PDA_SEED;
-        let bump = Pubkey::find_program_address(&[signer_seed], &ctx.accounts.self_program.key()).1;
-        let signer_seeds = [signer_seed, &[bump]];
-
-        let inputs = create_cpi_inputs_for_account_update(
-            proof,
-            old_compressed_account,
-            new_compressed_account,
-            cpi_context,
-        );
-
-        verify(ctx, &inputs, &[&signer_seeds])?;
+        ctx.light_accounts.record.rdata = new_rdata;
 
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn delete_record<'info>(
-        ctx: Context<'_, '_, '_, 'info, NameService<'info>>,
-        proof: CompressedProof,
-        merkle_context: PackedMerkleContext,
-        merkle_tree_root_index: u16,
-        address_merkle_context: PackedAddressMerkleContext,
-        name: String,
-        rdata: RData,
-        cpi_context: Option<CompressedCpiContext>,
+        ctx: LightContext<'_, '_, '_, 'info, DeleteRecord<'info>>,
     ) -> Result<()> {
-        let unpacked_address_merkle_context =
-            unpack_address_merkle_context(address_merkle_context, ctx.remaining_accounts);
-        let address_seed = derive_address_seed(
-            &[
-                ctx.accounts.signer.key.to_bytes().as_slice(),
-                name.as_bytes(),
-            ],
-            &crate::ID,
-            &unpacked_address_merkle_context,
-        );
-
-        let record = NameRecord {
-            owner: ctx.accounts.signer.key(),
-            name,
-            rdata,
-        };
-        let compressed_account = input_compressed_account(
-            &record,
-            &address_seed,
-            &crate::ID,
-            &merkle_context,
-            merkle_tree_root_index,
-            &address_merkle_context,
-            ctx.remaining_accounts,
-        )?;
-
-        let signer_seed = CPI_AUTHORITY_PDA_SEED;
-        let bump = Pubkey::find_program_address(&[signer_seed], &ctx.accounts.self_program.key()).1;
-        let signer_seeds = [signer_seed, &[bump]];
-
-        let inputs = create_cpi_inputs_for_account_deletion(proof, compressed_account, cpi_context);
-
-        verify(ctx, &inputs, &[&signer_seeds])?;
-
         Ok(())
     }
 }
@@ -221,8 +63,14 @@ impl AsByteVec for RData {
     }
 }
 
+impl Default for RData {
+    fn default() -> Self {
+        Self::A(Ipv4Addr::new(127, 0, 0, 1))
+    }
+}
+
 #[light_account]
-#[derive(Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct NameRecord {
     #[truncate]
     pub owner: Pubkey,
@@ -242,8 +90,7 @@ pub enum CustomError {
 }
 
 #[light_accounts]
-#[derive(Accounts, LightTraits)]
-pub struct NameService<'info> {
+pub struct CreateRecord<'info> {
     #[account(mut)]
     #[fee_payer]
     pub signer: Signer<'info>,
@@ -252,4 +99,37 @@ pub struct NameService<'info> {
     /// CHECK: Checked in light-system-program.
     #[authority]
     pub cpi_signer: AccountInfo<'info>,
+
+    #[light_account(init, seeds = [b"name-service", record.name.as_bytes()])]
+    pub record: LightAccount<NameRecord>,
+}
+
+#[light_accounts]
+pub struct UpdateRecord<'info> {
+    #[account(mut)]
+    #[fee_payer]
+    pub signer: Signer<'info>,
+    #[self_program]
+    pub self_program: Program<'info, crate::program::NameService>,
+    /// CHECK: Checked in light-system-program.
+    #[authority]
+    pub cpi_signer: AccountInfo<'info>,
+
+    #[light_account(mut, seeds = [b"name-service", record.name.as_bytes()])]
+    pub record: LightAccount<NameRecord>,
+}
+
+#[light_accounts]
+pub struct DeleteRecord<'info> {
+    #[account(mut)]
+    #[fee_payer]
+    pub signer: Signer<'info>,
+    #[self_program]
+    pub self_program: Program<'info, crate::program::NameService>,
+    /// CHECK: Checked in light-system-program.
+    #[authority]
+    pub cpi_signer: AccountInfo<'info>,
+
+    #[light_account(close, seeds = [b"name-service", record.name.as_bytes()])]
+    pub record: LightAccount<NameRecord>,
 }

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/escrow.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/escrow.rs
@@ -10,7 +10,7 @@ use light_compressed_token::{
 };
 use light_hasher::{errors::HasherError, DataHasher, Hasher, Poseidon};
 use light_sdk::{
-    light_accounts, utils::create_cpi_inputs_for_new_account, verify::verify, LightTraits,
+    light_system_accounts, utils::create_cpi_inputs_for_new_account, verify::verify, LightTraits,
 };
 use light_system_program::{
     invoke::processor::CompressedProof,
@@ -23,7 +23,7 @@ use light_system_program::{
     NewAddressParamsPacked, OutputCompressedAccountWithPackedContext,
 };
 
-#[light_accounts]
+#[light_system_accounts]
 #[derive(Accounts, LightTraits)]
 pub struct EscrowCompressedTokensWithCompressedPda<'info> {
     #[account(mut)]
@@ -117,7 +117,7 @@ fn cpi_compressed_pda_transfer<'info>(
         Some(cpi_context),
     );
 
-    verify(ctx, &inputs_struct, &[&signer_seeds])?;
+    verify(&ctx, &inputs_struct, &[&signer_seeds])?;
 
     Ok(())
 }

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/withdrawal.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/withdrawal.rs
@@ -150,7 +150,7 @@ fn cpi_compressed_pda_withdrawal<'info>(
         cpi_context: Some(cpi_context),
     };
 
-    verify(ctx, &inputs_struct, &[&signer_seeds])?;
+    verify(&ctx, &inputs_struct, &[&signer_seeds])?;
 
     Ok(())
 }

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_pda/escrow.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_pda/escrow.rs
@@ -7,10 +7,10 @@ use light_compressed_token::{
     },
     program::LightCompressedToken,
 };
-use light_sdk::{light_accounts, LightTraits};
+use light_sdk::{light_system_accounts, LightTraits};
 use light_system_program::invoke::processor::CompressedProof;
 
-#[light_accounts]
+#[light_system_accounts]
 #[derive(Accounts, LightTraits)]
 pub struct EscrowCompressedTokensWithPda<'info> {
     #[account(mut)]

--- a/macros/light/src/accounts.rs
+++ b/macros/light/src/accounts.rs
@@ -1,65 +1,70 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use syn::{Data, DeriveInput, Fields, Result};
+use syn::{
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+    token::PathSep,
+    Error, Expr, Fields, Ident, ItemStruct, Meta, Path, PathSegment, Result, Token, Type, TypePath,
+};
 
-pub(crate) fn process_light_accounts(input: DeriveInput) -> Result<TokenStream> {
+pub(crate) fn process_light_system_accounts(input: ItemStruct) -> Result<TokenStream> {
     let mut output = input.clone();
 
-    if let Data::Struct(ref mut data_struct) = output.data {
-        if let Fields::Named(ref mut fields) = data_struct.fields {
-            let fields_to_add = [
-                (
-                    "light_system_program",
-                    "Program<'info, ::light_system_program::program::LightSystemProgram>",
-                ),
-                ("system_program", "Program<'info, System>"),
-                (
-                    "account_compression_program",
-                    "Program<'info, ::account_compression::program::AccountCompression>",
-                ),
-            ];
-            let fields_to_add_check = [
-                (
-                    "registered_program_pda",
-                    "Account<'info, ::account_compression::RegisteredProgram>",
-                ),
-                ("noop_program", "AccountInfo<'info>"),
-                ("account_compression_authority", "AccountInfo<'info>"),
-            ];
-            let existing_field_names: Vec<_> = fields
-                .named
-                .iter()
-                .map(|f| f.ident.as_ref().unwrap().to_string())
-                .collect();
+    let fields =
+        match output.fields {
+            Fields::Named(ref mut fields) => fields,
+            _ => return Err(Error::new_spanned(
+                input,
+                "`light_system_accounts` attribute can only be used with structs that have named fields.",
+            )),
+        };
 
-            // TODO: Eventually we want to provide flexibility to override.
-            // Until then, we error if the fields are manually defined.
-            for (field_name, field_type) in fields_to_add.iter().chain(fields_to_add_check.iter()) {
-                if existing_field_names.contains(&field_name.to_string()) {
-                    return Err(syn::Error::new_spanned(
-                        &output,
-                        format!("Field `{}` already exists in the struct.", field_name),
-                    ));
-                }
+    let fields_to_add = [
+        (
+            "light_system_program",
+            "Program<'info, ::light_system_program::program::LightSystemProgram>",
+        ),
+        ("system_program", "Program<'info, System>"),
+        (
+            "account_compression_program",
+            "Program<'info, ::account_compression::program::AccountCompression>",
+        ),
+    ];
+    let fields_to_add_check = [
+        (
+            "registered_program_pda",
+            "Account<'info, ::account_compression::RegisteredProgram>",
+        ),
+        ("noop_program", "AccountInfo<'info>"),
+        ("account_compression_authority", "AccountInfo<'info>"),
+    ];
+    let existing_field_names: Vec<_> = fields
+        .named
+        .iter()
+        .map(|f| f.ident.as_ref().unwrap().to_string())
+        .collect();
 
-                let new_field = syn::Field {
-                    attrs: vec![],
-                    vis: syn::Visibility::Public(syn::token::Pub {
-                        span: proc_macro2::Span::call_site(),
-                    }),
-                    mutability: syn::FieldMutability::None,
-                    ident: Some(syn::Ident::new(field_name, proc_macro2::Span::call_site())),
-                    colon_token: Some(syn::Token![:](proc_macro2::Span::call_site())),
-                    ty: syn::parse_str(field_type)?,
-                };
-                fields.named.push(new_field);
-            }
+    // TODO: Eventually we want to provide flexibility to override.
+    // Until then, we error if the fields are manually defined.
+    for (field_name, field_type) in fields_to_add.iter().chain(fields_to_add_check.iter()) {
+        if existing_field_names.contains(&field_name.to_string()) {
+            return Err(syn::Error::new_spanned(
+                &output,
+                format!("Field `{}` already exists in the struct.", field_name),
+            ));
         }
-    } else {
-        return Err(syn::Error::new_spanned(
-            &output,
-            "`light_accounts` attribute can only be used with structs that have named fields.",
-        ));
+
+        let new_field = syn::Field {
+            attrs: vec![],
+            vis: syn::Visibility::Public(syn::token::Pub {
+                span: proc_macro2::Span::call_site(),
+            }),
+            mutability: syn::FieldMutability::None,
+            ident: Some(syn::Ident::new(field_name, proc_macro2::Span::call_site())),
+            colon_token: Some(syn::Token![:](proc_macro2::Span::call_site())),
+            ty: syn::parse_str(field_type)?,
+        };
+        fields.named.push(new_field);
     }
 
     let expanded = quote! {
@@ -69,21 +74,352 @@ pub(crate) fn process_light_accounts(input: DeriveInput) -> Result<TokenStream> 
     Ok(expanded)
 }
 
+pub(crate) fn process_light_accounts(input: ItemStruct) -> Result<TokenStream> {
+    let mut anchor_accounts_strct = input.clone();
+
+    let (_, type_gen, _) = input.generics.split_for_impl();
+
+    let anchor_accounts_name = input.ident.clone();
+    let light_accounts_name = Ident::new(&format!("Light{}", input.ident), Span::call_site());
+
+    let mut light_accounts_fields: Punctuated<syn::Field, Token![,]> = Punctuated::new();
+
+    let fields =
+        match anchor_accounts_strct.fields {
+            Fields::Named(ref mut fields) => fields,
+            _ => return Err(Error::new_spanned(
+                input,
+                "`light_accounts` attribute can only be used with structs that have named fields.",
+            )),
+        };
+
+    let mut anchor_fields = Punctuated::new();
+    let mut anchor_field_idents = Vec::new();
+    let mut light_field_idents = Vec::new();
+    let mut derive_address_seed_calls = Vec::new();
+
+    for field in fields.named.iter() {
+        let mut light_account = false;
+        for attr in &field.attrs {
+            if attr.path().is_ident("light_account") {
+                light_account = true;
+            }
+        }
+
+        if light_account {
+            light_accounts_fields.push(field.clone());
+            light_field_idents.push(field.ident.clone());
+
+            let field_ident = &field.ident;
+
+            let mut account_args = None;
+            for attribute in &field.attrs {
+                let attribute_list = match &attribute.meta {
+                    Meta::List(attribute_list) => attribute_list,
+                    _ => continue,
+                };
+                account_args = Some(syn::parse2::<LightAccountArgs>(
+                    attribute_list.tokens.clone(),
+                )?);
+                break;
+            }
+            let account_args = match account_args {
+                Some(account_args) => account_args,
+                None => {
+                    return Err(Error::new_spanned(
+                        input,
+                        "no arguments provided in `light_account`",
+                    ))
+                }
+            };
+
+            let seeds = account_args.seeds;
+
+            derive_address_seed_calls.push(quote! {
+                let address_seed = ::light_sdk::address::derive_address_seed(
+                    &#seeds,
+                    &crate::ID,
+                    &unpacked_address_merkle_context,
+                );
+                #field_ident.set_address_seed(address_seed);
+            });
+        } else {
+            anchor_fields.push(field.clone());
+            anchor_field_idents.push(field.ident.clone());
+        }
+    }
+
+    fields.named = anchor_fields;
+
+    let light_accounts_strct = if light_accounts_fields.is_empty() {
+        quote! {
+            #[derive(::light_sdk::LightAccounts)]
+            pub struct #light_accounts_name {}
+        }
+    } else {
+        quote! {
+            #[derive(::light_sdk::LightAccounts)]
+            pub struct #light_accounts_name {
+                #light_accounts_fields
+            }
+        }
+    };
+
+    let expanded = quote! {
+        #[::light_sdk::light_system_accounts]
+        #[derive(::anchor_lang::Accounts, ::light_sdk::LightTraits)]
+        #anchor_accounts_strct
+
+        #light_accounts_strct
+
+        impl<'a, 'b, 'c, 'info> LightContextExt for ::light_sdk::context::LightContext<
+            'a, 'b, 'c, 'info, #anchor_accounts_name #type_gen, #light_accounts_name,
+        > {
+            #[allow(unused_variables)]
+            fn derive_address_seeds(
+                &mut self,
+                address_merkle_context: PackedAddressMerkleContext,
+            ) {
+                let #anchor_accounts_name { #(#anchor_field_idents),*, .. } = &self.anchor_context.accounts;
+                let #light_accounts_name { #(#light_field_idents),* } = &mut self.light_accounts;
+
+                let unpacked_address_merkle_context =
+                    ::light_sdk::program_merkle_context::unpack_address_merkle_context(
+                        address_merkle_context, self.anchor_context.remaining_accounts);
+
+                #(#derive_address_seed_calls)*
+            }
+        }
+    };
+
+    Ok(expanded)
+}
+
+pub(crate) enum LightAccountAction {
+    Init,
+    Mut,
+    Close,
+}
+
+pub(crate) struct LightAccountArgs {
+    action: LightAccountAction,
+    seeds: Expr,
+}
+
+impl Parse for LightAccountArgs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let action = match input.parse::<Token![mut]>() {
+            Ok(_) => LightAccountAction::Mut,
+            Err(_) => {
+                let action_ident: Ident = input.parse()?;
+                match action_ident.to_string().as_str() {
+                    "init" => LightAccountAction::Init,
+                    "mut" => LightAccountAction::Mut,
+                    "close" => LightAccountAction::Close,
+                    _ => {
+                        return Err(Error::new(
+                            Span::call_site(),
+                            "unsupported light account action type",
+                        ))
+                    }
+                }
+            }
+        };
+
+        input.parse::<Token![,]>()?;
+
+        let _seeds_ident: Ident = input.parse()?;
+
+        input.parse::<Token![=]>()?;
+
+        let seeds: Expr = input.parse()?;
+
+        Ok(Self { action, seeds })
+    }
+}
+
+pub(crate) fn process_light_accounts_derive(input: ItemStruct) -> Result<TokenStream> {
+    let strct_name = &input.ident;
+    let (impl_gen, type_gen, where_clause) = input.generics.split_for_impl();
+
+    let mut try_from_slice_calls = Vec::new();
+    let mut field_idents = Vec::new();
+    let mut new_address_params_calls = Vec::new();
+    let mut input_account_calls = Vec::new();
+    let mut output_account_calls = Vec::new();
+
+    let fields = match input.fields {
+        Fields::Named(ref fields) => fields,
+        _ => {
+            return Err(Error::new_spanned(
+                input,
+                "Only structs with named fields can derive LightAccounts",
+            ))
+        }
+    };
+
+    for (i, field) in fields.named.iter().enumerate() {
+        let field_ident = &field.ident;
+        field_idents.push(field_ident);
+
+        let mut account_args = None;
+        for attribute in &field.attrs {
+            let attribute_list = match &attribute.meta {
+                Meta::List(attribute_list) => attribute_list,
+                _ => continue,
+            };
+            account_args = Some(syn::parse2::<LightAccountArgs>(
+                attribute_list.tokens.clone(),
+            )?);
+            break;
+        }
+        let account_args = match account_args {
+            Some(account_args) => account_args,
+            None => {
+                return Err(Error::new_spanned(
+                    input,
+                    "no arguments provided in `light_account`",
+                ))
+            }
+        };
+
+        let type_path = match field.ty {
+            Type::Path(ref type_path) => type_path,
+            _ => {
+                return Err(Error::new_spanned(
+                    input,
+                    "Only struct with typed fields can derive LightAccounts",
+                ))
+            }
+        };
+
+        let type_path_without_args = TypePath {
+            qself: type_path.qself.clone(),
+            path: Path {
+                leading_colon: type_path.path.leading_colon,
+                segments: type_path
+                    .path
+                    .segments
+                    .iter()
+                    .map(|segment| PathSegment {
+                        ident: segment.ident.clone(),
+                        arguments: syn::PathArguments::None,
+                    })
+                    .collect::<Punctuated<PathSegment, PathSep>>(),
+            },
+        };
+        let try_from_slice_call = match account_args.action {
+            LightAccountAction::Init => quote! {
+                let mut #field_ident: #type_path = #type_path_without_args::new_init(
+                    &merkle_context,
+                    &address_merkle_context,
+                    address_merkle_tree_root_index,
+                );
+            },
+            LightAccountAction::Mut => quote! {
+                let mut #field_ident: #type_path = #type_path_without_args::try_from_slice_mut(
+                    inputs[#i].as_slice(),
+                    &merkle_context,
+                    merkle_tree_root_index,
+                    &address_merkle_context,
+                )?;
+            },
+            LightAccountAction::Close => quote! {
+                let mut #field_ident: #type_path = #type_path_without_args::try_from_slice_close(
+                    inputs[#i].as_slice(),
+                    &merkle_context,
+                    merkle_tree_root_index,
+                    &address_merkle_context,
+                )?;
+            },
+        };
+        try_from_slice_calls.push(try_from_slice_call);
+
+        new_address_params_calls.push(quote! {
+            if let Some(new_address_params_for_acc) = self.#field_ident.new_address_params() {
+                new_address_params.push(new_address_params_for_acc);
+            }
+        });
+        input_account_calls.push(quote! {
+            if let Some(compressed_account) = self.#field_ident.input_compressed_account(
+                &crate::ID,
+                remaining_accounts,
+            )? {
+                accounts.push(compressed_account);
+            }
+        });
+        output_account_calls.push(quote! {
+            if let Some(compressed_account) = self.#field_ident.output_compressed_account(
+                &crate::ID,
+                remaining_accounts,
+            )? {
+                accounts.push(compressed_account);
+            }
+        })
+    }
+
+    let expanded = quote! {
+        impl #impl_gen ::light_sdk::compressed_account::LightAccounts for #strct_name #type_gen #where_clause {
+            fn try_light_accounts(
+                inputs: Vec<Vec<u8>>,
+                merkle_context: ::light_sdk::merkle_context::PackedMerkleContext,
+                merkle_tree_root_index: u16,
+                address_merkle_context: ::light_sdk::merkle_context::PackedAddressMerkleContext,
+                address_merkle_tree_root_index: u16,
+                remaining_accounts: &[::anchor_lang::prelude::AccountInfo],
+            ) -> Result<Self> {
+                let unpacked_address_merkle_context =
+                     ::light_sdk::program_merkle_context::unpack_address_merkle_context(
+                         address_merkle_context, remaining_accounts);
+
+                #(#try_from_slice_calls)*
+                Ok(Self {
+                    #(#field_idents),*
+                })
+            }
+
+            fn new_address_params(&self) -> Vec<::light_sdk::compressed_account::NewAddressParamsPacked> {
+                let mut new_address_params = Vec::new();
+                #(#new_address_params_calls)*
+                new_address_params
+            }
+
+            fn input_accounts(&self, remaining_accounts: &[::anchor_lang::prelude::AccountInfo]) -> Result<Vec<::light_sdk::compressed_account::PackedCompressedAccountWithMerkleContext>> {
+                let mut accounts = Vec::new();
+                #(#input_account_calls)*
+                Ok(accounts)
+            }
+
+            fn output_accounts(&self, remaining_accounts: &[::anchor_lang::prelude::AccountInfo]) -> Result<Vec<::light_sdk::compressed_account::OutputCompressedAccountWithPackedContext>> {
+                let mut accounts = Vec::new();
+                #(#output_account_calls)*
+                Ok(accounts)
+            }
+        }
+    };
+
+    Ok(expanded)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use syn::{parse_quote, DeriveInput};
+    use syn::{parse_quote, ItemStruct};
 
     #[test]
-    fn test_process_light_accounts_adds_fields_correctly() {
-        let input: DeriveInput = parse_quote! {
+    fn test_process_light_system_accounts_adds_fields_correctly() {
+        let input: ItemStruct = parse_quote! {
             struct TestStruct {
+                #[light_account(mut)]
+                foo: u64,
                 existing_field: u32,
             }
         };
 
-        let output = process_light_accounts(input).unwrap();
+        let output = process_light_system_accounts(input).unwrap();
         let output_string = output.to_string();
+
+        println!("{output_string}");
 
         assert!(output_string.contains("light_system_program"));
         assert!(output_string.contains("system_program"));
@@ -94,15 +430,15 @@ mod tests {
     }
 
     #[test]
-    fn test_process_light_accounts_fails_on_existing_field() {
-        let input: DeriveInput = parse_quote! {
+    fn test_process_light_system_accounts_fails_on_existing_field() {
+        let input: ItemStruct = parse_quote! {
             struct TestStruct {
                 existing_field: u32,
                 system_program: Program<'info, System>,
             }
         };
 
-        let result = process_light_accounts(input);
+        let result = process_light_system_accounts(input);
         assert!(result.is_err());
         let error_message = result.unwrap_err().to_string();
         assert!(error_message.contains("Field `system_program` already exists in the struct."));

--- a/macros/light/src/program.rs
+++ b/macros/light/src/program.rs
@@ -1,0 +1,140 @@
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{
+    parse_quote, visit_mut::VisitMut, Attribute, FnArg, GenericArgument, Ident, Item, ItemFn,
+    ItemMod, PathArguments, Result, Stmt, Type,
+};
+
+#[derive(Default)]
+struct LightProgramTransform {}
+
+impl VisitMut for LightProgramTransform {
+    fn visit_item_fn_mut(&mut self, i: &mut ItemFn) {
+        // Add `#[allow(clippy::too_many_arguments)]` attribute in case. We are
+        // injecting many arguments in this macro and they can easily go over
+        // the limit.
+        let clippy_attr: Attribute = parse_quote! {
+            #[allow(clippy::too_many_arguments)]
+        };
+        i.attrs.push(clippy_attr);
+
+        // Find the `ctx` argument.
+        let ctx_arg = i.sig.inputs.first_mut().unwrap();
+
+        // Retrieve the type of `ctx`.
+        let pat_type = match ctx_arg {
+            FnArg::Typed(pat_type) => pat_type,
+            _ => return,
+        };
+
+        // Get the last path segment of `ctx` type.
+        // It should be `LightContext`...
+        let type_path = match pat_type.ty.as_mut() {
+            Type::Path(type_path) => type_path,
+            _ => return,
+        };
+        let ctx_segment = &mut type_path.path.segments.last_mut().unwrap();
+        // ...and we replace it with Anchor's `Context`
+        ctx_segment.ident = Ident::new("Context", Span::call_site());
+
+        // Figure out what's are the names of:
+        //
+        // - The struct with Anchor accounts (implementing `anchor_lang::Accounts`) -
+        //   it's specified as the last generic argument in `ctx`, e.g. `MyInstruction`.
+        // - The struct with compressed accounds (implementing `LightAccounts`) -
+        //   it's derived by adding the `Light` prefix to the previous struct name,
+        //   e.g. `LightMyInstruction`.
+        let arguments = match &ctx_segment.arguments {
+            PathArguments::AngleBracketed(arguments) => arguments,
+            _ => return,
+        };
+        let last_arg = arguments.args.last().unwrap();
+        let last_arg_type = match last_arg {
+            GenericArgument::Type(last_arg_type) => last_arg_type,
+            _ => return,
+        };
+        let last_arg_type_path = match last_arg_type {
+            Type::Path(last_arg_type_path) => last_arg_type_path,
+            _ => return,
+        };
+        let accounts_segment = &last_arg_type_path.path.segments.last().unwrap();
+        let accounts_ident = accounts_segment.ident.clone();
+        let light_accounts_name = format!("Light{}", accounts_segment.ident);
+        let light_accounts_ident = Ident::new(&light_accounts_name, Span::call_site());
+
+        // Inject an `inputs: Vec<Vec<u8>>` argument to all instructions. The
+        // purpose of that additional argument is passing compressed accounts.
+        let inputs_arg: FnArg = parse_quote! { inputs: Vec<Vec<u8>> };
+        i.sig.inputs.insert(1, inputs_arg);
+
+        // Inject Merkle context related arguments.
+        let proof_arg: FnArg = parse_quote! { proof: CompressedProof };
+        i.sig.inputs.insert(2, proof_arg);
+        let merkle_context_arg: FnArg = parse_quote! { merkle_context: PackedMerkleContext };
+        i.sig.inputs.insert(3, merkle_context_arg);
+        let merkle_tree_root_index_arg: FnArg = parse_quote! { merkle_tree_root_index: u16 };
+        i.sig.inputs.insert(4, merkle_tree_root_index_arg);
+        let address_merkle_context_arg: FnArg =
+            parse_quote! { address_merkle_context: PackedAddressMerkleContext };
+        i.sig.inputs.insert(5, address_merkle_context_arg);
+        let address_merkle_tree_root_index_arg: FnArg =
+            parse_quote! { address_merkle_tree_root_index: u16 };
+        i.sig.inputs.insert(6, address_merkle_tree_root_index_arg);
+
+        // Inject a `LightContext` into the function body.
+        let light_context_stmt: Stmt = parse_quote! {
+            let mut ctx: ::light_sdk::context::LightContext<
+                #accounts_ident,
+                #light_accounts_ident
+            > = ::light_sdk::context::LightContext::new(
+                ctx,
+                inputs,
+                merkle_context,
+                merkle_tree_root_index,
+                address_merkle_context,
+                address_merkle_tree_root_index,
+            )?;
+        };
+        i.block.stmts.insert(0, light_context_stmt);
+
+        // Inject `derive_address_seeds` and  `verify` statements at the end of
+        // the function.
+        let stmts_len = i.block.stmts.len();
+        let derive_address_seed_stmt: Stmt = parse_quote! {
+            ctx.derive_address_seeds(address_merkle_context);
+        };
+        i.block
+            .stmts
+            .insert(stmts_len - 1, derive_address_seed_stmt);
+        let stmts_len = i.block.stmts.len();
+        let verify_stmt: Stmt = parse_quote! {
+            ctx.verify(proof)?;
+        };
+        i.block.stmts.insert(stmts_len - 1, verify_stmt);
+    }
+
+    fn visit_item_mod_mut(&mut self, i: &mut ItemMod) {
+        // Search for all functions inside the annotated `mod` and visit them.
+        if let Some((_, ref mut content)) = i.content {
+            for item in content.iter_mut() {
+                if let Item::Fn(item_fn) = item {
+                    self.visit_item_fn_mut(item_fn)
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn program(mut input: ItemMod) -> Result<TokenStream> {
+    let mut transform = LightProgramTransform::default();
+    transform.visit_item_mod_mut(&mut input);
+
+    Ok(quote! {
+        pub trait LightContextExt {
+            fn derive_address_seeds(&mut self, address_merkle_context: PackedAddressMerkleContext);
+        }
+
+        #[program]
+        #input
+    })
+}

--- a/sdk/src/compressed_account.rs
+++ b/sdk/src/compressed_account.rs
@@ -1,13 +1,13 @@
+use std::ops::{Deref, DerefMut};
+
 use anchor_lang::prelude::{AccountInfo, Key, ProgramError, Pubkey, Result};
-use borsh::BorshSerialize;
+use borsh::{BorshDeserialize, BorshSerialize};
 use light_hasher::{DataHasher, Discriminator, Poseidon};
-use light_system_program::{
-    sdk::{
-        address::derive_address,
-        compressed_account::{
-            CompressedAccount, CompressedAccountData, CompressedAccountWithMerkleContext,
-            PackedCompressedAccountWithMerkleContext, PackedMerkleContext,
-        },
+use light_system_program::sdk::address::derive_address;
+pub use light_system_program::{
+    sdk::compressed_account::{
+        CompressedAccount, CompressedAccountData, CompressedAccountWithMerkleContext,
+        PackedCompressedAccountWithMerkleContext, PackedMerkleContext,
     },
     NewAddressParamsPacked, OutputCompressedAccountWithPackedContext,
 };
@@ -15,6 +15,410 @@ use light_system_program::{
 use crate::merkle_context::{
     pack_merkle_context, PackedAddressMerkleContext, PackedMerkleOutputContext, RemainingAccounts,
 };
+
+pub trait LightAccounts: Sized {
+    fn try_light_accounts(
+        inputs: Vec<Vec<u8>>,
+        merkle_context: PackedMerkleContext,
+        merkle_tree_root_index: u16,
+        address_merkle_context: PackedAddressMerkleContext,
+        address_merkle_tree_root_index: u16,
+        remaining_accounts: &[AccountInfo],
+    ) -> Result<Self>;
+    fn new_address_params(&self) -> Vec<NewAddressParamsPacked>;
+    fn input_accounts(
+        &self,
+        remaining_accounts: &[AccountInfo],
+    ) -> Result<Vec<PackedCompressedAccountWithMerkleContext>>;
+    fn output_accounts(
+        &self,
+        remaining_accounts: &[AccountInfo],
+    ) -> Result<Vec<OutputCompressedAccountWithPackedContext>>;
+}
+
+/// A wrapper which abstracts away the UTXO model.
+pub enum LightAccount<T>
+where
+    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+{
+    Init(LightInitAccount<T>),
+    Mut(LightMutAccount<T>),
+    Close(LightCloseAccount<T>),
+}
+
+impl<T> LightAccount<T>
+where
+    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Default + Discriminator,
+{
+    pub fn new_init(
+        merkle_context: &PackedMerkleContext,
+        address_merkle_context: &PackedAddressMerkleContext,
+        address_merkle_tree_root_index: u16,
+    ) -> Self {
+        Self::Init(LightInitAccount::new(
+            merkle_context,
+            address_merkle_context,
+            address_merkle_tree_root_index,
+        ))
+    }
+
+    pub fn try_from_slice_mut(
+        v: &[u8],
+        merkle_context: &PackedMerkleContext,
+        merkle_tree_root_index: u16,
+        address_merkle_context: &PackedAddressMerkleContext,
+    ) -> Result<Self> {
+        Ok(Self::Mut(LightMutAccount::try_from_slice(
+            v,
+            merkle_context,
+            merkle_tree_root_index,
+            address_merkle_context,
+        )?))
+    }
+
+    pub fn try_from_slice_close(
+        v: &[u8],
+        merkle_context: &PackedMerkleContext,
+        merkle_tree_root_index: u16,
+        address_merkle_context: &PackedAddressMerkleContext,
+    ) -> Result<Self> {
+        Ok(Self::Close(LightCloseAccount::try_from_slice(
+            v,
+            merkle_context,
+            merkle_tree_root_index,
+            address_merkle_context,
+        )?))
+    }
+
+    pub fn set_address_seed(&mut self, address_seed: [u8; 32]) {
+        match self {
+            Self::Init(light_init_account) => light_init_account.set_address_seed(address_seed),
+            Self::Mut(light_mut_account) => light_mut_account.set_address_seed(address_seed),
+            Self::Close(light_close_account) => light_close_account.set_address_seed(address_seed),
+        }
+    }
+
+    pub fn new_address_params(&self) -> Option<NewAddressParamsPacked> {
+        match self {
+            Self::Init(self_init) => Some(self_init.new_address_params()),
+            Self::Mut(_) => None,
+            Self::Close(_) => None,
+        }
+    }
+
+    pub fn input_compressed_account(
+        &self,
+        program_id: &Pubkey,
+        remaining_accounts: &[AccountInfo],
+    ) -> Result<Option<PackedCompressedAccountWithMerkleContext>> {
+        match self {
+            Self::Init(_) => Ok(None),
+            Self::Mut(light_mut_account) => {
+                let account =
+                    light_mut_account.input_compressed_account(program_id, remaining_accounts)?;
+                Ok(Some(account))
+            }
+            Self::Close(light_close_account) => {
+                let account =
+                    light_close_account.input_compressed_account(program_id, remaining_accounts)?;
+                Ok(Some(account))
+            }
+        }
+    }
+
+    pub fn output_compressed_account(
+        &self,
+        program_id: &Pubkey,
+        remaining_accounts: &[AccountInfo],
+    ) -> Result<Option<OutputCompressedAccountWithPackedContext>> {
+        match self {
+            Self::Init(light_init_account) => {
+                let account =
+                    light_init_account.output_compressed_account(program_id, remaining_accounts)?;
+                Ok(Some(account))
+            }
+            Self::Mut(light_mut_account) => {
+                let account =
+                    light_mut_account.output_compressed_account(program_id, remaining_accounts)?;
+                Ok(Some(account))
+            }
+            Self::Close(_) => Ok(None),
+        }
+    }
+}
+
+impl<T> Deref for LightAccount<T>
+where
+    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Init(light_init_account) => &light_init_account.output_account,
+            Self::Mut(light_mut_account) => &light_mut_account.output_account,
+            Self::Close(light_close_account) => &light_close_account.input_account,
+        }
+    }
+}
+
+impl<T> DerefMut for LightAccount<T>
+where
+    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Self::Init(light_init_account) => &mut light_init_account.output_account,
+            Self::Mut(light_mut_account) => &mut light_mut_account.output_account,
+            Self::Close(light_close_account) => &mut light_close_account.input_account,
+        }
+    }
+}
+
+pub struct LightInitAccount<T>
+where
+    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+{
+    output_account: T,
+    address_seed: Option<[u8; 32]>,
+    merkle_context: PackedMerkleContext,
+    address_merkle_context: PackedAddressMerkleContext,
+    address_merkle_tree_root_index: u16,
+}
+
+impl<T> LightInitAccount<T>
+where
+    T: BorshDeserialize + BorshSerialize + Clone + Default + DataHasher + Discriminator,
+{
+    pub fn new(
+        merkle_context: &PackedMerkleContext,
+        address_merkle_context: &PackedAddressMerkleContext,
+        address_merkle_tree_root_index: u16,
+    ) -> Self {
+        let output_account = T::default();
+
+        Self {
+            output_account,
+            address_seed: None,
+            merkle_context: *merkle_context,
+            address_merkle_context: *address_merkle_context,
+            address_merkle_tree_root_index,
+        }
+    }
+
+    pub fn set_address_seed(&mut self, address_seed: [u8; 32]) {
+        self.address_seed = Some(address_seed);
+    }
+
+    pub fn new_address_params(&self) -> NewAddressParamsPacked {
+        NewAddressParamsPacked {
+            seed: self.address_seed.unwrap(),
+            address_merkle_tree_account_index: self
+                .address_merkle_context
+                .address_merkle_tree_pubkey_index,
+            address_queue_account_index: self.address_merkle_context.address_queue_pubkey_index,
+            address_merkle_tree_root_index: self.address_merkle_tree_root_index,
+        }
+    }
+
+    pub fn output_compressed_account(
+        &self,
+        program_id: &Pubkey,
+        remaining_accounts: &[AccountInfo],
+    ) -> Result<OutputCompressedAccountWithPackedContext> {
+        output_compressed_account(
+            &self.output_account,
+            &self.address_seed.unwrap(),
+            program_id,
+            &self.merkle_context,
+            &self.address_merkle_context,
+            remaining_accounts,
+        )
+    }
+}
+
+impl<T> Deref for LightInitAccount<T>
+where
+    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.output_account
+    }
+}
+
+impl<T> DerefMut for LightInitAccount<T>
+where
+    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.output_account
+    }
+}
+
+pub struct LightMutAccount<T>
+where
+    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+{
+    input_account: T,
+    output_account: T,
+    address_seed: Option<[u8; 32]>,
+    merkle_context: PackedMerkleContext,
+    merkle_tree_root_index: u16,
+    address_merkle_context: PackedAddressMerkleContext,
+}
+
+impl<T> LightMutAccount<T>
+where
+    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+{
+    pub fn try_from_slice(
+        v: &[u8],
+        merkle_context: &PackedMerkleContext,
+        merkle_tree_root_index: u16,
+        address_merkle_context: &PackedAddressMerkleContext,
+    ) -> Result<Self> {
+        let account = T::try_from_slice(v)?;
+
+        Ok(Self {
+            input_account: account.clone(),
+            output_account: account,
+            address_seed: None,
+            merkle_context: *merkle_context,
+            merkle_tree_root_index,
+            address_merkle_context: *address_merkle_context,
+        })
+    }
+
+    pub fn set_address_seed(&mut self, address_seed: [u8; 32]) {
+        self.address_seed = Some(address_seed);
+    }
+
+    pub fn input_compressed_account(
+        &self,
+        program_id: &Pubkey,
+        remaining_accounts: &[AccountInfo],
+    ) -> Result<PackedCompressedAccountWithMerkleContext> {
+        input_compressed_account(
+            &self.input_account,
+            &self.address_seed.unwrap(),
+            program_id,
+            &self.merkle_context,
+            self.merkle_tree_root_index,
+            &self.address_merkle_context,
+            remaining_accounts,
+        )
+    }
+
+    pub fn output_compressed_account(
+        &self,
+        program_id: &Pubkey,
+        remaining_accounts: &[AccountInfo],
+    ) -> Result<OutputCompressedAccountWithPackedContext> {
+        output_compressed_account(
+            &self.output_account,
+            &self.address_seed.unwrap(),
+            program_id,
+            &self.merkle_context,
+            &self.address_merkle_context,
+            remaining_accounts,
+        )
+    }
+}
+
+impl<T> Deref for LightMutAccount<T>
+where
+    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.output_account
+    }
+}
+
+impl<T> DerefMut for LightMutAccount<T>
+where
+    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.output_account
+    }
+}
+
+pub struct LightCloseAccount<T>
+where
+    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+{
+    input_account: T,
+    address_seed: Option<[u8; 32]>,
+    merkle_context: PackedMerkleContext,
+    merkle_tree_root_index: u16,
+    address_merkle_context: PackedAddressMerkleContext,
+}
+
+impl<T> LightCloseAccount<T>
+where
+    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+{
+    pub fn try_from_slice(
+        v: &[u8],
+        merkle_context: &PackedMerkleContext,
+        merkle_tree_root_index: u16,
+        address_merkle_context: &PackedAddressMerkleContext,
+    ) -> Result<Self> {
+        let input_account = T::try_from_slice(v)?;
+
+        Ok(Self {
+            input_account,
+            address_seed: None,
+            merkle_context: *merkle_context,
+            merkle_tree_root_index,
+            address_merkle_context: *address_merkle_context,
+        })
+    }
+
+    pub fn set_address_seed(&mut self, address_seed: [u8; 32]) {
+        self.address_seed = Some(address_seed);
+    }
+
+    pub fn input_compressed_account(
+        &self,
+        program_id: &Pubkey,
+        remaining_accounts: &[AccountInfo],
+    ) -> Result<PackedCompressedAccountWithMerkleContext> {
+        input_compressed_account(
+            &self.input_account,
+            &self.address_seed.unwrap(),
+            program_id,
+            &self.merkle_context,
+            self.merkle_tree_root_index,
+            &self.address_merkle_context,
+            remaining_accounts,
+        )
+    }
+}
+
+impl<T> Deref for LightCloseAccount<T>
+where
+    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.input_account
+    }
+}
+
+impl<T> DerefMut for LightCloseAccount<T>
+where
+    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.input_account
+    }
+}
 
 pub fn serialize_and_hash_account<T>(
     account: &T,

--- a/sdk/src/context.rs
+++ b/sdk/src/context.rs
@@ -1,0 +1,135 @@
+use std::ops::{Deref, DerefMut};
+
+use account_compression::utils::constants::CPI_AUTHORITY_PDA_SEED;
+use anchor_lang::{context::Context, prelude::Pubkey, Bumps, Key, Result};
+use light_system_program::{invoke::processor::CompressedProof, InstructionDataInvokeCpi};
+
+use crate::{
+    compressed_account::LightAccounts,
+    merkle_context::{PackedAddressMerkleContext, PackedMerkleContext},
+    traits::{
+        InvokeAccounts, InvokeCpiAccounts, InvokeCpiContextAccount, LightSystemAccount,
+        SignerAccounts,
+    },
+    verify::verify,
+};
+
+/// Provides non-argument inputs to the program, including light accounts and
+/// regular accounts.
+///
+/// # Example
+/// ```ignore
+/// pub fn set_data(ctx: Context<SetData>, age: u64, other_data: u32) -> Result<()> {
+///     // Set account data like this
+///     (*ctx.accounts.my_account).age = age;
+///     (*ctx.accounts.my_account).other_data = other_data;
+///     // or like this
+///     let my_account = &mut ctx.account.my_account;
+///     my_account.age = age;
+///     my_account.other_data = other_data;
+///     Ok(())
+/// }
+/// ```
+pub struct LightContext<'a, 'b, 'c, 'info, T, U>
+where
+    T: Bumps,
+    U: LightAccounts,
+{
+    /// Context provided by Anchor.
+    pub anchor_context: Context<'a, 'b, 'c, 'info, T>,
+    pub light_accounts: U,
+}
+
+impl<'a, 'b, 'c, 'info, T, U> Deref for LightContext<'a, 'b, 'c, 'info, T, U>
+where
+    T: Bumps,
+    U: LightAccounts,
+{
+    type Target = Context<'a, 'b, 'c, 'info, T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.anchor_context
+    }
+}
+
+impl<'a, 'b, 'c, 'info, T, U> DerefMut for LightContext<'a, 'b, 'c, 'info, T, U>
+where
+    T: Bumps,
+    U: LightAccounts,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.anchor_context
+    }
+}
+
+impl<'a, 'b, 'c, 'info, T, U> LightContext<'a, 'b, 'c, 'info, T, U>
+where
+    T: Bumps
+        + InvokeAccounts<'info>
+        + InvokeCpiAccounts<'info>
+        + InvokeCpiContextAccount<'info>
+        + LightSystemAccount<'info>
+        + SignerAccounts<'info>,
+    U: LightAccounts,
+{
+    pub fn new(
+        anchor_context: Context<'a, 'b, 'c, 'info, T>,
+        inputs: Vec<Vec<u8>>,
+        merkle_context: PackedMerkleContext,
+        merkle_tree_root_index: u16,
+        address_merkle_context: PackedAddressMerkleContext,
+        address_merkle_tree_root_index: u16,
+    ) -> Result<Self> {
+        let light_accounts = U::try_light_accounts(
+            inputs,
+            merkle_context,
+            merkle_tree_root_index,
+            address_merkle_context,
+            address_merkle_tree_root_index,
+            anchor_context.remaining_accounts,
+        )?;
+        Ok(Self {
+            anchor_context,
+            light_accounts,
+        })
+    }
+
+    pub fn verify(&mut self, proof: CompressedProof) -> Result<()> {
+        let bump = Pubkey::find_program_address(
+            &[CPI_AUTHORITY_PDA_SEED],
+            &self.anchor_context.accounts.get_invoking_program().key(),
+        )
+        .1;
+        let signer_seeds = [CPI_AUTHORITY_PDA_SEED, &[bump]];
+
+        // TODO(vadorovsky): Remove.
+        // self.light_accounts
+        //     .derive_address_seeds(address_merkle_context, remaining_accounts);
+        let new_address_params = self.light_accounts.new_address_params();
+        let input_compressed_accounts_with_merkle_context = self
+            .light_accounts
+            .input_accounts(self.anchor_context.remaining_accounts)?;
+        let output_compressed_accounts = self
+            .light_accounts
+            .output_accounts(self.anchor_context.remaining_accounts)?;
+
+        let instruction = InstructionDataInvokeCpi {
+            proof: Some(proof),
+            new_address_params,
+            relay_fee: None,
+            input_compressed_accounts_with_merkle_context,
+            output_compressed_accounts,
+            compress_or_decompress_lamports: None,
+            is_compress: false,
+            cpi_context: None,
+        };
+
+        verify(
+            &self.anchor_context,
+            &instruction,
+            &[signer_seeds.as_slice()],
+        )?;
+
+        Ok(())
+    }
+}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -2,7 +2,9 @@ pub use light_macros::*;
 
 pub mod address;
 pub mod compressed_account;
+pub mod context;
 pub mod merkle_context;
+pub mod program_merkle_context;
 pub mod traits;
 pub mod utils;
 pub mod verify;

--- a/sdk/src/merkle_context.rs
+++ b/sdk/src/merkle_context.rs
@@ -1,9 +1,6 @@
 use std::collections::HashMap;
 
-use anchor_lang::{
-    prelude::{AccountInfo, AccountMeta, AnchorDeserialize, AnchorSerialize, Pubkey},
-    Key,
-};
+use anchor_lang::prelude::{AccountMeta, AnchorDeserialize, AnchorSerialize, Pubkey};
 
 // TODO(vadorovsky): Consider moving these structs here.
 pub use light_system_program::sdk::compressed_account::{MerkleContext, PackedMerkleContext};
@@ -180,30 +177,4 @@ pub fn pack_address_merkle_context(
     remaining_accounts: &mut RemainingAccounts,
 ) -> PackedAddressMerkleContext {
     pack_address_merkle_contexts(&[address_merkle_context], remaining_accounts)[0]
-}
-
-pub fn unpack_address_merkle_contexts(
-    address_merkle_contexts: &[PackedAddressMerkleContext],
-    remaining_accounts: &[AccountInfo],
-) -> Vec<AddressMerkleContext> {
-    address_merkle_contexts
-        .iter()
-        .map(|x| {
-            let address_merkle_tree_pubkey =
-                remaining_accounts[x.address_merkle_tree_pubkey_index as usize].key();
-            let address_queue_pubkey =
-                remaining_accounts[x.address_queue_pubkey_index as usize].key();
-            AddressMerkleContext {
-                address_merkle_tree_pubkey,
-                address_queue_pubkey,
-            }
-        })
-        .collect::<Vec<_>>()
-}
-
-pub fn unpack_address_merkle_context(
-    address_merkle_context: PackedAddressMerkleContext,
-    remaining_accounts: &[AccountInfo],
-) -> AddressMerkleContext {
-    unpack_address_merkle_contexts(&[address_merkle_context], remaining_accounts)[0]
 }

--- a/sdk/src/program_merkle_context.rs
+++ b/sdk/src/program_merkle_context.rs
@@ -1,0 +1,59 @@
+use anchor_lang::{prelude::AccountInfo, Key};
+
+use crate::merkle_context::{AddressMerkleContext, PackedAddressMerkleContext};
+
+pub fn pack_address_merkle_contexts(
+    address_merkle_contexts: &[AddressMerkleContext],
+    remaining_accounts: &[AccountInfo],
+) -> Vec<PackedAddressMerkleContext> {
+    address_merkle_contexts
+        .iter()
+        .map(|x| {
+            let address_merkle_tree_pubkey_index = remaining_accounts
+                .iter()
+                .position(|account| account.key() == x.address_merkle_tree_pubkey)
+                .unwrap() as u8;
+            let address_queue_pubkey_index = remaining_accounts
+                .iter()
+                .position(|account| account.key() == x.address_queue_pubkey)
+                .unwrap() as u8;
+            PackedAddressMerkleContext {
+                address_merkle_tree_pubkey_index,
+                address_queue_pubkey_index,
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
+pub fn pack_address_merkle_context(
+    address_merkle_context: AddressMerkleContext,
+    remaining_accounts: &[AccountInfo],
+) -> PackedAddressMerkleContext {
+    pack_address_merkle_contexts(&[address_merkle_context], remaining_accounts)[0]
+}
+
+pub fn unpack_address_merkle_contexts(
+    address_merkle_contexts: &[PackedAddressMerkleContext],
+    remaining_accounts: &[AccountInfo],
+) -> Vec<AddressMerkleContext> {
+    address_merkle_contexts
+        .iter()
+        .map(|x| {
+            let address_merkle_tree_pubkey =
+                remaining_accounts[x.address_merkle_tree_pubkey_index as usize].key();
+            let address_queue_pubkey =
+                remaining_accounts[x.address_queue_pubkey_index as usize].key();
+            AddressMerkleContext {
+                address_merkle_tree_pubkey,
+                address_queue_pubkey,
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
+pub fn unpack_address_merkle_context(
+    address_merkle_context: PackedAddressMerkleContext,
+    remaining_accounts: &[AccountInfo],
+) -> AddressMerkleContext {
+    unpack_address_merkle_contexts(&[address_merkle_context], remaining_accounts)[0]
+}

--- a/sdk/src/utils.rs
+++ b/sdk/src/utils.rs
@@ -1,8 +1,8 @@
 use anchor_lang::solana_program::pubkey::Pubkey;
+pub use light_system_program::{invoke::processor::CompressedProof, InstructionDataInvokeCpi};
 use light_system_program::{
-    invoke::processor::CompressedProof,
     sdk::{compressed_account::PackedCompressedAccountWithMerkleContext, CompressedCpiContext},
-    InstructionDataInvokeCpi, NewAddressParamsPacked, OutputCompressedAccountWithPackedContext,
+    NewAddressParamsPacked, OutputCompressedAccountWithPackedContext,
 };
 
 pub fn get_registered_program_pda(program_id: &Pubkey) -> Pubkey {

--- a/sdk/src/verify.rs
+++ b/sdk/src/verify.rs
@@ -105,7 +105,7 @@ pub fn invoke_cpi<'info, 'a, 'b, 'c>(
 /// transition. Serializes CPI instruction data, configures necessary accounts,
 /// and executes the CPI.
 pub fn verify<'info, 'a, 'b, 'c>(
-    ctx: Context<
+    ctx: &Context<
         '_,
         '_,
         '_,
@@ -123,6 +123,6 @@ pub fn verify<'info, 'a, 'b, 'c>(
     let mut inputs: Vec<u8> = Vec::new();
     InstructionDataInvokeCpi::serialize(inputs_struct, &mut inputs).unwrap();
 
-    let cpi_accounts = setup_cpi_accounts(&ctx);
-    invoke_cpi(&ctx, cpi_accounts, inputs, signer_seeds)
+    let cpi_accounts = setup_cpi_accounts(ctx);
+    invoke_cpi(ctx, cpi_accounts, inputs, signer_seeds)
 }


### PR DESCRIPTION
Add the following macros:

- `#[light_program]` - wraps the program module and adds necessary code to the instruction functions.
- `#[light_accounts]` - wraps the instruction struct containing both the regular Anchor accounts and compressed accounts.

See the `name-server` example for the usage.

Related changes:

- Introduce `LightContext` - a new context type which contains `accounts` (regular) and `light_accounts` (compressed). It abstracts away the UTXO model from users, allowing to modify compressed accounts the same way as regular ones.
- Rename the former `#[light_accounts]` macro to `#[light_system_accounts]`.