### PR TITLE
feat: compress spl token account

### DIFF
--- a/js/compressed-token/README.md
+++ b/js/compressed-token/README.md
@@ -16,7 +16,6 @@
   <img src="https://img.shields.io/npm/dw/%40lightprotocol%2Fcompressed-token" alt="package weekly downloads" height="18" />
 </p>
 
-
 ### Installation
 
 **For use in Node.js or web**

--- a/js/compressed-token/tests/e2e/rpc-token-interop.test.ts
+++ b/js/compressed-token/tests/e2e/rpc-token-interop.test.ts
@@ -152,7 +152,6 @@ describe('rpc-interop token', () => {
         });
     });
 
-
     it('getCompressedTokenBalancesByOwnerV2 should match', async () => {
         const balances = (
             await rpc.getCompressedTokenBalancesByOwnerV2(bob.publicKey, {
@@ -177,9 +176,12 @@ describe('rpc-interop token', () => {
             })
         ).value.items;
         const balancesReceiverTest = (
-            await testRpc.getCompressedTokenBalancesByOwnerV2(charlie.publicKey, {
-                mint,
-            })
+            await testRpc.getCompressedTokenBalancesByOwnerV2(
+                charlie.publicKey,
+                {
+                    mint,
+                },
+            )
         ).value.items;
 
         assert.equal(balancesReceiver.length, balancesReceiverTest.length);

--- a/programs/compressed-token/src/process_compress_spl_token_account.rs
+++ b/programs/compressed-token/src/process_compress_spl_token_account.rs
@@ -1,0 +1,107 @@
+use super::TransferInstruction;
+use crate::{
+    process_transfer::{
+        process_transfer, CompressedTokenInstructionDataTransfer, PackedTokenTransferOutputData,
+    },
+    ErrorCode,
+};
+use anchor_lang::prelude::*;
+use light_system_program::sdk::CompressedCpiContext;
+
+pub fn process_compress_spl_token_account<'info>(
+    ctx: Context<'_, '_, '_, 'info, TransferInstruction<'info>>,
+    owner: Pubkey,
+    remaining_amount: Option<u64>,
+    cpi_context: Option<CompressedCpiContext>,
+) -> Result<()> {
+    let compression_token_account =
+        if let Some(token_account) = ctx.accounts.compress_or_decompress_token_account.as_ref() {
+            token_account
+        } else {
+            return err!(ErrorCode::CompressedPdaUndefinedForCompress);
+        };
+    let compress_amount = compression_token_account
+        .amount
+        .checked_sub(remaining_amount.unwrap_or_default())
+        .ok_or(ErrorCode::ArithmeticUnderflow)?;
+    let compressed_output_account = PackedTokenTransferOutputData {
+        owner,
+        lamports: None,
+        amount: compress_amount,
+        tlv: None,
+        merkle_tree_index: 0,
+    };
+
+    let inputs = CompressedTokenInstructionDataTransfer {
+        proof: None,
+        mint: compression_token_account.mint,
+        delegated_transfer: None,
+        is_compress: true,
+        input_token_data_with_context: Vec::new(),
+        output_compressed_accounts: vec![compressed_output_account],
+        cpi_context,
+        lamports_change_account_merkle_tree_index: None,
+        compress_or_decompress_amount: Some(compress_amount),
+    };
+    process_transfer(ctx, inputs)
+}
+
+#[cfg(not(target_os = "solana"))]
+pub mod sdk {
+    use crate::get_token_pool_pda;
+    use anchor_lang::prelude::AccountMeta;
+    use anchor_lang::InstructionData;
+    use anchor_lang::ToAccountMetas;
+    use anchor_spl::token::ID as TokenProgramId;
+    use light_system_program::sdk::CompressedCpiContext;
+    use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_compress_spl_token_account_instruction(
+        owner: &Pubkey,
+        remaining_amount: Option<u64>,
+        cpi_context: Option<CompressedCpiContext>,
+        fee_payer: &Pubkey,
+        authority: &Pubkey,
+        mint: &Pubkey,
+        output_merkle_tree: &Pubkey,
+        token_account: &Pubkey,
+    ) -> Instruction {
+        let instruction_data = crate::instruction::CompressSplTokenAccount {
+            owner: *owner,
+            remaining_amount,
+            cpi_context,
+        };
+        let (cpi_authority_pda, _) = crate::process_transfer::get_cpi_authority_pda();
+        let token_pool_pda = get_token_pool_pda(mint);
+
+        let accounts = crate::accounts::TransferInstruction {
+            fee_payer: *fee_payer,
+            authority: *authority,
+            cpi_authority_pda,
+            light_system_program: light_system_program::ID,
+            registered_program_pda: light_system_program::utils::get_registered_program_pda(
+                &light_system_program::ID,
+            ),
+            noop_program: Pubkey::new_from_array(
+                account_compression::utils::constants::NOOP_PUBKEY,
+            ),
+            account_compression_authority: light_system_program::utils::get_cpi_authority_pda(
+                &light_system_program::ID,
+            ),
+            account_compression_program: account_compression::ID,
+            self_program: crate::ID,
+            token_pool_pda: Some(token_pool_pda),
+            compress_or_decompress_token_account: Some(*token_account),
+            token_program: Some(TokenProgramId),
+            system_program: solana_sdk::system_program::ID,
+        };
+        let remaining_accounts = vec![AccountMeta::new(*output_merkle_tree, false)];
+
+        Instruction {
+            program_id: crate::ID,
+            accounts: [accounts.to_account_metas(Some(true)), remaining_accounts].concat(),
+            data: instruction_data.data(),
+        }
+    }
+}

--- a/programs/compressed-token/src/process_transfer.rs
+++ b/programs/compressed-token/src/process_transfer.rs
@@ -33,14 +33,11 @@ use light_utils::hash_to_bn254_field_size_be;
 /// 4.  create_output_compressed_accounts
 /// 5.  Serialize and add token_data data to in compressed_accounts.
 /// 6.  Invoke light_system_program::execute_compressed_transaction.
+#[inline(always)]
 pub fn process_transfer<'a, 'b, 'c, 'info: 'b + 'c>(
     ctx: Context<'a, 'b, 'c, 'info, TransferInstruction<'info>>,
-    inputs: Vec<u8>,
+    inputs: CompressedTokenInstructionDataTransfer,
 ) -> Result<()> {
-    bench_sbf_start!("t_deserialize");
-    let inputs: CompressedTokenInstructionDataTransfer =
-        CompressedTokenInstructionDataTransfer::deserialize(&mut inputs.as_slice())?;
-    bench_sbf_end!("t_deserialize");
     bench_sbf_start!("t_context_and_check_sig");
     if inputs.input_token_data_with_context.is_empty()
         && inputs.compress_or_decompress_amount.is_none()

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -8,6 +8,7 @@ npx nx run-many --target=lint:fix --all
 cargo fmt --all
 cargo clippy \
       --workspace \
+      --exclude name-service \
       --exclude photon-api \
       -- -A clippy::result_large_err \
          -A clippy::empty-docs \

--- a/test-utils/src/spl.rs
+++ b/test-utils/src/spl.rs
@@ -79,7 +79,7 @@ pub async fn mint_spl_tokens<R: RpcConnection>(
     rpc.create_and_send_transaction(
         &[mint_to_instruction],
         &mint_authority.pubkey(),
-        &[&mint_authority],
+        &[mint_authority],
     )
     .await
 }
@@ -163,7 +163,7 @@ pub async fn create_token_pool<R: RpcConnection>(
         .get_minimum_balance_for_rent_exemption(Mint::LEN)
         .await
         .unwrap();
-    let (instructions, __) = create_initialize_mint_instructions(
+    let (instructions, _) = create_initialize_mint_instructions(
         &payer.pubkey(),
         mint_authority,
         mint_rent,
@@ -624,6 +624,7 @@ pub async fn decompress_test<R: RpcConnection, I: Indexer<R>>(
     );
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn perform_compress_spl_token_account<R: RpcConnection, I: Indexer<R>>(
     rpc: &mut R,
     test_indexer: &mut I,
@@ -645,15 +646,15 @@ pub async fn perform_compress_spl_token_account<R: RpcConnection, I: Indexer<R>>
         None,
         &payer.pubkey(),
         &token_owner.pubkey(),
-        &mint,
-        &merkle_tree_pubkey,
+        mint,
+        merkle_tree_pubkey,
         token_account,
     );
     let (event, _, _) = rpc
         .create_and_send_transaction_with_event::<PublicTransactionEvent>(
             &[instruction],
             &token_owner.pubkey(),
-            &[&payer, &token_owner],
+            &[payer, token_owner],
             None,
         )
         .await?


### PR DESCRIPTION
### Changes:
- add instruction to compress a spl token account with an optional remaining amount
- `process_compress_spl_token_account`
    - creates an `compressed_output_account`
    - wraps `process_transfer`
- moved instruction data deserialization out of  `process_transfer` so that `process_compress_spl_token_account` can wrap it