### PR TITLE
fix: Use `solana-program` in `light-hasher` indiscriminately

### DIFF
--- a/merkle-tree/hasher/Cargo.toml
+++ b/merkle-tree/hasher/Cargo.toml
@@ -7,11 +7,11 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
-solana = ["solana-program"]
+solana = []
 
 [dependencies]
 light-poseidon = "0.2.0"
-solana-program = { workspace = true, optional = true }
+solana-program = { workspace = true }
 thiserror = "1.0"
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]

--- a/merkle-tree/hasher/src/bytes.rs
+++ b/merkle-tree/hasher/src/bytes.rs
@@ -84,7 +84,6 @@ impl AsByteVec for String {
     }
 }
 
-#[cfg(feature = "solana")]
 impl AsByteVec for solana_program::pubkey::Pubkey {
     fn as_byte_vec(&self) -> Vec<Vec<u8>> {
         vec![self.to_bytes().to_vec()]

--- a/merkle-tree/hasher/src/errors.rs
+++ b/merkle-tree/hasher/src/errors.rs
@@ -1,6 +1,4 @@
-#[cfg(not(target_os = "solana"))]
 use light_poseidon::PoseidonError;
-#[cfg(target_os = "solana")]
 use solana_program::poseidon::PoseidonSyscallError;
 use thiserror::Error;
 
@@ -8,10 +6,8 @@ use thiserror::Error;
 pub enum HasherError {
     #[error("Integer overflow, value too large")]
     IntegerOverflow,
-    #[cfg(not(target_os = "solana"))]
     #[error("Poseidon hasher error: {0}")]
     Poseidon(#[from] PoseidonError),
-    #[cfg(target_os = "solana")]
     #[error("Poseidon syscall error: {0}")]
     PoseidonSyscall(#[from] PoseidonSyscallError),
     #[error("Unknown Solana syscall error: {0}")]
@@ -20,21 +16,17 @@ pub enum HasherError {
 
 // NOTE(vadorovsky): Unfortunately, we need to do it by hand. `num_derive::ToPrimitive`
 // doesn't support data-carrying enums.
-#[cfg(feature = "solana")]
 impl From<HasherError> for u32 {
     fn from(e: HasherError) -> u32 {
         match e {
             HasherError::IntegerOverflow => 7001,
-            #[cfg(not(target_os = "solana"))]
             HasherError::Poseidon(_) => 7002,
-            #[cfg(target_os = "solana")]
             HasherError::PoseidonSyscall(e) => (u64::from(e)).try_into().unwrap_or(7003),
             HasherError::UnknownSolanaSyscall(e) => e.try_into().unwrap_or(7004),
         }
     }
 }
 
-#[cfg(feature = "solana")]
 impl From<HasherError> for solana_program::program_error::ProgramError {
     fn from(e: HasherError) -> Self {
         solana_program::program_error::ProgramError::Custom(e.into())


### PR DESCRIPTION
We were inconsistently using `#[cfg(feature = "solana")]` and `#[cfg(target_os = "solana")]` in different places, which was leading to issues when some third-party crate was using `light-hasher` without `solana` feature, but in sBPF environment.

This feature is a footgun and there is no real benefit of not using solana-program as a dependency, so just stop using it.

The `solana` feature is stil listed in `Cargo.toml`, but doesn't do anything. That's because there are still crates depending on that feature. We can remove it once we are ready to affect them.