### PR TITLE
refactor: Simplify the check for `light_account` attribute

### DIFF
--- a/.github/workflows/light-examples-tests.yml
+++ b/.github/workflows/light-examples-tests.yml
@@ -4,11 +4,13 @@ on:
       - main
     paths:
       - "examples/**"
+      - "macros/light-sdk-macros/**"
   pull_request:
     branches:
       - "*"
     paths:
       - "examples/**"
+      - "macros/light-sdk-macros/**"
     types:
       - opened
       - synchronize


### PR DESCRIPTION
Instead of a manual loop, use `.find()` and `.map()`.