### PR TITLE
fix: Use `AnchorDeserialize`/`AnchorSerialize` instead of borsh directly

### DIFF
--- a/.github/workflows/light-examples-tests.yml
+++ b/.github/workflows/light-examples-tests.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - "examples/**"
       - "macros/light-sdk-macros/**"
+      - "sdk/**"
     types:
       - opened
       - synchronize

--- a/sdk/src/address.rs
+++ b/sdk/src/address.rs
@@ -1,10 +1,9 @@
-use anchor_lang::solana_program::pubkey::Pubkey;
-use borsh::{BorshDeserialize, BorshSerialize};
+use anchor_lang::{solana_program::pubkey::Pubkey, AnchorDeserialize, AnchorSerialize};
 use light_utils::{hash_to_bn254_field_size_be, hashv_to_bn254_field_size_be};
 
 use crate::merkle_context::{AddressMerkleContext, RemainingAccounts};
 
-#[derive(Debug, PartialEq, Default, Clone, BorshDeserialize, BorshSerialize)]
+#[derive(Debug, PartialEq, Default, Clone, AnchorDeserialize, AnchorSerialize)]
 pub struct NewAddressParams {
     pub seed: [u8; 32],
     pub address_queue_pubkey: Pubkey,
@@ -12,16 +11,13 @@ pub struct NewAddressParams {
     pub address_merkle_tree_root_index: u16,
 }
 
-#[derive(Debug, PartialEq, Default, Clone, Copy, BorshDeserialize, BorshSerialize)]
+#[derive(Debug, PartialEq, Default, Clone, Copy, AnchorDeserialize, AnchorSerialize)]
 pub struct NewAddressParamsPacked {
     pub seed: [u8; 32],
     pub address_queue_account_index: u8,
     pub address_merkle_tree_account_index: u8,
     pub address_merkle_tree_root_index: u16,
 }
-
-#[cfg(feature = "idl-build")]
-impl anchor_lang::IdlBuild for NewAddressParamsPacked {}
 
 pub struct AddressWithMerkleContext {
     pub address: [u8; 32],

--- a/sdk/src/compressed_account.rs
+++ b/sdk/src/compressed_account.rs
@@ -1,7 +1,8 @@
 use std::ops::{Deref, DerefMut};
 
-use anchor_lang::prelude::{AccountInfo, ProgramError, Pubkey, Result};
-use borsh::{BorshDeserialize, BorshSerialize};
+use anchor_lang::prelude::{
+    AccountInfo, AnchorDeserialize, AnchorSerialize, ProgramError, Pubkey, Result,
+};
 use light_hasher::{DataHasher, Discriminator, Hasher, Poseidon};
 use light_utils::hash_to_bn254_field_size_be;
 
@@ -37,7 +38,7 @@ pub trait LightAccounts: Sized {
 /// A wrapper which abstracts away the UTXO model.
 pub enum LightAccount<T>
 where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+    T: AnchorDeserialize + AnchorSerialize + Clone + DataHasher + Discriminator,
 {
     Init(LightInitAccount<T>),
     Mut(LightMutAccount<T>),
@@ -46,7 +47,7 @@ where
 
 impl<T> LightAccount<T>
 where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Default + Discriminator,
+    T: AnchorDeserialize + AnchorSerialize + Clone + DataHasher + Default + Discriminator,
 {
     pub fn new_init(
         merkle_context: &PackedMerkleContext,
@@ -147,7 +148,7 @@ where
 
 impl<T> Deref for LightAccount<T>
 where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+    T: AnchorDeserialize + AnchorSerialize + Clone + DataHasher + Discriminator,
 {
     type Target = T;
 
@@ -162,7 +163,7 @@ where
 
 impl<T> DerefMut for LightAccount<T>
 where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+    T: AnchorDeserialize + AnchorSerialize + Clone + DataHasher + Discriminator,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
@@ -175,7 +176,7 @@ where
 
 pub struct LightInitAccount<T>
 where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+    T: AnchorDeserialize + AnchorSerialize + Clone + DataHasher + Discriminator,
 {
     output_account: T,
     address_seed: Option<[u8; 32]>,
@@ -186,7 +187,7 @@ where
 
 impl<T> LightInitAccount<T>
 where
-    T: BorshDeserialize + BorshSerialize + Clone + Default + DataHasher + Discriminator,
+    T: AnchorDeserialize + AnchorSerialize + Clone + Default + DataHasher + Discriminator,
 {
     pub fn new(
         merkle_context: &PackedMerkleContext,
@@ -237,7 +238,7 @@ where
 
 impl<T> Deref for LightInitAccount<T>
 where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+    T: AnchorDeserialize + AnchorSerialize + Clone + DataHasher + Discriminator,
 {
     type Target = T;
 
@@ -248,7 +249,7 @@ where
 
 impl<T> DerefMut for LightInitAccount<T>
 where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+    T: AnchorDeserialize + AnchorSerialize + Clone + DataHasher + Discriminator,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.output_account
@@ -257,7 +258,7 @@ where
 
 pub struct LightMutAccount<T>
 where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+    T: AnchorDeserialize + AnchorSerialize + Clone + DataHasher + Discriminator,
 {
     input_account: T,
     output_account: T,
@@ -269,7 +270,7 @@ where
 
 impl<T> LightMutAccount<T>
 where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+    T: AnchorDeserialize + AnchorSerialize + Clone + DataHasher + Discriminator,
 {
     pub fn try_from_slice(
         v: &[u8],
@@ -327,7 +328,7 @@ where
 
 impl<T> Deref for LightMutAccount<T>
 where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+    T: AnchorDeserialize + AnchorSerialize + Clone + DataHasher + Discriminator,
 {
     type Target = T;
 
@@ -338,7 +339,7 @@ where
 
 impl<T> DerefMut for LightMutAccount<T>
 where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+    T: AnchorDeserialize + AnchorSerialize + Clone + DataHasher + Discriminator,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.output_account
@@ -347,7 +348,7 @@ where
 
 pub struct LightCloseAccount<T>
 where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+    T: AnchorDeserialize + AnchorSerialize + Clone + DataHasher + Discriminator,
 {
     input_account: T,
     address_seed: Option<[u8; 32]>,
@@ -358,7 +359,7 @@ where
 
 impl<T> LightCloseAccount<T>
 where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+    T: AnchorDeserialize + AnchorSerialize + Clone + DataHasher + Discriminator,
 {
     pub fn try_from_slice(
         v: &[u8],
@@ -400,7 +401,7 @@ where
 
 impl<T> Deref for LightCloseAccount<T>
 where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+    T: AnchorDeserialize + AnchorSerialize + Clone + DataHasher + Discriminator,
 {
     type Target = T;
 
@@ -411,14 +412,14 @@ where
 
 impl<T> DerefMut for LightCloseAccount<T>
 where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Discriminator,
+    T: AnchorDeserialize + AnchorSerialize + Clone + DataHasher + Discriminator,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.input_account
     }
 }
 
-#[derive(Debug, PartialEq, Default, Clone, BorshDeserialize, BorshSerialize)]
+#[derive(Debug, PartialEq, Default, Clone, AnchorDeserialize, AnchorSerialize)]
 pub struct CompressedAccount {
     pub owner: Pubkey,
     pub lamports: u64,
@@ -488,20 +489,20 @@ impl CompressedAccount {
     }
 }
 
-#[derive(Debug, PartialEq, Default, Clone, BorshDeserialize, BorshSerialize)]
+#[derive(Debug, PartialEq, Default, Clone, AnchorDeserialize, AnchorSerialize)]
 pub struct CompressedAccountData {
     pub discriminator: [u8; 8],
     pub data: Vec<u8>,
     pub data_hash: [u8; 32],
 }
 
-#[derive(Debug, PartialEq, Default, Clone, BorshDeserialize, BorshSerialize)]
+#[derive(Debug, PartialEq, Default, Clone, AnchorDeserialize, AnchorSerialize)]
 pub struct CompressedAccountWithMerkleContext {
     pub compressed_account: CompressedAccount,
     pub merkle_context: MerkleContext,
 }
 
-#[derive(Debug, PartialEq, Default, Clone, BorshDeserialize, BorshSerialize)]
+#[derive(Debug, PartialEq, Default, Clone, AnchorDeserialize, AnchorSerialize)]
 pub struct PackedCompressedAccountWithMerkleContext {
     pub compressed_account: CompressedAccount,
     pub merkle_context: PackedMerkleContext,
@@ -520,7 +521,7 @@ impl CompressedAccountWithMerkleContext {
     }
 }
 
-#[derive(Debug, PartialEq, Default, Clone, BorshDeserialize, BorshSerialize)]
+#[derive(Debug, PartialEq, Default, Clone, AnchorDeserialize, AnchorSerialize)]
 pub struct OutputCompressedAccountWithPackedContext {
     pub compressed_account: CompressedAccount,
     pub merkle_tree_index: u8,
@@ -534,7 +535,7 @@ pub fn serialize_and_hash_account<T>(
     remaining_accounts: &[AccountInfo],
 ) -> Result<CompressedAccount>
 where
-    T: BorshSerialize + DataHasher + Discriminator,
+    T: AnchorSerialize + DataHasher + Discriminator,
 {
     let data = account.try_to_vec()?;
     let data_hash = account.hash::<Poseidon>().map_err(ProgramError::from)?;
@@ -568,7 +569,7 @@ pub fn input_compressed_account<T>(
     remaining_accounts: &[AccountInfo],
 ) -> Result<PackedCompressedAccountWithMerkleContext>
 where
-    T: BorshSerialize + DataHasher + Discriminator,
+    T: AnchorSerialize + DataHasher + Discriminator,
 {
     let compressed_account = serialize_and_hash_account(
         account,
@@ -595,7 +596,7 @@ pub fn output_compressed_account<T>(
     remaining_accounts: &[AccountInfo],
 ) -> Result<OutputCompressedAccountWithPackedContext>
 where
-    T: BorshSerialize + DataHasher + Discriminator,
+    T: AnchorSerialize + DataHasher + Discriminator,
 {
     let compressed_account = serialize_and_hash_account(
         account,

--- a/sdk/src/event.rs
+++ b/sdk/src/event.rs
@@ -1,15 +1,15 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use anchor_lang::{AnchorDeserialize, AnchorSerialize};
 use solana_program::pubkey::Pubkey;
 
 use crate::compressed_account::OutputCompressedAccountWithPackedContext;
 
-#[derive(Debug, Clone, BorshDeserialize, BorshSerialize, Default, PartialEq)]
+#[derive(Debug, Clone, AnchorDeserialize, AnchorSerialize, Default, PartialEq)]
 pub struct MerkleTreeSequenceNumber {
     pub pubkey: Pubkey,
     pub seq: u64,
 }
 
-#[derive(Debug, Clone, BorshDeserialize, BorshSerialize, Default, PartialEq)]
+#[derive(Debug, Clone, AnchorDeserialize, AnchorSerialize, Default, PartialEq)]
 pub struct PublicTransactionEvent {
     pub input_compressed_account_hashes: Vec<[u8; 32]>,
     pub output_compressed_account_hashes: Vec<[u8; 32]>,

--- a/sdk/src/proof.rs
+++ b/sdk/src/proof.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use anchor_lang::{AnchorDeserialize, AnchorSerialize};
 use light_indexed_merkle_tree::array::IndexedElement;
 use num_bigint::BigUint;
 use solana_program::pubkey::Pubkey;
@@ -28,15 +28,12 @@ pub struct NewAddressProofWithContext {
     pub new_element_next_value: Option<BigUint>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+#[derive(Debug, Clone, PartialEq, Eq, AnchorDeserialize, AnchorSerialize)]
 pub struct CompressedProof {
     pub a: [u8; 32],
     pub b: [u8; 64],
     pub c: [u8; 32],
 }
-
-#[cfg(feature = "idl-build")]
-impl anchor_lang::IdlBuild for CompressedProof {}
 
 #[derive(Debug)]
 pub struct ProofRpcResult {
@@ -44,6 +41,3 @@ pub struct ProofRpcResult {
     pub root_indices: Vec<u16>,
     pub address_root_indices: Vec<u16>,
 }
-
-#[cfg(feature = "idl-build")]
-impl anchor_lang::IdlBuild for ProofRpcResult {}

--- a/sdk/src/state.rs
+++ b/sdk/src/state.rs
@@ -1,7 +1,7 @@
-use borsh::BorshDeserialize;
+use anchor_lang::{AnchorDeserialize, AnchorSerialize};
 use solana_program::pubkey::Pubkey;
 
-#[derive(BorshDeserialize, Debug, PartialEq, Default)]
+#[derive(AnchorDeserialize, AnchorSerialize, Debug, PartialEq, Default)]
 pub struct MerkleTreeMetadata {
     pub access_metadata: AccessMetadata,
     pub rollover_metadata: RolloverMetadata,
@@ -11,7 +11,7 @@ pub struct MerkleTreeMetadata {
     pub next_merkle_tree: Pubkey,
 }
 
-#[derive(BorshDeserialize, Debug, PartialEq, Default)]
+#[derive(AnchorDeserialize, AnchorSerialize, Debug, PartialEq, Default)]
 pub struct AccessMetadata {
     /// Owner of the Merkle tree.
     pub owner: Pubkey,
@@ -26,7 +26,7 @@ pub struct AccessMetadata {
     pub forester: Pubkey,
 }
 
-#[derive(BorshDeserialize, Debug, PartialEq, Default)]
+#[derive(AnchorDeserialize, AnchorSerialize, Debug, PartialEq, Default)]
 pub struct RolloverMetadata {
     /// Unique index.
     pub index: u64,

--- a/sdk/src/token.rs
+++ b/sdk/src/token.rs
@@ -1,16 +1,16 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use anchor_lang::{AnchorDeserialize, AnchorSerialize};
 use solana_program::pubkey::Pubkey;
 
 use crate::compressed_account::CompressedAccountWithMerkleContext;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, AnchorDeserialize, AnchorSerialize)]
 #[repr(u8)]
 pub enum AccountState {
     Initialized,
     Frozen,
 }
 
-#[derive(Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, Clone)]
+#[derive(Debug, PartialEq, Eq, AnchorDeserialize, AnchorSerialize, Clone)]
 pub struct TokenData {
     /// The mint associated with this account
     pub mint: Pubkey,

--- a/sdk/src/verify.rs
+++ b/sdk/src/verify.rs
@@ -1,5 +1,4 @@
 use anchor_lang::{prelude::*, Bumps};
-use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::{instruction::Instruction, program::invoke_signed};
 
 use crate::{
@@ -32,7 +31,7 @@ pub struct CompressedCpiContext {
     pub cpi_context_account_index: u8,
 }
 
-#[derive(Debug, PartialEq, Default, Clone, BorshDeserialize, BorshSerialize)]
+#[derive(Debug, PartialEq, Default, Clone, AnchorDeserialize, AnchorSerialize)]
 pub struct InstructionDataInvokeCpi {
     pub proof: Option<CompressedProof>,
     pub new_address_params: Vec<NewAddressParamsPacked>,
@@ -186,7 +185,7 @@ pub fn setup_cpi_accounts<'info>(
     (account_infos, account_metas)
 }
 
-#[derive(BorshDeserialize, BorshSerialize)]
+#[derive(AnchorDeserialize, AnchorSerialize)]
 pub struct InvokeCpi {
     pub inputs: Vec<u8>,
 }
@@ -234,7 +233,7 @@ pub fn verify<'info, 'a, 'b, 'c, T>(
     signer_seeds: &'a [&'b [&'c [u8]]],
 ) -> Result<()>
 where
-    T: BorshSerialize,
+    T: AnchorSerialize,
 {
     if ctx.accounts.get_light_system_program().key() != PROGRAM_ID_LIGHT_SYSTEM {
         return err!(LightSdkError::InvalidLightSystemProgram);


### PR DESCRIPTION
Using Borsh traits directly (`BorshDeserialize`, `BorshSerialize`) instead of the Anchor variants doesn't play well with idl-build.