### PR TITLE
feat: forester: enable optional metrics reporting via CLI flag

### DIFF
--- a/forester/src/cli.rs
+++ b/forester/src/cli.rs
@@ -3,6 +3,9 @@ use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[clap(author, version, about, long_about=None)]
 pub struct Cli {
+    #[arg(long, default_value_t = false, global = true)]
+    pub enable_metrics: bool,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 }

--- a/forester/src/config.rs
+++ b/forester/src/config.rs
@@ -50,6 +50,7 @@ pub struct ForesterConfig {
     pub slot_update_interval_seconds: u64,
     pub address_tree_data: Vec<TreeAccounts>,
     pub state_tree_data: Vec<TreeAccounts>,
+    pub enable_metrics: bool,
 }
 
 impl Clone for ForesterConfig {
@@ -68,6 +69,7 @@ impl Clone for ForesterConfig {
             state_tree_data: self.state_tree_data.clone(),
             address_tree_data: self.address_tree_data.clone(),
             slot_update_interval_seconds: self.slot_update_interval_seconds,
+            enable_metrics: self.enable_metrics,
         }
     }
 }

--- a/forester/src/settings.rs
+++ b/forester/src/settings.rs
@@ -90,7 +90,7 @@ fn build_config() -> Result<Config, ForesterError> {
         .map_err(|e| ForesterError::ConfigError(e.to_string()))
 }
 
-pub fn init_config() -> Result<ForesterConfig, ForesterError> {
+pub fn init_config(enable_metrics: bool) -> Result<ForesterConfig, ForesterError> {
     let settings = build_config()?;
     let registry_pubkey = light_registry::program::LightRegistry::id().to_string();
 
@@ -135,6 +135,7 @@ pub fn init_config() -> Result<ForesterConfig, ForesterError> {
             as u64,
         address_tree_data: vec![],
         state_tree_data: vec![],
+        enable_metrics,
     };
 
     debug!("Config: {:?}", config);

--- a/forester/tests/test_utils.rs
+++ b/forester/tests/test_utils.rs
@@ -97,6 +97,7 @@ pub fn forester_config() -> ForesterConfig {
         slot_update_interval_seconds: 10,
         address_tree_data: vec![],
         state_tree_data: vec![],
+        enable_metrics: false,
     }
 }
 


### PR DESCRIPTION
Added a new CLI flag, `enable_metrics`, to control metrics reporting. Updated configuration initialization and relevant components to respect this flag, ensuring metrics are processed and pushed conditionally based on user input.