### PR TITLE
chore: bump cli version and add .npmignore

### DIFF
--- a/cli/.npmignore
+++ b/cli/.npmignore
@@ -1,0 +1,1 @@
+bin/cargo-generate

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightprotocol/zk-compression-cli",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "ZK Compression: Secure Scaling on Solana",
   "maintainers": [
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,10 +398,6 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@22.5.5)(@vitest/browser@1.6.0)(terser@5.31.0)
 
-  hasher.rs/src/main/wasm: {}
-
-  hasher.rs/src/main/wasm-simd: {}
-
   js/compressed-token:
     dependencies:
       '@coral-xyz/anchor':


### PR DESCRIPTION
issue:
- `cargo-generate` bin was bundled accidentally with release of cli this way the cli release `0.18.0` init command only works for mac os without manually removing the bundled `cargo-generate` binary

Changes:
- bump cli version to `0.18.1`
- add `.npmignore` file to remove the footgun of accidentally bundling `cargo-generate`  