### PR TITLE
chore(cli): Supress the CodeQL shell-command error

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -25,8 +25,8 @@
   "dependencies": {
     "@coral-xyz/anchor": "0.29.0",
     "@lightprotocol/compressed-token": "workspace:*",
-    "@lightprotocol/hasher.rs": "workspace:*",
     "@lightprotocol/stateless.js": "workspace:*",
+    "@lightprotocol/hasher.rs": "workspace:*",
     "@oclif/core": "^3.26.2",
     "@oclif/plugin-autocomplete": "^3.0.13",
     "@oclif/plugin-help": "^6.0.20",
@@ -34,7 +34,6 @@
     "@oclif/plugin-plugins": "^5.0.7",
     "@solana-developers/helpers": "^1.5.1",
     "@solana/web3.js": "^1.95.3",
-    "@types/shell-quote": "^1.7.5",
     "axios": "^1.6.8",
     "case-anything": "^2.1.13",
     "cli-progress": "^3.12.0",

--- a/cli/src/utils/process.ts
+++ b/cli/src/utils/process.ts
@@ -5,7 +5,6 @@ import find from "find-process";
 import { exec as execCb } from "node:child_process";
 import { promisify } from "util";
 import axios from "axios";
-import * as shellQuote from "shell-quote";
 const waitOn = require("wait-on");
 
 export async function killProcess(processName: string) {
@@ -19,8 +18,7 @@ export async function killProcess(processName: string) {
 }
 
 export async function killProcessByPort(port: number) {
-  const portArg = shellQuote.quote([`-i:${port}`]);
-  await execute(`lsof -t ${portArg} | while read line; do kill -9 $line; done`);
+  await execute(`lsof -t -i:${port} | while read line; do kill -9 $line; done`);
 }
 
 /**

--- a/cli/src/utils/process.ts
+++ b/cli/src/utils/process.ts
@@ -18,6 +18,12 @@ export async function killProcess(processName: string) {
 }
 
 export async function killProcessByPort(port: number) {
+  if (port < 0) {
+    throw new Error("Value must be non-negative");
+  }
+  // NOTE(vadorovsky): The lint error in this case doesn't make sense. `port`
+  // is a harmless number.
+  // codeql [js/shell-command-constructed-from-input]: warning
   await execute(`lsof -t -i:${port} | while read line; do kill -9 $line; done`);
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,9 +65,6 @@ importers:
       '@solana/web3.js':
         specifier: ^1.95.3
         version: 1.95.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@types/shell-quote':
-        specifier: ^1.7.5
-        version: 1.7.5
       axios:
         specifier: ^1.6.8
         version: 1.6.8
@@ -3312,9 +3309,6 @@ packages:
 
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
-
-  '@types/shell-quote@1.7.5':
-    resolution: {integrity: sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw==}
 
   '@types/sinon@10.0.16':
     resolution: {integrity: sha512-j2Du5SYpXZjJVJtXBokASpPRj+e2z+VUhCPHmM6WMfe3dpHu6iVKJMU6AiBcMp/XTAYnEj6Wc1trJUWwZ0QaAQ==}
@@ -11902,8 +11896,6 @@ snapshots:
   '@types/semver@7.5.2': {}
 
   '@types/semver@7.5.8': {}
-
-  '@types/shell-quote@1.7.5': {}
 
   '@types/sinon@10.0.16':
     dependencies:


### PR DESCRIPTION
`port` is a `number`. Using it in command construction is safe.