### PR TITLE
feat: bump to 0.50.0, add getCompressedTokenBalancesByOwnerV2

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # ZK Compression CLI
 
-CLI to interact with ZK compression.
+CLI to interact with compressed accounts and compressed tokens on Solana.
 
 ## Requirements
 
@@ -179,9 +179,7 @@ FLAGS
 
 ```
 
-#### Compress native SOL
-
-> **Note:** Ensure the SOL omnibus account of the Light system program is already initialized by running: `light init-sol-pool`
+#### Assign native SOL to a compressed account
 
 ```bash
 light compress-sol --amount 1000 --to "YOUR_WALLET_ADDRESS_BASE58"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightprotocol/zk-compression-cli",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "ZK Compression: Secure Scaling on Solana",
   "maintainers": [
     {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightprotocol/zk-compression-cli",
-  "version": "0.19.3",
+  "version": "0.20.0",
   "description": "ZK Compression: Secure Scaling on Solana",
   "maintainers": [
     {
@@ -21,6 +21,10 @@
     "./config.json",
     "/npm-shrinkwrap.json",
     "/oclif.manifest.json",
+    "!bin/proving-keys/address-append_26_1.key",
+    "!bin/proving-keys/address-append_26_1.vkey",
+    "!bin/proving-keys/address-append_26_10.key",
+    "!bin/proving-keys/address-append_26_10.vkey",
     "!bin/proving-keys/append-with-proofs_26_10.key",
     "!bin/proving-keys/append-with-proofs_26_10.vkey",
     "!bin/proving-keys/append-with-subtrees_26_10.key",

--- a/cli/src/utils/constants.ts
+++ b/cli/src/utils/constants.ts
@@ -19,7 +19,7 @@ export const SOLANA_VALIDATOR_PROCESS_NAME = "solana-test-validator";
 export const LIGHT_PROVER_PROCESS_NAME = "light-prover";
 export const INDEXER_PROCESS_NAME = "photon";
 
-export const PHOTON_VERSION = "0.48.0";
+export const PHOTON_VERSION = "0.50.0";
 
 export const LIGHT_PROTOCOL_PROGRAMS_DIR_ENV = "LIGHT_PROTOCOL_PROGRAMS_DIR";
 export const BASE_PATH = "../../bin/";

--- a/js/compressed-token/README.md
+++ b/js/compressed-token/README.md
@@ -1,24 +1,36 @@
-# TS client for Interacting with the Compressed-Token Program
+<p align="center">
+  <img src="https://github.com/ldiego08/light-protocol/raw/main/assets/logo.svg" width="90" />
+</p>
 
-Use this to interact with the compressed-token program on Solana via the
-Compression RPC API.
+<h1 align="center">@lightprotocol/compressed-token</h1>
+
+<p align="center">
+  <b>This is the JavaScript SDK for interacting with the compressed token program on Solana.</b>
+</p>
+
+<p align="center">
+  <a href="https://badge.fury.io/js/@lightprotocol%2Fcompressed-token">
+    <img src="https://badge.fury.io/js/@lightprotocol%2Fcompressed-token.svg" alt="package npm version" height="18" />
+  </a>
+  <img src="https://img.shields.io/npm/l/%40lightprotocol%2Fcompressed-token" alt="package license" height="18">
+  <img src="https://img.shields.io/npm/dw/%40lightprotocol%2Fcompressed-token" alt="package weekly downloads" height="18" />
+</p>
+
 
 ### Installation
 
-**For use in Node.js or a web application**
+**For use in Node.js or web**
 
 ```bash
 npm install --save \
     @lightprotocol/compressed-token \
     @lightprotocol/stateless.js \
-    @solana/web3.js \
-    @coral-xyz/anchor@0.29
 ```
 
 ### Documentation and examples
 
 -   [Latest Source code](https://github.com/lightprotocol/lightprotocol/tree/main/js/compressed-token)
--   Documentation and examples will be linked here soon!
+-   [Creating and sending compressed tokens](https://www.zkcompression.com/developers/typescript-client#creating-minting-and-transferring-a-compressed-token)
 
 ### Getting help
 

--- a/js/compressed-token/README.md
+++ b/js/compressed-token/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">@lightprotocol/compressed-token</h1>
 
 <p align="center">
-  <b>This is the JavaScript SDK for interacting with the compressed token program on Solana.</b>
+  <b>This is the JavaScript SDK for interacting with the Compressed Token program on Solana.</b>
 </p>
 
 <p align="center">

--- a/js/compressed-token/package.json
+++ b/js/compressed-token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightprotocol/compressed-token",
-    "version": "0.14.3",
+    "version": "0.15.0",
     "description": "JS client to interact with the compressed-token program",
     "sideEffects": false,
     "main": "dist/cjs/node/index.cjs",

--- a/js/compressed-token/package.json
+++ b/js/compressed-token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightprotocol/compressed-token",
-    "version": "0.15.0",
+    "version": "0.15.1",
     "description": "JS client to interact with the compressed-token program",
     "sideEffects": false,
     "main": "dist/cjs/node/index.cjs",

--- a/js/compressed-token/tests/e2e/rpc-token-interop.test.ts
+++ b/js/compressed-token/tests/e2e/rpc-token-interop.test.ts
@@ -152,6 +152,44 @@ describe('rpc-interop token', () => {
         });
     });
 
+
+    it('getCompressedTokenBalancesByOwnerV2 should match', async () => {
+        const balances = (
+            await rpc.getCompressedTokenBalancesByOwnerV2(bob.publicKey, {
+                mint,
+            })
+        ).value.items;
+        const balancesTest = (
+            await testRpc.getCompressedTokenBalancesByOwnerV2(bob.publicKey, {
+                mint,
+            })
+        ).value.items;
+
+        assert.equal(balances.length, balancesTest.length);
+
+        balances.forEach((balance, index) => {
+            assert.isTrue(balance.balance.eq(balancesTest[index].balance));
+        });
+
+        const balancesReceiver = (
+            await rpc.getCompressedTokenBalancesByOwnerV2(charlie.publicKey, {
+                mint,
+            })
+        ).value.items;
+        const balancesReceiverTest = (
+            await testRpc.getCompressedTokenBalancesByOwnerV2(charlie.publicKey, {
+                mint,
+            })
+        ).value.items;
+
+        assert.equal(balancesReceiver.length, balancesReceiverTest.length);
+        balancesReceiver.forEach((balance, index) => {
+            assert.isTrue(
+                balance.balance.eq(balancesReceiverTest[index].balance),
+            );
+        });
+    });
+
     it('[test-rpc missing] getSignaturesForTokenOwner should match', async () => {
         const signatures = (
             await rpc.getCompressionSignaturesForTokenOwner(bob.publicKey)

--- a/js/stateless.js/README.md
+++ b/js/stateless.js/README.md
@@ -2,10 +2,10 @@
   <img src="https://github.com/ldiego08/light-protocol/raw/main/assets/logo.svg" width="90" />
 </p>
 
-<h1 align="center">Stateless.js</h1>
+<h1 align="center">@lightprotocol/stateless.js</h1>
 
 <p align="center">
-  <b>Integrate server and web applications with ZK Compression on Solana.</b>
+  <b>This is the JavaScript SDK for building applications with ZK Compression for Node and web.</b>
 </p>
 
 <p align="center">
@@ -16,14 +16,6 @@
   <img src="https://img.shields.io/npm/dw/%40lightprotocol%2Fstateless.js" alt="package weekly downloads" height="18" />
 </p>
 
-## Overview
-
-This package provides server and web applications with clients, utilities, and types to leverage the power of [ZK Compression](https://www.zkcompression.com/) on Solana via the Compression RPC API.
-
-> The core ZK Compression Solana programs and clients are maintained by
-> [Light](https://github.com/lightprotocol) as a part of the Light Protocol. The RPC API and indexer are maintained by
-> [Helius Labs](https://github.com/helius-labs).
-
 ## Usage
 
 ### Installation
@@ -31,22 +23,14 @@ This package provides server and web applications with clients, utilities, and t
 Install this package in your project by running the following terminal command:
 
 ```bin
-npm install --save \
-    @lightprotocol/stateless.js \
-    @solana/web3.js \
-    @coral-xyz/anchor@0.29
+npm install --save @lightprotocol/stateless.js
 ```
-
-### Dependencies
-
--   [`@solana/web3.js`](https://www.npmjs.com/package/@solana/web3.js) — provides access to the Solana network via RPC.
--   [`@coral-xyz/anchor`](https://www.npmjs.com/package/@coral-xyz/anchor) — a client for [Anchor](https://www.anchor-lang.com/) Solana programs.
 
 ## Documentation and Examples
 
 For a more detailed documentation on usage, please check [the respective section at the ZK Compression documentation.](https://www.zkcompression.com/developers/typescript-client)
 
-For example implementations, including web and server, refer to the respective repositories:
+For example implementations, including web and Node, refer to the respective repositories:
 
 -   [Web application example implementation](https://github.com/Lightprotocol/example-web-client)
 
@@ -55,7 +39,7 @@ For example implementations, including web and server, refer to the respective r
 ## Troubleshooting
 
 Have a question or a problem?
-Feel free to ask in the [Light](https://discord.gg/CYvjBgzRFP) and [Helius](https://discord.gg/Uzzf6a7zKr) developer Discord servers. Please, include the following information to better be able to respond:
+Feel free to ask in the [Light](https://discord.gg/CYvjBgzRFP) and [Helius](https://discord.gg/Uzzf6a7zKr) developer Discord servers. Please, include the following information:
 
 -   A detailed description or context of the issue or what you are trying to achieve.
 -   A code example that we can use to test and debug (if possible). Use [CodeSandbox](https://codesandbox.io/p/sandbox/vanilla-ts) or any other live environment provider.

--- a/js/stateless.js/README.md
+++ b/js/stateless.js/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">@lightprotocol/stateless.js</h1>
 
 <p align="center">
-  <b>This is the JavaScript SDK for building applications with ZK Compression for Node and web.</b>
+  <b>This is the JavaScript SDK for building Solana applications with ZK Compression for Node and web.</b>
 </p>
 
 <p align="center">

--- a/js/stateless.js/package.json
+++ b/js/stateless.js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightprotocol/stateless.js",
-    "version": "0.15.0",
+    "version": "0.15.1",
     "description": "JavaScript API for Light and ZK Compression",
     "sideEffects": false,
     "main": "dist/cjs/node/index.cjs",

--- a/js/stateless.js/package.json
+++ b/js/stateless.js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightprotocol/stateless.js",
-    "version": "0.14.4",
+    "version": "0.15.0",
     "description": "JavaScript API for Light and ZK Compression",
     "sideEffects": false,
     "main": "dist/cjs/node/index.cjs",

--- a/js/stateless.js/src/rpc-interface.ts
+++ b/js/stateless.js/src/rpc-interface.ts
@@ -131,11 +131,12 @@ export interface GetCompressedTokenAccountsByOwnerOrDelegateOptions {
     limit?: BN;
 }
 export type TokenBalance = { balance: BN; mint: PublicKey };
-export type GetCompressedMintTokenHoldersOptions = PaginatedOptions;
-export type GetCompressedTokenBalancesByOwnerOptions = PaginatedOptions;
-export type GetCompressionSignaturesForOwnerOptions = PaginatedOptions;
-export type GetCompressionSignaturesForAddressOptions = PaginatedOptions;
 
+/**
+ * **Cursor** is a unique identifier for a page of results by which the next page can be fetched.
+ *
+ * **Limit** is the maximum number of results to return per page.
+ */
 export interface PaginatedOptions {
     cursor?: string;
     limit?: BN;
@@ -556,7 +557,7 @@ export interface CompressionApiInterface {
 
     getCompressedMintTokenHolders(
         mint: PublicKey,
-        options?: GetCompressedMintTokenHoldersOptions,
+        options?: PaginatedOptions,
     ): Promise<WithContext<WithCursor<CompressedMintTokenHolders[]>>>;
 
     getCompressedTokenAccountsByOwner(
@@ -591,17 +592,17 @@ export interface CompressionApiInterface {
 
     getCompressionSignaturesForAddress(
         address: PublicKey,
-        options?: GetCompressionSignaturesForAddressOptions,
+        options?: PaginatedOptions,
     ): Promise<WithCursor<SignatureWithMetadata[]>>;
 
     getCompressionSignaturesForOwner(
         owner: PublicKey,
-        options?: GetCompressionSignaturesForOwnerOptions,
+        options?: PaginatedOptions,
     ): Promise<WithCursor<SignatureWithMetadata[]>>;
 
     getCompressionSignaturesForTokenOwner(
         owner: PublicKey,
-        options?: GetCompressionSignaturesForOwnerOptions,
+        options?: PaginatedOptions,
     ): Promise<WithCursor<SignatureWithMetadata[]>>;
 
     getLatestNonVotingSignatures(

--- a/js/stateless.js/src/rpc-interface.ts
+++ b/js/stateless.js/src/rpc-interface.ts
@@ -130,8 +130,13 @@ export interface GetCompressedTokenAccountsByOwnerOrDelegateOptions {
     cursor?: string;
     limit?: BN;
 }
+export type TokenBalance = { balance: BN; mint: PublicKey };
+export type GetCompressedMintTokenHoldersOptions = PaginatedOptions;
+export type GetCompressedTokenBalancesByOwnerOptions = PaginatedOptions;
+export type GetCompressionSignaturesForOwnerOptions = PaginatedOptions;
+export type GetCompressionSignaturesForAddressOptions = PaginatedOptions;
 
-export interface GetCompressedMintTokenHoldersOptions {
+export interface PaginatedOptions {
     cursor?: string;
     limit?: BN;
 }
@@ -441,6 +446,11 @@ export const TokenBalanceListResult = pick({
     cursor: nullable(string()),
 });
 
+export const TokenBalanceListResultV2 = pick({
+    items: array(TokenBalanceResult),
+    cursor: nullable(string()),
+});
+
 export const CompressedMintTokenHoldersResult = pick({
     cursor: nullable(string()),
     items: array(
@@ -564,7 +574,12 @@ export interface CompressionApiInterface {
     getCompressedTokenBalancesByOwner(
         publicKey: PublicKey,
         options: GetCompressedTokenAccountsByOwnerOrDelegateOptions,
-    ): Promise<WithCursor<{ balance: BN; mint: PublicKey }[]>>;
+    ): Promise<WithCursor<TokenBalance[]>>;
+
+    getCompressedTokenBalancesByOwnerV2(
+        publicKey: PublicKey,
+        options: GetCompressedTokenAccountsByOwnerOrDelegateOptions,
+    ): Promise<WithContext<WithCursor<TokenBalance[]>>>;
 
     getTransactionWithCompressionInfo(
         signature: string,
@@ -576,18 +591,22 @@ export interface CompressionApiInterface {
 
     getCompressionSignaturesForAddress(
         address: PublicKey,
+        options?: GetCompressionSignaturesForAddressOptions,
     ): Promise<WithCursor<SignatureWithMetadata[]>>;
 
     getCompressionSignaturesForOwner(
         owner: PublicKey,
+        options?: GetCompressionSignaturesForOwnerOptions,
     ): Promise<WithCursor<SignatureWithMetadata[]>>;
 
     getCompressionSignaturesForTokenOwner(
         owner: PublicKey,
+        options?: GetCompressionSignaturesForOwnerOptions,
     ): Promise<WithCursor<SignatureWithMetadata[]>>;
 
     getLatestNonVotingSignatures(
         limit?: number,
+        cursor?: string,
     ): Promise<LatestNonVotingSignatures>;
 
     getLatestCompressionSignatures(

--- a/js/stateless.js/src/rpc.ts
+++ b/js/stateless.js/src/rpc.ts
@@ -41,12 +41,9 @@ import {
     HashWithTree,
     CompressedMintTokenHoldersResult,
     CompressedMintTokenHolders,
-    GetCompressedMintTokenHoldersOptions,
     TokenBalance,
     TokenBalanceListResultV2,
-    GetCompressedTokenBalancesByOwnerOptions,
-    GetCompressionSignaturesForOwnerOptions,
-    GetCompressionSignaturesForAddressOptions,
+    PaginatedOptions,
 } from './rpc-interface';
 import {
     MerkleContextWithMerkleProof,
@@ -1045,7 +1042,7 @@ export class Rpc extends Connection implements CompressionApiInterface {
      */
     async getCompressionSignaturesForAddress(
         address: PublicKey,
-        options?: GetCompressionSignaturesForAddressOptions,
+        options?: PaginatedOptions,
     ): Promise<WithCursor<SignatureWithMetadata[]>> {
         const unsafeRes = await rpcRequest(
             this.compressionApiEndpoint,
@@ -1085,7 +1082,7 @@ export class Rpc extends Connection implements CompressionApiInterface {
      */
     async getCompressionSignaturesForOwner(
         owner: PublicKey,
-        options?: GetCompressionSignaturesForOwnerOptions,
+        options?: PaginatedOptions,
     ): Promise<WithCursor<SignatureWithMetadata[]>> {
         const unsafeRes = await rpcRequest(
             this.compressionApiEndpoint,
@@ -1123,7 +1120,7 @@ export class Rpc extends Connection implements CompressionApiInterface {
      */
     async getCompressionSignaturesForTokenOwner(
         owner: PublicKey,
-        options?: GetCompressedTokenBalancesByOwnerOptions,
+        options?: PaginatedOptions,
     ): Promise<WithCursor<SignatureWithMetadata[]>> {
         const unsafeRes = await rpcRequest(
             this.compressionApiEndpoint,
@@ -1206,9 +1203,12 @@ export class Rpc extends Connection implements CompressionApiInterface {
         return res.result;
     }
 
+    /**
+     * Fetch all the compressed token holders for a given mint. Paginated.
+     */
     async getCompressedMintTokenHolders(
         mint: PublicKey,
-        options?: GetCompressedMintTokenHoldersOptions,
+        options?: PaginatedOptions,
     ): Promise<WithContext<WithCursor<CompressedMintTokenHolders[]>>> {
         const unsafeRes = await rpcRequest(
             this.compressionApiEndpoint,

--- a/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
@@ -20,6 +20,8 @@ import {
     CompressedTransaction,
     GetCompressedAccountsByOwnerConfig,
     GetCompressedMintTokenHoldersOptions,
+    GetCompressionSignaturesForAddressOptions,
+    GetCompressionSignaturesForOwnerOptions,
     HashWithTree,
     LatestNonVotingSignatures,
     LatestNonVotingSignaturesPaginated,
@@ -32,6 +34,7 @@ import {
     CompressionApiInterface,
     GetCompressedTokenAccountsByOwnerOrDelegateOptions,
     ParsedTokenAccount,
+    TokenBalance,
 } from '../../rpc-interface';
 import {
     BN254,
@@ -418,8 +421,9 @@ export class TestRpc extends Connection implements CompressionApiInterface {
     }
 
     /**
+     * @deprecated use {@link getCompressedTokenBalancesByOwnerV2}.
      * Fetch all the compressed token balances owned by the specified public
-     * key. Can filter by mint
+     * key. Can filter by mint.
      */
     async getCompressedTokenBalancesByOwner(
         publicKey: PublicKey,
@@ -440,6 +444,31 @@ export class TestRpc extends Connection implements CompressionApiInterface {
     }
 
     /**
+     * Fetch all the compressed token balances owned by the specified public
+     * key. Can filter by mint. Uses context.
+     */
+    async getCompressedTokenBalancesByOwnerV2(
+        publicKey: PublicKey,
+        options: GetCompressedTokenAccountsByOwnerOrDelegateOptions,
+    ): Promise<WithContext<WithCursor<TokenBalance[]>>> {
+        const accounts = await getCompressedTokenAccountsByOwnerTest(
+            this,
+            publicKey,
+            options.mint!,
+        );
+        return {
+            context: { slot: 1 },
+            value: {
+                items: accounts.items.map(account => ({
+                    balance: bn(account.parsed.amount),
+                    mint: account.parsed.mint,
+                })),
+                cursor: null,
+            },
+        };
+    }
+
+    /**
      * Returns confirmed signatures for transactions involving the specified
      * account hash forward in time from genesis to the most recent confirmed
      * block
@@ -447,7 +476,7 @@ export class TestRpc extends Connection implements CompressionApiInterface {
      * @param hash queried account hash
      */
     async getCompressionSignaturesForAccount(
-        hash: BN254,
+        _hash: BN254,
     ): Promise<SignatureWithMetadata[]> {
         throw new Error(
             'getCompressionSignaturesForAccount not implemented in test-rpc',
@@ -459,7 +488,7 @@ export class TestRpc extends Connection implements CompressionApiInterface {
      * CompressionInfo
      */
     async getTransactionWithCompressionInfo(
-        signature: string,
+        _signature: string,
     ): Promise<CompressedTransaction | null> {
         throw new Error('getCompressedTransaction not implemented in test-rpc');
     }
@@ -473,6 +502,7 @@ export class TestRpc extends Connection implements CompressionApiInterface {
      */
     async getCompressionSignaturesForAddress(
         _address: PublicKey,
+        _options?: GetCompressionSignaturesForAddressOptions,
     ): Promise<WithCursor<SignatureWithMetadata[]>> {
         throw new Error('getSignaturesForAddress3 not implemented');
     }
@@ -485,7 +515,8 @@ export class TestRpc extends Connection implements CompressionApiInterface {
      * @param owner queried owner public key
      */
     async getCompressionSignaturesForOwner(
-        owner: PublicKey,
+        _owner: PublicKey,
+        _options?: GetCompressionSignaturesForOwnerOptions,
     ): Promise<WithCursor<SignatureWithMetadata[]>> {
         throw new Error('getSignaturesForOwner not implemented');
     }
@@ -496,7 +527,8 @@ export class TestRpc extends Connection implements CompressionApiInterface {
      * recent confirmed block
      */
     async getCompressionSignaturesForTokenOwner(
-        owner: PublicKey,
+        _owner: PublicKey,
+        _options?: GetCompressionSignaturesForOwnerOptions,
     ): Promise<WithCursor<SignatureWithMetadata[]>> {
         throw new Error('getSignaturesForTokenOwner not implemented');
     }

--- a/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/test-rpc.ts
@@ -19,9 +19,7 @@ import {
     CompressedMintTokenHolders,
     CompressedTransaction,
     GetCompressedAccountsByOwnerConfig,
-    GetCompressedMintTokenHoldersOptions,
-    GetCompressionSignaturesForAddressOptions,
-    GetCompressionSignaturesForOwnerOptions,
+    PaginatedOptions,
     HashWithTree,
     LatestNonVotingSignatures,
     LatestNonVotingSignaturesPaginated,
@@ -502,7 +500,7 @@ export class TestRpc extends Connection implements CompressionApiInterface {
      */
     async getCompressionSignaturesForAddress(
         _address: PublicKey,
-        _options?: GetCompressionSignaturesForAddressOptions,
+        _options?: PaginatedOptions,
     ): Promise<WithCursor<SignatureWithMetadata[]>> {
         throw new Error('getSignaturesForAddress3 not implemented');
     }
@@ -516,7 +514,7 @@ export class TestRpc extends Connection implements CompressionApiInterface {
      */
     async getCompressionSignaturesForOwner(
         _owner: PublicKey,
-        _options?: GetCompressionSignaturesForOwnerOptions,
+        _options?: PaginatedOptions,
     ): Promise<WithCursor<SignatureWithMetadata[]>> {
         throw new Error('getSignaturesForOwner not implemented');
     }
@@ -528,7 +526,7 @@ export class TestRpc extends Connection implements CompressionApiInterface {
      */
     async getCompressionSignaturesForTokenOwner(
         _owner: PublicKey,
-        _options?: GetCompressionSignaturesForOwnerOptions,
+        _options?: PaginatedOptions,
     ): Promise<WithCursor<SignatureWithMetadata[]>> {
         throw new Error('getSignaturesForTokenOwner not implemented');
     }
@@ -613,7 +611,7 @@ export class TestRpc extends Connection implements CompressionApiInterface {
 
     async getCompressedMintTokenHolders(
         _mint: PublicKey,
-        _options?: GetCompressedMintTokenHoldersOptions,
+        _options?: PaginatedOptions,
     ): Promise<WithContext<WithCursor<CompressedMintTokenHolders[]>>> {
         throw new Error(
             'getCompressedMintTokenHolders not implemented in test-rpc',

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,7 +13,7 @@ VERSIONS=(
     "solana:1.18.22"
     "anchor:anchor-v0.29.0"
     "jq:jq-1.7.1"
-    "photon:0.48.0"
+    "photon:0.50.0"
 )
 
 # Architecture-specific suffixes
@@ -212,7 +212,7 @@ main() {
     download_gnark_keys "$key_type"
     install_dependencies
 
-    rm -f "$INSTALL_LOG"
+    # rm -f "$INSTALL_LOG"
 
     echo "✨ Light Protocol development dependencies installed"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -187,12 +187,17 @@ install_dependencies() {
 main() {
     mkdir -p "${PREFIX}/bin"
 
-   # Parse command line arguments
+    # Parse command line arguments
     local key_type="light"
+    local reset_log=true
     while [[ $# -gt 0 ]]; do
         case $1 in
             --full-keys)
                 key_type="full"
+                shift
+                ;;
+            --no-reset)
+                reset_log=false
                 shift
                 ;;
             *)
@@ -201,6 +206,10 @@ main() {
                 ;;
         esac
     done
+
+    if $reset_log; then
+        rm -f "$INSTALL_LOG"
+    fi
 
     install_go
     install_rust
@@ -211,8 +220,6 @@ main() {
     install_jq
     download_gnark_keys "$key_type"
     install_dependencies
-
-    # rm -f "$INSTALL_LOG"
 
     echo "✨ Light Protocol development dependencies installed"
 }


### PR DESCRIPTION
+ extends endpoints with opt. cursors, non-breaking
+ adds --no-reset flag to install.sh
+ cleans up the js readmes
