### PR TITLE
fix: add yield_now call in tree_finder loop

### DIFF
--- a/forester/src/tree_finder.rs
+++ b/forester/src/tree_finder.rs
@@ -52,6 +52,8 @@ impl<R: RpcConnection> TreeFinder<R> {
                     error!("Error checking for new trees: {:?}", e);
                 }
             }
+
+            tokio::task::yield_now().await;
         }
     }
 


### PR DESCRIPTION
Inserting a yield_now call ensures the task scheduler gets a chance to run other tasks, improving the overall system responsiveness. 