### PR TITLE
fix: forester: epoch recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,7 +2319,6 @@ dependencies = [
  "light-registry",
  "light-system-program",
  "light-test-utils",
- "log",
  "num-bigint 0.4.6",
  "num-traits",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5270,6 +5270,7 @@ dependencies = [
  "account-compression",
  "anchor-lang",
  "anchor-spl",
+ "forester-utils",
  "light-compressed-token",
  "light-concurrent-merkle-tree",
  "light-hasher",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,6 +2319,7 @@ dependencies = [
  "light-registry",
  "light-system-program",
  "light-test-utils",
+ "log",
  "num-bigint 0.4.6",
  "num-traits",
  "once_cell",

--- a/forester/Cargo.toml
+++ b/forester/Cargo.toml
@@ -53,6 +53,7 @@ lazy_static = "1.4"
 warp = "0.3"
 dashmap = "6.1.0"
 scopeguard = "1.2.0"
+log = "0.4.22"
 
 [dev-dependencies]
 function_name = "0.3.0"

--- a/forester/Cargo.toml
+++ b/forester/Cargo.toml
@@ -53,7 +53,6 @@ lazy_static = "1.4"
 warp = "0.3"
 dashmap = "6.1.0"
 scopeguard = "1.2.0"
-log = "0.4.22"
 
 [dev-dependencies]
 function_name = "0.3.0"

--- a/forester/src/epoch_manager.rs
+++ b/forester/src/epoch_manager.rs
@@ -141,6 +141,7 @@ impl<R: RpcConnection, I: Indexer<R>> EpochManager<R, I> {
         });
 
         while let Some(epoch) = rx.recv().await {
+            debug!("Received new epoch: {}", epoch);
             let self_clone = Arc::clone(&self);
             tokio::spawn(async move {
                 if let Err(e) = self_clone.process_epoch(epoch).await {
@@ -215,6 +216,7 @@ impl<R: RpcConnection, I: Indexer<R>> EpochManager<R, I> {
     }
 
     async fn recover_registration_info(&self, epoch: u64) -> Result<ForesterEpochInfo> {
+        debug!("Recovering registration info for epoch {}", epoch);
         let forester_epoch_pda_pubkey =
             get_forester_epoch_pda_from_authority(&self.config.payer_keypair.pubkey(), epoch).0;
         let mut rpc = self.rpc_pool.get_connection().await?;
@@ -238,17 +240,20 @@ impl<R: RpcConnection, I: Indexer<R>> EpochManager<R, I> {
         let previous_epoch = current_epoch.saturating_sub(1);
 
         // Process previous epoch if still in active or later phase
-        if slot < current_phases.registration.start {
+        if slot > current_phases.registration.start {
+            debug!("Processing previous epoch: {}", previous_epoch);
             tx.send(previous_epoch).await.map_err(|e| {
                 ForesterError::Custom(format!("Failed to send previous epoch: {}", e))
             })?;
         }
 
         // Process current epoch
+        debug!("Processing current epoch: {}", current_epoch);
         tx.send(current_epoch)
             .await
             .map_err(|e| ForesterError::Custom(format!("Failed to send current epoch: {}", e)))?;
 
+        debug!("Finished processing current and previous epochs");
         Ok(())
     }
 
@@ -270,8 +275,10 @@ impl<R: RpcConnection, I: Indexer<R>> EpochManager<R, I> {
             debug!("Epoch {} is already being processed, skipping", epoch);
             return Ok(());
         }
+        let phases = get_epoch_phases(&self.protocol_config, epoch);
 
         // Attempt to recover registration info
+        debug!("Recovering registration info for epoch {}", epoch);
         let mut registration_info = match self.recover_registration_info(epoch).await {
             Ok(info) => info,
             Err(e) => {
@@ -281,15 +288,10 @@ impl<R: RpcConnection, I: Indexer<R>> EpochManager<R, I> {
                     .await?
             }
         };
-
-        let phases = get_epoch_phases(&self.protocol_config, epoch);
+        debug!("Recovered registration info for epoch {}", epoch);
 
         // Wait for active phase
-
-        if self.sync_slot().await? < phases.active.start {
-            // Wait for active phase
-            registration_info = self.wait_for_active_phase(&registration_info).await?;
-        }
+        registration_info = self.wait_for_active_phase(&registration_info).await?;
 
         // Perform work
         if self.sync_slot().await? < phases.active.end {
@@ -596,6 +598,10 @@ impl<R: RpcConnection, I: Indexer<R>> EpochManager<R, I> {
 
         let mut handles: Vec<JoinHandle<Result<()>>> = Vec::new();
 
+        debug!(
+            "Creating threads for tree processing. Trees: {:?}",
+            epoch_info.trees
+        );
         for tree in epoch_info.trees.iter() {
             info!("Creating thread for queue {}", tree.tree_accounts.queue);
             let self_clone = self_arc.clone();
@@ -616,17 +622,20 @@ impl<R: RpcConnection, I: Indexer<R>> EpochManager<R, I> {
 
         debug!("Threads created. Waiting for active phase to end");
 
-        let mut rpc = self.rpc_pool.get_connection().await?;
-        wait_until_slot_reached(&mut *rpc, &self.slot_tracker, active_phase_end).await?;
-
         // Wait for all tasks to complete
         for result in join_all(handles).await {
             match result {
-                Ok(Ok(())) => {}
+                Ok(Ok(())) => {
+                    debug!("Queue processed successfully");
+                }
                 Ok(Err(e)) => error!("Error processing queue: {:?}", e),
                 Err(e) => error!("Task panicked: {:?}", e),
             }
         }
+
+        debug!("Waiting for active phase to end");
+        let mut rpc = self.rpc_pool.get_connection().await?;
+        wait_until_slot_reached(&mut *rpc, &self.slot_tracker, active_phase_end).await?;
 
         info!("Completed active work");
         Ok(())

--- a/forester/src/epoch_manager.rs
+++ b/forester/src/epoch_manager.rs
@@ -291,8 +291,9 @@ impl<R: RpcConnection, I: Indexer<R>> EpochManager<R, I> {
         debug!("Recovered registration info for epoch {}", epoch);
 
         // Wait for active phase
-        registration_info = self.wait_for_active_phase(&registration_info).await?;
-
+        if self.sync_slot().await? < phases.active.start {
+            registration_info = self.wait_for_active_phase(&registration_info).await?;
+        }
         // Perform work
         if self.sync_slot().await? < phases.active.end {
             self.perform_active_work(&registration_info).await?;

--- a/forester/tests/e2e_test.rs
+++ b/forester/tests/e2e_test.rs
@@ -7,7 +7,6 @@ use forester_utils::indexer::{AddressMerkleTreeAccounts, StateMerkleTreeAccounts
 use forester_utils::registry::register_test_forester;
 use forester_utils::rpc::solana_rpc::SolanaRpcUrl;
 use forester_utils::rpc::{RpcConnection, RpcError, SolanaRpcConnection};
-use light_registry::protocol_config::state::ProtocolConfig;
 use light_registry::utils::{get_epoch_pda_address, get_forester_epoch_pda_from_authority};
 use light_registry::{EpochPda, ForesterEpochPda};
 use light_test_utils::e2e_test_env::E2ETestEnv;

--- a/test-programs/registry-test/Cargo.toml
+++ b/test-programs/registry-test/Cargo.toml
@@ -31,6 +31,7 @@ num-traits = "0.2.19"
 spl-token = { workspace = true }
 anchor-spl = { workspace = true }
 anchor-lang = { workspace = true }
+forester-utils = { path = "../../forester-utils" }
 light-registry = { path = "../../programs/registry"  , features = ["cpi"]}
 light-compressed-token = { path = "../../programs/compressed-token"  , features = ["cpi"]}
 light-system-program = { path = "../../programs/system"  , features = ["cpi"]}

--- a/test-programs/registry-test/tests/tests.rs
+++ b/test-programs/registry-test/tests/tests.rs
@@ -105,9 +105,7 @@ fn test_protocol_config_active_phase_continuity_for_config(config: ProtocolConfi
     for slot in config.genesis_slot..(config.genesis_slot + total_slots_to_test) {
         if slot < config.genesis_slot + config.registration_phase_length {
             // assert that is registration phase
-            assert_eq!(
-                config.get_latest_register_epoch(slot).unwrap(),0
-            );
+            assert_eq!(config.get_latest_register_epoch(slot).unwrap(), 0);
             continue;
         }
         let mut active_epochs = HashSet::new();

--- a/test-programs/registry-test/tests/tests.rs
+++ b/test-programs/registry-test/tests/tests.rs
@@ -95,13 +95,15 @@ fn test_protocol_config_active_phase_continuity() {
     }
 }
 
+// Test that each slot is active in exactly one epoch
 fn test_protocol_config_active_phase_continuity_for_config(config: ProtocolConfig) {
-    let EPOCHS = 10;
-    // Test for a range of slots covering multiple epochs
+    // Test for 10 epochs
+    let epochs = 10;
+
     let total_slots_to_test = (config.registration_phase_length
         + config.active_phase_length
         + config.report_work_phase_length)
-        * EPOCHS; // Test across 10 epochs
+        * epochs;
 
     for slot in config.genesis_slot..(config.genesis_slot + total_slots_to_test) {
         let mut active_epochs = HashSet::new();

--- a/test-programs/registry-test/tests/tests.rs
+++ b/test-programs/registry-test/tests/tests.rs
@@ -100,12 +100,16 @@ fn test_protocol_config_active_phase_continuity_for_config(config: ProtocolConfi
     // Test for 10 epochs
     let epochs = 10;
 
-    let total_slots_to_test = (config.registration_phase_length
-        + config.active_phase_length
-        + config.report_work_phase_length)
-        * epochs;
+    let total_slots_to_test = config.active_phase_length * epochs;
 
     for slot in config.genesis_slot..(config.genesis_slot + total_slots_to_test) {
+        if slot < config.genesis_slot + config.registration_phase_length {
+            // assert that is registration phase
+            assert_eq!(
+                config.get_latest_register_epoch(slot).unwrap(),0
+            );
+            continue;
+        }
         let mut active_epochs = HashSet::new();
         for offset in -1..1 {
             let epoch = config.get_current_epoch(slot) as i64 + offset;

--- a/test-programs/registry-test/tests/tests.rs
+++ b/test-programs/registry-test/tests/tests.rs
@@ -96,19 +96,21 @@ fn test_protocol_config_active_phase_continuity() {
 }
 
 fn test_protocol_config_active_phase_continuity_for_config(config: ProtocolConfig) {
+    let EPOCHS = 10;
     // Test for a range of slots covering multiple epochs
     let total_slots_to_test = (config.registration_phase_length
         + config.active_phase_length
         + config.report_work_phase_length)
-        * 10; // Test across 10 epochs
+        * EPOCHS; // Test across 10 epochs
 
     for slot in config.genesis_slot..(config.genesis_slot + total_slots_to_test) {
         let mut active_epochs = HashSet::new();
-        for epoch_offset in 0..2 {
-            let epoch = config.get_current_epoch(slot) as i64 + epoch_offset;
+        for offset in -1..1 {
+            let epoch = config.get_current_epoch(slot) as i64 + offset;
             if epoch < 0 {
                 continue;
             }
+
             let phases = get_epoch_phases(&config, epoch as u64);
 
             if slot >= phases.active.start && slot <= phases.active.end {


### PR DESCRIPTION
1. Fixed epoch recovery.
2. Introduced a new test to ensure the continuity of the active phase in different protocol configurations. 