### PR TITLE
fix: hash-set capacity pub -> private

### DIFF
--- a/forester-utils/src/address_merkle_tree_config.rs
+++ b/forester-utils/src/address_merkle_tree_config.rs
@@ -25,7 +25,7 @@ pub async fn get_address_bundle_config<R: RpcConnection>(
     let queue_config = AddressQueueConfig {
         network_fee: Some(address_queue_meta_data.rollover_metadata.network_fee),
         // rollover_threshold: address_queue_meta_data.rollover_threshold,
-        capacity: address_queue.capacity as u16,
+        capacity: address_queue.get_capacity() as u16,
         sequence_threshold: address_queue.sequence_threshold as u64,
     };
     let address_tree_meta_data =
@@ -78,7 +78,7 @@ pub async fn get_state_bundle_config<R: RpcConnection>(
         unsafe { get_hash_set::<QueueAccount, R>(rpc, state_tree_bundle.nullifier_queue).await };
     let queue_config = NullifierQueueConfig {
         network_fee: Some(address_queue_meta_data.rollover_metadata.network_fee),
-        capacity: address_queue.capacity as u16,
+        capacity: address_queue.get_capacity() as u16,
         sequence_threshold: address_queue.sequence_threshold as u64,
     };
     let address_tree_meta_data =

--- a/js/stateless.js/src/actions/create-account.ts
+++ b/js/stateless.js/src/actions/create-account.ts
@@ -56,7 +56,11 @@ export async function createAccount(
     const address = await deriveAddress(seed, addressTree);
 
     const proof = await rpc.getValidityProofV0(undefined, [
-        { address: bn(address.toBytes()), tree: addressTree, queue: addressQueue },
+        {
+            address: bn(address.toBytes()),
+            tree: addressTree,
+            queue: addressQueue,
+        },
     ]);
 
     const params: NewAddressParams = {

--- a/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
@@ -620,7 +620,6 @@ export class TestRpc extends Connection implements CompressionApiInterface {
         hashes: BN254[] = [],
         newAddresses: BN254[] = [],
     ): Promise<CompressedProofWithContext> {
-
         if (newAddresses.some(address => !(address instanceof BN))) {
             throw new Error('AddressWithTree is not supported in test-rpc');
         }

--- a/js/stateless.js/tests/e2e/compress.test.ts
+++ b/js/stateless.js/tests/e2e/compress.test.ts
@@ -74,7 +74,7 @@ describe('compress', () => {
 
     it('should create account with address', async () => {
         const preCreateAccountsBalance = await rpc.getBalance(payer.publicKey);
-        
+
         await createAccount(
             rpc as TestRpc,
             payer,

--- a/js/stateless.js/tests/e2e/rpc-interop.test.ts
+++ b/js/stateless.js/tests/e2e/rpc-interop.test.ts
@@ -644,7 +644,14 @@ describe('rpc-interop', () => {
         const addressQueue = defaultTestStateTreeAccounts().addressQueue;
         const address = await deriveAddress(seed, addressTree);
 
-        await createAccount(rpc, payer, seed, LightSystemProgram.programId, addressTree, addressQueue);
+        await createAccount(
+            rpc,
+            payer,
+            seed,
+            LightSystemProgram.programId,
+            addressTree,
+            addressQueue,
+        );
 
         // fetch the owners latest account
         const accounts = await rpc.getCompressedAccountsByOwner(

--- a/merkle-tree/hash-set/src/lib.rs
+++ b/merkle-tree/hash-set/src/lib.rs
@@ -567,7 +567,7 @@ impl<'a> Iterator for HashSetIterator<'a> {
     type Item = (usize, &'a HashSetCell);
 
     fn next(&mut self) -> Option<Self::Item> {
-        while self.current < self.hash_set.capacity {
+        while self.current < self.hash_set.get_capacity() {
             let element_index = self.current;
             self.current += 1;
 

--- a/merkle-tree/hash-set/src/lib.rs
+++ b/merkle-tree/hash-set/src/lib.rs
@@ -108,7 +108,7 @@ impl HashSetCell {
 #[derive(Debug)]
 pub struct HashSet {
     /// Capacity of the buckets.
-    pub capacity: usize,
+    capacity: usize,
     /// Difference of sequence numbers, after which the given element can be
     /// replaced by an another one (with a sequence number higher than the
     /// threshold).
@@ -258,6 +258,10 @@ impl HashSet {
         } else {
             None
         }
+    }
+
+    pub fn get_capacity(&self) -> usize {
+        self.capacity
     }
 
     fn insert_into_occupied_cell(

--- a/merkle-tree/hash-set/src/zero_copy.rs
+++ b/merkle-tree/hash-set/src/zero_copy.rs
@@ -183,7 +183,7 @@ mod test {
             };
 
             // Ensure that the underlying data were properly initialized.
-            assert_eq!(hs.hash_set.capacity, VALUES);
+            assert_eq!(hs.hash_set.get_capacity(), VALUES);
             assert_eq!(hs.hash_set.sequence_threshold, SEQUENCE_THRESHOLD);
             for i in 0..VALUES {
                 assert!(unsafe { &*hs.hash_set.buckets.as_ptr().add(i) }.is_none());

--- a/programs/account-compression/src/instructions/rollover_address_merkle_tree_and_queue.rs
+++ b/programs/account-compression/src/instructions/rollover_address_merkle_tree_and_queue.rs
@@ -133,7 +133,7 @@ pub fn process_rollover_address_merkle_tree_and_queue<'a, 'b, 'c: 'info, 'info>(
             Some(queue_metadata.access_metadata.program_owner),
             Some(queue_metadata.access_metadata.forester),
             ctx.accounts.new_address_merkle_tree.key(),
-            queue.hash_set.capacity as u16,
+            queue.hash_set.get_capacity() as u16,
             queue.hash_set.sequence_threshold as u64,
             queue_metadata.rollover_metadata.network_fee,
             Some(queue_metadata.rollover_metadata.rollover_threshold),

--- a/programs/account-compression/src/instructions/rollover_state_merkle_tree_and_queue.rs
+++ b/programs/account-compression/src/instructions/rollover_state_merkle_tree_and_queue.rs
@@ -141,7 +141,7 @@ pub fn process_rollover_state_merkle_tree_nullifier_queue_pair<'a, 'b, 'c: 'info
             Some(queue_metadata.access_metadata.program_owner),
             Some(queue_metadata.access_metadata.forester),
             ctx.accounts.new_state_merkle_tree.key(),
-            nullifier_queue.hash_set.capacity as u16,
+            nullifier_queue.hash_set.get_capacity() as u16,
             nullifier_queue.hash_set.sequence_threshold as u64,
             Some(queue_metadata.rollover_metadata.rollover_threshold),
             Some(queue_metadata.rollover_metadata.close_threshold),

--- a/test-programs/account-compression-test/tests/merkle_tree_tests.rs
+++ b/test-programs/account-compression-test/tests/merkle_tree_tests.rs
@@ -380,7 +380,7 @@ async fn test_full_nullifier_queue(
     let replacement_value = find_overlapping_probe_index(
         1,
         replacement_start_value,
-        nullifier_queue.hash_set.capacity,
+        nullifier_queue.hash_set.get_capacity(),
     );
     // CHECK: 5
     let element: [u8; 32] =
@@ -2043,7 +2043,7 @@ pub async fn set_nullifier_queue_to_full<R: RpcConnection>(
     let capacity;
     {
         let hash_set = &mut unsafe { queue_from_bytes_zero_copy_mut(&mut data).unwrap() };
-        capacity = hash_set.hash_set.capacity - left_over_indices;
+        capacity = hash_set.hash_set.get_capacity() - left_over_indices;
         println!("capacity: {}", capacity);
         let arbitrary_sequence_number = 0;
         for i in 0..capacity {

--- a/test-utils/src/address_tree_rollover.rs
+++ b/test-utils/src/address_tree_rollover.rs
@@ -262,7 +262,10 @@ pub async fn assert_rolled_over_address_merkle_tree_and_queue<R: RpcConnection>(
         let new_address_queue =
             unsafe { get_hash_set::<QueueAccount, R>(rpc, *new_queue_pubkey).await };
 
-        assert_eq!(old_address_queue.capacity, new_address_queue.capacity);
+        assert_eq!(
+            old_address_queue.get_capacity(),
+            new_address_queue.get_capacity()
+        );
 
         assert_eq!(
             old_address_queue.sequence_threshold,

--- a/test-utils/src/assert_queue.rs
+++ b/test-utils/src/assert_queue.rs
@@ -180,7 +180,7 @@ pub async fn assert_queue<R: RpcConnection>(
     assert_eq!(queue_account.metadata, expected_queue_meta_data);
 
     let queue = unsafe { get_hash_set::<QueueAccount, R>(rpc, *queue_pubkey).await };
-    assert_eq!(queue.capacity, queue_config.capacity as usize);
+    assert_eq!(queue.get_capacity(), queue_config.capacity as usize);
     assert_eq!(
         queue.sequence_threshold,
         queue_config.sequence_threshold as usize

--- a/test-utils/src/state_tree_rollover.rs
+++ b/test-utils/src/state_tree_rollover.rs
@@ -276,7 +276,10 @@ pub async fn assert_rolled_over_pair<R: RpcConnection>(
     let new_address_queue =
         unsafe { get_hash_set::<QueueAccount, R>(rpc, *new_nullifier_queue_pubkey).await };
 
-    assert_eq!(old_address_queue.capacity, new_address_queue.capacity);
+    assert_eq!(
+        old_address_queue.get_capacity(),
+        new_address_queue.get_capacity()
+    );
 
     assert_eq!(
         old_address_queue.sequence_threshold,

--- a/test-utils/src/test_forester.rs
+++ b/test-utils/src/test_forester.rs
@@ -85,7 +85,7 @@ pub async fn nullify_compressed_accounts<R: RpcConnection>(
 
     let first = nullifier_queue.first_no_seq().unwrap();
 
-    for i in 0..nullifier_queue.capacity {
+    for i in 0..nullifier_queue.get_capacity() {
         let bucket = nullifier_queue.get_bucket(i).unwrap();
         if let Some(bucket) = bucket {
             if bucket.sequence_number.is_none() {


### PR DESCRIPTION
Issue:
- HashSet capacity can be unsafely set

Changes:
- change hash set field capacity from pub to private and add a getter