### PR TITLE
refactor: unified public inputs into hashchain

### DIFF
--- a/circuit-lib/light-prover-client/src/batch_append.rs
+++ b/circuit-lib/light-prover-client/src/batch_append.rs
@@ -1,0 +1,32 @@
+use crate::helpers::bigint_to_u8_32;
+use num_bigint::BigInt;
+
+#[derive(Clone, Debug, Default)]
+pub struct BatchAppendCircuitInputs {
+    pub public_input_hash: BigInt,
+    pub old_sub_tree_hash_chain: BigInt,
+    pub new_sub_tree_hash_chain: BigInt,
+    pub new_root: BigInt,
+    pub hashchain_hash: BigInt,
+    pub start_index: BigInt,
+    pub hash_chain_start_index: BigInt,
+    pub tree_height: BigInt,
+    pub leaves: Vec<BigInt>,
+    pub subtrees: Vec<BigInt>,
+}
+
+impl BatchAppendCircuitInputs {
+    pub fn public_inputs_arr(&self) -> [u8; 32] {
+        bigint_to_u8_32(&self.public_input_hash).unwrap()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BatchAppendInputs<'a>(pub &'a [BatchAppendCircuitInputs]);
+
+impl BatchAppendInputs<'_> {
+    pub fn public_inputs(&self) -> Vec<[u8; 32]> {
+        // Concatenate all public inputs into a single flat vector
+        vec![self.0[0].public_inputs_arr()]
+    }
+}

--- a/circuit-lib/light-prover-client/src/batch_update.rs
+++ b/circuit-lib/light-prover-client/src/batch_update.rs
@@ -1,0 +1,31 @@
+use crate::helpers::bigint_to_u8_32;
+use num_bigint::BigInt;
+
+#[derive(Clone, Debug)]
+pub struct BatchUpdateCircuitInputs {
+    pub public_input_hash: BigInt,
+    pub old_root: BigInt,
+    pub new_root: BigInt,
+    pub leaves_hashchain_hash: BigInt,
+    pub leaves: Vec<BigInt>,
+    pub merkle_proofs: Vec<Vec<BigInt>>,
+    pub path_indices: Vec<u32>,
+    pub height: u32,
+    pub batch_size: u32,
+}
+
+impl BatchUpdateCircuitInputs {
+    pub fn public_inputs_arr(&self) -> [u8; 32] {
+        bigint_to_u8_32(&self.public_input_hash).unwrap()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BatchUpdateInputs<'a>(pub &'a [BatchUpdateCircuitInputs]);
+
+impl BatchUpdateInputs<'_> {
+    pub fn public_inputs(&self) -> Vec<[u8; 32]> {
+        // Concatenate all public inputs into a single flat vector
+        vec![self.0[0].public_inputs_arr()]
+    }
+}

--- a/circuit-lib/light-prover-client/src/gnark/batch_append_json_formatter.rs
+++ b/circuit-lib/light-prover-client/src/gnark/batch_append_json_formatter.rs
@@ -1,0 +1,103 @@
+use crate::batch_append::BatchAppendCircuitInputs;
+use crate::gnark::helpers::{big_int_to_string, create_json_from_struct};
+use num_traits::ToPrimitive;
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+pub struct BatchAppendJsonStruct {
+    #[serde(rename(serialize = "publicInputHash"))]
+    pub public_input_hash: String,
+    #[serde(rename(serialize = "oldSubTreeHashChain"))]
+    pub old_sub_tree_hash_chain: String,
+    #[serde(rename(serialize = "newSubTreeHashChain"))]
+    pub new_sub_tree_hash_chain: String,
+    #[serde(rename(serialize = "newRoot"))]
+    pub new_root: String,
+    #[serde(rename(serialize = "hashchainHash"))]
+    pub hashchain_hash: String,
+    #[serde(rename(serialize = "startIndex"))]
+    pub start_index: u32,
+    #[serde(rename(serialize = "hashChainStartIndex"))]
+    pub hash_chain_start_index: u32,
+    #[serde(rename(serialize = "treeHeight"))]
+    pub tree_height: u32,
+    #[serde(rename(serialize = "leaves"))]
+    pub leaves: Vec<String>,
+    #[serde(rename(serialize = "subtrees"))]
+    pub subtrees: Vec<String>,
+}
+
+impl BatchAppendJsonStruct {
+    pub fn from_append_inputs(inputs: &BatchAppendCircuitInputs) -> Self {
+        let public_input_hash = big_int_to_string(&inputs.public_input_hash);
+        let old_sub_tree_hash_chain = big_int_to_string(&inputs.old_sub_tree_hash_chain);
+        let new_sub_tree_hash_chain = big_int_to_string(&inputs.new_sub_tree_hash_chain);
+        let new_root = big_int_to_string(&inputs.new_root);
+        let hashchain_hash = big_int_to_string(&inputs.hashchain_hash);
+        let start_index = inputs.start_index.to_u32().unwrap();
+        let hash_chain_start_index = inputs.hash_chain_start_index.to_u32().unwrap();
+        let tree_height = inputs.tree_height.to_u32().unwrap();
+
+        let leaves = inputs
+            .leaves
+            .iter()
+            .map(big_int_to_string)
+            .collect::<Vec<String>>();
+
+        let subtrees = inputs
+            .subtrees
+            .iter()
+            .map(big_int_to_string)
+            .collect::<Vec<String>>();
+
+        Self {
+            public_input_hash,
+            old_sub_tree_hash_chain,
+            new_sub_tree_hash_chain,
+            new_root,
+            hashchain_hash,
+            start_index,
+            hash_chain_start_index,
+            tree_height,
+            leaves,
+            subtrees,
+        }
+    }
+
+    #[allow(clippy::inherent_to_string)]
+    pub fn to_string(&self) -> String {
+        create_json_from_struct(&self)
+    }
+}
+
+pub fn append_inputs_string(inputs: &BatchAppendCircuitInputs) -> String {
+    let json_struct = BatchAppendJsonStruct::from_append_inputs(inputs);
+    json_struct.to_string()
+}
+
+pub fn new_with_append_inputs() -> (BatchAppendJsonStruct, BatchAppendCircuitInputs) {
+    let append_inputs = BatchAppendCircuitInputs::default();
+
+    let json_struct = BatchAppendJsonStruct {
+        public_input_hash: big_int_to_string(&append_inputs.public_input_hash),
+        old_sub_tree_hash_chain: big_int_to_string(&append_inputs.old_sub_tree_hash_chain),
+        new_sub_tree_hash_chain: big_int_to_string(&append_inputs.new_sub_tree_hash_chain),
+        new_root: big_int_to_string(&append_inputs.new_root),
+        hashchain_hash: big_int_to_string(&append_inputs.hashchain_hash),
+        start_index: append_inputs.start_index.to_u32().unwrap(),
+        hash_chain_start_index: append_inputs.hash_chain_start_index.to_u32().unwrap(),
+        tree_height: append_inputs.tree_height.to_u32().unwrap(),
+        leaves: append_inputs
+            .leaves
+            .iter()
+            .map(big_int_to_string)
+            .collect::<Vec<String>>(),
+        subtrees: append_inputs
+            .subtrees
+            .iter()
+            .map(big_int_to_string)
+            .collect::<Vec<String>>(),
+    };
+
+    (json_struct, append_inputs)
+}

--- a/circuit-lib/light-prover-client/src/gnark/batch_update_json_formatter.rs
+++ b/circuit-lib/light-prover-client/src/gnark/batch_update_json_formatter.rs
@@ -1,0 +1,80 @@
+use crate::{
+    batch_update::BatchUpdateCircuitInputs,
+    gnark::helpers::{big_int_to_string, create_json_from_struct},
+};
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+pub struct BatchUpdateProofInputsJson {
+    #[serde(rename(serialize = "publicInputHash"))]
+    pub public_input_hash: String,
+    #[serde(rename(serialize = "oldRoot"))]
+    pub old_root: String,
+    #[serde(rename(serialize = "newRoot"))]
+    pub new_root: String,
+    #[serde(rename(serialize = "leavesHashchainHash"))]
+    pub leaves_hashchain_hash: String,
+    #[serde(rename(serialize = "leaves"))]
+    pub leaves: Vec<String>,
+    #[serde(rename(serialize = "newMerkleProofs"))]
+    pub merkle_proofs: Vec<Vec<String>>,
+    #[serde(rename(serialize = "pathIndices"))]
+    pub path_indices: Vec<u32>,
+    #[serde(rename(serialize = "height"))]
+    pub height: u32,
+    #[serde(rename(serialize = "batchSize"))]
+    pub batch_size: u32,
+}
+
+#[derive(Serialize, Debug)]
+pub struct BatchUpdateParametersJson {
+    #[serde(rename(serialize = "batch-update-inputs"))]
+    pub inputs: BatchUpdateProofInputsJson,
+}
+
+impl BatchUpdateProofInputsJson {
+    pub fn from_update_inputs(inputs: &BatchUpdateCircuitInputs) -> Self {
+        let public_input_hash = big_int_to_string(&inputs.public_input_hash);
+        let old_root = big_int_to_string(&inputs.old_root);
+        let new_root = big_int_to_string(&inputs.new_root);
+        let leaves_hashchain_hash = big_int_to_string(&inputs.leaves_hashchain_hash);
+
+        let leaves = inputs
+            .leaves
+            .iter()
+            .map(big_int_to_string)
+            .collect::<Vec<String>>();
+
+        let merkle_proofs = inputs
+            .merkle_proofs
+            .iter()
+            .map(|proof| proof.iter().map(big_int_to_string).collect())
+            .collect();
+
+        let path_indices = inputs.path_indices.clone();
+        let height = inputs.height;
+        let batch_size = inputs.batch_size;
+
+        Self {
+            public_input_hash,
+            old_root,
+            new_root,
+            leaves_hashchain_hash,
+            leaves,
+            merkle_proofs,
+            path_indices,
+            height,
+            batch_size,
+        }
+    }
+
+    #[allow(clippy::inherent_to_string)]
+    pub fn to_string(&self) -> String {
+        create_json_from_struct(&self)
+    }
+}
+
+pub fn update_inputs_string(inputs: &BatchUpdateCircuitInputs) -> String {
+    let json_struct = BatchUpdateProofInputsJson::from_update_inputs(inputs);
+    json_struct.to_string()
+}

--- a/circuit-lib/light-prover-client/src/gnark/mod.rs
+++ b/circuit-lib/light-prover-client/src/gnark/mod.rs
@@ -1,3 +1,5 @@
+pub mod batch_append_json_formatter;
+pub mod batch_update_json_formatter;
 pub mod combined_json_formatter;
 pub mod constants;
 pub mod helpers;

--- a/circuit-lib/light-prover-client/src/lib.rs
+++ b/circuit-lib/light-prover-client/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod batch_append;
+pub mod batch_update;
 pub mod combined;
 pub mod errors;
 #[cfg(feature = "gnark")]

--- a/light-prover/merkle-tree/merkle_tree.go
+++ b/light-prover/merkle-tree/merkle_tree.go
@@ -1,8 +1,9 @@
 package merkle_tree
 
 import (
-	"github.com/iden3/go-iden3-crypto/poseidon"
 	"math/big"
+
+	"github.com/iden3/go-iden3-crypto/poseidon"
 )
 
 type PoseidonNode interface {
@@ -157,19 +158,19 @@ func deepCopyNode(node PoseidonNode) PoseidonNode {
 func deepCopyFullNode(node *PoseidonFullNode) *PoseidonFullNode {
 	if node == nil {
 		return nil
-				}
+	}
 	return &PoseidonFullNode{
 		dep:   node.dep,
 		val:   *new(big.Int).Set(&node.val),
 		Left:  deepCopyNode(node.Left),
 		Right: deepCopyNode(node.Right),
-			}
+	}
 }
 
 func deepCopyEmptyNode(node *PoseidonEmptyNode) *PoseidonEmptyNode {
 	if node == nil {
 		return nil
-		}
+	}
 	emptyTreeValues := make([]big.Int, len(node.emptyTreeValues))
 	for i, v := range node.emptyTreeValues {
 		emptyTreeValues[i] = *new(big.Int).Set(&v)

--- a/light-prover/prover/batch_append_circuit_test.go
+++ b/light-prover/prover/batch_append_circuit_test.go
@@ -251,12 +251,12 @@ func TestBatchAppendCircuit(t *testing.T) {
 
 func createCircuit(params *BatchAppendParameters) BatchAppendCircuit {
 	circuit := BatchAppendCircuit{
+		PublicInputHash:     frontend.Variable(0),
 		OldSubTreeHashChain: frontend.Variable(0),
 		NewSubTreeHashChain: frontend.Variable(0),
 		NewRoot:             frontend.Variable(0),
 		HashchainHash:       frontend.Variable(0),
 		StartIndex:          frontend.Variable(0),
-		HashChainStartIndex: frontend.Variable(0),
 		Leaves:              make([]frontend.Variable, len(params.Leaves)),
 		Subtrees:            make([]frontend.Variable, len(params.Subtrees)),
 		BatchSize:           uint32(len(params.Leaves)),
@@ -275,12 +275,12 @@ func createCircuit(params *BatchAppendParameters) BatchAppendCircuit {
 
 func createWitness(params *BatchAppendParameters) *BatchAppendCircuit {
 	witness := &BatchAppendCircuit{
+		PublicInputHash:     frontend.Variable(params.PublicInputHash),
 		OldSubTreeHashChain: frontend.Variable(params.OldSubTreeHashChain),
 		NewSubTreeHashChain: frontend.Variable(params.NewSubTreeHashChain),
 		NewRoot:             frontend.Variable(params.NewRoot),
 		HashchainHash:       frontend.Variable(params.HashchainHash),
 		StartIndex:          frontend.Variable(params.StartIndex),
-		HashChainStartIndex: frontend.Variable(params.HashChainStartIndex),
 		Leaves:              make([]frontend.Variable, len(params.Leaves)),
 		Subtrees:            make([]frontend.Variable, len(params.Subtrees)),
 		BatchSize:           uint32(len(params.Leaves)),

--- a/light-prover/prover/batch_update_circuit_test.go
+++ b/light-prover/prover/batch_update_circuit_test.go
@@ -20,6 +20,7 @@ func TestBatchUpdateCircuit(t *testing.T) {
 		params := BuildTestBatchUpdateTree(treeDepth, batchSize, nil, nil)
 
 		circuit := BatchUpdateCircuit{
+			PublicInputHash:     frontend.Variable(0),
 			OldRoot:             frontend.Variable(0),
 			NewRoot:             frontend.Variable(0),
 			LeavesHashchainHash: frontend.Variable(0),
@@ -35,6 +36,7 @@ func TestBatchUpdateCircuit(t *testing.T) {
 		}
 
 		witness := BatchUpdateCircuit{
+			PublicInputHash:     frontend.Variable(params.PublicInputHash),
 			OldRoot:             frontend.Variable(params.OldRoot),
 			NewRoot:             frontend.Variable(params.NewRoot),
 			LeavesHashchainHash: frontend.Variable(params.LeavesHashchainHash),
@@ -162,6 +164,7 @@ func TestBatchUpdateCircuit(t *testing.T) {
 
 func createBatchUpdateCircuit(treeDepth, batchSize int) BatchUpdateCircuit {
 	circuit := BatchUpdateCircuit{
+		PublicInputHash:     frontend.Variable(0),
 		OldRoot:             frontend.Variable(0),
 		NewRoot:             frontend.Variable(0),
 		LeavesHashchainHash: frontend.Variable(0),
@@ -181,6 +184,7 @@ func createBatchUpdateCircuit(treeDepth, batchSize int) BatchUpdateCircuit {
 
 func createBatchUpdateWitness(params *BatchUpdateParameters, startIndex, count int) BatchUpdateCircuit {
 	witness := BatchUpdateCircuit{
+		PublicInputHash:     frontend.Variable(params.PublicInputHash),
 		OldRoot:             frontend.Variable(params.OldRoot),
 		NewRoot:             frontend.Variable(params.NewRoot),
 		LeavesHashchainHash: frontend.Variable(params.LeavesHashchainHash),

--- a/light-prover/prover/marshal_append.go
+++ b/light-prover/prover/marshal_append.go
@@ -7,6 +7,7 @@ import (
 )
 
 type BatchAppendParametersJSON struct {
+	PublicInputHash     string   `json:"publicInputHash"`
 	OldSubTreeHashChain string   `json:"oldSubTreeHashChain"`
 	NewSubTreeHashChain string   `json:"newSubTreeHashChain"`
 	NewRoot             string   `json:"newRoot"`
@@ -34,6 +35,7 @@ func (p *BatchAppendParameters) MarshalJSON() ([]byte, error) {
 
 func (p *BatchAppendParameters) CreateBatchAppendParametersJSON() BatchAppendParametersJSON {
 	paramsJson := BatchAppendParametersJSON{
+		PublicInputHash:     toHex(p.PublicInputHash),
 		OldSubTreeHashChain: toHex(p.OldSubTreeHashChain),
 		NewSubTreeHashChain: toHex(p.NewSubTreeHashChain),
 		NewRoot:             toHex(p.NewRoot),

--- a/light-prover/prover/marshal_update.go
+++ b/light-prover/prover/marshal_update.go
@@ -7,6 +7,7 @@ import (
 )
 
 type BatchUpdateProofInputsJSON struct {
+	PublicInputHash     string     `json:"publicInputHash"`
 	OldRoot             string     `json:"oldRoot"`
 	NewRoot             string     `json:"newRoot"`
 	LeavesHashchainHash string     `json:"leavesHashchainHash"`
@@ -36,6 +37,7 @@ func (p *BatchUpdateParameters) MarshalJSON() ([]byte, error) {
 
 func (p *BatchUpdateParameters) CreateBatchUpdateParametersJSON() BatchUpdateParametersJSON {
 	paramsJson := BatchUpdateParametersJSON{}
+	paramsJson.Inputs.PublicInputHash = toHex(p.PublicInputHash)
 	paramsJson.Inputs.OldRoot = toHex(p.OldRoot)
 	paramsJson.Inputs.NewRoot = toHex(p.NewRoot)
 	paramsJson.Inputs.LeavesHashchainHash = toHex(p.LeavesHashchainHash)

--- a/light-prover/prover/test_data_helpers.go
+++ b/light-prover/prover/test_data_helpers.go
@@ -2,10 +2,11 @@ package prover
 
 import (
 	"fmt"
-	"github.com/iden3/go-iden3-crypto/poseidon"
 	merkletree "light/light-prover/merkle-tree"
 	"math/big"
 	"math/rand"
+
+	"github.com/iden3/go-iden3-crypto/poseidon"
 )
 
 func rangeIn(low, hi int) int {
@@ -132,7 +133,15 @@ func BuildAndUpdateBatchAppendParameters(treeDepth uint32, batchSize uint32, sta
 	newRoot := tree.Root.Value()
 	hashchainHash := calculateHashChain(newLeaves, int(batchSize))
 
+	publicInputHash := calculateHashChain([]*big.Int{
+		oldSubTreeHashChain,
+		newSubTreeHashChain,
+		&newRoot,
+		hashchainHash,
+		big.NewInt(int64(startIndex))},
+		5)
 	params := BatchAppendParameters{
+		PublicInputHash:     publicInputHash,
 		OldSubTreeHashChain: oldSubTreeHashChain,
 		NewSubTreeHashChain: newSubTreeHashChain,
 		NewRoot:             &newRoot,
@@ -243,7 +252,13 @@ func BuildTestBatchUpdateTree(treeDepth int, batchSize int, previousTree *merkle
 	leavesHashchainHash := calculateHashChain(leaves, batchSize)
 	newRoot := tree.Root.Value()
 
+	publicInputHash := calculateHashChain([]*big.Int{
+		&oldRoot,
+		&newRoot,
+		leavesHashchainHash},
+		3)
 	return &BatchUpdateParameters{
+		PublicInputHash:     publicInputHash,
 		OldRoot:             &oldRoot,
 		NewRoot:             &newRoot,
 		LeavesHashchainHash: leavesHashchainHash,


### PR DESCRIPTION
Changes in append and update circuits:
- add public input `PublicInputHash`
- make existing public inputs private
- remove `HashChainStartIndex` in append circuit
- add rust json formatters (untested)