### PR TITLE
fix: switch to bash in build and devenv scripts

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 command -v pnpm >/dev/null 2>&1 || { echo >&2 "pnpm is not installed.  Aborting."; exit 1; }
 command -v npx >/dev/null 2>&1 || { echo >&2 "npx is not installed.  Aborting."; exit 1; }

--- a/scripts/devenv.sh
+++ b/scripts/devenv.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Command to deactivate the devenv. It sets the old environment variables.
 deactivate () {
     PS1="${LIGHT_PROTOCOL_OLD_PS1}"


### PR DESCRIPTION
If we run build.sh we'll get an error:
`./scripts/build.sh: 64: ./scripts/devenv.sh: [[: not found`

This PR fixes it.