### PR TITLE
chore: photon 0.45.0, add: getValidityProofV0 for custom tree support

### DIFF
--- a/cli/src/utils/constants.ts
+++ b/cli/src/utils/constants.ts
@@ -21,7 +21,7 @@ export const LIGHT_PROVER_PROCESS_NAME = "light-prover";
 export const INDEXER_PROCESS_NAME = "photon";
 export const FORESTER_PROCESS_NAME = "forester";
 
-export const PHOTON_VERSION = "0.44.0";
+export const PHOTON_VERSION = "0.45.0";
 
 export const LIGHT_PROTOCOL_PROGRAMS_DIR_ENV = "LIGHT_PROTOCOL_PROGRAMS_DIR";
 export const BASE_PATH = "../../bin/";

--- a/js/stateless.js/src/actions/create-account.ts
+++ b/js/stateless.js/src/actions/create-account.ts
@@ -55,9 +55,8 @@ export async function createAccount(
     /// TODO: enforce program-derived
     const address = await deriveAddress(seed, addressTree);
 
-    /// TODO: pass trees
-    const proof = await rpc.getValidityProof(undefined, [
-        bn(address.toBytes()),
+    const proof = await rpc.getValidityProofV0(undefined, [
+        { address: bn(address.toBytes()), tree: addressTree, queue: addressQueue },
     ]);
 
     const params: NewAddressParams = {

--- a/js/stateless.js/src/rpc-interface.ts
+++ b/js/stateless.js/src/rpc-interface.ts
@@ -62,6 +62,18 @@ export interface SignatureWithMetadata {
     slot: number;
 }
 
+export interface HashWithTree {
+    hash: BN254;
+    tree: PublicKey;
+    queue: PublicKey;
+}
+
+export interface AddressWithTree {
+    address: BN254;
+    tree: PublicKey;
+    queue: PublicKey;
+}
+
 export interface CompressedTransaction {
     compressionInfo: {
         closedAccounts: {
@@ -497,9 +509,14 @@ export interface CompressionApiInterface {
         newAddresses: BN254[],
     ): Promise<CompressedProofWithContext>;
 
+    getValidityProofV0(
+        hashes: HashWithTree[],
+        newAddresses: AddressWithTree[],
+    ): Promise<CompressedProofWithContext>;
+
     getValidityProofAndRpcContext(
-        hashes: BN254[],
-        newAddresses: BN254[],
+        hashes: HashWithTree[],
+        newAddresses: AddressWithTree[],
     ): Promise<WithContext<CompressedProofWithContext>>;
 
     getCompressedAccountsByOwner(

--- a/js/stateless.js/tests/e2e/compress.test.ts
+++ b/js/stateless.js/tests/e2e/compress.test.ts
@@ -59,6 +59,7 @@ function txFees(
 
     return totalFee.toNumber();
 }
+
 /// TODO: add test case for payer != address
 describe('compress', () => {
     const { merkleTree } = defaultTestStateTreeAccounts();
@@ -73,7 +74,7 @@ describe('compress', () => {
 
     it('should create account with address', async () => {
         const preCreateAccountsBalance = await rpc.getBalance(payer.publicKey);
-
+        
         await createAccount(
             rpc as TestRpc,
             payer,

--- a/js/stateless.js/tests/e2e/rpc-interop.test.ts
+++ b/js/stateless.js/tests/e2e/rpc-interop.test.ts
@@ -641,9 +641,10 @@ describe('rpc-interop', () => {
     it('getCompressedAccount with address param should work ', async () => {
         const seed = new Uint8Array(randomBytes(32));
         const addressTree = defaultTestStateTreeAccounts().addressTree;
+        const addressQueue = defaultTestStateTreeAccounts().addressQueue;
         const address = await deriveAddress(seed, addressTree);
 
-        await createAccount(rpc, payer, seed, LightSystemProgram.programId);
+        await createAccount(rpc, payer, seed, LightSystemProgram.programId, addressTree, addressQueue);
 
         // fetch the owners latest account
         const accounts = await rpc.getCompressedAccountsByOwner(

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,7 +13,7 @@ VERSIONS=(
     "solana:1.18.22"
     "anchor:anchor-v0.29.0"
     "jq:jq-1.7.1"
-    "photon:0.44.0"
+    "photon:0.45.0"
 )
 
 # Architecture-specific suffixes


### PR DESCRIPTION
uses getValidityProofV0 in createAccount action, ie included in test coverage