### PR TITLE
chore: compress spl token audit informational fixes 

### DIFF
--- a/js/compressed-token/src/idl/light_compressed_token.ts
+++ b/js/compressed-token/src/idl/light_compressed_token.ts
@@ -159,6 +159,11 @@ export type LightCompressedToken = {
         },
         {
             name: 'compressSplTokenAccount';
+            docs: [
+                'Compresses the balance of an spl token account sub an optional remaining',
+                'amount. This instruction does not close the spl token account. To close',
+                'the account bundle a close spl account instruction in your transaction.',
+            ];
             accounts: [
                 {
                     name: 'feePayer';
@@ -1827,6 +1832,11 @@ export const IDL: LightCompressedToken = {
         },
         {
             name: 'compressSplTokenAccount',
+            docs: [
+                'Compresses the balance of an spl token account sub an optional remaining',
+                'amount. This instruction does not close the spl token account. To close',
+                'the account bundle a close spl account instruction in your transaction.',
+            ],
             accounts: [
                 {
                     name: 'feePayer',

--- a/js/stateless.js/src/idls/light_compressed_token.ts
+++ b/js/stateless.js/src/idls/light_compressed_token.ts
@@ -159,6 +159,11 @@ export type LightCompressedToken = {
         },
         {
             name: 'compressSplTokenAccount';
+            docs: [
+                'Compresses the balance of an spl token account sub an optional remaining',
+                'amount. This instruction does not close the spl token account. To close',
+                'the account bundle a close spl account instruction in your transaction.',
+            ];
             accounts: [
                 {
                     name: 'feePayer';
@@ -1827,6 +1832,11 @@ export const IDL: LightCompressedToken = {
         },
         {
             name: 'compressSplTokenAccount',
+            docs: [
+                'Compresses the balance of an spl token account sub an optional remaining',
+                'amount. This instruction does not close the spl token account. To close',
+                'the account bundle a close spl account instruction in your transaction.',
+            ],
             accounts: [
                 {
                     name: 'feePayer',

--- a/programs/compressed-token/src/lib.rs
+++ b/programs/compressed-token/src/lib.rs
@@ -62,6 +62,9 @@ pub mod light_compressed_token {
         process_mint_to(ctx, public_keys, amounts, lamports)
     }
 
+    /// Compresses the balance of an spl token account sub an optional remaining
+    /// amount. This instruction does not close the spl token account. To close
+    /// the account bundle a close spl account instruction in your transaction.
     pub fn compress_spl_token_account<'info>(
         ctx: Context<'_, '_, '_, 'info, TransferInstruction<'info>>,
         owner: Pubkey,
@@ -204,4 +207,6 @@ pub enum ErrorCode {
     NoInputsProvided,
     MintHasNoFreezeAuthority,
     MintWithInvalidExtension,
+    #[msg("The token account balance is less than the remaining amount.")]
+    InsufficientTokenAccountBalance,
 }

--- a/programs/compressed-token/src/process_compress_spl_token_account.rs
+++ b/programs/compressed-token/src/process_compress_spl_token_account.rs
@@ -23,7 +23,7 @@ pub fn process_compress_spl_token_account<'info>(
     let compress_amount = compression_token_account
         .amount
         .checked_sub(remaining_amount.unwrap_or_default())
-        .ok_or(ErrorCode::ArithmeticUnderflow)?;
+        .ok_or(crate::ErrorCode::InsufficientTokenAccountBalance)?;
     let compressed_output_account = PackedTokenTransferOutputData {
         owner,
         lamports: None,

--- a/test-programs/compressed-token-test/tests/test.rs
+++ b/test-programs/compressed-token-test/tests/test.rs
@@ -441,6 +441,7 @@ async fn test_mint_to(amounts: Vec<u64>, iterations: usize, lamports: Option<u64
 /// - Mint 10 tokens to spl token account
 /// - Compress spl token account
 /// - Mint 20 more tokens to spl token account
+/// - failing to compress spl token account with 21 remaining balance
 /// - Compress spl token account with 1 remaining token
 #[tokio::test]
 async fn compress_spl_account() {
@@ -510,6 +511,21 @@ async fn compress_spl_account() {
         )
         .await
         .unwrap();
+        {
+            let result = perform_compress_spl_token_account(
+                &mut rpc,
+                &mut test_indexer,
+                &payer,
+                &token_owner,
+                &mint,
+                &token_account_keypair.pubkey(),
+                &merkle_tree_pubkey,
+                Some(first_token_account_balance + 1), // invalid remaining amount
+                is_token_22,
+            )
+            .await;
+            assert_rpc_error(result, 0, ErrorCode::InsufficientTokenAccountBalance.into()).unwrap();
+        }
         perform_compress_spl_token_account(
             &mut rpc,
             &mut test_indexer,


### PR DESCRIPTION
**Changes:**
1. add doc string to compress_spl_token_account
2. replace ArithmeticUnderflow error with InsufficientTokenAccountBalance
3. add failing test InsufficientTokenAccountBalance