### PR TITLE
chore: fix cargo metadata error on first use of build.sh

### DIFF
--- a/js/stateless.js/src/idls/account_compression.ts
+++ b/js/stateless.js/src/idls/account_compression.ts
@@ -1161,6 +1161,10 @@ export type AccountCompression = {
             code: 6025;
             name: 'InvalidGroup';
         },
+        {
+            code: 6026;
+            name: 'ProofLengthMismatch';
+        },
     ];
 };
 
@@ -2326,6 +2330,10 @@ export const IDL: AccountCompression = {
         {
             code: 6025,
             name: 'InvalidGroup',
+        },
+        {
+            code: 6026,
+            name: 'ProofLengthMismatch',
         },
     ],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,10 +413,6 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@22.4.1)(@vitest/browser@1.6.0)(terser@5.31.0)
 
-  hasher.rs/src/main/wasm: {}
-
-  hasher.rs/src/main/wasm-simd: {}
-
   js/compressed-token:
     dependencies:
       '@coral-xyz/anchor':

--- a/scripts/devenv.sh
+++ b/scripts/devenv.sh
@@ -5,9 +5,13 @@ deactivate () {
     CARGO_HOME="${LIGHT_PROTOCOL_OLD_CARGO_HOME}"
     NPM_CONFIG_PREFIX="${LIGHT_PROTOCOL_OLD_NPM_CONFIG_PREFIX}"
     PATH="${LIGHT_PROTOCOL_OLD_PATH}"
+    [ -n "${LIGHT_PROTOCOL_OLD_RUST_PATH}" ] && PATH="${LIGHT_PROTOCOL_OLD_RUST_PATH}"
     unset LIGHT_PROTOCOL_DEVENV
     unset LIGHT_PROTOCOL_TOPLEVEL
     unset GOROOT
+    unset RUSTUP_HOME
+    unset CARGO_HOME
+    unset LIGHT_PROTOCOL_OLD_RUST_PATH
 }
 
 # Stop early if already in devenv.
@@ -41,8 +45,17 @@ PATH="${LIGHT_PROTOCOL_TOPLEVEL}/.local/cargo/bin:${PATH}"
 PATH="${LIGHT_PROTOCOL_TOPLEVEL}/.local/go/bin:${PATH}"
 PATH="${LIGHT_PROTOCOL_TOPLEVEL}/.local/npm-global/bin:${PATH}"
 
+# Remove the original Rust-related PATH entries
+PATH=$(echo "$PATH" | tr ':' '\n' | grep -vE "/.rustup/|/.cargo/" | tr '\n' ':' | sed 's/:$//')
+
 # Define alias of `light` to use the CLI built from source.
 alias light="${LIGHT_PROTOCOL_TOPLEVEL}/cli/test_bin/run"
 
 # Define GOROOT for Go.
-GOROOT="${LIGHT_PROTOCOL_TOPLEVEL}/.local/go"
+export GOROOT="${LIGHT_PROTOCOL_TOPLEVEL}/.local/go"
+
+# Ensure Rust binaries are in PATH
+PATH="${CARGO_HOME}/bin:${PATH}"
+
+# Export the modified PATH
+export PATH


### PR DESCRIPTION
If we try to run: `git clean -dfx && ./scripts/install.sh && . ./scripts.devenv.sh && ./scripts/build.sh` we'll get an error (see below), and then the second call ./scripts/build.sh will run without any errors. This PR fixes this first cargo metadata error on the first build attempt.

```
./scripts/build.sh 
+ pnpm install
Scope: all 12 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date
cli postinstall$ [ -d ./bin ] && find ./bin -type f -exec chmod +x {} + || echo 'No bin directory found, skipping chmod'
│ No bin directory found, skipping chmod
└─ Done in 11ms
Done in 1s
+ '[' '!' -f target/deploy/spl_noop.so ']'
+ mkdir -p target/deploy
+ cp third-party/solana-program-library/spl_noop.so target/deploy
+ npx nx run-many --target=build --all

 NX   Running target build for 8 projects

   ✖  nx run @lightprotocol/hasher.rs:build
      > @lightprotocol/hasher.rs@0.2.0 build /Users/tsv/Developer/light-protocol/hasher.rs
      > rm -rf dist/ && pnpm build:wasm && pnpm build:wasm-simd && pnpm build:bundle
      
      
      > @lightprotocol/hasher.rs@0.2.0 build:wasm /Users/tsv/Developer/light-protocol/hasher.rs
      > wasm-pack build -t web --out-dir ../main/wasm src/wasm
      
      Error: cargo metadata exited with an error: info: syncing channel updates for '1.79-aarch64-apple-darwin'
      info: latest update on 2024-06-13, rust version 1.79.0 (129f3b996 2024-06-10)
      info: downloading component 'cargo'
      info: downloading component 'clippy'
      info: downloading component 'rust-docs'
      error: component download failed for rust-docs-aarch64-apple-darwin: could not rename downloaded file from '/Users/tsv/.rustup/downloads/1c03a379902552e60242dc4a2ae422c1d08de704e2c7d1b3cde3788ff97d8359.partial' to '/Users/tsv/.rustup/downloads/1c03a379902552e60242dc4a2ae422c1d08de704e2c7d1b3cde3788ff97d8359'
      
      Caused by: cargo metadata exited with an error: info: syncing channel updates for '1.79-aarch64-apple-darwin'
      info: latest update on 2024-06-13, rust version 1.79.0 (129f3b996 2024-06-10)
      info: downloading component 'cargo'
      info: downloading component 'clippy'
      info: downloading component 'rust-docs'
      error: component download failed for rust-docs-aarch64-apple-darwin: could not rename downloaded file from '/Users/tsv/.rustup/downloads/1c03a379902552e60242dc4a2ae422c1d08de704e2c7d1b3cde3788ff97d8359.partial' to '/Users/tsv/.rustup/downloads/1c03a379902552e60242dc4a2ae422c1d08de704e2c7d1b3cde3788ff97d8359'
      
       ELIFECYCLE  Command failed with exit code 1.
       ELIFECYCLE  Command failed with exit code 1.
```