### PR TITLE
refactor: forester: remove debug logging from SlotTracker and Solana RPC

### DIFF
--- a/forester-utils/src/rpc/solana_rpc.rs
+++ b/forester-utils/src/rpc/solana_rpc.rs
@@ -361,7 +361,6 @@ impl RpcConnection for SolanaRpcConnection {
     }
 
     async fn get_slot(&mut self) -> Result<u64, RpcError> {
-        debug!("Calling get_slot");
         self.client.get_slot().map_err(RpcError::from)
     }
 

--- a/forester/src/slot_tracker.rs
+++ b/forester/src/slot_tracker.rs
@@ -34,13 +34,8 @@ impl SlotTracker {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_millis() as u64;
-        let old_slot = self.last_known_slot.load(Ordering::Acquire);
         self.last_known_slot.store(new_slot, Ordering::Release);
         self.last_update_time.store(now, Ordering::Release);
-        debug!(
-            "SlotTracker updated: old_slot={}, new_slot={}",
-            old_slot, new_slot
-        );
     }
 
     pub fn estimated_current_slot(&self) -> u64 {
@@ -65,7 +60,6 @@ impl SlotTracker {
             match rpc.get_slot().await {
                 Ok(slot) => {
                     self.update(slot);
-                    debug!("SlotTracker run: Updated slot to {}", slot);
                 }
                 Err(e) => error!("Failed to get slot: {:?}", e),
             }


### PR DESCRIPTION
Eliminate redundant debug statements in SlotTracker's update method and Solana RPC's get_slot function for cleaner code and potentially improved performance.