### PR TITLE
chore: bump sdk 0.11.0, sdk-macros 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3713,7 +3713,7 @@ dependencies = [
 
 [[package]]
 name = "light-sdk"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "account-compression",
  "aligned-sized",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-macros"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bs58 0.4.0",
  "light-hasher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,8 +78,8 @@ light-indexed-merkle-tree = { path = "merkle-tree/indexed", version = "1.1.0" }
 light-macros = { path = "macros/light", version = "1.1.0" }
 light-merkle-tree-reference = { path = "merkle-tree/reference", version = "1.1.0" }
 light-prover-client = { path = "circuit-lib/light-prover-client", version = "1.2.0" }
-light-sdk = { path = "sdk", version = "0.10.0" }
-light-sdk-macros = { path = "macros/light-sdk-macros", version = "0.3.0" }
+light-sdk = { path = "sdk", version = "0.11.0" }
+light-sdk-macros = { path = "macros/light-sdk-macros", version = "0.4.0" }
 light-utils = { path = "utils", version = "1.1.0" }
 light-verifier = { path = "circuit-lib/verifier", version = "1.1.0" }
 photon-api = { path = "photon-api", version = "0.45.0" }

--- a/macros/light-sdk-macros/Cargo.toml
+++ b/macros/light-sdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-sdk-macros"
-version = "0.3.0"
+version = "0.4.0"
 description = "Macros for Programs using the Light SDK for ZK Compression "
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-sdk"
-version = "0.10.0"
+version = "0.11.0"
 description = "Rust SDK for ZK Compression on Solana"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"
@@ -35,7 +35,7 @@ num-bigint = { workspace = true }
 
 aligned-sized = { version = "1.1.0", path = "../macros/aligned-sized" }
 light-macros = { version = "1.1.0", path = "../macros/light" }
-light-sdk-macros = { version = "0.3.0", path = "../macros/light-sdk-macros" }
+light-sdk-macros = { version = "0.4.0", path = "../macros/light-sdk-macros" }
 bytemuck = "1.17"
 light-hasher = { version = "1.1.0", path = "../merkle-tree/hasher", features=["solana"] }
 light-heap = { version = "1.1.0", path = "../heap", optional = true }


### PR DESCRIPTION
note: cli init does not yet use the new sdk release. awaiting program-template update