### PR TITLE
refactor: Remove dependency on programs in SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,12 +717,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-dropper"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d901072ae4dcdca2201b98beb02d31fb4b6b2472fbd0e870b12ec15b8b35b2d2"
+dependencies = [
+ "async-dropper-derive",
+ "async-dropper-simple",
+ "async-trait",
+ "futures 0.3.30",
+ "tokio",
+]
+
+[[package]]
+name = "async-dropper-derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35cf17a37761f1c88b8e770b5956820fe84c12854165b6f930c604ea186e47e"
+dependencies = [
+ "async-trait",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "tokio",
+]
+
+[[package]]
+name = "async-dropper-simple"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c4748dfe8cd3d625ec68fc424fa80c134319881185866f9e173af9e5d8add8"
+dependencies = [
+ "async-scoped",
+ "async-trait",
+ "futures 0.3.30",
+ "rustc_version",
+ "tokio",
+]
+
+[[package]]
 name = "async-mutex"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
 dependencies = [
  "event-listener",
+]
+
+[[package]]
+name = "async-scoped"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4042078ea593edffc452eef14e99fdb2b120caa4ad9618bcdeabc4a023b98740"
+dependencies = [
+ "futures 0.3.30",
+ "pin-project",
+ "tokio",
 ]
 
 [[package]]
@@ -1255,12 +1305,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "caps"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190baaad529bcfbde9e1a19022c42781bdb6ff9de25721abdb8fd98c0807730b"
 dependencies = [
  "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
  "thiserror",
 ]
 
@@ -3637,7 +3719,7 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-std",
- "borsh 0.9.3",
+ "borsh 0.10.3",
  "bytemuck",
  "color-eyre",
  "duct",
@@ -3686,9 +3768,9 @@ dependencies = [
 name = "light-sdk"
 version = "0.8.0"
 dependencies = [
- "account-compression",
  "aligned-sized",
  "anchor-lang",
+ "anchor-spl",
  "borsh 0.10.3",
  "bytemuck",
  "groth16-solana",
@@ -3696,13 +3778,11 @@ dependencies = [
  "light-concurrent-merkle-tree",
  "light-hash-set",
  "light-hasher",
- "light-heap",
  "light-indexed-merkle-tree",
  "light-macros",
  "light-merkle-tree-reference",
  "light-prover-client",
  "light-sdk-macros",
- "light-system-program",
  "light-utils",
  "light-verifier",
  "num-bigint 0.4.6",
@@ -3712,6 +3792,7 @@ dependencies = [
  "serde_json",
  "solana-banks-interface",
  "solana-cli-output",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "tokio",
@@ -3747,6 +3828,22 @@ dependencies = [
  "rand 0.8.5",
  "solana-sdk",
  "solana-security-txt",
+]
+
+[[package]]
+name = "light-test-sdk"
+version = "0.8.0"
+dependencies = [
+ "anchor-lang",
+ "async-dropper",
+ "async-trait",
+ "cargo_metadata",
+ "light-macros",
+ "light-sdk",
+ "photon-api",
+ "solana-client",
+ "solana-sdk",
+ "tokio",
 ]
 
 [[package]]
@@ -4086,20 +4183,17 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 name = "name-service"
 version = "0.6.0"
 dependencies = [
- "account-compression",
  "anchor-lang",
  "borsh 0.10.3",
- "light-compressed-token",
  "light-hasher",
- "light-heap",
  "light-macros",
  "light-sdk",
  "light-sdk-macros",
- "light-system-program",
- "light-test-utils",
+ "light-test-sdk",
  "light-utils",
  "light-verifier",
- "solana-program-test",
+ "photon-api",
+ "solana-client",
  "solana-sdk",
  "tokio",
 ]
@@ -5731,6 +5825,9 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "seqlock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "programs/compressed-token",
     "programs/registry",
     "sdk",
+    "test-sdk",
     "test-utils",
     "utils",
     "xtask",
@@ -23,7 +24,7 @@ members = [
     "forester-utils",
     "forester",
     "photon-api",
-    "sdk"]
+]
 
 [profile.release]
 overflow-checks = true
@@ -52,6 +53,10 @@ quote = "1.0"
 syn = { version = "2.0", features = ["visit-mut", "full"] }
 
 tokio = { version = "1.39.1", features = ["rt", "macros", "rt-multi-thread"] }
+async-trait = "0.1"
+async-dropper = { version = "0.3", features = ["simple", "tokio"] }
+
+cargo_metadata = "0.18"
 
 [patch.crates-io]
 "solana-account-decoder" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }

--- a/examples/name-service/programs/name-service/Cargo.toml
+++ b/examples/name-service/programs/name-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "name-service"
 version = "0.6.0"
-description = "Created with Anchor"
+description = "Simple DNS service on Light Protocol"
 edition = "2021"
 rust-version = "1.75.0" 
 license = "Apache-2.0"
@@ -15,19 +15,15 @@ no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
 cpi = ["no-entrypoint"]
-custom-heap = ["light-heap"]
-default = ["custom-heap"]
+default = ["idl-build"]
 test-sbf = []
 bench-sbf = []
+idl-build = ["anchor-lang/idl-build", "light-sdk/idl-build"]
 
 [dependencies]
 anchor-lang = { workspace = true, features = ["init-if-needed"] }
 borsh = "0.10"
-light-compressed-token = { path = "../../../../programs/compressed-token", version = "1.0.0", features = ["cpi"] }
-light-system-program = { path = "../../../../programs/system", version = "1.0.0", features = ["cpi"]}
-account-compression = { path = "../../../../programs/account-compression", version = "1.0.0",  features = ["cpi"] }
-light-hasher = { path = "../../../../merkle-tree/hasher", version = "1.0.0" }
-light-heap = { path = "../../../../heap", version = "1.0.0", optional = true }
+light-hasher = { path = "../../../../merkle-tree/hasher", version = "1.0.0", features = ["solana"] }
 light-macros = { path = "../../../../macros/light", version = "1.0.0" }
 light-sdk-macros = { path = "../../../../macros/light-sdk-macros", version = "0.1.0" }
 light-sdk = { path = "../../../../sdk", version = "0.8.0" }
@@ -38,6 +34,7 @@ light-verifier = { path = "../../../../circuit-lib/verifier", version = "1.0.0" 
 solana-sdk = { workspace = true }
 
 [dev-dependencies]
-light-test-utils = { path = "../../../../test-utils", version = "1.0.0" }
-solana-program-test = { workspace = true }
-tokio = "1.36.0"
+light-test-sdk = { path = "../../../../test-sdk", version = "0.8.0" }
+photon-api = { path = "../../../../photon-api", version = "0.44.0" }
+solana-client = { workspace = true }
+tokio = { workspace = true }

--- a/examples/name-service/programs/name-service/src/lib.rs
+++ b/examples/name-service/programs/name-service/src/lib.rs
@@ -4,11 +4,9 @@ use anchor_lang::prelude::*;
 use borsh::{BorshDeserialize, BorshSerialize};
 use light_hasher::bytes::AsByteVec;
 use light_sdk::{
-    compressed_account::LightAccount,
-    light_account, light_accounts, light_program,
-    merkle_context::{PackedAddressMerkleContext, PackedMerkleContext},
+    compressed_account::LightAccount, light_account, light_accounts, light_program,
+    merkle_context::PackedAddressMerkleContext,
 };
-use light_system_program::invoke::processor::CompressedProof;
 
 declare_id!("7yucc7fL3JGbyMwg4neUaenNSdySS39hbAk89Ao3t1Hz");
 

--- a/examples/name-service/programs/name-service/tests/test.rs
+++ b/examples/name-service/programs/name-service/tests/test.rs
@@ -1,21 +1,23 @@
-#![cfg(feature = "test-sbf")]
+#![cfg(any(not(os = "solana"), feature = "test-sbf"))]
 
 use std::net::{Ipv4Addr, Ipv6Addr};
+use std::process::{Command, Stdio};
 
-use account_compression::utils::constants::CPI_AUTHORITY_PDA_SEED;
 use anchor_lang::{AnchorDeserialize, InstructionData, ToAccountMetas};
-use light_sdk::address::derive_address_seed;
+use light_sdk::address::{derive_address, derive_address_seed};
+use light_sdk::compressed_account::CompressedAccountWithMerkleContext;
 use light_sdk::merkle_context::{
     pack_address_merkle_context, pack_merkle_context, AddressMerkleContext, MerkleContext,
     PackedAddressMerkleContext, RemainingAccounts,
 };
-use light_system_program::sdk::address::derive_address;
-use light_system_program::sdk::compressed_account::CompressedAccountWithMerkleContext;
-use light_test_utils::indexer::test_indexer::TestIndexer;
-use light_test_utils::rpc::ProgramTestRpcConnection;
-use light_test_utils::test_env::{setup_test_programs_with_accounts, EnvAccounts};
-use light_test_utils::{Indexer, RpcConnection};
+use light_sdk::utils::get_cpi_authority_pda;
+use light_sdk::{
+    CPI_AUTHORITY_PDA_SEED, PROGRAM_ID_ACCOUNT_COMPRESSION, PROGRAM_ID_NOOP, PROGRAM_ID_SYSTEM,
+};
+use light_test_sdk::LightTest;
 use name_service::{NameRecord, RData};
+use photon_api::models::GetCompressedAccountsByOwnerPostRequestParams;
+use solana_client::rpc_client::RpcClient;
 use solana_sdk::instruction::Instruction;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, Signer};
@@ -27,41 +29,46 @@ fn find_cpi_signer() -> (Pubkey, u8) {
 
 #[tokio::test]
 async fn test_name_service() {
-    let (mut rpc, env) = setup_test_programs_with_accounts(Some(vec![(
-        String::from("name_service"),
-        name_service::ID,
-    )]))
-    .await;
-    let payer = rpc.get_payer().insecure_clone();
+    let env = LightTest::new("name_service").await;
+    let rpc = env.client();
+    let payer = env.payer();
 
-    let mut test_indexer: TestIndexer<ProgramTestRpcConnection> =
-        TestIndexer::init_from_env(&payer, &env, true, true).await;
+    let request = photon_api::models::GetCompressedAccountsByOwnerPostRequest {
+        params: Box::from(GetCompressedAccountsByOwnerPostRequestParams {
+            cursor: None,
+            limit: None,
+            owner: name_service::ID.to_string(),
+        }),
+        ..Default::default()
+    };
+    let result = photon_api::apis::default_api::get_compressed_accounts_by_owner_post(
+        &env.photon_configuration,
+        request,
+    )
+    .await
+    .unwrap();
+
+    println!("RESULT: {result:?}");
+
+    // let mut test_indexer: TestIndexer<ProgramTestRpcConnection> =
+    //     TestIndexer::init_from_env(&payer, &env, true, true).await;
 
     let name = "example.io";
 
     let mut remaining_accounts = RemainingAccounts::default();
 
-    let address_merkle_context = AddressMerkleContext {
-        address_merkle_tree_pubkey: env.address_merkle_tree_pubkey,
-        address_queue_pubkey: env.address_merkle_tree_queue_pubkey,
-    };
+    let address_merkle_context = env.address_merkle_context();
 
-    let address_seed = derive_address_seed(
-        &[b"name-service", name.as_bytes()],
-        &name_service::ID,
-        &address_merkle_context,
-    );
-    println!("ADDRESS_SEED: {address_seed:?}");
-    let address = derive_address(&env.address_merkle_tree_pubkey, &address_seed).unwrap();
+    let address_seed = derive_address_seed(&[b"name-service", name.as_bytes()], &name_service::ID);
+    let address = derive_address(&address_seed, &address_merkle_context);
 
     let address_merkle_context =
         pack_address_merkle_context(address_merkle_context, &mut remaining_accounts);
 
-    let account_compression_authority =
-        light_system_program::utils::get_cpi_authority_pda(&light_system_program::ID);
+    let account_compression_authority = get_cpi_authority_pda(&PROGRAM_ID_SYSTEM);
     let registered_program_pda = Pubkey::find_program_address(
-        &[light_system_program::ID.to_bytes().as_slice()],
-        &account_compression::ID,
+        &[PROGRAM_ID_SYSTEM.to_bytes().as_slice()],
+        &PROGRAM_ID_ACCOUNT_COMPRESSION,
     )
     .0;
 
@@ -70,9 +77,7 @@ async fn test_name_service() {
     create_record(
         &name,
         &rdata_1,
-        &mut rpc,
-        &mut test_indexer,
-        &env,
+        &rpc,
         &mut remaining_accounts,
         &payer,
         &address,
@@ -82,69 +87,67 @@ async fn test_name_service() {
     )
     .await;
 
-    // Check that it was created correctly.
-    let compressed_accounts = test_indexer.get_compressed_accounts_by_owner(&name_service::ID);
-    assert_eq!(compressed_accounts.len(), 1);
-    let compressed_account = &compressed_accounts[0];
-    let record = &compressed_account
-        .compressed_account
-        .data
-        .as_ref()
-        .unwrap()
-        .data;
-    let record = NameRecord::deserialize(&mut &record[..]).unwrap();
-    assert_eq!(record.name, "example.io");
-    assert_eq!(record.rdata, rdata_1);
+    // // Check that it was created correctly.
+    // let compressed_accounts = test_indexer.get_compressed_accounts_by_owner(&name_service::ID);
+    // assert_eq!(compressed_accounts.len(), 1);
+    // let compressed_account = &compressed_accounts[0];
+    // let record = &compressed_account
+    //     .compressed_account
+    //     .data
+    //     .as_ref()
+    //     .unwrap()
+    //     .data;
+    // let record = NameRecord::deserialize(&mut &record[..]).unwrap();
+    // assert_eq!(record.name, "example.io");
+    // assert_eq!(record.rdata, rdata_1);
 
-    // Update the record to example.io -> 2001:db8::1.
-    let rdata_2 = RData::AAAA(Ipv6Addr::new(8193, 3512, 0, 0, 0, 0, 0, 1));
-    update_record(
-        &mut rpc,
-        &mut test_indexer,
-        &mut remaining_accounts,
-        &rdata_2,
-        &payer,
-        compressed_account,
-        &address_merkle_context,
-        &account_compression_authority,
-        &registered_program_pda,
-    )
-    .await;
+    // // Update the record to example.io -> 2001:db8::1.
+    // let rdata_2 = RData::AAAA(Ipv6Addr::new(8193, 3512, 0, 0, 0, 0, 0, 1));
+    // update_record(
+    //     &mut rpc,
+    //     &mut test_indexer,
+    //     &mut remaining_accounts,
+    //     &rdata_2,
+    //     &payer,
+    //     compressed_account,
+    //     &address_merkle_context,
+    //     &account_compression_authority,
+    //     &registered_program_pda,
+    // )
+    // .await;
 
-    // Check that it was updated correctly.
-    let compressed_accounts = test_indexer.get_compressed_accounts_by_owner(&name_service::ID);
-    assert_eq!(compressed_accounts.len(), 1);
-    let compressed_account = &compressed_accounts[0];
-    let record = &compressed_account
-        .compressed_account
-        .data
-        .as_ref()
-        .unwrap()
-        .data;
-    let record = NameRecord::deserialize(&mut &record[..]).unwrap();
-    assert_eq!(record.name, "example.io");
-    assert_eq!(record.rdata, rdata_2);
+    // // Check that it was updated correctly.
+    // let compressed_accounts = test_indexer.get_compressed_accounts_by_owner(&name_service::ID);
+    // assert_eq!(compressed_accounts.len(), 1);
+    // let compressed_account = &compressed_accounts[0];
+    // let record = &compressed_account
+    //     .compressed_account
+    //     .data
+    //     .as_ref()
+    //     .unwrap()
+    //     .data;
+    // let record = NameRecord::deserialize(&mut &record[..]).unwrap();
+    // assert_eq!(record.name, "example.io");
+    // assert_eq!(record.rdata, rdata_2);
 
-    // Delete the example.io record.
-    delete_record(
-        &mut rpc,
-        &mut test_indexer,
-        &mut remaining_accounts,
-        &payer,
-        compressed_account,
-        &address_merkle_context,
-        &account_compression_authority,
-        &registered_program_pda,
-    )
-    .await;
+    // // Delete the example.io record.
+    // delete_record(
+    //     &mut rpc,
+    //     &mut test_indexer,
+    //     &mut remaining_accounts,
+    //     &payer,
+    //     compressed_account,
+    //     &address_merkle_context,
+    //     &account_compression_authority,
+    //     &registered_program_pda,
+    // )
+    // .await;
 }
 
-async fn create_record<R: RpcConnection>(
+async fn create_record(
     name: &str,
     rdata: &RData,
-    rpc: &mut R,
-    test_indexer: &mut TestIndexer<R>,
-    env: &EnvAccounts,
+    rpc: &RpcClient,
     remaining_accounts: &mut RemainingAccounts,
     payer: &Keypair,
     address: &[u8; 32],
@@ -185,11 +188,11 @@ async fn create_record<R: RpcConnection>(
 
     let accounts = name_service::accounts::CreateRecord {
         signer: payer.pubkey(),
-        light_system_program: light_system_program::ID,
-        account_compression_program: account_compression::ID,
+        light_system_program: PROGRAM_ID_SYSTEM,
+        account_compression_program: PROGRAM_ID_ACCOUNT_COMPRESSION,
         account_compression_authority: *account_compression_authority,
         registered_program_pda: *registered_program_pda,
-        noop_program: Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
+        noop_program: PROGRAM_ID_NOOP,
         self_program: name_service::ID,
         cpi_signer,
         system_program: solana_sdk::system_program::id(),
@@ -211,151 +214,151 @@ async fn create_record<R: RpcConnection>(
     test_indexer.add_compressed_accounts_with_token_data(&event.0);
 }
 
-async fn update_record<R: RpcConnection>(
-    rpc: &mut R,
-    test_indexer: &mut TestIndexer<R>,
-    remaining_accounts: &mut RemainingAccounts,
-    new_rdata: &RData,
-    payer: &Keypair,
-    compressed_account: &CompressedAccountWithMerkleContext,
-    address_merkle_context: &PackedAddressMerkleContext,
-    account_compression_authority: &Pubkey,
-    registered_program_pda: &Pubkey,
-) {
-    let hash = compressed_account.hash().unwrap();
-    let merkle_tree_pubkey = compressed_account.merkle_context.merkle_tree_pubkey;
-
-    let rpc_result = test_indexer
-        .create_proof_for_compressed_accounts(
-            Some(&[hash]),
-            Some(&[merkle_tree_pubkey]),
-            None,
-            None,
-            rpc,
-        )
-        .await;
-
-    let merkle_context = pack_merkle_context(compressed_account.merkle_context, remaining_accounts);
-
-    let inputs = vec![
-        compressed_account
-            .compressed_account
-            .data
-            .clone()
-            .unwrap()
-            .data,
-    ];
-
-    let instruction_data = name_service::instruction::UpdateRecord {
-        inputs,
-        proof: rpc_result.proof,
-        merkle_context,
-        merkle_tree_root_index: rpc_result.root_indices[0],
-        address_merkle_context: *address_merkle_context,
-        address_merkle_tree_root_index: 0,
-        new_rdata: new_rdata.clone(),
-    };
-
-    let (cpi_signer, _) = find_cpi_signer();
-
-    let accounts = name_service::accounts::UpdateRecord {
-        signer: payer.pubkey(),
-        light_system_program: light_system_program::ID,
-        account_compression_program: account_compression::ID,
-        account_compression_authority: *account_compression_authority,
-        registered_program_pda: *registered_program_pda,
-        noop_program: Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
-        self_program: name_service::ID,
-        cpi_signer,
-        system_program: solana_sdk::system_program::id(),
-    };
-
-    let remaining_accounts = remaining_accounts.to_account_metas();
-
-    let instruction = Instruction {
-        program_id: name_service::ID,
-        accounts: [accounts.to_account_metas(Some(true)), remaining_accounts].concat(),
-        data: instruction_data.data(),
-    };
-
-    let event = rpc
-        .create_and_send_transaction_with_event(&[instruction], &payer.pubkey(), &[payer], None)
-        .await
-        .unwrap()
-        .unwrap();
-    test_indexer.add_compressed_accounts_with_token_data(&event.0);
-}
-
-async fn delete_record<R: RpcConnection>(
-    rpc: &mut R,
-    test_indexer: &mut TestIndexer<R>,
-    remaining_accounts: &mut RemainingAccounts,
-    payer: &Keypair,
-    compressed_account: &CompressedAccountWithMerkleContext,
-    address_merkle_context: &PackedAddressMerkleContext,
-    account_compression_authority: &Pubkey,
-    registered_program_pda: &Pubkey,
-) {
-    let hash = compressed_account.hash().unwrap();
-    let merkle_tree_pubkey = compressed_account.merkle_context.merkle_tree_pubkey;
-
-    let rpc_result = test_indexer
-        .create_proof_for_compressed_accounts(
-            Some(&[hash]),
-            Some(&[merkle_tree_pubkey]),
-            None,
-            None,
-            rpc,
-        )
-        .await;
-
-    let merkle_context = pack_merkle_context(compressed_account.merkle_context, remaining_accounts);
-
-    let inputs = vec![
-        compressed_account
-            .compressed_account
-            .data
-            .clone()
-            .unwrap()
-            .data,
-    ];
-
-    let instruction_data = name_service::instruction::DeleteRecord {
-        inputs,
-        proof: rpc_result.proof,
-        merkle_context,
-        merkle_tree_root_index: rpc_result.root_indices[0],
-        address_merkle_context: *address_merkle_context,
-        address_merkle_tree_root_index: 0,
-    };
-
-    let (cpi_signer, _) = find_cpi_signer();
-
-    let accounts = name_service::accounts::DeleteRecord {
-        signer: payer.pubkey(),
-        light_system_program: light_system_program::ID,
-        account_compression_program: account_compression::ID,
-        account_compression_authority: *account_compression_authority,
-        registered_program_pda: *registered_program_pda,
-        noop_program: Pubkey::new_from_array(account_compression::utils::constants::NOOP_PUBKEY),
-        self_program: name_service::ID,
-        cpi_signer,
-        system_program: solana_sdk::system_program::id(),
-    };
-
-    let remaining_accounts = remaining_accounts.to_account_metas();
-
-    let instruction = Instruction {
-        program_id: name_service::ID,
-        accounts: [accounts.to_account_metas(Some(true)), remaining_accounts].concat(),
-        data: instruction_data.data(),
-    };
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&payer.pubkey()),
-        &[&payer],
-        rpc.get_latest_blockhash().await.unwrap(),
-    );
-    rpc.process_transaction(transaction).await.unwrap();
-}
+// async fn update_record<R: RpcConnection>(
+//     rpc: &mut R,
+//     test_indexer: &mut TestIndexer<R>,
+//     remaining_accounts: &mut RemainingAccounts,
+//     new_rdata: &RData,
+//     payer: &Keypair,
+//     compressed_account: &CompressedAccountWithMerkleContext,
+//     address_merkle_context: &PackedAddressMerkleContext,
+//     account_compression_authority: &Pubkey,
+//     registered_program_pda: &Pubkey,
+// ) {
+//     let hash = compressed_account.hash().unwrap();
+//     let merkle_tree_pubkey = compressed_account.merkle_context.merkle_tree_pubkey;
+//
+//     let rpc_result = test_indexer
+//         .create_proof_for_compressed_accounts(
+//             Some(&[hash]),
+//             Some(&[merkle_tree_pubkey]),
+//             None,
+//             None,
+//             rpc,
+//         )
+//         .await;
+//
+//     let merkle_context = pack_merkle_context(compressed_account.merkle_context, remaining_accounts);
+//
+//     let inputs = vec![
+//         compressed_account
+//             .compressed_account
+//             .data
+//             .clone()
+//             .unwrap()
+//             .data,
+//     ];
+//
+//     let instruction_data = name_service::instruction::UpdateRecord {
+//         inputs,
+//         proof: rpc_result.proof,
+//         merkle_context,
+//         merkle_tree_root_index: rpc_result.root_indices[0],
+//         address_merkle_context: *address_merkle_context,
+//         address_merkle_tree_root_index: 0,
+//         new_rdata: new_rdata.clone(),
+//     };
+//
+//     let (cpi_signer, _) = find_cpi_signer();
+//
+//     let accounts = name_service::accounts::UpdateRecord {
+//         signer: payer.pubkey(),
+//         light_system_program: PROGRAM_ID_SYSTEM,
+//         account_compression_program: PROGRAM_ID_ACCOUNT_COMPRESSION,
+//         account_compression_authority: *account_compression_authority,
+//         registered_program_pda: *registered_program_pda,
+//         noop_program: PROGRAM_ID_NOOP,
+//         self_program: name_service::ID,
+//         cpi_signer,
+//         system_program: solana_sdk::system_program::id(),
+//     };
+//
+//     let remaining_accounts = remaining_accounts.to_account_metas();
+//
+//     let instruction = Instruction {
+//         program_id: name_service::ID,
+//         accounts: [accounts.to_account_metas(Some(true)), remaining_accounts].concat(),
+//         data: instruction_data.data(),
+//     };
+//
+//     let event = rpc
+//         .create_and_send_transaction_with_event(&[instruction], &payer.pubkey(), &[payer], None)
+//         .await
+//         .unwrap()
+//         .unwrap();
+//     test_indexer.add_compressed_accounts_with_token_data(&event.0);
+// }
+//
+// async fn delete_record<R: RpcConnection>(
+//     rpc: &mut R,
+//     test_indexer: &mut TestIndexer<R>,
+//     remaining_accounts: &mut RemainingAccounts,
+//     payer: &Keypair,
+//     compressed_account: &CompressedAccountWithMerkleContext,
+//     address_merkle_context: &PackedAddressMerkleContext,
+//     account_compression_authority: &Pubkey,
+//     registered_program_pda: &Pubkey,
+// ) {
+//     let hash = compressed_account.hash().unwrap();
+// //     let merkle_tree_pubkey = compressed_account.merkle_context.merkle_tree_pubkey;
+// //
+// //     let rpc_result = test_indexer
+// //         .create_proof_for_compressed_accounts(
+// //             Some(&[hash]),
+// //             Some(&[merkle_tree_pubkey]),
+// //             None,
+// //             None,
+// //             rpc,
+// //         )
+// //         .await;
+// //
+// //     let merkle_context = pack_merkle_context(compressed_account.merkle_context, remaining_accounts);
+// //
+// //     let inputs = vec![
+// //         compressed_account
+// //             .compressed_account
+// //             .data
+// //             .clone()
+// //             .unwrap()
+// //             .data,
+// //     ];
+// //
+// //     let instruction_data = name_service::instruction::DeleteRecord {
+// //         inputs,
+//         proof: rpc_result.proof,
+//         merkle_context,
+//         merkle_tree_root_index: rpc_result.root_indices[0],
+//         address_merkle_context: *address_merkle_context,
+//         address_merkle_tree_root_index: 0,
+//     };
+//
+//     let (cpi_signer, _) = find_cpi_signer();
+//
+//     let accounts = name_service::accounts::DeleteRecord {
+//         signer: payer.pubkey(),
+//         light_system_program: PROGRAM_ID_SYSTEM,
+//         account_compression_program: PROGRAM_ID_ACCOUNT_COMPRESSION,
+//         account_compression_authority: *account_compression_authority,
+//         registered_program_pda: *registered_program_pda,
+//         noop_program: PROGRAM_ID_NOOP,
+//         self_program: name_service::ID,
+//         cpi_signer,
+//         system_program: solana_sdk::system_program::id(),
+//     };
+//
+//     let remaining_accounts = remaining_accounts.to_account_metas();
+//
+//     let instruction = Instruction {
+//         program_id: name_service::ID,
+//         accounts: [accounts.to_account_metas(Some(true)), remaining_accounts].concat(),
+//         data: instruction_data.data(),
+//     };
+//
+//     let transaction = Transaction::new_signed_with_payer(
+//         &[instruction],
+//         Some(&payer.pubkey()),
+//         &[&payer],
+//         rpc.get_latest_blockhash().await.unwrap(),
+//     );
+//     rpc.process_transaction(transaction).await.unwrap();
+// }

--- a/examples/token-escrow/programs/token-escrow/Cargo.toml
+++ b/examples/token-escrow/programs/token-escrow/Cargo.toml
@@ -26,7 +26,7 @@ light-system-program = { path = "../../../../programs/system", version = "1.0.0"
 account-compression = { path = "../../../../programs/account-compression", version = "1.0.0",  features = ["cpi"] }
 light-hasher = { path = "../../../../merkle-tree/hasher", version = "1.0.0" }
 light-verifier = { path = "../../../../circuit-lib/verifier", version = "1.0.0" }
-light-sdk = { path = "../../../../sdk", version = "0.8.0", features = ["cpi"] }
+light-sdk = { path = "../../../../sdk", version = "0.8.0" }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 solana-sdk = { workspace = true }

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/sdk.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_compressed_pda/sdk.rs
@@ -7,14 +7,16 @@ use light_compressed_token::process_transfer::{
     transfer_sdk::{create_inputs_and_remaining_accounts_checked, to_account_metas},
     TokenTransferOutputData,
 };
-use light_system_program::{
-    invoke::processor::CompressedProof,
-    sdk::{
-        address::{add_and_get_remaining_account_indices, pack_new_address_params},
-        compressed_account::{pack_merkle_context, CompressedAccount, MerkleContext},
-        CompressedCpiContext,
-    },
-    NewAddressParams,
+use light_sdk::{
+    address::{NewAddressParams, NewAddressParamsPacked},
+    compressed_account::CompressedAccount,
+    merkle_context::{MerkleContext, PackedMerkleContext, QueueIndex},
+    proof::CompressedProof,
+    verify::CompressedCpiContext,
+};
+use light_system_program::sdk::{
+    address::{add_and_get_remaining_account_indices, pack_new_address_params},
+    compressed_account::pack_merkle_context,
 };
 use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
 
@@ -39,14 +41,60 @@ pub fn create_escrow_instruction(
     escrow_amount: u64,
 ) -> Instruction {
     let token_owner_pda = get_token_owner_pda(input_params.signer);
+
+    // TODO(vadorovsky): Instead of doing these conversions, move all necessary
+    // types from light-compressed-token into a separate crate.
+    let input_compressed_accounts = input_params
+        .input_compressed_accounts
+        .iter()
+        .map(
+            |x| light_system_program::sdk::compressed_account::CompressedAccount {
+                owner: x.owner,
+                lamports: x.lamports,
+                address: x.address,
+                data: x.data.as_ref().map(|data| {
+                    light_system_program::sdk::compressed_account::CompressedAccountData {
+                        discriminator: data.discriminator,
+                        data: data.data.clone(),
+                        data_hash: data.data_hash,
+                    }
+                }),
+            },
+        )
+        .collect::<Vec<_>>();
+    let input_merkle_context = input_params
+        .input_merkle_context
+        .iter()
+        .map(
+            |context| light_system_program::sdk::compressed_account::MerkleContext {
+                merkle_tree_pubkey: context.merkle_tree_pubkey,
+                nullifier_queue_pubkey: context.nullifier_queue_pubkey,
+                leaf_index: context.leaf_index,
+                queue_index: context.queue_index.map(|queue_index| {
+                    light_system_program::sdk::compressed_account::QueueIndex {
+                        queue_id: queue_index.queue_id,
+                        index: queue_index.index,
+                    }
+                }),
+            },
+        )
+        .collect::<Vec<_>>();
+    let proof = input_params.proof.as_ref().map(|proof| {
+        light_system_program::invoke::processor::CompressedProof {
+            a: proof.a,
+            b: proof.b,
+            c: proof.c,
+        }
+    });
+
     let (mut remaining_accounts, inputs) = create_inputs_and_remaining_accounts_checked(
         input_params.input_token_data,
-        input_params.input_compressed_accounts,
-        input_params.input_merkle_context,
+        input_compressed_accounts.as_slice(),
+        input_merkle_context.as_slice(),
         None,
         input_params.output_compressed_accounts,
         input_params.root_indices,
-        input_params.proof,
+        &proof,
         *input_params.mint,
         input_params.signer,
         false,
@@ -61,8 +109,25 @@ pub fn create_escrow_instruction(
         &mut remaining_accounts,
     );
 
+    // TODO(vadorovsky): Instead of doing this conversion, move all necessary
+    // types from light-compressed-token into a separate crate.
+    let new_address_params = light_system_program::invoke::instruction::NewAddressParams {
+        seed: input_params.new_address_params.seed,
+        address_queue_pubkey: input_params.new_address_params.address_queue_pubkey,
+        address_merkle_tree_pubkey: input_params.new_address_params.address_merkle_tree_pubkey,
+        address_merkle_tree_root_index: input_params
+            .new_address_params
+            .address_merkle_tree_root_index,
+    };
     let new_address_params =
-        pack_new_address_params(&[input_params.new_address_params], &mut remaining_accounts);
+        pack_new_address_params(&[new_address_params], &mut remaining_accounts)[0];
+    let new_address_params = NewAddressParamsPacked {
+        seed: new_address_params.seed,
+        address_queue_account_index: new_address_params.address_queue_account_index,
+        address_merkle_tree_account_index: new_address_params.address_merkle_tree_account_index,
+        address_merkle_tree_root_index: new_address_params.address_merkle_tree_root_index,
+    };
+
     let cpi_context_account_index: u8 = match remaining_accounts
         .get(input_params.cpi_context_account)
     {
@@ -80,7 +145,7 @@ pub fn create_escrow_instruction(
         signer_is_delegate: false,
         input_token_data_with_context: inputs.input_token_data_with_context,
         output_state_merkle_tree_account_indices: merkle_tree_indices,
-        new_address_params: new_address_params[0],
+        new_address_params,
         cpi_context: CompressedCpiContext {
             set_context: false,
             first_set_context: true,
@@ -153,14 +218,78 @@ pub fn create_withdrawal_instruction(
     withdrawal_amount: u64,
 ) -> Instruction {
     let (token_owner_pda, bump) = get_token_owner_pda(input_params.signer);
+
+    // TODO(vadorovsky): Instead of doing these conversions, move all necessary
+    // types from light-compressed-token into a separate crate.
+    let input_compressed_accounts = input_params
+        .input_compressed_accounts
+        .iter()
+        .map(
+            |x| light_system_program::sdk::compressed_account::CompressedAccount {
+                owner: x.owner,
+                lamports: x.lamports,
+                address: x.address,
+                data: x.data.as_ref().map(|data| {
+                    light_system_program::sdk::compressed_account::CompressedAccountData {
+                        discriminator: data.discriminator,
+                        data: data.data.clone(),
+                        data_hash: data.data_hash,
+                    }
+                }),
+            },
+        )
+        .collect::<Vec<_>>();
+    let input_cpda_merkle_context = light_system_program::sdk::compressed_account::MerkleContext {
+        merkle_tree_pubkey: input_params.input_cpda_merkle_context.merkle_tree_pubkey,
+        nullifier_queue_pubkey: input_params
+            .input_cpda_merkle_context
+            .nullifier_queue_pubkey,
+        leaf_index: input_params.input_cpda_merkle_context.leaf_index,
+        queue_index: input_params
+            .input_cpda_merkle_context
+            .queue_index
+            .map(
+                |queue_index| light_system_program::sdk::compressed_account::QueueIndex {
+                    queue_id: queue_index.queue_id,
+                    index: queue_index.index,
+                },
+            ),
+    };
+    let input_token_escrow_merkle_context =
+        light_system_program::sdk::compressed_account::MerkleContext {
+            merkle_tree_pubkey: input_params
+                .input_token_escrow_merkle_context
+                .merkle_tree_pubkey,
+            nullifier_queue_pubkey: input_params
+                .input_token_escrow_merkle_context
+                .nullifier_queue_pubkey,
+            leaf_index: input_params.input_token_escrow_merkle_context.leaf_index,
+            queue_index: input_params
+                .input_token_escrow_merkle_context
+                .queue_index
+                .map(
+                    |queue_index| light_system_program::sdk::compressed_account::QueueIndex {
+                        queue_id: queue_index.queue_id,
+                        index: queue_index.index,
+                    },
+                ),
+        };
+    let proof = input_params.proof.as_ref().map(|proof| {
+        light_system_program::invoke::processor::CompressedProof {
+            a: proof.a,
+            b: proof.b,
+            c: proof.c,
+        }
+    });
+
     let (mut remaining_accounts, inputs) = create_inputs_and_remaining_accounts_checked(
         input_params.input_token_data,
-        input_params.input_compressed_accounts,
-        &[input_params.input_token_escrow_merkle_context],
+        input_compressed_accounts.as_slice(),
+        &[input_token_escrow_merkle_context],
         None,
         input_params.output_compressed_accounts,
         input_params.root_indices,
-        input_params.proof,
+        &proof,
         *input_params.mint,
         &token_owner_pda,
         false,
@@ -176,12 +305,21 @@ pub fn create_withdrawal_instruction(
     );
 
     let merkle_context_packed = pack_merkle_context(
-        &[
-            input_params.input_cpda_merkle_context,
-            input_params.input_token_escrow_merkle_context,
-        ],
+        &[input_cpda_merkle_context, input_token_escrow_merkle_context],
         &mut remaining_accounts,
     );
+    let merkle_context_packed = PackedMerkleContext {
+        merkle_tree_pubkey_index: merkle_context_packed[0].merkle_tree_pubkey_index,
+        nullifier_queue_pubkey_index: merkle_context_packed[0].nullifier_queue_pubkey_index,
+        leaf_index: merkle_context_packed[0].leaf_index,
+        queue_index: merkle_context_packed[0]
+            .queue_index
+            .map(|queue_index| QueueIndex {
+                queue_id: queue_index.queue_id,
+                index: queue_index.index,
+            }),
+    };
+
     let cpi_context_account_index: u8 = match remaining_accounts
         .get(input_params.cpi_context_account)
     {
@@ -200,7 +338,7 @@ pub fn create_withdrawal_instruction(
         old_lock_up_time: input_params.old_lock_up_time,
         new_lock_up_time: input_params.new_lock_up_time,
         address: input_params.address,
-        merkle_context: merkle_context_packed[0],
+        merkle_context: merkle_context_packed,
         root_index: input_params.root_indices[0],
     };
     let instruction_data = crate::instruction::WithdrawCompressedTokensWithCompressedPda {

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_pda/escrow.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_pda/escrow.rs
@@ -7,8 +7,7 @@ use light_compressed_token::{
     },
     program::LightCompressedToken,
 };
-use light_sdk::{light_system_accounts, LightTraits};
-use light_system_program::invoke::processor::CompressedProof;
+use light_sdk::{light_system_accounts, proof::CompressedProof, LightTraits};
 
 #[light_system_accounts]
 #[derive(Accounts, LightTraits)]
@@ -82,6 +81,14 @@ pub fn cpi_compressed_token_transfer<'info>(
     input_token_data_with_context: Vec<InputTokenDataWithContext>,
     output_compressed_accounts: Vec<PackedTokenTransferOutputData>,
 ) -> Result<()> {
+    // TODO(vadorovsky): Instead of doing this conversion, move all necessary
+    // types from light-compressed-token into a separate crate.
+    let proof = light_system_program::invoke::processor::CompressedProof {
+        a: proof.a,
+        b: proof.b,
+        c: proof.c,
+    };
+
     let inputs_struct = CompressedTokenInstructionDataTransfer {
         proof: Some(proof),
         mint,

--- a/examples/token-escrow/programs/token-escrow/src/escrow_with_pda/withdrawal.rs
+++ b/examples/token-escrow/programs/token-escrow/src/escrow_with_pda/withdrawal.rs
@@ -3,7 +3,7 @@ use light_compressed_token::process_transfer::{
     CompressedTokenInstructionDataTransfer, InputTokenDataWithContext,
     PackedTokenTransferOutputData,
 };
-use light_system_program::invoke::processor::CompressedProof;
+use light_sdk::proof::CompressedProof;
 
 use crate::{
     create_change_output_compressed_token_account, EscrowCompressedTokensWithPda, EscrowError,
@@ -62,6 +62,14 @@ pub fn withdrawal_cpi_compressed_token_transfer<'info>(
     input_token_data_with_context: Vec<InputTokenDataWithContext>,
     output_compressed_accounts: Vec<PackedTokenTransferOutputData>,
 ) -> Result<()> {
+    // TODO(vadorovsky): Instead of doing this conversion, move all necessary
+    // types from light-compressed-token into a separate crate.
+    let proof = light_system_program::invoke::processor::CompressedProof {
+        a: proof.a,
+        b: proof.b,
+        c: proof.c,
+    };
+
     let inputs_struct = CompressedTokenInstructionDataTransfer {
         proof: Some(proof),
         mint,

--- a/examples/token-escrow/programs/token-escrow/src/lib.rs
+++ b/examples/token-escrow/programs/token-escrow/src/lib.rs
@@ -3,14 +3,14 @@ use anchor_lang::prelude::*;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use light_compressed_token::process_transfer::InputTokenDataWithContext;
 use light_compressed_token::process_transfer::PackedTokenTransferOutputData;
-use light_system_program::invoke::processor::CompressedProof;
+use light_sdk::{
+    address::NewAddressParamsPacked, proof::CompressedProof, verify::CompressedCpiContext,
+};
 pub mod escrow_with_compressed_pda;
 pub mod escrow_with_pda;
 
 pub use escrow_with_compressed_pda::escrow::*;
 pub use escrow_with_pda::escrow::*;
-use light_system_program::sdk::CompressedCpiContext;
-use light_system_program::NewAddressParamsPacked;
 
 #[error_code]
 pub enum EscrowError {

--- a/examples/token-escrow/programs/token-escrow/tests/test.rs
+++ b/examples/token-escrow/programs/token-escrow/tests/test.rs
@@ -11,7 +11,8 @@
 // release compressed tokens
 
 use light_hasher::Poseidon;
-use light_system_program::sdk::{compressed_account::MerkleContext, event::PublicTransactionEvent};
+use light_sdk::event::PublicTransactionEvent;
+use light_system_program::sdk::compressed_account::MerkleContext;
 use light_test_utils::indexer::TestIndexer;
 use light_test_utils::spl::{create_mint_helper, mint_tokens_helper};
 use light_test_utils::test_env::{setup_test_programs_with_accounts, EnvAccounts};

--- a/examples/token-escrow/programs/token-escrow/tests/test_compressed_pda.rs
+++ b/examples/token-escrow/programs/token-escrow/tests/test_compressed_pda.rs
@@ -15,10 +15,10 @@
 
 use anchor_lang::AnchorDeserialize;
 use light_hasher::{Hasher, Poseidon};
+use light_sdk::{
+    address::NewAddressParams, event::PublicTransactionEvent, merkle_context::MerkleContext,
+};
 use light_system_program::sdk::address::derive_address;
-use light_system_program::sdk::compressed_account::MerkleContext;
-use light_system_program::sdk::event::PublicTransactionEvent;
-use light_system_program::NewAddressParams;
 use light_test_utils::indexer::TestIndexer;
 use light_test_utils::spl::{create_mint_helper, mint_tokens_helper};
 use light_test_utils::test_env::{setup_test_programs_with_accounts, EnvAccounts};

--- a/macros/light-sdk-macros/src/accounts.rs
+++ b/macros/light-sdk-macros/src/accounts.rs
@@ -20,21 +20,12 @@ pub(crate) fn process_light_system_accounts(input: ItemStruct) -> Result<TokenSt
         };
 
     let fields_to_add = [
-        (
-            "light_system_program",
-            "Program<'info, ::light_system_program::program::LightSystemProgram>",
-        ),
+        ("light_system_program", "AccountInfo<'info>"),
         ("system_program", "Program<'info, System>"),
-        (
-            "account_compression_program",
-            "Program<'info, ::account_compression::program::AccountCompression>",
-        ),
+        ("account_compression_program", "AccountInfo<'info>"),
     ];
     let fields_to_add_check = [
-        (
-            "registered_program_pda",
-            "Account<'info, ::account_compression::RegisteredProgram>",
-        ),
+        ("registered_program_pda", "AccountInfo<'info>"),
         ("noop_program", "AccountInfo<'info>"),
         ("account_compression_authority", "AccountInfo<'info>"),
     ];
@@ -139,7 +130,6 @@ pub(crate) fn process_light_accounts(input: ItemStruct) -> Result<TokenStream> {
                 let address_seed = ::light_sdk::address::derive_address_seed(
                     &#seeds,
                     &crate::ID,
-                    &unpacked_address_merkle_context,
                 );
                 #field_ident.set_address_seed(address_seed);
             });
@@ -378,7 +368,7 @@ pub(crate) fn process_light_accounts_derive(input: ItemStruct) -> Result<TokenSt
                 })
             }
 
-            fn new_address_params(&self) -> Vec<::light_sdk::compressed_account::NewAddressParamsPacked> {
+            fn new_address_params(&self) -> Vec<::light_sdk::address::NewAddressParamsPacked> {
                 let mut new_address_params = Vec::new();
                 #(#new_address_params_calls)*
                 new_address_params

--- a/macros/light-sdk-macros/src/program.rs
+++ b/macros/light-sdk-macros/src/program.rs
@@ -68,14 +68,14 @@ impl VisitMut for LightProgramTransform {
         i.sig.inputs.insert(1, inputs_arg);
 
         // Inject Merkle context related arguments.
-        let proof_arg: FnArg = parse_quote! { proof: CompressedProof };
+        let proof_arg: FnArg = parse_quote! { proof: ::light_sdk::proof::CompressedProof };
         i.sig.inputs.insert(2, proof_arg);
-        let merkle_context_arg: FnArg = parse_quote! { merkle_context: PackedMerkleContext };
+        let merkle_context_arg: FnArg =
+            parse_quote! { merkle_context: ::light_sdk::merkle_context::PackedMerkleContext };
         i.sig.inputs.insert(3, merkle_context_arg);
         let merkle_tree_root_index_arg: FnArg = parse_quote! { merkle_tree_root_index: u16 };
         i.sig.inputs.insert(4, merkle_tree_root_index_arg);
-        let address_merkle_context_arg: FnArg =
-            parse_quote! { address_merkle_context: PackedAddressMerkleContext };
+        let address_merkle_context_arg: FnArg = parse_quote! { address_merkle_context: ::light_sdk::merkle_context::PackedAddressMerkleContext };
         i.sig.inputs.insert(5, address_merkle_context_arg);
         let address_merkle_tree_root_index_arg: FnArg =
             parse_quote! { address_merkle_tree_root_index: u16 };

--- a/macros/light-sdk-macros/src/traits.rs
+++ b/macros/light-sdk-macros/src/traits.rs
@@ -212,20 +212,14 @@ fn process_fields_and_attributes(name: &Ident, fields: FieldsNamed) -> TokenStre
                 }
             }
             impl<'info> ::light_sdk::traits::LightSystemAccount<'info> for #name<'info> {
-                fn get_light_system_program(&self) -> &::anchor_lang::prelude::Program<
-                    'info,
-                    ::light_system_program::program::LightSystemProgram
-                > {
+                fn get_light_system_program(&self) -> &::anchor_lang::prelude::AccountInfo<'info> {
                     &self.#light_system_program_field
                 }
             }
         };
         let invoke_accounts_impl = quote! {
             impl<'info> ::light_sdk::traits::InvokeAccounts<'info> for #name<'info> {
-                fn get_registered_program_pda(&self) -> &::anchor_lang::prelude::Account<
-                    'info,
-                    ::account_compression::RegisteredProgram
-                > {
+                fn get_registered_program_pda(&self) -> &::anchor_lang::prelude::AccountInfo<'info> {
                     &self.#registered_program_pda_field
                 }
                 fn get_noop_program(&self) -> &::anchor_lang::prelude::AccountInfo<'info> {
@@ -234,10 +228,7 @@ fn process_fields_and_attributes(name: &Ident, fields: FieldsNamed) -> TokenStre
                 fn get_account_compression_authority(&self) -> &::anchor_lang::prelude::AccountInfo<'info> {
                     &self.#account_compression_authority_field
                 }
-                fn get_account_compression_program(&self) -> &::anchor_lang::prelude::Program<
-                    'info,
-                    ::account_compression::program::AccountCompression
-                > {
+                fn get_account_compression_program(&self) -> &::anchor_lang::prelude::AccountInfo<'info> {
                     &self.#account_compression_program_field
                 }
                 fn get_system_program(&self) -> &::anchor_lang::prelude::Program<'info, System> {
@@ -257,10 +248,7 @@ fn process_fields_and_attributes(name: &Ident, fields: FieldsNamed) -> TokenStre
                 #invoke_accounts_impl
                 impl<'info> ::light_sdk::traits::InvokeCpiContextAccount<'info> for #name<'info> {
                     fn get_cpi_context_account(&self) -> Option<
-                        &::anchor_lang::prelude::Account<
-                            'info,
-                            ::light_system_program::invoke_cpi::account::CpiContextAccount
-                        >
+                        &::anchor_lang::prelude::AccountInfo<'info>
                     > {
                         None
                     }
@@ -272,10 +260,7 @@ fn process_fields_and_attributes(name: &Ident, fields: FieldsNamed) -> TokenStre
                 #invoke_accounts_impl
                 impl<'info> ::light_sdk::traits::InvokeCpiContextAccount<'info> for #name<'info> {
                     fn get_cpi_context_account(&self) -> Option<
-                        &::anchor_lang::prelude::Account<
-                            'info,
-                            ::light_system_program::invoke_cpi::account::CpiContextAccount
-                        >
+                        &::anchor_lang::prelude::AccountInfo<'info>
                     > {
                         Some(&self.#cpi_context_account_field)
                     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 PREFIX="${PWD}/.local"
 INSTALL_LOG="${PREFIX}/.install_log"
+LIGHT_PROTOCOL_TOPLEVEL="`git rev-parse --show-toplevel`"
 
 # Versions
 VERSIONS=(
@@ -184,6 +185,16 @@ install_dependencies() {
     fi
 }
 
+create_cli_symlink() {
+    local symlink="${LIGHT_PROTOCOL_TOPLEVEL}/.local/bin/light"
+    local source_file="${LIGHT_PROTOCOL_TOPLEVEL}/cli/test_bin/run"
+
+    if [ ! -L "$symlink" ]; then
+        echo "Creating a symlink to the light CLI..."
+        ln -s "$source_file" "$symlink"
+    fi
+}
+
 main() {
     mkdir -p "${PREFIX}/bin"
 
@@ -196,6 +207,7 @@ main() {
     install_jq
     download_gnark_keys
     install_dependencies
+    create_cli_symlink
 
     rm -f "$INSTALL_LOG"
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -11,31 +11,23 @@ crate-type = ["cdylib", "lib"]
 name = "light_sdk"
 
 [features]
-no-entrypoint = []
-no-idl = []
-no-log-ix-name = []
-cpi = ["no-entrypoint"]
-custom-heap = ["light-heap"]
-mem-profiling = []
-default = ["custom-heap"]
-test-sbf = []
-bench-sbf = []
+default = []
+idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
 aligned-sized = { version = "1.0.0", path = "../macros/aligned-sized" }
 light-macros = { version = "1.0.0", path = "../macros/light" }
 light-sdk-macros = { version = "0.1.0", path = "../macros/light-sdk-macros" }
 anchor-lang = { workspace = true }
+anchor-spl = { workspace = true }
 bytemuck = "1.17"
-light-hasher = { version = "1.0.0", path = "../merkle-tree/hasher" }
-light-heap = { version = "1.0.0", path = "../heap", optional = true }
-account-compression = { version = "1.0.0", path = "../programs/account-compression", features = ["cpi"] }
-light-system-program = { version = "1.0.0", path = "../programs/system", features = ["cpi"] }
+light-hasher = { version = "1.0.0", path = "../merkle-tree/hasher", features = ["solana"] }
 light-concurrent-merkle-tree = { path = "../merkle-tree/concurrent", version = "1.0.0" }
 light-utils = { version = "1.0.0", path = "../utils" }
 groth16-solana = "0.0.3"
 light-verifier = { path = "../circuit-lib/verifier", version = "1.0.0", features = ["solana"] }
 borsh = "0.10.0"
+solana-program = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 solana-sdk = { workspace = true }

--- a/sdk/src/address.rs
+++ b/sdk/src/address.rs
@@ -1,37 +1,88 @@
 use anchor_lang::solana_program::pubkey::Pubkey;
+use borsh::{BorshDeserialize, BorshSerialize};
 use light_utils::hashv_to_bn254_field_size_be;
 
-use crate::merkle_context::AddressMerkleContext;
+use crate::merkle_context::{AddressMerkleContext, RemainingAccounts};
+
+#[derive(Debug, PartialEq, Default, Clone, BorshDeserialize, BorshSerialize)]
+pub struct NewAddressParams {
+    pub seed: [u8; 32],
+    pub address_queue_pubkey: Pubkey,
+    pub address_merkle_tree_pubkey: Pubkey,
+    pub address_merkle_tree_root_index: u16,
+}
+
+#[derive(Debug, PartialEq, Default, Clone, Copy, BorshDeserialize, BorshSerialize)]
+pub struct NewAddressParamsPacked {
+    pub seed: [u8; 32],
+    pub address_queue_account_index: u8,
+    pub address_merkle_tree_account_index: u8,
+    pub address_merkle_tree_root_index: u16,
+}
+
+#[cfg(feature = "idl-build")]
+impl anchor_lang::IdlBuild for NewAddressParamsPacked {}
+
+pub fn pack_new_addresses_params(
+    addresses_params: &[NewAddressParams],
+    remaining_accounts: &mut RemainingAccounts,
+) -> Vec<NewAddressParamsPacked> {
+    addresses_params
+        .iter()
+        .map(|x| {
+            let address_queue_account_index =
+                remaining_accounts.insert_or_get(x.address_queue_pubkey);
+            let address_merkle_tree_account_index =
+                remaining_accounts.insert_or_get(x.address_merkle_tree_pubkey);
+            NewAddressParamsPacked {
+                seed: x.seed,
+                address_queue_account_index,
+                address_merkle_tree_account_index,
+                address_merkle_tree_root_index: x.address_merkle_tree_root_index,
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
+pub fn pack_new_address_params(
+    address_params: NewAddressParams,
+    remaining_accounts: &mut RemainingAccounts,
+) -> NewAddressParamsPacked {
+    pack_new_addresses_params(&[address_params], remaining_accounts)[0]
+}
 
 /// Derives a single address seed for a compressed account, based on the
-/// provided multiple `seeds`, `program_id` and `merkle_tree_pubkey`.
+/// provided multiple `seeds` and `program_id`.
 ///
 /// # Examples
 ///
 /// ```ignore
 /// use light_sdk::{address::derive_address, pubkey};
 ///
-/// let address = derive_address(
+/// let address = derive_address_seed(
 ///     &[b"my_compressed_account"],
 ///     &crate::ID,
-///     &address_merkle_context,
 /// );
 /// ```
-pub fn derive_address_seed(
-    seeds: &[&[u8]],
-    program_id: &Pubkey,
-    address_merkle_context: &AddressMerkleContext,
-) -> [u8; 32] {
-    let mut inputs = Vec::with_capacity(seeds.len() + 2);
+pub fn derive_address_seed(seeds: &[&[u8]], program_id: &Pubkey) -> [u8; 32] {
+    let mut inputs = Vec::with_capacity(seeds.len() + 1);
 
     let program_id = program_id.to_bytes();
     inputs.push(program_id.as_slice());
 
-    let merkle_tree_pubkey = address_merkle_context.address_merkle_tree_pubkey.to_bytes();
-    inputs.push(merkle_tree_pubkey.as_slice());
-
     inputs.extend(seeds);
 
-    let address = hashv_to_bn254_field_size_be(inputs.as_slice());
-    address
+    hashv_to_bn254_field_size_be(inputs.as_slice())
+}
+
+/// Derives an address for a compressed account, based on the provided singular
+/// `seed` and `address_merkle_context`:
+pub fn derive_address(
+    address_seed: &[u8; 32],
+    address_merkle_context: &AddressMerkleContext,
+) -> [u8; 32] {
+    let merkle_tree_pubkey = address_merkle_context.address_merkle_tree_pubkey.to_bytes();
+    let inputs = vec![merkle_tree_pubkey.as_slice(), address_seed.as_slice()];
+
+    hashv_to_bn254_field_size_be(inputs.as_slice())
 }

--- a/sdk/src/compressed_account.rs
+++ b/sdk/src/compressed_account.rs
@@ -1,19 +1,17 @@
 use std::ops::{Deref, DerefMut};
 
-use anchor_lang::prelude::{AccountInfo, Key, ProgramError, Pubkey, Result};
+use anchor_lang::prelude::{AccountInfo, ProgramError, Pubkey, Result};
 use borsh::{BorshDeserialize, BorshSerialize};
-use light_hasher::{DataHasher, Discriminator, Poseidon};
-use light_system_program::sdk::address::derive_address;
-pub use light_system_program::{
-    sdk::compressed_account::{
-        CompressedAccount, CompressedAccountData, CompressedAccountWithMerkleContext,
-        PackedCompressedAccountWithMerkleContext, PackedMerkleContext,
-    },
-    NewAddressParamsPacked, OutputCompressedAccountWithPackedContext,
-};
+use light_hasher::{DataHasher, Discriminator, Hasher, Poseidon};
+use light_utils::hash_to_bn254_field_size_be;
 
-use crate::merkle_context::{
-    pack_merkle_context, PackedAddressMerkleContext, PackedMerkleOutputContext, RemainingAccounts,
+use crate::{
+    address::{derive_address, NewAddressParamsPacked},
+    merkle_context::{
+        pack_merkle_context, MerkleContext, PackedAddressMerkleContext, PackedMerkleContext,
+        RemainingAccounts,
+    },
+    program_merkle_context::unpack_address_merkle_context,
 };
 
 pub trait LightAccounts: Sized {
@@ -420,6 +418,114 @@ where
     }
 }
 
+#[derive(Debug, PartialEq, Default, Clone, BorshDeserialize, BorshSerialize)]
+pub struct CompressedAccount {
+    pub owner: Pubkey,
+    pub lamports: u64,
+    pub address: Option<[u8; 32]>,
+    pub data: Option<CompressedAccountData>,
+}
+
+/// Hashing scheme:
+/// H(owner || leaf_index || merkle_tree_pubkey || lamports || address || data.discriminator || data.data_hash)
+impl CompressedAccount {
+    pub fn hash_with_hashed_values<H: Hasher>(
+        &self,
+        &owner_hashed: &[u8; 32],
+        &merkle_tree_hashed: &[u8; 32],
+        leaf_index: &u32,
+    ) -> Result<[u8; 32]> {
+        let capacity = 3
+            + std::cmp::min(self.lamports, 1) as usize
+            + self.address.is_some() as usize
+            + self.data.is_some() as usize * 2;
+        let mut vec: Vec<&[u8]> = Vec::with_capacity(capacity);
+        vec.push(owner_hashed.as_slice());
+
+        // leaf index and merkle tree pubkey are used to make every compressed account hash unique
+        let leaf_index = leaf_index.to_le_bytes();
+        vec.push(leaf_index.as_slice());
+
+        vec.push(merkle_tree_hashed.as_slice());
+
+        // Lamports are only hashed if non-zero to safe CU
+        // For safety we prefix the lamports with 1 in 1 byte.
+        // Thus even if the discriminator has the same value as the lamports, the hash will be different.
+        let mut lamports_bytes = [1, 0, 0, 0, 0, 0, 0, 0, 0];
+        if self.lamports != 0 {
+            lamports_bytes[1..].copy_from_slice(&self.lamports.to_le_bytes());
+            vec.push(lamports_bytes.as_slice());
+        }
+
+        if self.address.is_some() {
+            vec.push(self.address.as_ref().unwrap().as_slice());
+        }
+
+        let mut discriminator_bytes = [2, 0, 0, 0, 0, 0, 0, 0, 0];
+        if let Some(data) = &self.data {
+            discriminator_bytes[1..].copy_from_slice(&data.discriminator);
+            vec.push(&discriminator_bytes);
+            vec.push(&data.data_hash);
+        }
+        let hash = H::hashv(&vec).map_err(ProgramError::from)?;
+        Ok(hash)
+    }
+
+    pub fn hash<H: Hasher>(
+        &self,
+        &merkle_tree_pubkey: &Pubkey,
+        leaf_index: &u32,
+    ) -> Result<[u8; 32]> {
+        self.hash_with_hashed_values::<H>(
+            &hash_to_bn254_field_size_be(&self.owner.to_bytes())
+                .unwrap()
+                .0,
+            &hash_to_bn254_field_size_be(&merkle_tree_pubkey.to_bytes())
+                .unwrap()
+                .0,
+            leaf_index,
+        )
+    }
+}
+
+#[derive(Debug, PartialEq, Default, Clone, BorshDeserialize, BorshSerialize)]
+pub struct CompressedAccountData {
+    pub discriminator: [u8; 8],
+    pub data: Vec<u8>,
+    pub data_hash: [u8; 32],
+}
+
+#[derive(Debug, PartialEq, Default, Clone, BorshDeserialize, BorshSerialize)]
+pub struct PackedCompressedAccountWithMerkleContext {
+    pub compressed_account: CompressedAccount,
+    pub merkle_context: PackedMerkleContext,
+    /// Index of root used in inclusion validity proof.
+    pub root_index: u16,
+    /// Placeholder to mark accounts read-only unimplemented set to false.
+    pub read_only: bool,
+}
+
+#[derive(Debug, PartialEq, Default, Clone, BorshDeserialize, BorshSerialize)]
+pub struct CompressedAccountWithMerkleContext {
+    pub compressed_account: CompressedAccount,
+    pub merkle_context: MerkleContext,
+}
+
+impl CompressedAccountWithMerkleContext {
+    pub fn hash(&self) -> Result<[u8; 32]> {
+        self.compressed_account.hash::<Poseidon>(
+            &self.merkle_context.merkle_tree_pubkey,
+            &self.merkle_context.leaf_index,
+        )
+    }
+}
+
+#[derive(Debug, PartialEq, Default, Clone, BorshDeserialize, BorshSerialize)]
+pub struct OutputCompressedAccountWithPackedContext {
+    pub compressed_account: CompressedAccount,
+    pub merkle_tree_index: u8,
+}
+
 pub fn serialize_and_hash_account<T>(
     account: &T,
     address_seed: &[u8; 32],
@@ -438,11 +544,10 @@ where
         data_hash,
     };
 
-    let address = derive_address(
-        &remaining_accounts[address_merkle_context.address_merkle_tree_pubkey_index as usize].key(),
-        address_seed,
-    )
-    .map_err(|_| ProgramError::InvalidArgument)?;
+    let address_merkle_context =
+        unpack_address_merkle_context(*address_merkle_context, remaining_accounts);
+
+    let address = derive_address(address_seed, &address_merkle_context);
 
     let compressed_account = CompressedAccount {
         owner: *program_id,
@@ -452,44 +557,6 @@ where
     };
 
     Ok(compressed_account)
-}
-
-pub fn new_compressed_account<T>(
-    account: &T,
-    address_seed: &[u8; 32],
-    program_id: &Pubkey,
-    merkle_output_context: &PackedMerkleOutputContext,
-    address_merkle_context: &PackedAddressMerkleContext,
-    address_merkle_tree_root_index: u16,
-    remaining_accounts: &[AccountInfo],
-) -> Result<(
-    OutputCompressedAccountWithPackedContext,
-    NewAddressParamsPacked,
-)>
-where
-    T: BorshSerialize + DataHasher + Discriminator,
-{
-    let compressed_account = serialize_and_hash_account(
-        account,
-        address_seed,
-        program_id,
-        address_merkle_context,
-        remaining_accounts,
-    )?;
-
-    let compressed_account = OutputCompressedAccountWithPackedContext {
-        compressed_account,
-        merkle_tree_index: merkle_output_context.merkle_tree_pubkey_index,
-    };
-
-    let new_address_params = NewAddressParamsPacked {
-        seed: *address_seed,
-        address_merkle_tree_account_index: address_merkle_context.address_merkle_tree_pubkey_index,
-        address_queue_account_index: address_merkle_context.address_queue_pubkey_index,
-        address_merkle_tree_root_index,
-    };
-
-    Ok((compressed_account, new_address_params))
 }
 
 pub fn input_compressed_account<T>(

--- a/sdk/src/constants.rs
+++ b/sdk/src/constants.rs
@@ -1,0 +1,14 @@
+use light_macros::pubkey;
+use solana_program::pubkey::Pubkey;
+
+/// Seed of the CPI authority.
+pub const CPI_AUTHORITY_PDA_SEED: &[u8] = b"cpi_authority";
+
+/// ID of the account-compression program.
+pub const PROGRAM_ID_ACCOUNT_COMPRESSION: Pubkey =
+    pubkey!("compr6CUsB5m2jS4Y3831ztGSTnDpnKJTKS95d64XVq");
+pub const PROGRAM_ID_NOOP: Pubkey = pubkey!("noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV");
+/// ID of the light-system program.
+pub const PROGRAM_ID_SYSTEM: Pubkey = pubkey!("SySTEM1eSU2p4BGQfQpimFEWWSC1XDFeun3Nqzz3rT7");
+/// ID of the light-compressed-token program.
+pub const PROGRAM_ID_TOKEN: Pubkey = pubkey!("cTokenmWW8bLPjZEBAUgYy3zKxQZW6VKi7bqNFEVv3m");

--- a/sdk/src/context.rs
+++ b/sdk/src/context.rs
@@ -1,17 +1,17 @@
 use std::ops::{Deref, DerefMut};
 
-use account_compression::utils::constants::CPI_AUTHORITY_PDA_SEED;
 use anchor_lang::{context::Context, prelude::Pubkey, Bumps, Key, Result};
-use light_system_program::{invoke::processor::CompressedProof, InstructionDataInvokeCpi};
 
 use crate::{
     compressed_account::LightAccounts,
+    constants::CPI_AUTHORITY_PDA_SEED,
     merkle_context::{PackedAddressMerkleContext, PackedMerkleContext},
+    proof::CompressedProof,
     traits::{
         InvokeAccounts, InvokeCpiAccounts, InvokeCpiContextAccount, LightSystemAccount,
         SignerAccounts,
     },
-    verify::verify,
+    verify::{verify, InstructionDataInvokeCpi},
 };
 
 /// Provides non-argument inputs to the program, including light accounts and

--- a/sdk/src/event.rs
+++ b/sdk/src/event.rs
@@ -1,0 +1,24 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::pubkey::Pubkey;
+
+use crate::compressed_account::OutputCompressedAccountWithPackedContext;
+
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize, Default, PartialEq)]
+pub struct MerkleTreeSequenceNumber {
+    pub pubkey: Pubkey,
+    pub seq: u64,
+}
+
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize, Default, PartialEq)]
+pub struct PublicTransactionEvent {
+    pub input_compressed_account_hashes: Vec<[u8; 32]>,
+    pub output_compressed_account_hashes: Vec<[u8; 32]>,
+    pub output_compressed_accounts: Vec<OutputCompressedAccountWithPackedContext>,
+    pub output_leaf_indices: Vec<u32>,
+    pub sequence_numbers: Vec<MerkleTreeSequenceNumber>,
+    pub relay_fee: Option<u64>,
+    pub is_compress: bool,
+    pub compress_or_decompress_lamports: Option<u64>,
+    pub pubkey_array: Vec<Pubkey>,
+    pub message: Option<Vec<u8>>,
+}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -3,9 +3,13 @@ pub use light_sdk_macros::*;
 
 pub mod address;
 pub mod compressed_account;
+pub mod constants;
+pub use constants::*;
 pub mod context;
+pub mod event;
 pub mod merkle_context;
 pub mod program_merkle_context;
+pub mod proof;
 pub mod traits;
 pub mod utils;
 pub mod verify;

--- a/sdk/src/merkle_context.rs
+++ b/sdk/src/merkle_context.rs
@@ -2,9 +2,6 @@ use std::collections::HashMap;
 
 use anchor_lang::prelude::{AccountMeta, AnchorDeserialize, AnchorSerialize, Pubkey};
 
-// TODO(vadorovsky): Consider moving these structs here.
-pub use light_system_program::sdk::compressed_account::{MerkleContext, PackedMerkleContext};
-
 /// Collection of remaining accounts which are sent to the program.
 #[derive(Default)]
 pub struct RemainingAccounts {
@@ -54,6 +51,34 @@ impl RemainingAccounts {
             .collect::<Vec<AccountMeta>>();
         remaining_accounts
     }
+}
+
+#[derive(Debug, Clone, Copy, AnchorSerialize, AnchorDeserialize, PartialEq, Default)]
+pub struct QueueIndex {
+    /// Id of queue in queue account.
+    pub queue_id: u8,
+    /// Index of compressed account hash in queue.
+    pub index: u16,
+}
+
+#[derive(Debug, Clone, Copy, AnchorSerialize, AnchorDeserialize, PartialEq, Default)]
+pub struct MerkleContext {
+    pub merkle_tree_pubkey: Pubkey,
+    pub nullifier_queue_pubkey: Pubkey,
+    pub leaf_index: u32,
+    /// Index of leaf in queue. Placeholder of batched Merkle tree updates
+    /// currently unimplemented.
+    pub queue_index: Option<QueueIndex>,
+}
+
+#[derive(Debug, Clone, Copy, AnchorSerialize, AnchorDeserialize, PartialEq, Default)]
+pub struct PackedMerkleContext {
+    pub merkle_tree_pubkey_index: u8,
+    pub nullifier_queue_pubkey_index: u8,
+    pub leaf_index: u32,
+    /// Index of leaf in queue. Placeholder of batched Merkle tree updates
+    /// currently unimplemented.
+    pub queue_index: Option<QueueIndex>,
 }
 
 pub fn pack_merkle_contexts(

--- a/sdk/src/proof.rs
+++ b/sdk/src/proof.rs
@@ -1,0 +1,116 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_sdk::pubkey::Pubkey;
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct CompressedProof {
+    pub a: [u8; 32],
+    pub b: [u8; 64],
+    pub c: [u8; 32],
+}
+
+#[cfg(feature = "idl-build")]
+impl anchor_lang::IdlBuild for CompressedProof {}
+
+#[derive(Debug)]
+pub struct ProofRpcResult {
+    pub proof: CompressedProof,
+    pub root_indices: Vec<u16>,
+    pub address_root_indices: Vec<u16>,
+}
+
+#[cfg(feature = "idl-build")]
+impl anchor_lang::IdlBuild for ProofRpcResult {}
+
+async fn create_proof_for_compressed_accounts(
+    compressed_accounts: Option<&[[u8; 32]]>,
+    state_merkle_tree_pubkeys: Option<&[Pubkey]>,
+    new_addresses: Option<&[[u8; 32]]>,
+    address_merkle_tree_pubkeys: Option<Vec<Pubkey>>,
+    rpc: &mut R,
+) -> ProofRpcResult {
+    if compressed_accounts.is_some()
+        && ![1usize, 2usize, 3usize, 4usize, 8usize].contains(&compressed_accounts.unwrap().len())
+    {
+        panic!(
+            "compressed_accounts must be of length 1, 2, 3, 4 or 8 != {}",
+            compressed_accounts.unwrap().len()
+        )
+    }
+    if new_addresses.is_some() && ![1usize, 2usize].contains(&new_addresses.unwrap().len()) {
+        panic!("new_addresses must be of length 1, 2")
+    }
+    let client = Client::new();
+    let (root_indices, address_root_indices, json_payload) =
+        match (compressed_accounts, new_addresses) {
+            (Some(accounts), None) => {
+                let (payload, indices) = self
+                    .process_inclusion_proofs(state_merkle_tree_pubkeys.unwrap(), accounts, rpc)
+                    .await;
+                (indices, Vec::new(), payload.to_string())
+            }
+            (None, Some(addresses)) => {
+                let (payload, indices) = self
+                    .process_non_inclusion_proofs(
+                        address_merkle_tree_pubkeys.unwrap().as_slice(),
+                        addresses,
+                        rpc,
+                    )
+                    .await;
+                (Vec::<u16>::new(), indices, payload.to_string())
+            }
+            (Some(accounts), Some(addresses)) => {
+                let (inclusion_payload, inclusion_indices) = self
+                    .process_inclusion_proofs(state_merkle_tree_pubkeys.unwrap(), accounts, rpc)
+                    .await;
+                let (non_inclusion_payload, non_inclusion_indices) = self
+                    .process_non_inclusion_proofs(
+                        address_merkle_tree_pubkeys.unwrap().as_slice(),
+                        addresses,
+                        rpc,
+                    )
+                    .await;
+
+                let combined_payload = CombinedJsonStruct {
+                    inclusion: inclusion_payload.inputs,
+                    non_inclusion: non_inclusion_payload.inputs,
+                }
+                .to_string();
+                (inclusion_indices, non_inclusion_indices, combined_payload)
+            }
+            _ => {
+                panic!("At least one of compressed_accounts or new_addresses must be provided")
+            }
+        };
+
+    let mut retries = 3;
+    while retries > 0 {
+        let response_result = client
+            .post(&format!("{}{}", SERVER_ADDRESS, PROVE_PATH))
+            .header("Content-Type", "text/plain; charset=utf-8")
+            .body(json_payload.clone())
+            .send()
+            .await
+            .expect("Failed to execute request.");
+        if response_result.status().is_success() {
+            let body = response_result.text().await.unwrap();
+            let proof_json = deserialize_gnark_proof_json(&body).unwrap();
+            let (proof_a, proof_b, proof_c) = proof_from_json_struct(proof_json);
+            let (proof_a, proof_b, proof_c) = compress_proof(&proof_a, &proof_b, &proof_c);
+            return ProofRpcResult {
+                root_indices,
+                address_root_indices,
+                proof: CompressedProof {
+                    a: proof_a,
+                    b: proof_b,
+                    c: proof_c,
+                },
+            };
+        } else {
+            warn!("Error: {}", response_result.text().await.unwrap());
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            spawn_prover(true, self.proof_types.as_slice()).await;
+            retries -= 1;
+        }
+    }
+    panic!("Failed to get proof from server");
+}

--- a/sdk/src/traits.rs
+++ b/sdk/src/traits.rs
@@ -1,22 +1,18 @@
 // Ported from light-system-program, adjusted for caller programs.
-use account_compression::program::AccountCompression;
 use anchor_lang::prelude::*;
-use light_system_program::{invoke_cpi::account::CpiContextAccount, program::LightSystemProgram};
 
 pub trait InvokeAccounts<'info> {
-    fn get_registered_program_pda(
-        &self,
-    ) -> &Account<'info, account_compression::instructions::register_program::RegisteredProgram>;
+    fn get_registered_program_pda(&self) -> &AccountInfo<'info>;
     fn get_noop_program(&self) -> &AccountInfo<'info>;
     fn get_account_compression_authority(&self) -> &AccountInfo<'info>;
-    fn get_account_compression_program(&self) -> &Program<'info, AccountCompression>;
+    fn get_account_compression_program(&self) -> &AccountInfo<'info>;
     fn get_system_program(&self) -> &Program<'info, System>;
     fn get_compressed_sol_pda(&self) -> Option<&AccountInfo<'info>>;
     fn get_compression_recipient(&self) -> Option<&AccountInfo<'info>>;
 }
 
 pub trait LightSystemAccount<'info> {
-    fn get_light_system_program(&self) -> &Program<'info, LightSystemProgram>;
+    fn get_light_system_program(&self) -> &AccountInfo<'info>;
 }
 
 pub trait SignerAccounts<'info> {
@@ -26,11 +22,11 @@ pub trait SignerAccounts<'info> {
 
 // Only used within the systemprogram
 pub trait InvokeCpiContextAccountMut<'info> {
-    fn get_cpi_context_account_mut(&mut self) -> &mut Option<Account<'info, CpiContextAccount>>;
+    fn get_cpi_context_account_mut(&mut self) -> &mut Option<AccountInfo<'info>>;
 }
 
 pub trait InvokeCpiContextAccount<'info> {
-    fn get_cpi_context_account(&self) -> Option<&Account<'info, CpiContextAccount>>;
+    fn get_cpi_context_account(&self) -> Option<&AccountInfo<'info>>;
 }
 
 pub trait InvokeCpiAccounts<'info> {

--- a/sdk/src/utils.rs
+++ b/sdk/src/utils.rs
@@ -1,14 +1,19 @@
 use anchor_lang::solana_program::pubkey::Pubkey;
-pub use light_system_program::{invoke::processor::CompressedProof, InstructionDataInvokeCpi};
-use light_system_program::{
-    sdk::{compressed_account::PackedCompressedAccountWithMerkleContext, CompressedCpiContext},
-    NewAddressParamsPacked, OutputCompressedAccountWithPackedContext,
+
+use crate::{
+    address::NewAddressParamsPacked,
+    compressed_account::{
+        OutputCompressedAccountWithPackedContext, PackedCompressedAccountWithMerkleContext,
+    },
+    proof::CompressedProof,
+    verify::{CompressedCpiContext, InstructionDataInvokeCpi},
+    PROGRAM_ID_ACCOUNT_COMPRESSION,
 };
 
 pub fn get_registered_program_pda(program_id: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(
         &[program_id.to_bytes().as_slice()],
-        &account_compression::ID,
+        &PROGRAM_ID_ACCOUNT_COMPRESSION,
     )
     .0
 }

--- a/sdk/src/verify.rs
+++ b/sdk/src/verify.rs
@@ -1,37 +1,72 @@
-use anchor_lang::{error::Error, prelude::*, Bumps};
+use anchor_lang::{prelude::*, Bumps};
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::{instruction::Instruction, program::invoke_signed};
 
-use crate::traits::{
-    InvokeAccounts, InvokeCpiAccounts, InvokeCpiContextAccount, LightSystemAccount, SignerAccounts,
-};
-use light_system_program::{
-    cpi::accounts::InvokeCpiInstruction, errors::SystemProgramError::CpiContextAccountUndefined,
-    sdk::CompressedCpiContext, InstructionDataInvokeCpi,
+use crate::{
+    address::NewAddressParamsPacked,
+    compressed_account::{
+        OutputCompressedAccountWithPackedContext, PackedCompressedAccountWithMerkleContext,
+    },
+    proof::CompressedProof,
+    traits::{
+        InvokeAccounts, InvokeCpiAccounts, InvokeCpiContextAccount, LightSystemAccount,
+        SignerAccounts,
+    },
+    PROGRAM_ID_SYSTEM,
 };
 
-// TODO: properly document compressed-cpi-context
-// TODO: turn into a simple check!
-// TOOD: CHECK needed bc can be different from own, if called from another program.
-pub fn get_compressed_cpi_context_account<'info>(
-    ctx: &Context<
-        '_,
-        '_,
-        '_,
-        'info,
-        impl InvokeAccounts<'info>
-            + LightSystemAccount<'info>
-            + InvokeCpiAccounts<'info>
-            + SignerAccounts<'info>
-            + Bumps,
-    >,
-    compressed_cpi_context: &CompressedCpiContext,
-) -> Result<AccountInfo<'info>> {
-    let cpi_context_account = ctx
-        .remaining_accounts
-        .get(compressed_cpi_context.cpi_context_account_index as usize)
-        .map(|account| account.to_account_info())
-        .ok_or_else(|| Error::from(CpiContextAccountUndefined))?;
-    Ok(cpi_context_account)
+#[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CompressedCpiContext {
+    /// Is set by the program that is invoking the CPI to signal that is should
+    /// set the cpi context.
+    pub set_context: bool,
+    /// Is set to wipe the cpi context since someone could have set it before
+    /// with unrelated data.
+    pub first_set_context: bool,
+    /// Index of cpi context account in remaining accounts.
+    pub cpi_context_account_index: u8,
 }
+
+#[derive(Debug, PartialEq, Default, Clone, BorshDeserialize, BorshSerialize)]
+pub struct InstructionDataInvokeCpi {
+    pub proof: Option<CompressedProof>,
+    pub new_address_params: Vec<NewAddressParamsPacked>,
+    pub input_compressed_accounts_with_merkle_context:
+        Vec<PackedCompressedAccountWithMerkleContext>,
+    pub output_compressed_accounts: Vec<OutputCompressedAccountWithPackedContext>,
+    pub relay_fee: Option<u64>,
+    pub compress_or_decompress_lamports: Option<u64>,
+    pub is_compress: bool,
+    pub cpi_context: Option<CompressedCpiContext>,
+}
+
+// TODO: Currently, this function is not used anywhere. Before revisiting it,
+// it needs:
+//
+// - Proper documentation of cpi-context and how to use it in SDK.
+// - Turning into a simple check.
+//
+// pub fn get_compressed_cpi_context_account<'info>(
+//     ctx: &Context<
+//         '_,
+//         '_,
+//         '_,
+//         'info,
+//         impl InvokeAccounts<'info>
+//             + LightSystemAccount<'info>
+//             + InvokeCpiAccounts<'info>
+//             + SignerAccounts<'info>
+//             + Bumps,
+//     >,
+//     compressed_cpi_context: &CompressedCpiContext,
+// ) -> Result<AccountInfo<'info>> {
+//     let cpi_context_account = ctx
+//         .remaining_accounts
+//         .get(compressed_cpi_context.cpi_context_account_index as usize)
+//         .map(|account| account.to_account_info())
+//         .ok_or_else(|| Error::from(CpiContextAccountUndefined))?;
+//     Ok(cpi_context_account)
+// }
 
 #[inline(always)]
 pub fn setup_cpi_accounts<'info>(
@@ -47,58 +82,159 @@ pub fn setup_cpi_accounts<'info>(
             + InvokeCpiContextAccount<'info>
             + Bumps,
     >,
-) -> InvokeCpiInstruction<'info> {
-    InvokeCpiInstruction {
-        fee_payer: ctx.accounts.get_fee_payer().to_account_info(),
-        authority: ctx.accounts.get_authority().to_account_info(),
-        registered_program_pda: ctx.accounts.get_registered_program_pda().to_account_info(),
-        noop_program: ctx.accounts.get_noop_program().to_account_info(),
-        account_compression_authority: ctx
-            .accounts
+) -> (Vec<AccountInfo<'info>>, Vec<AccountMeta>) {
+    // The trick for having `None` accounts is to pass program ID, see
+    // https://github.com/coral-xyz/anchor/pull/2101
+    let none_account_info = ctx.accounts.get_light_system_program().to_account_info();
+
+    let (cpi_context_account_info, cpi_context_account_meta) =
+        match ctx.accounts.get_cpi_context_account() {
+            Some(acc) => (
+                acc.to_account_info(),
+                AccountMeta {
+                    pubkey: acc.key(),
+                    is_signer: false,
+                    is_writable: true,
+                },
+            ),
+            None => (
+                none_account_info.clone(),
+                AccountMeta {
+                    pubkey: ctx.accounts.get_light_system_program().key(),
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ),
+        };
+
+    let mut account_infos = vec![
+        // fee_payer
+        ctx.accounts.get_fee_payer().to_account_info(),
+        // authority
+        ctx.accounts.get_authority().to_account_info(),
+        // registered_program_pda
+        ctx.accounts.get_registered_program_pda().to_account_info(),
+        // noop_program
+        ctx.accounts.get_noop_program().to_account_info(),
+        // account_compression_authority
+        ctx.accounts
             .get_account_compression_authority()
             .to_account_info(),
-        account_compression_program: ctx
-            .accounts
+        // account_compression_program
+        ctx.accounts
             .get_account_compression_program()
             .to_account_info(),
-        invoking_program: ctx.accounts.get_invoking_program().to_account_info(),
-        sol_pool_pda: None,
-        decompression_recipient: None,
-        system_program: ctx.accounts.get_system_program().to_account_info(),
-        cpi_context_account: ctx
-            .accounts
-            .get_cpi_context_account()
-            .map(|acc| acc.to_account_info()),
+        // invoking_program
+        ctx.accounts.get_invoking_program().to_account_info(),
+        // sol_pool_pda
+        none_account_info.clone(),
+        // decompression_recipient
+        none_account_info,
+        // system_program
+        ctx.accounts.get_system_program().to_account_info(),
+        // cpi_context_account
+        cpi_context_account_info,
+    ];
+    for remaining_account in ctx.remaining_accounts {
+        account_infos.push(remaining_account.to_owned());
     }
+
+    let mut account_metas = vec![
+        // fee_payer
+        AccountMeta {
+            pubkey: account_infos[0].key(),
+            is_signer: true,
+            is_writable: true,
+        },
+        // authority
+        AccountMeta {
+            pubkey: account_infos[1].key(),
+            is_signer: true,
+            is_writable: false,
+        },
+        // registered_program_pda
+        AccountMeta {
+            pubkey: account_infos[2].key(),
+            is_signer: false,
+            is_writable: false,
+        },
+        // noop_program
+        AccountMeta {
+            pubkey: account_infos[3].key(),
+            is_signer: false,
+            is_writable: false,
+        },
+        // account_compression_authority
+        AccountMeta {
+            pubkey: account_infos[4].key(),
+            is_signer: false,
+            is_writable: false,
+        },
+        // account_compression_program
+        AccountMeta {
+            pubkey: account_infos[5].key(),
+            is_signer: false,
+            is_writable: false,
+        },
+        // invoking_program
+        AccountMeta {
+            pubkey: account_infos[6].key(),
+            is_signer: false,
+            is_writable: false,
+        },
+        // sol_pool_pda
+        AccountMeta {
+            pubkey: account_infos[7].key(),
+            is_signer: false,
+            is_writable: false,
+        },
+        // decompression_recipient
+        AccountMeta {
+            pubkey: account_infos[8].key(),
+            is_signer: false,
+            is_writable: false,
+        },
+        // system_program
+        AccountMeta {
+            pubkey: account_infos[9].key(),
+            is_signer: false,
+            is_writable: false,
+        },
+        cpi_context_account_meta,
+    ];
+    for remaining_account in ctx.remaining_accounts {
+        account_metas.extend(remaining_account.to_account_metas(None));
+    }
+
+    (account_infos, account_metas)
+}
+
+#[derive(BorshDeserialize, BorshSerialize)]
+pub struct InvokeCpi {
+    pub inputs: Vec<u8>,
 }
 
 #[inline(always)]
-pub fn invoke_cpi<'info, 'a, 'b, 'c>(
-    ctx: &Context<
-        '_,
-        '_,
-        '_,
-        'info,
-        impl InvokeAccounts<'info>
-            + LightSystemAccount<'info>
-            + InvokeCpiAccounts<'info>
-            + SignerAccounts<'info>
-            + InvokeCpiContextAccount<'info>
-            + Bumps,
-    >,
-    cpi_accounts: light_system_program::cpi::accounts::InvokeCpiInstruction<'info>,
+pub fn invoke_cpi(
+    account_infos: &[AccountInfo],
+    accounts_metas: Vec<AccountMeta>,
     inputs: Vec<u8>,
-    signer_seeds: &'a [&'b [&'c [u8]]],
+    signer_seeds: &[&[&[u8]]],
 ) -> Result<()> {
-    light_system_program::cpi::invoke_cpi(
-        CpiContext::new_with_signer(
-            ctx.accounts.get_light_system_program().to_account_info(),
-            cpi_accounts,
-            signer_seeds,
-        )
-        .with_remaining_accounts(ctx.remaining_accounts.to_vec()),
-        inputs,
-    )
+    let instruction_data = InvokeCpi { inputs };
+
+    // `InvokeCpi`'s discriminator
+    let mut data = [49, 212, 191, 129, 39, 194, 43, 196].to_vec();
+    data.extend(instruction_data.try_to_vec()?);
+
+    let instruction = Instruction {
+        program_id: PROGRAM_ID_SYSTEM,
+        accounts: accounts_metas,
+        data,
+    };
+    invoke_signed(&instruction, account_infos, signer_seeds)?;
+
+    Ok(())
 }
 
 /// Invokes the light system program to verify and apply a zk-compressed state
@@ -123,6 +259,7 @@ pub fn verify<'info, 'a, 'b, 'c>(
     let mut inputs: Vec<u8> = Vec::new();
     InstructionDataInvokeCpi::serialize(inputs_struct, &mut inputs).unwrap();
 
-    let cpi_accounts = setup_cpi_accounts(ctx);
-    invoke_cpi(ctx, cpi_accounts, inputs, signer_seeds)
+    let (account_infos, account_metas) = setup_cpi_accounts(ctx);
+    invoke_cpi(&account_infos, account_metas, inputs, signer_seeds)?;
+    Ok(())
 }


### PR DESCRIPTION
Having Light Protocol programs as dependencies for all users wanting to use Light Protocol is undesired. This change moves all types necessary for calling the system program via CPI to SDK.