### PR TITLE
feat: Add `constraint =` attribute to `#[light_accounts]` macro

### DIFF
--- a/macros/light-sdk-macros/src/program.rs
+++ b/macros/light-sdk-macros/src/program.rs
@@ -97,6 +97,12 @@ impl VisitMut for LightProgramTransform {
         };
         i.block.stmts.insert(0, light_context_stmt);
 
+        // Inject `check_constraints` call right after.
+        let check_constraints_stmt: Stmt = parse_quote! {
+            ctx.check_constraints()?;
+        };
+        i.block.stmts.insert(1, check_constraints_stmt);
+
         // Inject `derive_address_seeds` and  `verify` statements at the end of
         // the function.
         let stmts_len = i.block.stmts.len();
@@ -131,6 +137,7 @@ pub(crate) fn program(mut input: ItemMod) -> Result<TokenStream> {
 
     Ok(quote! {
         pub trait LightContextExt {
+            fn check_constraints(&self) -> Result<()>;
             fn derive_address_seeds(&mut self, address_merkle_context: PackedAddressMerkleContext);
         }
 

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -1,0 +1,7 @@
+use anchor_lang::prelude::error_code;
+
+#[error_code]
+pub enum LightSdkError {
+    #[msg("Constraint violation")]
+    ConstraintViolation,
+}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -4,6 +4,7 @@ pub use light_sdk_macros::*;
 pub mod address;
 pub mod compressed_account;
 pub mod context;
+pub mod error;
 pub mod merkle_context;
 pub mod program_merkle_context;
 pub mod traits;


### PR DESCRIPTION
Similarly to Anchor's `constraint =` attribute, it can be used to ensure constraints for the given accounts. The constraint can use both regular and compressed accounts.

The most common use-case for it is ensuring the equality of public keys across regular and compressed accounts for security checks.

DNS example is updated to use it for ensuring that compressed `NameRecord` accounts can be modified only by original signers, with `constraint = record.owner == signer.key()`.