### PR TITLE
refactor: forester: switch to SolanaRpcConnection for epoch registration & work submission.

### DIFF
--- a/forester/src/epoch_manager.rs
+++ b/forester/src/epoch_manager.rs
@@ -492,7 +492,8 @@ impl<R: RpcConnection, I: Indexer<R>> EpochManager<R, I> {
     ))]
     async fn register_for_epoch(&self, epoch: u64) -> Result<ForesterEpochInfo> {
         info!("Registering for epoch: {}", epoch);
-        let mut rpc = SolanaRpcConnection::new(self.config.external_services.rpc_url.as_str(), None);
+        let mut rpc =
+            SolanaRpcConnection::new(self.config.external_services.rpc_url.as_str(), None);
         let slot = rpc.get_slot().await?;
         let phases = get_epoch_phases(&self.protocol_config, epoch);
 
@@ -944,7 +945,8 @@ impl<R: RpcConnection, I: Indexer<R>> EpochManager<R, I> {
     ))]
     async fn report_work(&self, epoch_info: &ForesterEpochInfo) -> Result<()> {
         info!("Reporting work");
-        let mut rpc = SolanaRpcConnection::new(self.config.external_services.rpc_url.as_str(), None);
+        let mut rpc =
+            SolanaRpcConnection::new(self.config.external_services.rpc_url.as_str(), None);
 
         let forester_epoch_pda_pubkey = get_forester_epoch_pda_from_authority(
             &self.config.payer_keypair.pubkey(),


### PR DESCRIPTION
We need it for the theoretical case: if the rpc pool is busy (CPU congestion), we might miss the registration for the next epoch.