### PR TITLE
fix: IDL generation in programs using light-sdk

### DIFF
--- a/examples/name-service/programs/name-service/src/lib.rs
+++ b/examples/name-service/programs/name-service/src/lib.rs
@@ -11,6 +11,7 @@ use light_sdk::{
 declare_id!("7yucc7fL3JGbyMwg4neUaenNSdySS39hbAk89Ao3t1Hz");
 
 #[light_program]
+#[program]
 pub mod name_service {
     use super::*;
 

--- a/macros/light-sdk-macros/src/program.rs
+++ b/macros/light-sdk-macros/src/program.rs
@@ -285,7 +285,6 @@ pub(crate) fn program(mut input: ItemMod) -> Result<TokenStream> {
     Ok(quote! {
         #instruction_params
 
-        #[program]
         #input
     })
 }


### PR DESCRIPTION
Even when using `idl-build` feature, Anchor still parses the code of the program and expects the `#[program]` attribute applied on the main module.

Before this change, annotating the program module only with `#[light_program]` was preventing the IDL generation. Fix that by requiring both attributes:

```rust
#[light_program]
#[program]
```

And not injecting the `#[program]` inside `#[light_program]`.