### PR TITLE
chore: added rollover logic to forester(once per slot) and test

### DIFF
--- a/forester/tests/test_utils.rs
+++ b/forester/tests/test_utils.rs
@@ -47,7 +47,7 @@ pub fn keypair_action_config() -> KeypairActionConfig {
         mint_spl: Some(1.0),
         transfer_spl: Some(1.0),
         max_output_accounts: Some(3),
-        fee_assert: true,
+        fee_assert: false,
         approve_spl: None,
         revoke_spl: None,
         freeze_spl: None,

--- a/test-programs/registry-test/tests/tests.rs
+++ b/test-programs/registry-test/tests/tests.rs
@@ -652,7 +652,7 @@ async fn test_register_and_update_forester_pda() {
     // create work 1 item in address and nullifier queue each
     let (mut state_merkle_tree_bundle, mut address_merkle_tree, mut rpc) = {
         let mut e2e_env = init_program_test_env(rpc, &env).await;
-        e2e_env.create_address(None).await;
+        e2e_env.create_address(None, None).await;
         e2e_env
             .compress_sol_deterministic(&forester_keypair, 1_000_000, None)
             .await;

--- a/test-utils/src/e2e_test_env.rs
+++ b/test-utils/src/e2e_test_env.rs
@@ -765,7 +765,7 @@ where
         let cpi_context_keypair = Keypair::new();
         let rollover_threshold = if let Some(rollover_threshold) = rollover_threshold {
             Some(rollover_threshold)
-        } else if self.rng.gen_bool(0.5) {
+        } else if self.rng.gen_bool(0.5) && !self.keypair_action_config.fee_assert {
             Some(self.rng.gen_range(1..100))
         } else {
             None
@@ -791,6 +791,8 @@ where
                 sequence_threshold: merkle_tree_config.roots_size + SAFETY_MARGIN,
                 network_fee: None,
             }
+        } else if rollover_threshold.is_some() {
+            panic!("rollover_threshold should not be set when fee_assert is set (keypair_action_config.fee_assert)");
         } else {
             NullifierQueueConfig::default()
         };
@@ -844,7 +846,7 @@ where
         let nullifier_queue_keypair = Keypair::new();
         let rollover_threshold = if let Some(rollover_threshold) = rollover_threshold {
             Some(rollover_threshold)
-        } else if self.rng.gen_bool(0.5) {
+        } else if self.rng.gen_bool(0.5) && !self.keypair_action_config.fee_assert {
             Some(self.rng.gen_range(1..100))
         } else {
             None


### PR DESCRIPTION
Issue:
- foresters only check once per active phase for every tree whether it can be rolledover, for long epochs with high traffic this is insufficient

Changes:
- check whether a tree can be rolledover once per light slot
- move rollover  into `process_queue`
- modify test to test a rollover  