### PR TITLE
refactor: forester: switch logging from `log` to `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2295,7 +2295,6 @@ dependencies = [
  "light-registry",
  "light-system-program",
  "light-test-utils",
- "log",
  "num-bigint 0.4.6",
  "num-traits",
  "once_cell",

--- a/forester-utils/src/rpc/solana_rpc.rs
+++ b/forester-utils/src/rpc/solana_rpc.rs
@@ -5,7 +5,7 @@ use anchor_lang::prelude::Pubkey;
 use anchor_lang::solana_program::clock::Slot;
 use anchor_lang::solana_program::hash::Hash;
 use anchor_lang::AnchorDeserialize;
-use log::{debug, info, warn};
+use log::{debug, warn};
 use solana_client::rpc_client::RpcClient;
 use solana_client::rpc_config::{RpcSendTransactionConfig, RpcTransactionConfig};
 use solana_program_test::BanksClientError;
@@ -151,7 +151,7 @@ impl RpcConnection for SolanaRpcConnection {
         &self,
         program_id: &Pubkey,
     ) -> Result<Vec<(Pubkey, Account)>, RpcError> {
-        info!(
+        debug!(
             "Fetching accounts for program: {}, client url: {}",
             program_id,
             self.client.url()
@@ -361,7 +361,7 @@ impl RpcConnection for SolanaRpcConnection {
     }
 
     async fn get_slot(&mut self) -> Result<u64, RpcError> {
-        println!("Calling get_slot");
+        debug!("Calling get_slot");
         self.client.get_slot().map_err(RpcError::from)
     }
 

--- a/forester/Cargo.toml
+++ b/forester/Cargo.toml
@@ -37,7 +37,6 @@ photon-api = { path = "../photon-api" }
 bincode = "1.3"
 sysinfo = "0.31"
 forester-utils = { path = "../forester-utils" }
-log = "0.4"
 env_logger = "0.11"
 rand = "0.8.5"
 dotenvy = "0.15.7"

--- a/forester/src/config.rs
+++ b/forester/src/config.rs
@@ -1,8 +1,8 @@
 use forester_utils::forester_epoch::{Epoch, TreeAccounts, TreeForesterSchedule};
 use light_registry::{EpochPda, ForesterEpochPda};
-use log::info;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Keypair;
+use tracing::debug;
 
 #[derive(Debug, Clone)]
 pub struct ForesterEpochInfo {
@@ -21,9 +21,9 @@ impl ForesterEpochInfo {
         // let state = self.phases.get_current_epoch_state(current_solana_slot);
         // TODO: add epoch state to sync schedule
         for tree in trees {
-            info!("Adding tree schedule for {:?}", tree);
-            info!("Current slot: {}", current_solana_slot);
-            info!("Epoch: {:?}", self.epoch_pda);
+            debug!("Adding tree schedule for {:?}", tree);
+            debug!("Current slot: {}", current_solana_slot);
+            debug!("Epoch: {:?}", self.epoch_pda);
             let tree_schedule = TreeForesterSchedule::new_with_schedule(
                 tree,
                 current_solana_slot,

--- a/forester/src/lib.rs
+++ b/forester/src/lib.rs
@@ -28,12 +28,12 @@ pub use config::{ForesterConfig, ForesterEpochInfo};
 use forester_utils::forester_epoch::{TreeAccounts, TreeType};
 use forester_utils::indexer::Indexer;
 use forester_utils::rpc::{RpcConnection, SolanaRpcConnection};
-use log::info;
 pub use settings::init_config;
 use solana_sdk::commitment_config::CommitmentConfig;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc, oneshot, Mutex};
+use tracing::debug;
 
 pub async fn run_queue_info(
     config: Arc<ForesterConfig>,
@@ -55,7 +55,7 @@ pub async fn run_queue_info(
         QUEUE_LENGTH
             .with_label_values(&[&*queue_type.to_string(), &tree_data.merkle_tree.to_string()])
             .set(queue_length as i64);
-        info!(
+        println!(
             "{:?} queue {} length: {}",
             queue_type, tree_data.queue, queue_length
         );
@@ -102,7 +102,7 @@ pub async fn run_pipeline<R: RpcConnection, I: Indexer<R>>(
         SlotTracker::run(arc_slot_tracker_clone, &mut *rpc).await;
     });
 
-    info!("Starting Forester pipeline");
+    debug!("Starting Forester pipeline");
     run_service(
         config,
         Arc::new(protocol_config),

--- a/forester/src/main.rs
+++ b/forester/src/main.rs
@@ -8,10 +8,10 @@ use forester::tree_data_sync::fetch_trees;
 use forester::{init_config, run_pipeline, run_queue_info};
 use forester_utils::forester_epoch::TreeType;
 use forester_utils::rpc::{RpcConnection, SolanaRpcConnection};
-use log::{debug, info, warn};
 use std::sync::Arc;
 use tokio::signal::ctrl_c;
 use tokio::sync::{mpsc, oneshot};
+use tracing::{debug, warn};
 
 #[tokio::main]
 async fn main() -> Result<(), ForesterError> {
@@ -55,8 +55,8 @@ async fn main() -> Result<(), ForesterError> {
             run_pipeline(config, indexer, shutdown_receiver, work_report_sender).await?
         }
         Some(Commands::Status) => {
-            info!("Fetching trees...");
-            info!("RPC URL: {}", config.external_services.rpc_url);
+            debug!("Fetching trees...");
+            debug!("RPC URL: {}", config.external_services.rpc_url);
             let rpc = SolanaRpcConnection::new(config.external_services.rpc_url.to_string(), None);
             let trees = fetch_trees(&rpc).await;
             if trees.is_empty() {

--- a/forester/src/metrics.rs
+++ b/forester/src/metrics.rs
@@ -5,7 +5,7 @@ use reqwest::Client;
 use std::sync::Once;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::Mutex;
-use tracing::{error, info};
+use tracing::{debug, error};
 
 lazy_static! {
     pub static ref REGISTRY: Registry = Registry::new();
@@ -94,7 +94,7 @@ pub fn update_transactions_processed(epoch: u64, count: usize, duration: std::ti
         .with_label_values(&[&epoch.to_string()])
         .set(rate);
 
-    info!(
+    debug!(
         "Updated metrics for epoch {}: processed = {}, rate = {} tx/s",
         epoch, count, rate
     );
@@ -120,13 +120,13 @@ pub async fn push_metrics(url: &str) -> Result<()> {
     let mut buffer = Vec::new();
     encoder.encode(&metric_families, &mut buffer)?;
 
-    info!("Pushing metrics to Pushgateway");
+    debug!("Pushing metrics to Pushgateway");
 
     let client = Client::new();
     let res = client.post(url).body(buffer).send().await?;
 
     if res.status().is_success() {
-        println!("Successfully pushed metrics to Pushgateway");
+        debug!("Successfully pushed metrics to Pushgateway");
         Ok(())
     } else {
         let error_message = format!(

--- a/forester/src/photon_indexer.rs
+++ b/forester/src/photon_indexer.rs
@@ -2,11 +2,11 @@ use crate::utils::decode_hash;
 use account_compression::initialize_address_merkle_tree::Pubkey;
 use forester_utils::indexer::{Indexer, IndexerError, MerkleProof, NewAddressProofWithContext};
 use forester_utils::rpc::RpcConnection;
-use log::{debug, info};
 use photon_api::apis::configuration::{ApiKey, Configuration};
 use photon_api::models::GetCompressedAccountsByOwnerPostRequestParams;
 use solana_sdk::bs58;
 use std::fmt::Debug;
+use tracing::debug;
 
 pub struct PhotonIndexer<R: RpcConnection> {
     configuration: Configuration,
@@ -132,7 +132,7 @@ impl<R: RpcConnection> Indexer<R> for PhotonIndexer<R> {
             ..Default::default()
         };
 
-        info!("Request: {:?}", request);
+        debug!("Request: {:?}", request);
 
         let result = photon_api::apis::default_api::get_multiple_new_address_proofs_post(
             &self.configuration,

--- a/forester/src/queue_helpers.rs
+++ b/forester/src/queue_helpers.rs
@@ -3,8 +3,8 @@ use account_compression::initialize_address_merkle_tree::Pubkey;
 use account_compression::QueueAccount;
 use forester_utils::rpc::RpcConnection;
 use light_hash_set::HashSet;
-use log::debug;
 use std::mem;
+use tracing::debug;
 
 #[derive(Debug, Clone)]
 pub struct QueueItemData {
@@ -37,7 +37,7 @@ pub async fn fetch_queue_item_data<R: RpcConnection>(
             }
         })
         .collect();
-    log::info!("Queue data fetched: {:?}", filtered_queue);
+    debug!("Queue data fetched: {:?}", filtered_queue);
     Ok(filtered_queue)
 }
 

--- a/forester/src/rollover/operations.rs
+++ b/forester/src/rollover/operations.rs
@@ -5,13 +5,13 @@ use light_registry::account_compression_cpi::sdk::{
     CreateRolloverMerkleTreeInstructionInputs,
 };
 use light_registry::protocol_config::state::ProtocolConfig;
-use log::info;
 use solana_sdk::instruction::Instruction;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer;
 use solana_sdk::transaction::Transaction;
 use tokio::sync::Mutex;
+use tracing::{info, debug};
 
 use crate::errors::ForesterError;
 use crate::ForesterConfig;
@@ -42,7 +42,7 @@ pub async fn is_tree_ready_for_rollover<R: RpcConnection>(
     tree_pubkey: Pubkey,
     tree_type: TreeType,
 ) -> Result<bool, ForesterError> {
-    info!(
+    debug!(
         "Checking if tree is ready for rollover: {:?}",
         tree_pubkey.to_string()
     );
@@ -53,7 +53,7 @@ pub async fn is_tree_ready_for_rollover<R: RpcConnection>(
                 .await?
                 .unwrap();
             // let account_info = rpc.get_account(tree_pubkey).await?.unwrap();
-
+            
             let is_already_rolled_over =
                 account.metadata.rollover_metadata.rolledover_slot != u64::MAX;
             if is_already_rolled_over {

--- a/forester/src/rollover/operations.rs
+++ b/forester/src/rollover/operations.rs
@@ -11,7 +11,7 @@ use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer;
 use solana_sdk::transaction::Transaction;
 use tokio::sync::Mutex;
-use tracing::{info, debug};
+use tracing::{debug, info};
 
 use crate::errors::ForesterError;
 use crate::ForesterConfig;
@@ -53,7 +53,7 @@ pub async fn is_tree_ready_for_rollover<R: RpcConnection>(
                 .await?
                 .unwrap();
             // let account_info = rpc.get_account(tree_pubkey).await?.unwrap();
-            
+
             let is_already_rolled_over =
                 account.metadata.rollover_metadata.rolledover_slot != u64::MAX;
             if is_already_rolled_over {

--- a/forester/src/send_transaction.rs
+++ b/forester/src/send_transaction.rs
@@ -16,7 +16,6 @@ use light_registry::account_compression_cpi::sdk::{
     create_nullify_instruction, create_update_address_merkle_tree_instruction,
     CreateNullifyInstructionInputs, UpdateAddressMerkleTreeInstructionInputs,
 };
-use log::info;
 use solana_sdk::compute_budget::ComputeBudgetInstruction;
 use solana_sdk::instruction::Instruction;
 use solana_sdk::pubkey::Pubkey;
@@ -29,6 +28,7 @@ use std::sync::Arc;
 use std::{time::Duration, vec};
 use tokio::sync::Mutex;
 use tokio::time::sleep;
+use tracing::{debug, warn};
 
 pub trait TransactionBuilder {
     fn build_signed_transaction_batch(
@@ -125,9 +125,9 @@ pub async fn send_batched_transactions<T: TransactionBuilder, R: RpcConnection>(
                 .await;
             num_sent_transactions += transactions.len();
 
-            info!("build transaction time {:?}", start_time.elapsed());
+            debug!("build transaction time {:?}", start_time.elapsed());
             let start_time_get_connections = tokio::time::Instant::now();
-            info!(
+            debug!(
                 "get get connections txs time {:?}",
                 start_time_get_connections.elapsed()
             );
@@ -145,7 +145,7 @@ pub async fn send_batched_transactions<T: TransactionBuilder, R: RpcConnection>(
                 all_results.await;
             });
 
-            info!(
+            debug!(
                 "get send txs time {:?}",
                 start_time_get_connections.elapsed()
             );
@@ -156,7 +156,7 @@ pub async fn send_batched_transactions<T: TransactionBuilder, R: RpcConnection>(
         // 8. If work items is empty, await minimum batch time.
         // If this is triggered we could switch to subscribing to the queue
         if work_items.is_empty() {
-            info!("Work items empty, waiting for next batch epoch {:?}", epoch);
+            debug!("Work items empty, waiting for next batch epoch {:?}", epoch);
             tokio::time::sleep(batch_time).await;
         }
     }
@@ -201,7 +201,7 @@ pub async fn send_signed_transaction(
                 // info!("Transaction sent: {}", signature);
             }
             Err(e) => {
-                info!("Error sending transaction: {:?}", e);
+                warn!("Error sending transaction: {:?}", e);
                 return Err(ForesterError::from(e));
             }
         }

--- a/forester/src/settings.rs
+++ b/forester/src/settings.rs
@@ -4,12 +4,12 @@ use crate::ForesterConfig;
 use account_compression::initialize_address_merkle_tree::Pubkey;
 use anchor_lang::Id;
 use config::{Config, Environment};
-use log::info;
 use solana_sdk::signature::{Keypair, Signer};
 use std::fmt::{Display, Formatter};
 use std::path::Path;
 use std::str::FromStr;
 use std::{env, fmt};
+use tracing::debug;
 
 pub enum SettingsKey {
     Payer,
@@ -137,7 +137,7 @@ pub fn init_config() -> Result<ForesterConfig, ForesterError> {
         state_tree_data: vec![],
     };
 
-    info!("Config: {:?}", config);
+    debug!("Config: {:?}", config);
     Ok(config)
 }
 

--- a/forester/src/slot_tracker.rs
+++ b/forester/src/slot_tracker.rs
@@ -1,9 +1,9 @@
 use forester_utils::rpc::RpcConnection;
-use log::{debug, error};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::UNIX_EPOCH;
 use std::{sync::Arc, time::SystemTime};
 use tokio::time::{sleep, Duration};
+use tracing::{debug, error};
 
 pub fn slot_duration() -> Duration {
     Duration::from_nanos(solana_sdk::genesis_config::GenesisConfig::default().ns_per_slot() as u64)

--- a/forester/src/telemetry.rs
+++ b/forester/src/telemetry.rs
@@ -1,7 +1,7 @@
 use env_logger::Env;
 use std::sync::Once;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
-use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 
 static INIT: Once = Once::new();
 
@@ -13,15 +13,34 @@ pub fn setup_telemetry() {
         let env_filter = EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| EnvFilter::new("info,forester=debug"));
 
+        let file_env_filter = EnvFilter::new("info,forester=debug");
+        let stdout_env_filter =
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+        let stdout_layer = fmt::Layer::new()
+            .with_writer(std::io::stdout)
+            .with_ansi(true)
+            .with_filter(stdout_env_filter);
+
+        let file_layer = fmt::Layer::new()
+            .with_writer(non_blocking)
+            .with_filter(file_env_filter);
+
         tracing_subscriber::registry()
             .with(env_filter)
-            .with(
-                fmt::Layer::new()
-                    .with_writer(std::io::stdout)
-                    .with_ansi(true),
-            )
-            .with(fmt::Layer::new().with_writer(non_blocking).json())
+            .with(stdout_layer)
+            .with(file_layer)
             .init();
+
+        // tracing_subscriber::registry()
+        //     .with(env_filter)
+        //     .with(
+        //         fmt::Layer::new()
+        //             .with_writer(std::io::stdout)
+        //             .with_ansi(true),
+        //     )
+        //     .with(fmt::Layer::new().with_writer(non_blocking).json())
+        //     .init();
 
         // Keep _guard in scope to keep the non-blocking writer alive
         std::mem::forget(_guard);

--- a/forester/src/telemetry.rs
+++ b/forester/src/telemetry.rs
@@ -32,16 +32,6 @@ pub fn setup_telemetry() {
             .with(file_layer)
             .init();
 
-        // tracing_subscriber::registry()
-        //     .with(env_filter)
-        //     .with(
-        //         fmt::Layer::new()
-        //             .with_writer(std::io::stdout)
-        //             .with_ansi(true),
-        //     )
-        //     .with(fmt::Layer::new().with_writer(non_blocking).json())
-        //     .init();
-
         // Keep _guard in scope to keep the non-blocking writer alive
         std::mem::forget(_guard);
     });

--- a/forester/src/tree_data_sync.rs
+++ b/forester/src/tree_data_sync.rs
@@ -4,9 +4,9 @@ use account_compression::{AddressMerkleTreeAccount, MerkleTreeMetadata, StateMer
 use borsh::BorshDeserialize;
 use forester_utils::forester_epoch::{TreeAccounts, TreeType};
 use forester_utils::rpc::RpcConnection;
-use log::debug;
 use solana_sdk::account::Account;
 use solana_sdk::pubkey::Pubkey;
+use tracing::debug;
 
 pub async fn fetch_trees<R: RpcConnection>(rpc: &R) -> Vec<TreeAccounts> {
     let program_id = account_compression::id();

--- a/forester/src/utils.rs
+++ b/forester/src/utils.rs
@@ -1,10 +1,10 @@
 use forester_utils::rpc::RpcConnection;
 use light_registry::protocol_config::state::{ProtocolConfig, ProtocolConfigPda};
 use light_registry::utils::get_protocol_config_pda_address;
-use log::{debug, info};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 use sysinfo::{Signal, System};
+use tracing::debug;
 
 #[derive(Debug)]
 pub struct LightValidatorConfig {
@@ -90,7 +90,7 @@ pub async fn get_protocol_config<R: RpcConnection>(rpc: &mut R) -> ProtocolConfi
         .await
         .unwrap()
         .unwrap();
-    info!("Protocol config account: {:?}", protocol_config_account);
+    debug!("Protocol config account: {:?}", protocol_config_account);
     protocol_config_account.config
 }
 

--- a/forester/tests/test_utils.rs
+++ b/forester/tests/test_utils.rs
@@ -10,8 +10,8 @@ use forester_utils::rpc::{RpcConnection, SolanaRpcConnection};
 use light_test_utils::e2e_test_env::{GeneralActionConfig, KeypairActionConfig, User};
 use light_test_utils::indexer::TestIndexer;
 use light_test_utils::test_env::get_test_env_accounts;
-use log::{debug, info};
 use solana_sdk::signature::{Keypair, Signer};
+use tracing::debug;
 
 #[allow(dead_code)]
 pub async fn init(config: Option<LightValidatorConfig>) {
@@ -137,7 +137,7 @@ pub async fn assert_new_address_proofs_for_photon_and_test_indexer<R: RpcConnect
             address_proof_photon.unwrap().first().unwrap().clone();
         let test_indexer_result: NewAddressProofWithContext =
             address_proof_test_indexer.unwrap().first().unwrap().clone();
-        info!(
+        debug!(
             "assert proofs for address: {} photon result: {:?} test indexer result: {:?}",
             address, photon_result, test_indexer_result
         );


### PR DESCRIPTION
* Replaced the `log` crate with `tracing` for improved structured logging. 
* Adjusted dependencies in `Cargo.toml` and removed `log` crate.