### PR TITLE
fix: remove custom signer seeds from invoke_cpi

### DIFF
--- a/examples/name-service/programs/name-service/src/lib.rs
+++ b/examples/name-service/programs/name-service/src/lib.rs
@@ -16,6 +16,7 @@ declare_id!("7yucc7fL3JGbyMwg4neUaenNSdySS39hbAk89Ao3t1Hz");
 
 #[program]
 pub mod name_service {
+    use account_compression::utils::constants::CPI_AUTHORITY_PDA_SEED;
     use light_sdk::{
         address::derive_address_seed,
         compressed_account::{
@@ -64,7 +65,7 @@ pub mod name_service {
             ctx.remaining_accounts,
         )?;
 
-        let signer_seed = b"cpi_signer".as_slice();
+        let signer_seed = CPI_AUTHORITY_PDA_SEED;
         let bump = Pubkey::find_program_address(&[signer_seed], &ctx.accounts.self_program.key()).1;
         let signer_seeds = [signer_seed, &[bump]];
 
@@ -136,7 +137,7 @@ pub mod name_service {
             ctx.remaining_accounts,
         )?;
 
-        let signer_seed = b"cpi_signer".as_slice();
+        let signer_seed = CPI_AUTHORITY_PDA_SEED;
         let bump = Pubkey::find_program_address(&[signer_seed], &ctx.accounts.self_program.key()).1;
         let signer_seeds = [signer_seed, &[bump]];
 
@@ -189,7 +190,7 @@ pub mod name_service {
             ctx.remaining_accounts,
         )?;
 
-        let signer_seed = b"cpi_signer".as_slice();
+        let signer_seed = CPI_AUTHORITY_PDA_SEED;
         let bump = Pubkey::find_program_address(&[signer_seed], &ctx.accounts.self_program.key()).1;
         let signer_seeds = [signer_seed, &[bump]];
 

--- a/examples/name-service/programs/name-service/src/lib.rs
+++ b/examples/name-service/programs/name-service/src/lib.rs
@@ -72,7 +72,6 @@ pub mod name_service {
             proof,
             new_address_params,
             compressed_account,
-            &signer_seeds,
             cpi_context,
         );
 
@@ -145,7 +144,6 @@ pub mod name_service {
             proof,
             old_compressed_account,
             new_compressed_account,
-            &signer_seeds,
             cpi_context,
         );
 
@@ -195,12 +193,7 @@ pub mod name_service {
         let bump = Pubkey::find_program_address(&[signer_seed], &ctx.accounts.self_program.key()).1;
         let signer_seeds = [signer_seed, &[bump]];
 
-        let inputs = create_cpi_inputs_for_account_deletion(
-            proof,
-            compressed_account,
-            &signer_seeds,
-            cpi_context,
-        );
+        let inputs = create_cpi_inputs_for_account_deletion(proof, compressed_account, cpi_context);
 
         verify(ctx, &inputs, &[&signer_seeds])?;
 

--- a/examples/name-service/programs/name-service/tests/test.rs
+++ b/examples/name-service/programs/name-service/tests/test.rs
@@ -2,6 +2,7 @@
 
 use std::net::{Ipv4Addr, Ipv6Addr};
 
+use account_compression::utils::constants::CPI_AUTHORITY_PDA_SEED;
 use anchor_lang::{AnchorDeserialize, InstructionData, ToAccountMetas};
 use light_sdk::address::derive_address_seed;
 use light_sdk::merkle_context::{
@@ -21,7 +22,7 @@ use solana_sdk::signature::{Keypair, Signer};
 use solana_sdk::transaction::Transaction;
 
 fn find_cpi_signer() -> (Pubkey, u8) {
-    Pubkey::find_program_address(&[b"cpi_signer"], &name_service::ID)
+    Pubkey::find_program_address([CPI_AUTHORITY_PDA_SEED].as_slice(), &name_service::ID)
 }
 
 #[tokio::test]

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/escrow.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/escrow.rs
@@ -121,7 +121,6 @@ fn cpi_compressed_pda_transfer<'info>(
         proof,
         new_address_params,
         compressed_pda,
-        &signer_seeds,
         Some(cpi_context),
     );
 

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/sdk.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/sdk.rs
@@ -97,7 +97,7 @@ pub fn create_escrow_instruction(
     let account_compression_authority =
         light_system_program::utils::get_cpi_authority_pda(&light_system_program::ID);
     let cpi_authority_pda = light_sdk::utils::get_cpi_authority_pda(&crate::ID);
-    println!("cpi_authority_pda: {:?}", cpi_authority_pda);
+
     let accounts = crate::accounts::EscrowCompressedTokensWithCompressedPda {
         signer: *input_params.signer,
         noop_program: Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/sdk.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/sdk.rs
@@ -86,7 +86,6 @@ pub fn create_escrow_instruction(
             first_set_context: true,
             cpi_context_account_index,
         },
-        bump: token_owner_pda.1,
     };
 
     let registered_program_pda = Pubkey::find_program_address(
@@ -97,7 +96,8 @@ pub fn create_escrow_instruction(
     let compressed_token_cpi_authority_pda = get_cpi_authority_pda().0;
     let account_compression_authority =
         light_system_program::utils::get_cpi_authority_pda(&light_system_program::ID);
-
+    let cpi_authority_pda = light_sdk::utils::get_cpi_authority_pda(&crate::ID);
+    println!("cpi_authority_pda: {:?}", cpi_authority_pda);
     let accounts = crate::accounts::EscrowCompressedTokensWithCompressedPda {
         signer: *input_params.signer,
         noop_program: Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
@@ -111,6 +111,7 @@ pub fn create_escrow_instruction(
         token_owner_pda: token_owner_pda.0,
         system_program: solana_sdk::system_program::id(),
         cpi_context_account: *input_params.cpi_context_account,
+        cpi_authority_pda,
     };
     let remaining_accounts = to_account_metas(remaining_accounts);
 
@@ -222,6 +223,7 @@ pub fn create_withdrawal_instruction(
     let compressed_token_cpi_authority_pda = get_cpi_authority_pda().0;
     let account_compression_authority =
         light_system_program::utils::get_cpi_authority_pda(&light_system_program::ID);
+    let cpi_authority_pda = light_system_program::utils::get_cpi_authority_pda(&crate::ID);
 
     let accounts = crate::accounts::EscrowCompressedTokensWithCompressedPda {
         signer: *input_params.signer,
@@ -236,6 +238,7 @@ pub fn create_withdrawal_instruction(
         token_owner_pda,
         system_program: solana_sdk::system_program::id(),
         cpi_context_account: *input_params.cpi_context_account,
+        cpi_authority_pda,
     };
     let remaining_accounts = to_account_metas(remaining_accounts);
 

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/withdrawal.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/withdrawal.rs
@@ -1,3 +1,4 @@
+use account_compression::utils::constants::CPI_AUTHORITY_PDA_SEED;
 use anchor_lang::prelude::*;
 use light_compressed_token::process_transfer::{
     CompressedTokenInstructionDataTransfer, InputTokenDataWithContext,
@@ -63,7 +64,7 @@ pub fn process_withdraw_compressed_tokens_with_compressed_pda<'info>(
         cpi_context,
     )?;
 
-    cpi_compressed_pda_withdrawal(ctx, proof, old_state, new_state, cpi_context, bump)?;
+    cpi_compressed_pda_withdrawal(ctx, proof, old_state, new_state, cpi_context)?;
     Ok(())
 }
 
@@ -130,12 +131,11 @@ fn cpi_compressed_pda_withdrawal<'info>(
     old_state: PackedCompressedAccountWithMerkleContext,
     compressed_pda: OutputCompressedAccountWithPackedContext,
     mut cpi_context: CompressedCpiContext,
-    bump: u8,
 ) -> Result<()> {
     // Create CPI signer seed
-    let bump_seed = &[bump];
-    let signer_key_bytes = ctx.accounts.signer.key.to_bytes();
-    let signer_seeds = [&b"escrow"[..], &signer_key_bytes[..], bump_seed];
+    let bump = Pubkey::find_program_address(&[b"cpi_authority"], &crate::ID).1;
+    let bump = [bump];
+    let signer_seeds = [CPI_AUTHORITY_PDA_SEED, &bump];
     cpi_context.first_set_context = false;
 
     // Create CPI inputs

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/withdrawal.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/withdrawal.rs
@@ -147,7 +147,6 @@ fn cpi_compressed_pda_withdrawal<'info>(
         new_address_params: Vec::new(),
         compress_or_decompress_lamports: None,
         is_compress: false,
-        signer_seeds: signer_seeds.iter().map(|seed| seed.to_vec()).collect(),
         cpi_context: Some(cpi_context),
     };
 

--- a/examples/token-escrow/programs/token-escrow/src/lib.rs
+++ b/examples/token-escrow/programs/token-escrow/src/lib.rs
@@ -95,7 +95,6 @@ pub mod token_escrow {
         output_state_merkle_tree_account_indices: Vec<u8>,
         new_address_params: NewAddressParamsPacked,
         cpi_context: CompressedCpiContext,
-        bump: u8,
     ) -> Result<()> {
         process_escrow_compressed_tokens_with_compressed_pda(
             ctx,
@@ -108,7 +107,6 @@ pub mod token_escrow {
             output_state_merkle_tree_account_indices,
             new_address_params,
             cpi_context,
-            bump,
         )
     }
 

--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -1148,12 +1148,6 @@ export type LightCompressedToken = {
                         type: 'bool';
                     },
                     {
-                        name: 'signerSeeds';
-                        type: {
-                            vec: 'bytes';
-                        };
-                    },
-                    {
                         name: 'cpiContext';
                         type: {
                             option: {
@@ -1555,128 +1549,23 @@ export type LightCompressedToken = {
     errors: [
         {
             code: 6000;
-            name: 'PublicKeyAmountMissmatch';
-            msg: 'public keys and amounts must be of same length';
+            name: 'SignerCheckFailed';
+            msg: 'Signer check failed';
         },
         {
             code: 6001;
-            name: 'ComputeInputSumFailed';
-            msg: 'ComputeInputSumFailed';
+            name: 'CreateTransferInstructionFailed';
+            msg: 'Create transfer instruction failed';
         },
         {
             code: 6002;
-            name: 'ComputeOutputSumFailed';
-            msg: 'ComputeOutputSumFailed';
+            name: 'AccountNotFound';
+            msg: 'Account not found';
         },
         {
             code: 6003;
-            name: 'ComputeCompressSumFailed';
-            msg: 'ComputeCompressSumFailed';
-        },
-        {
-            code: 6004;
-            name: 'ComputeDecompressSumFailed';
-            msg: 'ComputeDecompressSumFailed';
-        },
-        {
-            code: 6005;
-            name: 'SumCheckFailed';
-            msg: 'SumCheckFailed';
-        },
-        {
-            code: 6006;
-            name: 'DecompressRecipientUndefinedForDecompress';
-            msg: 'DecompressRecipientUndefinedForDecompress';
-        },
-        {
-            code: 6007;
-            name: 'CompressedPdaUndefinedForDecompress';
-            msg: 'CompressedPdaUndefinedForDecompress';
-        },
-        {
-            code: 6008;
-            name: 'DeCompressAmountUndefinedForDecompress';
-            msg: 'DeCompressAmountUndefinedForDecompress';
-        },
-        {
-            code: 6009;
-            name: 'CompressedPdaUndefinedForCompress';
-            msg: 'CompressedPdaUndefinedForCompress';
-        },
-        {
-            code: 6010;
-            name: 'DeCompressAmountUndefinedForCompress';
-            msg: 'DeCompressAmountUndefinedForCompress';
-        },
-        {
-            code: 6011;
-            name: 'DelegateSignerCheckFailed';
-            msg: 'DelegateSignerCheckFailed';
-        },
-        {
-            code: 6012;
-            name: 'MintTooLarge';
-            msg: 'Minted amount greater than u64::MAX';
-        },
-        {
-            code: 6013;
-            name: 'SplTokenSupplyMismatch';
-            msg: 'SplTokenSupplyMismatch';
-        },
-        {
-            code: 6014;
-            name: 'HeapMemoryCheckFailed';
-            msg: 'HeapMemoryCheckFailed';
-        },
-        {
-            code: 6015;
-            name: 'InstructionNotCallable';
-            msg: 'The instruction is not callable';
-        },
-        {
-            code: 6016;
-            name: 'ArithmeticUnderflow';
-            msg: 'ArithmeticUnderflow';
-        },
-        {
-            code: 6017;
-            name: 'HashToFieldError';
-            msg: 'HashToFieldError';
-        },
-        {
-            code: 6018;
-            name: 'InvalidAuthorityMint';
-            msg: 'Expected the authority to be also a mint authority';
-        },
-        {
-            code: 6019;
-            name: 'InvalidFreezeAuthority';
-            msg: 'Provided authority is not the freeze authority';
-        },
-        {
-            code: 6020;
-            name: 'InvalidDelegateIndex';
-        },
-        {
-            code: 6021;
-            name: 'TokenPoolPdaUndefined';
-        },
-        {
-            code: 6022;
-            name: 'IsTokenPoolPda';
-            msg: 'Compress or decompress recipient is the same account as the token pool pda.';
-        },
-        {
-            code: 6023;
-            name: 'InvalidTokenPoolPda';
-        },
-        {
-            code: 6024;
-            name: 'NoInputTokenAccountsProvided';
-        },
-        {
-            code: 6025;
-            name: 'NoInputsProvided';
+            name: 'SerializationError';
+            msg: 'Serialization error';
         },
     ];
 };
@@ -2834,12 +2723,6 @@ export const IDL: LightCompressedToken = {
                         type: 'bool',
                     },
                     {
-                        name: 'signerSeeds',
-                        type: {
-                            vec: 'bytes',
-                        },
-                    },
-                    {
                         name: 'cpiContext',
                         type: {
                             option: {
@@ -3242,128 +3125,23 @@ export const IDL: LightCompressedToken = {
     errors: [
         {
             code: 6000,
-            name: 'PublicKeyAmountMissmatch',
-            msg: 'public keys and amounts must be of same length',
+            name: 'SignerCheckFailed',
+            msg: 'Signer check failed',
         },
         {
             code: 6001,
-            name: 'ComputeInputSumFailed',
-            msg: 'ComputeInputSumFailed',
+            name: 'CreateTransferInstructionFailed',
+            msg: 'Create transfer instruction failed',
         },
         {
             code: 6002,
-            name: 'ComputeOutputSumFailed',
-            msg: 'ComputeOutputSumFailed',
+            name: 'AccountNotFound',
+            msg: 'Account not found',
         },
         {
             code: 6003,
-            name: 'ComputeCompressSumFailed',
-            msg: 'ComputeCompressSumFailed',
-        },
-        {
-            code: 6004,
-            name: 'ComputeDecompressSumFailed',
-            msg: 'ComputeDecompressSumFailed',
-        },
-        {
-            code: 6005,
-            name: 'SumCheckFailed',
-            msg: 'SumCheckFailed',
-        },
-        {
-            code: 6006,
-            name: 'DecompressRecipientUndefinedForDecompress',
-            msg: 'DecompressRecipientUndefinedForDecompress',
-        },
-        {
-            code: 6007,
-            name: 'CompressedPdaUndefinedForDecompress',
-            msg: 'CompressedPdaUndefinedForDecompress',
-        },
-        {
-            code: 6008,
-            name: 'DeCompressAmountUndefinedForDecompress',
-            msg: 'DeCompressAmountUndefinedForDecompress',
-        },
-        {
-            code: 6009,
-            name: 'CompressedPdaUndefinedForCompress',
-            msg: 'CompressedPdaUndefinedForCompress',
-        },
-        {
-            code: 6010,
-            name: 'DeCompressAmountUndefinedForCompress',
-            msg: 'DeCompressAmountUndefinedForCompress',
-        },
-        {
-            code: 6011,
-            name: 'DelegateSignerCheckFailed',
-            msg: 'DelegateSignerCheckFailed',
-        },
-        {
-            code: 6012,
-            name: 'MintTooLarge',
-            msg: 'Minted amount greater than u64::MAX',
-        },
-        {
-            code: 6013,
-            name: 'SplTokenSupplyMismatch',
-            msg: 'SplTokenSupplyMismatch',
-        },
-        {
-            code: 6014,
-            name: 'HeapMemoryCheckFailed',
-            msg: 'HeapMemoryCheckFailed',
-        },
-        {
-            code: 6015,
-            name: 'InstructionNotCallable',
-            msg: 'The instruction is not callable',
-        },
-        {
-            code: 6016,
-            name: 'ArithmeticUnderflow',
-            msg: 'ArithmeticUnderflow',
-        },
-        {
-            code: 6017,
-            name: 'HashToFieldError',
-            msg: 'HashToFieldError',
-        },
-        {
-            code: 6018,
-            name: 'InvalidAuthorityMint',
-            msg: 'Expected the authority to be also a mint authority',
-        },
-        {
-            code: 6019,
-            name: 'InvalidFreezeAuthority',
-            msg: 'Provided authority is not the freeze authority',
-        },
-        {
-            code: 6020,
-            name: 'InvalidDelegateIndex',
-        },
-        {
-            code: 6021,
-            name: 'TokenPoolPdaUndefined',
-        },
-        {
-            code: 6022,
-            name: 'IsTokenPoolPda',
-            msg: 'Compress or decompress recipient is the same account as the token pool pda.',
-        },
-        {
-            code: 6023,
-            name: 'InvalidTokenPoolPda',
-        },
-        {
-            code: 6024,
-            name: 'NoInputTokenAccountsProvided',
-        },
-        {
-            code: 6025,
-            name: 'NoInputsProvided',
+            name: 'SerializationError',
+            msg: 'Serialization error',
         },
     ],
 };

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -1148,12 +1148,6 @@ export type LightCompressedToken = {
                         type: 'bool';
                     },
                     {
-                        name: 'signerSeeds';
-                        type: {
-                            vec: 'bytes';
-                        };
-                    },
-                    {
                         name: 'cpiContext';
                         type: {
                             option: {
@@ -1555,128 +1549,23 @@ export type LightCompressedToken = {
     errors: [
         {
             code: 6000;
-            name: 'PublicKeyAmountMissmatch';
-            msg: 'public keys and amounts must be of same length';
+            name: 'SignerCheckFailed';
+            msg: 'Signer check failed';
         },
         {
             code: 6001;
-            name: 'ComputeInputSumFailed';
-            msg: 'ComputeInputSumFailed';
+            name: 'CreateTransferInstructionFailed';
+            msg: 'Create transfer instruction failed';
         },
         {
             code: 6002;
-            name: 'ComputeOutputSumFailed';
-            msg: 'ComputeOutputSumFailed';
+            name: 'AccountNotFound';
+            msg: 'Account not found';
         },
         {
             code: 6003;
-            name: 'ComputeCompressSumFailed';
-            msg: 'ComputeCompressSumFailed';
-        },
-        {
-            code: 6004;
-            name: 'ComputeDecompressSumFailed';
-            msg: 'ComputeDecompressSumFailed';
-        },
-        {
-            code: 6005;
-            name: 'SumCheckFailed';
-            msg: 'SumCheckFailed';
-        },
-        {
-            code: 6006;
-            name: 'DecompressRecipientUndefinedForDecompress';
-            msg: 'DecompressRecipientUndefinedForDecompress';
-        },
-        {
-            code: 6007;
-            name: 'CompressedPdaUndefinedForDecompress';
-            msg: 'CompressedPdaUndefinedForDecompress';
-        },
-        {
-            code: 6008;
-            name: 'DeCompressAmountUndefinedForDecompress';
-            msg: 'DeCompressAmountUndefinedForDecompress';
-        },
-        {
-            code: 6009;
-            name: 'CompressedPdaUndefinedForCompress';
-            msg: 'CompressedPdaUndefinedForCompress';
-        },
-        {
-            code: 6010;
-            name: 'DeCompressAmountUndefinedForCompress';
-            msg: 'DeCompressAmountUndefinedForCompress';
-        },
-        {
-            code: 6011;
-            name: 'DelegateSignerCheckFailed';
-            msg: 'DelegateSignerCheckFailed';
-        },
-        {
-            code: 6012;
-            name: 'MintTooLarge';
-            msg: 'Minted amount greater than u64::MAX';
-        },
-        {
-            code: 6013;
-            name: 'SplTokenSupplyMismatch';
-            msg: 'SplTokenSupplyMismatch';
-        },
-        {
-            code: 6014;
-            name: 'HeapMemoryCheckFailed';
-            msg: 'HeapMemoryCheckFailed';
-        },
-        {
-            code: 6015;
-            name: 'InstructionNotCallable';
-            msg: 'The instruction is not callable';
-        },
-        {
-            code: 6016;
-            name: 'ArithmeticUnderflow';
-            msg: 'ArithmeticUnderflow';
-        },
-        {
-            code: 6017;
-            name: 'HashToFieldError';
-            msg: 'HashToFieldError';
-        },
-        {
-            code: 6018;
-            name: 'InvalidAuthorityMint';
-            msg: 'Expected the authority to be also a mint authority';
-        },
-        {
-            code: 6019;
-            name: 'InvalidFreezeAuthority';
-            msg: 'Provided authority is not the freeze authority';
-        },
-        {
-            code: 6020;
-            name: 'InvalidDelegateIndex';
-        },
-        {
-            code: 6021;
-            name: 'TokenPoolPdaUndefined';
-        },
-        {
-            code: 6022;
-            name: 'IsTokenPoolPda';
-            msg: 'Compress or decompress recipient is the same account as the token pool pda.';
-        },
-        {
-            code: 6023;
-            name: 'InvalidTokenPoolPda';
-        },
-        {
-            code: 6024;
-            name: 'NoInputTokenAccountsProvided';
-        },
-        {
-            code: 6025;
-            name: 'NoInputsProvided';
+            name: 'SerializationError';
+            msg: 'Serialization error';
         },
     ];
 };
@@ -2834,12 +2723,6 @@ export const IDL: LightCompressedToken = {
                         type: 'bool',
                     },
                     {
-                        name: 'signerSeeds',
-                        type: {
-                            vec: 'bytes',
-                        },
-                    },
-                    {
                         name: 'cpiContext',
                         type: {
                             option: {
@@ -3242,128 +3125,23 @@ export const IDL: LightCompressedToken = {
     errors: [
         {
             code: 6000,
-            name: 'PublicKeyAmountMissmatch',
-            msg: 'public keys and amounts must be of same length',
+            name: 'SignerCheckFailed',
+            msg: 'Signer check failed',
         },
         {
             code: 6001,
-            name: 'ComputeInputSumFailed',
-            msg: 'ComputeInputSumFailed',
+            name: 'CreateTransferInstructionFailed',
+            msg: 'Create transfer instruction failed',
         },
         {
             code: 6002,
-            name: 'ComputeOutputSumFailed',
-            msg: 'ComputeOutputSumFailed',
+            name: 'AccountNotFound',
+            msg: 'Account not found',
         },
         {
             code: 6003,
-            name: 'ComputeCompressSumFailed',
-            msg: 'ComputeCompressSumFailed',
-        },
-        {
-            code: 6004,
-            name: 'ComputeDecompressSumFailed',
-            msg: 'ComputeDecompressSumFailed',
-        },
-        {
-            code: 6005,
-            name: 'SumCheckFailed',
-            msg: 'SumCheckFailed',
-        },
-        {
-            code: 6006,
-            name: 'DecompressRecipientUndefinedForDecompress',
-            msg: 'DecompressRecipientUndefinedForDecompress',
-        },
-        {
-            code: 6007,
-            name: 'CompressedPdaUndefinedForDecompress',
-            msg: 'CompressedPdaUndefinedForDecompress',
-        },
-        {
-            code: 6008,
-            name: 'DeCompressAmountUndefinedForDecompress',
-            msg: 'DeCompressAmountUndefinedForDecompress',
-        },
-        {
-            code: 6009,
-            name: 'CompressedPdaUndefinedForCompress',
-            msg: 'CompressedPdaUndefinedForCompress',
-        },
-        {
-            code: 6010,
-            name: 'DeCompressAmountUndefinedForCompress',
-            msg: 'DeCompressAmountUndefinedForCompress',
-        },
-        {
-            code: 6011,
-            name: 'DelegateSignerCheckFailed',
-            msg: 'DelegateSignerCheckFailed',
-        },
-        {
-            code: 6012,
-            name: 'MintTooLarge',
-            msg: 'Minted amount greater than u64::MAX',
-        },
-        {
-            code: 6013,
-            name: 'SplTokenSupplyMismatch',
-            msg: 'SplTokenSupplyMismatch',
-        },
-        {
-            code: 6014,
-            name: 'HeapMemoryCheckFailed',
-            msg: 'HeapMemoryCheckFailed',
-        },
-        {
-            code: 6015,
-            name: 'InstructionNotCallable',
-            msg: 'The instruction is not callable',
-        },
-        {
-            code: 6016,
-            name: 'ArithmeticUnderflow',
-            msg: 'ArithmeticUnderflow',
-        },
-        {
-            code: 6017,
-            name: 'HashToFieldError',
-            msg: 'HashToFieldError',
-        },
-        {
-            code: 6018,
-            name: 'InvalidAuthorityMint',
-            msg: 'Expected the authority to be also a mint authority',
-        },
-        {
-            code: 6019,
-            name: 'InvalidFreezeAuthority',
-            msg: 'Provided authority is not the freeze authority',
-        },
-        {
-            code: 6020,
-            name: 'InvalidDelegateIndex',
-        },
-        {
-            code: 6021,
-            name: 'TokenPoolPdaUndefined',
-        },
-        {
-            code: 6022,
-            name: 'IsTokenPoolPda',
-            msg: 'Compress or decompress recipient is the same account as the token pool pda.',
-        },
-        {
-            code: 6023,
-            name: 'InvalidTokenPoolPda',
-        },
-        {
-            code: 6024,
-            name: 'NoInputTokenAccountsProvided',
-        },
-        {
-            code: 6025,
-            name: 'NoInputsProvided',
+            name: 'SerializationError',
+            msg: 'Serialization error',
         },
     ],
 };

--- a/js/stateless.js/src/idls/light_system_program.ts
+++ b/js/stateless.js/src/idls/light_system_program.ts
@@ -619,12 +619,6 @@ export type LightSystemProgram = {
                         type: 'bool';
                     },
                     {
-                        name: 'signerSeeds';
-                        type: {
-                            vec: 'bytes';
-                        };
-                    },
-                    {
                         name: 'cpiContext';
                         type: {
                             option: {
@@ -1692,12 +1686,6 @@ export const IDL: LightSystemProgram = {
                     {
                         name: 'isCompress',
                         type: 'bool',
-                    },
-                    {
-                        name: 'signerSeeds',
-                        type: {
-                            vec: 'bytes',
-                        },
                     },
                     {
                         name: 'cpiContext',

--- a/merkle-tree/hash-set/src/lib.rs
+++ b/merkle-tree/hash-set/src/lib.rs
@@ -446,14 +446,16 @@ impl HashSet {
                         continue;
                     }
                 }
-
                 None => {
+                    // A previous bucket could have been freed already even
+                    // though the whole hash set has not been used yet.
                     if first_free_element.is_none() {
                         first_free_element = Some((probe_index, true));
-                        // Since we encountered an empty element we know for sure
-                        // that the element is not in the hash set.
-                        break;
                     }
+                    // Since we encountered an empty bucket we know for sure
+                    // that the element is not in a bucket with higher probe
+                    // index.
+                    break;
                 }
             }
         }

--- a/programs/compressed-token/src/process_mint.rs
+++ b/programs/compressed-token/src/process_mint.rs
@@ -153,12 +153,11 @@ pub fn cpi_execute_compressed_transaction_mint_to<'info>(
     bench_sbf_start!("tm_cpi");
 
     let signer_seeds = get_cpi_signer_seeds();
-    let signer_seeds_vec = signer_seeds.iter().map(|seed| seed.to_vec()).collect();
 
     // 4300 CU for 10 accounts
     // 6700 CU for 20 accounts
     // 7,978 CU for 25 accounts
-    serialize_mint_to_cpi_instruction_data(inputs, &output_compressed_accounts, &signer_seeds_vec);
+    serialize_mint_to_cpi_instruction_data(inputs, &output_compressed_accounts);
 
     GLOBAL_ALLOCATOR.free_heap(pre_compressed_acounts_pos)?;
 
@@ -273,7 +272,6 @@ pub fn cpi_execute_compressed_transaction_mint_to<'info>(
 pub fn serialize_mint_to_cpi_instruction_data(
     inputs: &mut Vec<u8>,
     output_compressed_accounts: &[OutputCompressedAccountWithPackedContext],
-    seeds: &Vec<Vec<u8>>,
 ) {
     let len = output_compressed_accounts.len();
     // proof (option None)
@@ -302,8 +300,6 @@ pub fn serialize_mint_to_cpi_instruction_data(
         inputs.extend_from_slice(&[0u8; 2]); // None compression lamports, is compress bool = false
     }
 
-    // seeds
-    seeds.serialize(inputs).unwrap();
     // None compressed_cpi_context
     inputs.extend_from_slice(&[0u8]);
 }
@@ -491,7 +487,6 @@ mod test {
     };
     #[test]
     fn test_manual_ix_data_serialization_borsh_compat() {
-        use crate::process_transfer::get_cpi_signer_seeds;
         let pubkeys = vec![Pubkey::new_unique(), Pubkey::new_unique()];
         let amounts = vec![1, 2];
         let mint_pubkey = Pubkey::new_unique();
@@ -529,15 +524,8 @@ mod test {
             };
         }
 
-        let signer_seeds = get_cpi_signer_seeds();
-
-        let signer_seeds_vec = signer_seeds.iter().map(|seed| seed.to_vec()).collect();
         let mut inputs = Vec::<u8>::new();
-        serialize_mint_to_cpi_instruction_data(
-            &mut inputs,
-            &output_compressed_accounts,
-            &signer_seeds_vec,
-        );
+        serialize_mint_to_cpi_instruction_data(&mut inputs, &output_compressed_accounts);
         let inputs_struct = light_system_program::InstructionDataInvokeCpi {
             relay_fee: None,
             input_compressed_accounts_with_merkle_context: Vec::with_capacity(0),
@@ -546,7 +534,6 @@ mod test {
             new_address_params: Vec::with_capacity(0),
             compress_or_decompress_lamports: None,
             is_compress: false,
-            signer_seeds: signer_seeds_vec,
             cpi_context: None,
         };
         let mut reference = Vec::<u8>::new();
@@ -562,7 +549,6 @@ mod test {
 
     #[test]
     fn test_manual_ix_data_serialization_borsh_compat_random() {
-        use crate::process_transfer::get_cpi_signer_seeds;
         use rand::Rng;
 
         for _ in 0..10000 {
@@ -603,16 +589,8 @@ mod test {
                     merkle_tree_index: 0,
                 };
             }
-
-            let signer_seeds = get_cpi_signer_seeds();
-
-            let signer_seeds_vec = signer_seeds.iter().map(|seed| seed.to_vec()).collect();
             let mut inputs = Vec::<u8>::new();
-            serialize_mint_to_cpi_instruction_data(
-                &mut inputs,
-                &output_compressed_accounts,
-                &signer_seeds_vec,
-            );
+            serialize_mint_to_cpi_instruction_data(&mut inputs, &output_compressed_accounts);
             let sum = output_compressed_accounts
                 .iter()
                 .map(|x| x.compressed_account.lamports)
@@ -625,7 +603,6 @@ mod test {
                 new_address_params: Vec::with_capacity(0),
                 compress_or_decompress_lamports: Some(sum),
                 is_compress: true,
-                signer_seeds: signer_seeds_vec,
                 cpi_context: None,
             };
             let mut reference = Vec::<u8>::new();

--- a/programs/compressed-token/src/process_mint.rs
+++ b/programs/compressed-token/src/process_mint.rs
@@ -77,7 +77,7 @@ pub fn process_mint_to<'info>(
     {
         let option_compression_lamports = if lamports.unwrap_or(0) == 0 { 0 } else { 8 };
         let inputs_len =
-            1 + 4 + 4 + 4 + amounts.len() * 162 + 1 + 1 + 1 + 26 + 1 + option_compression_lamports;
+            1 + 4 + 4 + 4 + amounts.len() * 162 + 1 + 1 + 1 + 1 + option_compression_lamports;
         // inputs_len =
         //   1                          Option<Proof>
         // + 4                          Vec::new()
@@ -86,7 +86,6 @@ pub fn process_mint_to<'info>(
         // + 1                          Option<relay_fee>
         // + 1 + 8                         Option<compression_lamports>
         // + 1                          is_compress
-        // + 26                         seeds
         // + 1                          Option<CpiContextAccount>
         let mut inputs = Vec::<u8>::with_capacity(inputs_len);
         // # SAFETY: the inputs vector needs to be allocated before this point.

--- a/programs/compressed-token/src/process_transfer.rs
+++ b/programs/compressed-token/src/process_transfer.rs
@@ -364,7 +364,6 @@ pub fn cpi_execute_compressed_transaction_transfer<
         new_address_params: Vec::new(),
         compress_or_decompress_lamports: None,
         is_compress: false,
-        signer_seeds: signer_seeds.iter().map(|seed| seed.to_vec()).collect(),
         cpi_context,
     };
     let mut inputs = Vec::new();

--- a/programs/system/src/invoke_cpi/instruction.rs
+++ b/programs/system/src/invoke_cpi/instruction.rs
@@ -97,7 +97,6 @@ pub struct InstructionDataInvokeCpi {
     pub relay_fee: Option<u64>,
     pub compress_or_decompress_lamports: Option<u64>,
     pub is_compress: bool,
-    pub signer_seeds: Vec<Vec<u8>>,
     pub cpi_context: Option<CompressedCpiContext>,
 }
 
@@ -140,7 +139,6 @@ mod tests {
             relay_fee: Some(1),
             compress_or_decompress_lamports: Some(1),
             is_compress: true,
-            signer_seeds: vec![vec![0; 32], vec![1; 32]],
             cpi_context: None,
         };
         let other = InstructionDataInvokeCpi {
@@ -157,7 +155,6 @@ mod tests {
             compress_or_decompress_lamports: Some(1),
             is_compress: true,
             new_address_params: vec![NewAddressParamsPacked::default()],
-            signer_seeds: vec![],
             cpi_context: None,
         };
         instruction_data_transfer.combine(&[other]);

--- a/programs/system/src/invoke_cpi/process_cpi_context.rs
+++ b/programs/system/src/invoke_cpi/process_cpi_context.rs
@@ -123,7 +123,6 @@ fn clean_input_data(inputs: &mut InstructionDataInvokeCpi) {
     inputs.cpi_context = None;
     inputs.compress_or_decompress_lamports = None;
     inputs.relay_fee = None;
-    inputs.signer_seeds = Vec::new();
     inputs.proof = None;
 }
 
@@ -212,7 +211,6 @@ mod tests {
             relay_fee: None,
             compress_or_decompress_lamports: None,
             is_compress: false,
-            signer_seeds: vec![vec![iter; 32]],
             cpi_context: Some(CompressedCpiContext {
                 first_set_context,
                 set_context,

--- a/programs/system/src/invoke_cpi/processor.rs
+++ b/programs/system/src/invoke_cpi/processor.rs
@@ -20,7 +20,6 @@ pub fn process_invoke_cpi<'a, 'b, 'c: 'info + 'b, 'info>(
     cpi_signer_checks(
         &ctx.accounts.invoking_program.key(),
         &ctx.accounts.get_authority().key(),
-        &inputs.signer_seeds,
         &inputs.input_compressed_accounts_with_merkle_context,
         &inputs.output_compressed_accounts,
     )?;

--- a/programs/system/src/invoke_cpi/verify_signer.rs
+++ b/programs/system/src/invoke_cpi/verify_signer.rs
@@ -46,8 +46,6 @@ pub fn cpi_signer_checks(
 #[heap_neutral]
 pub fn cpi_signer_check(invoking_program: &Pubkey, authority: &Pubkey) -> Result<()> {
     let seeds = [CPI_AUTHORITY_PDA_SEED];
-    println!("seeds: {:?}", seeds);
-    println!("invoking program: {:?}", invoking_program);
     let derived_signer = Pubkey::try_find_program_address(&seeds, invoking_program)
         .ok_or(ProgramError::InvalidSeeds)?
         .0;
@@ -205,11 +203,8 @@ mod test {
     fn test_cpi_signer_check() {
         for _ in 0..1000 {
             let seeds = [CPI_AUTHORITY_PDA_SEED];
-            println!("seeds: {:?}", seeds);
             let invoking_program = Pubkey::new_unique();
             let (derived_signer, _) = Pubkey::find_program_address(&seeds[..], &invoking_program);
-            println!("derived_signer: {}", derived_signer);
-            println!("invoking_program: {}", invoking_program);
             assert_eq!(cpi_signer_check(&invoking_program, &derived_signer), Ok(()));
 
             let authority = Pubkey::new_unique();

--- a/programs/system/src/invoke_cpi/verify_signer.rs
+++ b/programs/system/src/invoke_cpi/verify_signer.rs
@@ -49,7 +49,7 @@ pub fn cpi_signer_check(invoking_program: &Pubkey, authority: &Pubkey) -> Result
     println!("seeds: {:?}", seeds);
     println!("invoking program: {:?}", invoking_program);
     let derived_signer = Pubkey::try_find_program_address(&seeds, invoking_program)
-        .ok_or_else(|| ProgramError::InvalidSeeds)?
+        .ok_or(ProgramError::InvalidSeeds)?
         .0;
     if derived_signer != *authority {
         msg!(

--- a/sdk/src/utils.rs
+++ b/sdk/src/utils.rs
@@ -22,7 +22,6 @@ pub fn create_cpi_inputs_for_new_account(
     proof: CompressedProof,
     new_address_params: NewAddressParamsPacked,
     compressed_pda: OutputCompressedAccountWithPackedContext,
-    signer_seeds: &[&[u8]],
     cpi_context: Option<CompressedCpiContext>,
 ) -> InstructionDataInvokeCpi {
     InstructionDataInvokeCpi {
@@ -33,10 +32,6 @@ pub fn create_cpi_inputs_for_new_account(
         output_compressed_accounts: vec![compressed_pda],
         compress_or_decompress_lamports: None,
         is_compress: false,
-        signer_seeds: signer_seeds
-            .iter()
-            .map(|x| x.to_vec())
-            .collect::<Vec<Vec<u8>>>(),
         cpi_context,
     }
 }
@@ -45,7 +40,6 @@ pub fn create_cpi_inputs_for_account_update(
     proof: CompressedProof,
     old_compressed_pda: PackedCompressedAccountWithMerkleContext,
     new_compressed_pda: OutputCompressedAccountWithPackedContext,
-    signer_seeds: &[&[u8]],
     cpi_context: Option<CompressedCpiContext>,
 ) -> InstructionDataInvokeCpi {
     InstructionDataInvokeCpi {
@@ -56,10 +50,6 @@ pub fn create_cpi_inputs_for_account_update(
         relay_fee: None,
         compress_or_decompress_lamports: None,
         is_compress: false,
-        signer_seeds: signer_seeds
-            .iter()
-            .map(|x| x.to_vec())
-            .collect::<Vec<Vec<u8>>>(),
         cpi_context,
     }
 }
@@ -67,7 +57,6 @@ pub fn create_cpi_inputs_for_account_update(
 pub fn create_cpi_inputs_for_account_deletion(
     proof: CompressedProof,
     compressed_pda: PackedCompressedAccountWithMerkleContext,
-    signer_seeds: &[&[u8]],
     cpi_context: Option<CompressedCpiContext>,
 ) -> InstructionDataInvokeCpi {
     InstructionDataInvokeCpi {
@@ -78,10 +67,6 @@ pub fn create_cpi_inputs_for_account_deletion(
         relay_fee: None,
         compress_or_decompress_lamports: None,
         is_compress: false,
-        signer_seeds: signer_seeds
-            .iter()
-            .map(|x| x.to_vec())
-            .collect::<Vec<Vec<u8>>>(),
         cpi_context,
     }
 }

--- a/test-programs/system-cpi-test/src/create_pda.rs
+++ b/test-programs/system-cpi-test/src/create_pda.rs
@@ -1,4 +1,4 @@
-use account_compression::program::AccountCompression;
+use account_compression::{program::AccountCompression, utils::constants::CPI_AUTHORITY_PDA_SEED};
 use anchor_lang::prelude::*;
 use light_hasher::{errors::HasherError, DataHasher, Poseidon};
 use light_system_program::{
@@ -192,7 +192,7 @@ fn cpi_compressed_pda_transfer_as_program<'info>(
         cpi_context,
     };
     // defining seeds again so that the cpi doesn't fail we want to test the check in the compressed pda program
-    let seeds: [&[u8]; 2] = [b"cpi_signer".as_slice(), &[bump]];
+    let seeds: [&[u8]; 2] = [CPI_AUTHORITY_PDA_SEED, &[bump]];
     let mut inputs = Vec::new();
     InstructionDataInvokeCpi::serialize(&inputs_struct, &mut inputs).unwrap();
 

--- a/test-programs/system-cpi-test/src/create_pda.rs
+++ b/test-programs/system-cpi-test/src/create_pda.rs
@@ -122,7 +122,6 @@ fn cpi_compressed_pda_transfer_as_non_program<'info>(
         new_address_params: vec![new_address_params],
         compress_or_decompress_lamports: None,
         is_compress: false,
-        signer_seeds: Vec::new(),
         cpi_context,
     };
 
@@ -162,10 +161,6 @@ fn cpi_compressed_pda_transfer_as_program<'info>(
     bump: u8,
     mode: CreatePdaMode,
 ) -> Result<()> {
-    let signer_seed = match mode {
-        CreatePdaMode::InvalidSignerSeeds => b"cpi_signer1".as_slice(),
-        _ => b"cpi_signer".as_slice(),
-    };
     let invoking_program = match mode {
         CreatePdaMode::InvalidInvokingProgram => ctx.accounts.signer.to_account_info(),
         _ => ctx.accounts.self_program.to_account_info(),
@@ -186,8 +181,6 @@ fn cpi_compressed_pda_transfer_as_program<'info>(
         _ => compressed_pda,
     };
 
-    let local_bump = Pubkey::find_program_address(&[signer_seed], &invoking_program.key()).1;
-    let seeds: [&[u8]; 2] = [signer_seed, &[local_bump]];
     let inputs_struct = InstructionDataInvokeCpi {
         relay_fee: None,
         input_compressed_accounts_with_merkle_context: Vec::new(),
@@ -196,7 +189,6 @@ fn cpi_compressed_pda_transfer_as_program<'info>(
         new_address_params: vec![new_address_params],
         compress_or_decompress_lamports: None,
         is_compress: false,
-        signer_seeds: seeds.iter().map(|seed| seed.to_vec()).collect(),
         cpi_context,
     };
     // defining seeds again so that the cpi doesn't fail we want to test the check in the compressed pda program

--- a/test-programs/system-cpi-test/src/invalidate_not_owned_account.rs
+++ b/test-programs/system-cpi-test/src/invalidate_not_owned_account.rs
@@ -29,7 +29,6 @@ pub enum WithInputAccountsMode {
     CpiContextFeePayerMismatch,
     CpiContextEmpty,
     CpiContextInvalidInvokingProgram,
-    CpiContextInvalidSignerSeeds,
     CpiContextWriteAccessCheckFailed,
     CpiContextWriteToNotOwnedAccount,
     Approve,
@@ -65,7 +64,6 @@ pub fn process_with_input_accounts<'info>(
         | WithInputAccountsMode::CpiContextAccountMissing
         | WithInputAccountsMode::CpiContextEmpty
         | WithInputAccountsMode::CpiContextInvalidInvokingProgram
-        | WithInputAccountsMode::CpiContextInvalidSignerSeeds
         | WithInputAccountsMode::CpiContextWriteToNotOwnedAccount => {
             process_invalidate_not_owned_compressed_account(
                 &ctx,
@@ -145,12 +143,6 @@ pub fn process_invalidate_not_owned_compressed_account<'info>(
         }
         _ => ctx.accounts.self_program.to_account_info(),
     };
-    let signer_seed = match mode {
-        WithInputAccountsMode::CpiContextInvalidSignerSeeds => b"cpi_signer1".as_slice(),
-        _ => b"cpi_signer".as_slice(),
-    };
-    let local_bump = Pubkey::find_program_address(&[signer_seed], &invoking_program.key()).1;
-    let seeds: [&[u8]; 2] = [signer_seed, &[local_bump]];
 
     let inputs_struct = InstructionDataInvokeCpi {
         relay_fee: None,
@@ -160,7 +152,6 @@ pub fn process_invalidate_not_owned_compressed_account<'info>(
         new_address_params: Vec::new(),
         compress_or_decompress_lamports: None,
         is_compress: false,
-        signer_seeds: seeds.iter().map(|seed| seed.to_vec()).collect(),
         cpi_context,
     };
 
@@ -636,7 +627,6 @@ fn write_into_cpi_account<'info>(
         new_address_params: Vec::new(),
         compress_or_decompress_lamports: None,
         is_compress: false,
-        signer_seeds: seeds.iter().map(|seed| seed.to_vec()).collect(),
         cpi_context,
     };
 

--- a/test-programs/system-cpi-test/src/invalidate_not_owned_account.rs
+++ b/test-programs/system-cpi-test/src/invalidate_not_owned_account.rs
@@ -1,4 +1,4 @@
-use account_compression::program::AccountCompression;
+use account_compression::{program::AccountCompression, utils::constants::CPI_AUTHORITY_PDA_SEED};
 use anchor_lang::prelude::*;
 use light_compressed_token::{
     delegation::{CompressedTokenInstructionDataApprove, CompressedTokenInstructionDataRevoke},
@@ -157,7 +157,7 @@ pub fn process_invalidate_not_owned_compressed_account<'info>(
 
     let mut inputs = Vec::new();
     InstructionDataInvokeCpi::serialize(&inputs_struct, &mut inputs).unwrap();
-    let seeds: [&[u8]; 2] = [b"cpi_signer".as_slice(), &[bump]];
+    let seeds: [&[u8]; 2] = [CPI_AUTHORITY_PDA_SEED, &[bump]];
 
     let cpi_accounts = light_system_program::cpi::accounts::InvokeCpiInstruction {
         fee_payer: ctx.accounts.signer.to_account_info(),
@@ -617,7 +617,7 @@ fn write_into_cpi_account<'info>(
         },
         merkle_tree_index: 0,
     };
-    let seeds: [&[u8]; 2] = [b"cpi_signer".as_slice(), &[bump]];
+    let seeds: [&[u8]; 2] = [CPI_AUTHORITY_PDA_SEED, &[bump]];
 
     let inputs_struct = InstructionDataInvokeCpi {
         relay_fee: None,

--- a/test-programs/system-cpi-test/src/sdk.rs
+++ b/test-programs/system-cpi-test/src/sdk.rs
@@ -37,8 +37,7 @@ pub struct CreateCompressedPdaInstructionInputs<'a> {
 }
 
 pub fn create_pda_instruction(input_params: CreateCompressedPdaInstructionInputs) -> Instruction {
-    let (cpi_signer, bump) =
-        Pubkey::find_program_address(&[b"cpi_signer".as_slice()], &crate::id());
+    let (cpi_signer, bump) = Pubkey::find_program_address(&[CPI_AUTHORITY_PDA_SEED], &crate::id());
     let mut remaining_accounts = HashMap::new();
     remaining_accounts.insert(
         *input_params.output_compressed_account_merkle_tree_pubkey,
@@ -100,8 +99,7 @@ pub fn create_invalidate_not_owned_account_instruction(
     input_params: InvalidateNotOwnedCompressedAccountInstructionInputs,
     mode: crate::WithInputAccountsMode,
 ) -> Instruction {
-    let (cpi_signer, bump) =
-        Pubkey::find_program_address(&[b"cpi_signer".as_slice()], &crate::id());
+    let (cpi_signer, bump) = Pubkey::find_program_address(&[CPI_AUTHORITY_PDA_SEED], &crate::id());
     let cpi_context = input_params.cpi_context;
 
     let mut remaining_accounts = HashMap::new();

--- a/test-programs/system-cpi-test/tests/test.rs
+++ b/test-programs/system-cpi-test/tests/test.rs
@@ -41,7 +41,6 @@ use system_cpi_test::{CreatePdaMode, ID};
 /// 6. provide cpi context account but no cpi context (CpiContextAccountUndefined)
 /// 7. provide cpi context account but cpi context is empty (CpiContextEmpty)
 /// 8. test signer checks trying to insert into cpi context account (invalid invoking program)
-/// 9. test signer checks trying to insert into cpi context account (invalid signer seeds)
 /// 10. provide cpi context account but cpi context has a different fee payer (CpiContextFeePayerMismatch)
 /// 11. write data to an account that it doesn't own (WriteAccessCheckFailed)
 /// 12. Spend Program owned account with program keypair (SignerCheckFailed)
@@ -206,19 +205,6 @@ async fn only_test_create_pda() {
         )
         .await
         .unwrap();
-        // // Failing 9 test signer checks trying to insert into cpi context account (invalid signer seeds) ----------------------------------------------
-        // perform_with_input_accounts(
-        //     &mut test_indexer,
-        //     &mut rpc,
-        //     &payer,
-        //     None,
-        //     &compressed_account,
-        //     None,
-        //     SystemProgramError::CpiSignerCheckFailed.into(),
-        //     WithInputAccountsMode::CpiContextInvalidSignerSeeds,
-        // )
-        // .await
-        // .unwrap();
         let compressed_token_account_data =
             test_indexer.get_compressed_token_accounts_by_owner(&payer.pubkey())[0].clone();
         // Failing 10 provide cpi context account but cpi context has a different proof ----------------------------------------------

--- a/test-programs/system-cpi-test/tests/test.rs
+++ b/test-programs/system-cpi-test/tests/test.rs
@@ -75,21 +75,6 @@ async fn only_test_create_pda() {
     let seed = [2u8; 32];
     let data = [3u8; 31];
 
-    // Failing 1 invalid signer seeds ----------------------------------------------
-    perform_create_pda_failing(
-        &mut test_indexer,
-        &mut rpc,
-        &env,
-        &payer,
-        seed,
-        &data,
-        &ID,
-        CreatePdaMode::InvalidSignerSeeds,
-        SystemProgramError::CpiSignerCheckFailed.into(),
-    )
-    .await
-    .unwrap();
-
     // Failing 2 invoking program ----------------------------------------------
     perform_create_pda_failing(
         &mut test_indexer,
@@ -221,19 +206,19 @@ async fn only_test_create_pda() {
         )
         .await
         .unwrap();
-        // Failing 9 test signer checks trying to insert into cpi context account (invalid signer seeds) ----------------------------------------------
-        perform_with_input_accounts(
-            &mut test_indexer,
-            &mut rpc,
-            &payer,
-            None,
-            &compressed_account,
-            None,
-            SystemProgramError::CpiSignerCheckFailed.into(),
-            WithInputAccountsMode::CpiContextInvalidSignerSeeds,
-        )
-        .await
-        .unwrap();
+        // // Failing 9 test signer checks trying to insert into cpi context account (invalid signer seeds) ----------------------------------------------
+        // perform_with_input_accounts(
+        //     &mut test_indexer,
+        //     &mut rpc,
+        //     &payer,
+        //     None,
+        //     &compressed_account,
+        //     None,
+        //     SystemProgramError::CpiSignerCheckFailed.into(),
+        //     WithInputAccountsMode::CpiContextInvalidSignerSeeds,
+        // )
+        // .await
+        // .unwrap();
         let compressed_token_account_data =
             test_indexer.get_compressed_token_accounts_by_owner(&payer.pubkey())[0].clone();
         // Failing 10 provide cpi context account but cpi context has a different proof ----------------------------------------------
@@ -823,7 +808,6 @@ pub async fn perform_with_input_accounts<R: RpcConnection>(
         | WithInputAccountsMode::CpiContextMissing
         | WithInputAccountsMode::CpiContextAccountMissing
         | WithInputAccountsMode::CpiContextInvalidInvokingProgram
-        | WithInputAccountsMode::CpiContextInvalidSignerSeeds
         | WithInputAccountsMode::CpiContextFeePayerMismatch
         | WithInputAccountsMode::CpiContextWriteToNotOwnedAccount => Some(CompressedCpiContext {
             cpi_context_account_index: 2,


### PR DESCRIPTION
Issue:
- informational suggestion in two audits  to remove custom signer seeds from invoke cpi

Changes:
- remove signer seeds from `InvokeCpiInstructionData`
- enforce default seed `cpi-authority`  instead of custom seeds 