### PR TITLE
refactor: Add more common types to `light-sdk`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3730,6 +3730,7 @@ dependencies = [
  "serde_json",
  "solana-banks-interface",
  "solana-cli-output",
+ "solana-program",
  "solana-program-test",
  "solana-sdk",
  "tokio",
@@ -8137,9 +8138,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.4.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,11 @@ thiserror = "1.0"
 
 # Light Protocol
 light-client = { path = "client", version = "0.8.0" }
+light-indexed-merkle-tree = { path = "merkle-tree/indexed", version = "1.0.0" }
 photon-api = { path = "photon-api" }
+
+# Math and crypto
+num-bigint = "0.4.6"
 
 [patch.crates-io]
 "solana-account-decoder" = { git = "https://github.com/lightprotocol/agave", branch = "v1.18.22-enforce-cpi-tracking" }

--- a/examples/name-service/programs/name-service/src/lib.rs
+++ b/examples/name-service/programs/name-service/src/lib.rs
@@ -4,11 +4,9 @@ use anchor_lang::prelude::*;
 use borsh::{BorshDeserialize, BorshSerialize};
 use light_hasher::bytes::AsByteVec;
 use light_sdk::{
-    compressed_account::LightAccount,
-    light_account, light_accounts, light_program,
-    merkle_context::{PackedAddressMerkleContext, PackedMerkleContext},
+    compressed_account::LightAccount, light_account, light_accounts, light_program,
+    merkle_context::PackedAddressMerkleContext,
 };
-use light_system_program::invoke::processor::CompressedProof;
 
 declare_id!("7yucc7fL3JGbyMwg4neUaenNSdySS39hbAk89Ao3t1Hz");
 

--- a/macros/light-sdk-macros/src/accounts.rs
+++ b/macros/light-sdk-macros/src/accounts.rs
@@ -582,19 +582,19 @@ pub(crate) fn process_light_accounts_derive(input: ItemStruct) -> Result<TokenSt
                 })
             }
 
-            fn new_address_params(&self) -> Vec<::light_sdk::compressed_account::NewAddressParamsPacked> {
+            fn new_address_params(&self) -> Vec<::light_sdk::legacy::NewAddressParamsPacked> {
                 let mut new_address_params = Vec::new();
                 #(#new_address_params_calls)*
                 new_address_params
             }
 
-            fn input_accounts(&self, remaining_accounts: &[::anchor_lang::prelude::AccountInfo]) -> Result<Vec<::light_sdk::compressed_account::PackedCompressedAccountWithMerkleContext>> {
+            fn input_accounts(&self, remaining_accounts: &[::anchor_lang::prelude::AccountInfo]) -> Result<Vec<::light_sdk::legacy::PackedCompressedAccountWithMerkleContext>> {
                 let mut accounts = Vec::new();
                 #(#input_account_calls)*
                 Ok(accounts)
             }
 
-            fn output_accounts(&self, remaining_accounts: &[::anchor_lang::prelude::AccountInfo]) -> Result<Vec<::light_sdk::compressed_account::OutputCompressedAccountWithPackedContext>> {
+            fn output_accounts(&self, remaining_accounts: &[::anchor_lang::prelude::AccountInfo]) -> Result<Vec<::light_sdk::legacy::OutputCompressedAccountWithPackedContext>> {
                 let mut accounts = Vec::new();
                 #(#output_account_calls)*
                 Ok(accounts)

--- a/macros/light-sdk-macros/src/program.rs
+++ b/macros/light-sdk-macros/src/program.rs
@@ -188,14 +188,14 @@ impl VisitMut for LightProgramTransform {
         i.sig.inputs.insert(1, inputs_arg);
 
         // Inject Merkle context related arguments.
-        let proof_arg: FnArg = parse_quote! { proof: CompressedProof };
+        let proof_arg: FnArg = parse_quote! { proof: ::light_sdk::legacy::CompressedProof };
         i.sig.inputs.insert(2, proof_arg);
-        let merkle_context_arg: FnArg = parse_quote! { merkle_context: PackedMerkleContext };
+        let merkle_context_arg: FnArg =
+            parse_quote! { merkle_context: ::light_sdk::merkle_context::PackedMerkleContext };
         i.sig.inputs.insert(3, merkle_context_arg);
         let merkle_tree_root_index_arg: FnArg = parse_quote! { merkle_tree_root_index: u16 };
         i.sig.inputs.insert(4, merkle_tree_root_index_arg);
-        let address_merkle_context_arg: FnArg =
-            parse_quote! { address_merkle_context: PackedAddressMerkleContext };
+        let address_merkle_context_arg: FnArg = parse_quote! { address_merkle_context: ::light_sdk::merkle_context::PackedAddressMerkleContext };
         i.sig.inputs.insert(5, address_merkle_context_arg);
         let address_merkle_tree_root_index_arg: FnArg =
             parse_quote! { address_merkle_tree_root_index: u16 };

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -22,13 +22,22 @@ test-sbf = []
 bench-sbf = []
 
 [dependencies]
+# Solana
+solana-program = { workspace = true }
+
+# Anchor
+anchor-lang = { workspace = true }
+
+# Math and crypto
+num-bigint = { workspace = true }
+
 aligned-sized = { version = "1.0.0", path = "../macros/aligned-sized" }
 light-macros = { version = "1.0.0", path = "../macros/light" }
 light-sdk-macros = { version = "0.1.0", path = "../macros/light-sdk-macros" }
-anchor-lang = { workspace = true }
 bytemuck = "1.17"
 light-hasher = { version = "1.0.0", path = "../merkle-tree/hasher" }
 light-heap = { version = "1.0.0", path = "../heap", optional = true }
+light-indexed-merkle-tree = { workspace = true }
 account-compression = { version = "1.0.0", path = "../programs/account-compression", features = ["cpi"] }
 light-system-program = { version = "1.0.0", path = "../programs/system", features = ["cpi"] }
 light-concurrent-merkle-tree = { path = "../merkle-tree/concurrent", version = "1.0.0" }
@@ -44,7 +53,6 @@ solana-sdk = { workspace = true }
 solana-banks-interface = { workspace = true }
 solana-cli-output = { workspace = true }
 solana-program-test = { workspace = true }
-solana-sdk = { workspace = true }
 serde_json = "1.0.114"
 reqwest = "0.12"
 tokio = { workspace = true }

--- a/sdk/src/address.rs
+++ b/sdk/src/address.rs
@@ -1,7 +1,60 @@
 use anchor_lang::solana_program::pubkey::Pubkey;
+use borsh::{BorshDeserialize, BorshSerialize};
 use light_utils::hashv_to_bn254_field_size_be;
 
-use crate::merkle_context::AddressMerkleContext;
+use crate::merkle_context::{AddressMerkleContext, RemainingAccounts};
+
+#[derive(Debug, PartialEq, Default, Clone, BorshDeserialize, BorshSerialize)]
+pub struct NewAddressParams {
+    pub seed: [u8; 32],
+    pub address_queue_pubkey: Pubkey,
+    pub address_merkle_tree_pubkey: Pubkey,
+    pub address_merkle_tree_root_index: u16,
+}
+
+#[derive(Debug, PartialEq, Default, Clone, Copy, BorshDeserialize, BorshSerialize)]
+pub struct NewAddressParamsPacked {
+    pub seed: [u8; 32],
+    pub address_queue_account_index: u8,
+    pub address_merkle_tree_account_index: u8,
+    pub address_merkle_tree_root_index: u16,
+}
+
+#[cfg(feature = "idl-build")]
+impl anchor_lang::IdlBuild for NewAddressParamsPacked {}
+
+pub struct AddressWithMerkleContext {
+    pub address: [u8; 32],
+    pub address_merkle_context: AddressMerkleContext,
+}
+
+pub fn pack_new_addresses_params(
+    addresses_params: &[NewAddressParams],
+    remaining_accounts: &mut RemainingAccounts,
+) -> Vec<NewAddressParamsPacked> {
+    addresses_params
+        .iter()
+        .map(|x| {
+            let address_queue_account_index =
+                remaining_accounts.insert_or_get(x.address_queue_pubkey);
+            let address_merkle_tree_account_index =
+                remaining_accounts.insert_or_get(x.address_merkle_tree_pubkey);
+            NewAddressParamsPacked {
+                seed: x.seed,
+                address_queue_account_index,
+                address_merkle_tree_account_index,
+                address_merkle_tree_root_index: x.address_merkle_tree_root_index,
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
+pub fn pack_new_address_params(
+    address_params: NewAddressParams,
+    remaining_accounts: &mut RemainingAccounts,
+) -> NewAddressParamsPacked {
+    pack_new_addresses_params(&[address_params], remaining_accounts)[0]
+}
 
 /// Derives a single address seed for a compressed account, based on the
 /// provided multiple `seeds`, `program_id` and `merkle_tree_pubkey`.

--- a/sdk/src/constants.rs
+++ b/sdk/src/constants.rs
@@ -1,0 +1,14 @@
+use light_macros::pubkey;
+use solana_program::pubkey::Pubkey;
+
+/// Seed of the CPI authority.
+pub const CPI_AUTHORITY_PDA_SEED: &[u8] = b"cpi_authority";
+
+/// ID of the account-compression program.
+pub const PROGRAM_ID_ACCOUNT_COMPRESSION: Pubkey =
+    pubkey!("compr6CUsB5m2jS4Y3831ztGSTnDpnKJTKS95d64XVq");
+pub const PROGRAM_ID_NOOP: Pubkey = pubkey!("noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV");
+/// ID of the light-system program.
+pub const PROGRAM_ID_SYSTEM: Pubkey = pubkey!("SySTEM1eSU2p4BGQfQpimFEWWSC1XDFeun3Nqzz3rT7");
+/// ID of the light-compressed-token program.
+pub const PROGRAM_ID_TOKEN: Pubkey = pubkey!("cTokenmWW8bLPjZEBAUgYy3zKxQZW6VKi7bqNFEVv3m");

--- a/sdk/src/context.rs
+++ b/sdk/src/context.rs
@@ -1,11 +1,10 @@
 use std::ops::{Deref, DerefMut};
 
-use account_compression::utils::constants::CPI_AUTHORITY_PDA_SEED;
 use anchor_lang::{context::Context, prelude::Pubkey, Bumps, Key, Result};
-use light_system_program::{invoke::processor::CompressedProof, InstructionDataInvokeCpi};
 
 use crate::{
     compressed_account::LightAccounts,
+    constants::CPI_AUTHORITY_PDA_SEED,
     merkle_context::{PackedAddressMerkleContext, PackedMerkleContext},
     traits::{
         InvokeAccounts, InvokeCpiAccounts, InvokeCpiContextAccount, LightSystemAccount,
@@ -94,7 +93,7 @@ where
         })
     }
 
-    pub fn verify(&mut self, proof: CompressedProof) -> Result<()> {
+    pub fn verify(&mut self, proof: crate::legacy::CompressedProof) -> Result<()> {
         let bump = Pubkey::find_program_address(
             &[CPI_AUTHORITY_PDA_SEED],
             &self.anchor_context.accounts.get_invoking_program().key(),
@@ -113,7 +112,7 @@ where
             .light_accounts
             .output_accounts(self.anchor_context.remaining_accounts)?;
 
-        let instruction = InstructionDataInvokeCpi {
+        let instruction = crate::legacy::InstructionDataInvokeCpi {
             proof: Some(proof),
             new_address_params,
             relay_fee: None,

--- a/sdk/src/event.rs
+++ b/sdk/src/event.rs
@@ -1,0 +1,24 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::pubkey::Pubkey;
+
+use crate::compressed_account::OutputCompressedAccountWithPackedContext;
+
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize, Default, PartialEq)]
+pub struct MerkleTreeSequenceNumber {
+    pub pubkey: Pubkey,
+    pub seq: u64,
+}
+
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize, Default, PartialEq)]
+pub struct PublicTransactionEvent {
+    pub input_compressed_account_hashes: Vec<[u8; 32]>,
+    pub output_compressed_account_hashes: Vec<[u8; 32]>,
+    pub output_compressed_accounts: Vec<OutputCompressedAccountWithPackedContext>,
+    pub output_leaf_indices: Vec<u32>,
+    pub sequence_numbers: Vec<MerkleTreeSequenceNumber>,
+    pub relay_fee: Option<u64>,
+    pub is_compress: bool,
+    pub compress_or_decompress_lamports: Option<u64>,
+    pub pubkey_array: Vec<Pubkey>,
+    pub message: Option<Vec<u8>>,
+}

--- a/sdk/src/legacy.rs
+++ b/sdk/src/legacy.rs
@@ -1,0 +1,15 @@
+//! Legacy types re-imported from programs which should be removed as soon as
+//! possible.
+
+pub use light_system_program::{
+    invoke::processor::CompressedProof,
+    sdk::{
+        compressed_account::{
+            CompressedAccount, CompressedAccountData, CompressedAccountWithMerkleContext,
+            PackedCompressedAccountWithMerkleContext, PackedMerkleContext, QueueIndex,
+        },
+        CompressedCpiContext,
+    },
+    InstructionDataInvokeCpi, NewAddressParams, NewAddressParamsPacked,
+    OutputCompressedAccountWithPackedContext,
+};

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -3,10 +3,15 @@ pub use light_sdk_macros::*;
 
 pub mod address;
 pub mod compressed_account;
+pub mod constants;
+pub use constants::*;
 pub mod context;
 pub mod error;
+pub mod event;
+pub mod legacy;
 pub mod merkle_context;
 pub mod program_merkle_context;
+pub mod proof;
 pub mod traits;
 pub mod utils;
 pub mod verify;

--- a/sdk/src/merkle_context.rs
+++ b/sdk/src/merkle_context.rs
@@ -2,9 +2,6 @@ use std::collections::HashMap;
 
 use anchor_lang::prelude::{AccountMeta, AnchorDeserialize, AnchorSerialize, Pubkey};
 
-// TODO(vadorovsky): Consider moving these structs here.
-pub use light_system_program::sdk::compressed_account::{MerkleContext, PackedMerkleContext};
-
 /// Collection of remaining accounts which are sent to the program.
 #[derive(Default)]
 pub struct RemainingAccounts {
@@ -54,6 +51,34 @@ impl RemainingAccounts {
             .collect::<Vec<AccountMeta>>();
         remaining_accounts
     }
+}
+
+#[derive(Debug, Clone, Copy, AnchorSerialize, AnchorDeserialize, PartialEq, Default)]
+pub struct QueueIndex {
+    /// Id of queue in queue account.
+    pub queue_id: u8,
+    /// Index of compressed account hash in queue.
+    pub index: u16,
+}
+
+#[derive(Debug, Clone, Copy, AnchorSerialize, AnchorDeserialize, PartialEq, Default)]
+pub struct MerkleContext {
+    pub merkle_tree_pubkey: Pubkey,
+    pub nullifier_queue_pubkey: Pubkey,
+    pub leaf_index: u32,
+    /// Index of leaf in queue. Placeholder of batched Merkle tree updates
+    /// currently unimplemented.
+    pub queue_index: Option<QueueIndex>,
+}
+
+#[derive(Debug, Clone, Copy, AnchorSerialize, AnchorDeserialize, PartialEq, Default)]
+pub struct PackedMerkleContext {
+    pub merkle_tree_pubkey_index: u8,
+    pub nullifier_queue_pubkey_index: u8,
+    pub leaf_index: u32,
+    /// Index of leaf in queue. Placeholder of batched Merkle tree updates
+    /// currently unimplemented.
+    pub queue_index: Option<QueueIndex>,
 }
 
 pub fn pack_merkle_contexts(

--- a/sdk/src/proof.rs
+++ b/sdk/src/proof.rs
@@ -1,0 +1,49 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use light_indexed_merkle_tree::array::IndexedElement;
+use num_bigint::BigUint;
+use solana_program::pubkey::Pubkey;
+
+#[derive(Debug, Clone)]
+pub struct MerkleProof {
+    pub hash: [u8; 32],
+    pub leaf_index: u64,
+    pub merkle_tree: Pubkey,
+    pub proof: Vec<[u8; 32]>,
+    pub root_seq: u64,
+}
+
+// For consistency with the Photon API.
+#[derive(Clone, Default, Debug, PartialEq)]
+pub struct NewAddressProofWithContext {
+    pub merkle_tree: Pubkey,
+    pub root: [u8; 32],
+    pub root_seq: u64,
+    pub low_address_index: u64,
+    pub low_address_value: [u8; 32],
+    pub low_address_next_index: u64,
+    pub low_address_next_value: [u8; 32],
+    pub low_address_proof: [[u8; 32]; 16],
+    pub new_low_element: Option<IndexedElement<usize>>,
+    pub new_element: Option<IndexedElement<usize>>,
+    pub new_element_next_value: Option<BigUint>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct CompressedProof {
+    pub a: [u8; 32],
+    pub b: [u8; 64],
+    pub c: [u8; 32],
+}
+
+#[cfg(feature = "idl-build")]
+impl anchor_lang::IdlBuild for CompressedProof {}
+
+#[derive(Debug)]
+pub struct ProofRpcResult {
+    pub proof: CompressedProof,
+    pub root_indices: Vec<u16>,
+    pub address_root_indices: Vec<u16>,
+}
+
+#[cfg(feature = "idl-build")]
+impl anchor_lang::IdlBuild for ProofRpcResult {}

--- a/sdk/src/utils.rs
+++ b/sdk/src/utils.rs
@@ -1,14 +1,18 @@
 use anchor_lang::solana_program::pubkey::Pubkey;
-pub use light_system_program::{invoke::processor::CompressedProof, InstructionDataInvokeCpi};
-use light_system_program::{
-    sdk::{compressed_account::PackedCompressedAccountWithMerkleContext, CompressedCpiContext},
-    NewAddressParamsPacked, OutputCompressedAccountWithPackedContext,
+
+use crate::{
+    compressed_account::{
+        OutputCompressedAccountWithPackedContext, PackedCompressedAccountWithMerkleContext,
+    },
+    proof::CompressedProof,
+    verify::{CompressedCpiContext, InstructionDataInvokeCpi},
+    PROGRAM_ID_ACCOUNT_COMPRESSION,
 };
 
 pub fn get_registered_program_pda(program_id: &Pubkey) -> Pubkey {
     Pubkey::find_program_address(
         &[program_id.to_bytes().as_slice()],
-        &account_compression::ID,
+        &PROGRAM_ID_ACCOUNT_COMPRESSION,
     )
     .0
 }
@@ -19,12 +23,12 @@ pub fn get_cpi_authority_pda(program_id: &Pubkey) -> Pubkey {
 
 /// Helper function to create data for creating a single PDA.
 pub fn create_cpi_inputs_for_new_account(
-    proof: CompressedProof,
-    new_address_params: NewAddressParamsPacked,
-    compressed_pda: OutputCompressedAccountWithPackedContext,
-    cpi_context: Option<CompressedCpiContext>,
-) -> InstructionDataInvokeCpi {
-    InstructionDataInvokeCpi {
+    proof: crate::legacy::CompressedProof,
+    new_address_params: crate::legacy::NewAddressParamsPacked,
+    compressed_pda: crate::legacy::OutputCompressedAccountWithPackedContext,
+    cpi_context: Option<crate::legacy::CompressedCpiContext>,
+) -> crate::legacy::InstructionDataInvokeCpi {
+    crate::legacy::InstructionDataInvokeCpi {
         proof: Some(proof),
         new_address_params: vec![new_address_params],
         relay_fee: None,

--- a/sdk/src/verify.rs
+++ b/sdk/src/verify.rs
@@ -1,12 +1,45 @@
 use anchor_lang::{error::Error, prelude::*, Bumps};
+use borsh::{BorshDeserialize, BorshSerialize};
 
-use crate::traits::{
-    InvokeAccounts, InvokeCpiAccounts, InvokeCpiContextAccount, LightSystemAccount, SignerAccounts,
+use crate::{
+    address::NewAddressParamsPacked,
+    compressed_account::{
+        OutputCompressedAccountWithPackedContext, PackedCompressedAccountWithMerkleContext,
+    },
+    proof::CompressedProof,
+    traits::{
+        InvokeAccounts, InvokeCpiAccounts, InvokeCpiContextAccount, LightSystemAccount,
+        SignerAccounts,
+    },
 };
 use light_system_program::{
     cpi::accounts::InvokeCpiInstruction, errors::SystemProgramError::CpiContextAccountUndefined,
-    sdk::CompressedCpiContext, InstructionDataInvokeCpi,
 };
+
+#[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CompressedCpiContext {
+    /// Is set by the program that is invoking the CPI to signal that is should
+    /// set the cpi context.
+    pub set_context: bool,
+    /// Is set to wipe the cpi context since someone could have set it before
+    /// with unrelated data.
+    pub first_set_context: bool,
+    /// Index of cpi context account in remaining accounts.
+    pub cpi_context_account_index: u8,
+}
+
+#[derive(Debug, PartialEq, Default, Clone, BorshDeserialize, BorshSerialize)]
+pub struct InstructionDataInvokeCpi {
+    pub proof: Option<CompressedProof>,
+    pub new_address_params: Vec<NewAddressParamsPacked>,
+    pub input_compressed_accounts_with_merkle_context:
+        Vec<PackedCompressedAccountWithMerkleContext>,
+    pub output_compressed_accounts: Vec<OutputCompressedAccountWithPackedContext>,
+    pub relay_fee: Option<u64>,
+    pub compress_or_decompress_lamports: Option<u64>,
+    pub is_compress: bool,
+    pub cpi_context: Option<CompressedCpiContext>,
+}
 
 // TODO: properly document compressed-cpi-context
 // TODO: turn into a simple check!
@@ -117,11 +150,11 @@ pub fn verify<'info, 'a, 'b, 'c>(
             + InvokeCpiContextAccount<'info>
             + Bumps,
     >,
-    inputs_struct: &InstructionDataInvokeCpi,
+    inputs_struct: &crate::legacy::InstructionDataInvokeCpi,
     signer_seeds: &'a [&'b [&'c [u8]]],
 ) -> Result<()> {
     let mut inputs: Vec<u8> = Vec::new();
-    InstructionDataInvokeCpi::serialize(inputs_struct, &mut inputs).unwrap();
+    crate::legacy::InstructionDataInvokeCpi::serialize(inputs_struct, &mut inputs).unwrap();
 
     let cpi_accounts = setup_cpi_accounts(ctx);
     invoke_cpi(ctx, cpi_accounts, inputs, signer_seeds)


### PR DESCRIPTION
Add more types, which are going to be used by third-party applications, which were until now defined in program crates:

- `address`
  - `NewAddressParams`
  - `NewAddressParamsPacked`
- `compressed_account`
  - `CompressedAccount`
  - `CompressedAccountData`
  - `CompressedAccountWithMerkleContext`
  - `PackedCompressedAccountWithMerkleContext`
  - `OutputCompressedAccountWithPackedContext`
- `event`
  - `MerkleTreeSequenceNumber`
  - `PublicTransactionEvent`
- `merkle_context`
  - `QueueIndex`
  - `MerkleContext`
  - `PackedMerkleContext`
- `proof`
  - `CompressedProof`
  - `ProofRpcResult`
- `verify`
  - `CompressedCpiContext`
  - `InstructionDataInvokeCpi`

This is a step in making third-party programs independent from Light Protocol program crates.

This change does **not** utilize these types in the `verify` function yet. They're going to be used in follow-up changes, for which we still need to do some work on RPC and indexer.