### PR TITLE
fix: implement idl build for unimplemented structs in root sdk

### DIFF
--- a/sdk/src/address.rs
+++ b/sdk/src/address.rs
@@ -1,4 +1,7 @@
-use anchor_lang::solana_program::pubkey::Pubkey;
+use anchor_lang::{
+    anchor_syn::idl::types::{IdlField, IdlType, IdlTypeDefinition, IdlTypeDefinitionTy},
+    solana_program::pubkey::Pubkey,
+};
 use borsh::{BorshDeserialize, BorshSerialize};
 use light_utils::{hash_to_bn254_field_size_be, hashv_to_bn254_field_size_be};
 
@@ -21,7 +24,53 @@ pub struct NewAddressParamsPacked {
 }
 
 #[cfg(feature = "idl-build")]
-impl anchor_lang::IdlBuild for NewAddressParamsPacked {}
+impl anchor_lang::IdlBuild for NewAddressParamsPacked {
+    fn __anchor_private_full_path() -> String {
+        format!("{}::{}", "light_sdk::address", "NewAddressParamsPacked")
+    }
+    fn __anchor_private_gen_idl_type(
+    ) -> Option<anchor_lang::anchor_syn::idl::types::IdlTypeDefinition> {
+        Some(IdlTypeDefinition {
+            docs: None,
+            generics: None,
+            name: "NewAddressParamsPacked".to_string(),
+            ty: IdlTypeDefinitionTy::Struct {
+                fields: vec![
+                    IdlField {
+                        name: "seed".into(),
+                        docs: None,
+                        ty: IdlType::Array(Box::new(IdlType::U8), 32),
+                    },
+                    IdlField {
+                        name: "address_queue_account_index".into(),
+                        docs: None,
+                        ty: IdlType::U8,
+                    },
+                    IdlField {
+                        name: "address_queue_account_index".into(),
+                        docs: None,
+                        ty: IdlType::U8,
+                    },
+                    IdlField {
+                        name: "address_queue_account_index".into(),
+                        docs: None,
+                        ty: IdlType::U16,
+                    },
+                ],
+            },
+        })
+    }
+    fn __anchor_private_insert_idl_defined(
+        _defined_types: &mut std::collections::HashMap<
+            String,
+            anchor_lang::anchor_syn::idl::types::IdlTypeDefinition,
+        >,
+    ) {
+        if let Some(ty) = Self::__anchor_private_gen_idl_type() {
+            _defined_types.insert(Self::__anchor_private_full_path(), ty);
+        }
+    }
+}
 
 pub struct AddressWithMerkleContext {
     pub address: [u8; 32],

--- a/sdk/src/proof.rs
+++ b/sdk/src/proof.rs
@@ -1,3 +1,6 @@
+use anchor_lang::anchor_syn::idl::types::{
+    IdlField, IdlType, IdlTypeDefinition, IdlTypeDefinitionTy,
+};
 use borsh::{BorshDeserialize, BorshSerialize};
 use light_indexed_merkle_tree::array::IndexedElement;
 use num_bigint::BigUint;
@@ -27,7 +30,6 @@ pub struct NewAddressProofWithContext {
     pub new_element: Option<IndexedElement<usize>>,
     pub new_element_next_value: Option<BigUint>,
 }
-
 #[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
 pub struct CompressedProof {
     pub a: [u8; 32],
@@ -36,7 +38,50 @@ pub struct CompressedProof {
 }
 
 #[cfg(feature = "idl-build")]
-impl anchor_lang::IdlBuild for CompressedProof {}
+impl anchor_lang::IdlBuild for CompressedProof {
+    fn __anchor_private_full_path() -> String {
+        format!("{}::{}", "light_sdk::proof", "CompressedProof")
+    }
+
+    fn __anchor_private_gen_idl_type(
+    ) -> Option<anchor_lang::anchor_syn::idl::types::IdlTypeDefinition> {
+        Some(IdlTypeDefinition {
+            name: "CompressedProof".to_string(),
+            generics: None,
+            docs: None,
+            ty: IdlTypeDefinitionTy::Struct {
+                fields: vec![
+                    IdlField {
+                        name: "a".into(),
+                        docs: None,
+                        ty: IdlType::Array(Box::new(IdlType::U8), 32),
+                    },
+                    IdlField {
+                        name: "b".into(),
+                        docs: None,
+                        ty: IdlType::Array(Box::new(IdlType::U8), 64),
+                    },
+                    IdlField {
+                        name: "c".into(),
+                        docs: None,
+                        ty: IdlType::Array(Box::new(IdlType::U8), 32),
+                    },
+                ],
+            },
+        })
+    }
+
+    fn __anchor_private_insert_idl_defined(
+        defined_types: &mut std::collections::HashMap<
+            String,
+            anchor_lang::anchor_syn::idl::types::IdlTypeDefinition,
+        >,
+    ) {
+        if let Some(ty) = Self::__anchor_private_gen_idl_type() {
+            defined_types.insert(Self::__anchor_private_full_path(), ty);
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct ProofRpcResult {
@@ -46,4 +91,46 @@ pub struct ProofRpcResult {
 }
 
 #[cfg(feature = "idl-build")]
-impl anchor_lang::IdlBuild for ProofRpcResult {}
+impl anchor_lang::IdlBuild for ProofRpcResult {
+    fn __anchor_private_full_path() -> String {
+        format!("{}::{}", "light_sdk::proof", "ProofRpcResult")
+    }
+    fn __anchor_private_gen_idl_type(
+    ) -> Option<anchor_lang::anchor_syn::idl::types::IdlTypeDefinition> {
+        Some(IdlTypeDefinition {
+            name: "ProofRpcResult".to_string(),
+            generics: None,
+            docs: None,
+            ty: IdlTypeDefinitionTy::Struct {
+                fields: vec![
+                    IdlField {
+                        name: "proof".into(),
+                        docs: None,
+                        ty: IdlType::Defined("light_sdk::proof::CompressedProof".to_string()),
+                    },
+                    IdlField {
+                        name: "root_indices".into(),
+                        docs: None,
+                        ty: IdlType::Vec(Box::new(IdlType::U16)),
+                    },
+                    IdlField {
+                        name: "address_root_indices".into(),
+                        docs: None,
+                        ty: IdlType::Vec(Box::new(IdlType::U16)),
+                    },
+                ],
+            },
+        })
+    }
+
+    fn __anchor_private_insert_idl_defined(
+        defined_types: &mut std::collections::HashMap<
+            String,
+            anchor_lang::anchor_syn::idl::types::IdlTypeDefinition,
+        >,
+    ) {
+        if let Some(ty) = Self::__anchor_private_gen_idl_type() {
+            defined_types.insert(Self::__anchor_private_full_path(), ty);
+        }
+    }
+}


### PR DESCRIPTION
Implements IDL build for the following structs:

1) NewAddressParamsPacked
2) CompressedProof
3) ProofRpcResult

Tested Compressed proof on name-service example
Generates on anchor build now
<img width="371" alt="image" src="https://github.com/user-attachments/assets/5d9f76ba-0f7b-4cc7-af4c-e897d2fc8c6c">
<img width="390" alt="image" src="https://github.com/user-attachments/assets/4cdde5da-3076-4343-a05b-27f9cbd362f1">
