### PR TITLE
feat: ts-sdk token 2022 support

### DIFF
--- a/cli/src/commands/compress-spl/index.ts
+++ b/cli/src/commands/compress-spl/index.ts
@@ -11,6 +11,7 @@ import { getTestRpc } from "@lightprotocol/stateless.js";
 import { compress } from "@lightprotocol/compressed-token";
 import { getAssociatedTokenAddressSync } from "@solana/spl-token";
 import { WasmFactory } from "@lightprotocol/hasher.rs";
+import { CompressedTokenProgram } from "@lightprotocol/compressed-token";
 
 /// TODO: add ability to compress from non-fee payer
 class CompressSplCommand extends Command {
@@ -54,11 +55,17 @@ class CompressSplCommand extends Command {
       const toPublicKey = new PublicKey(to);
       const mintPublicKey = new PublicKey(mint);
       const payer = defaultSolanaWalletKeypair();
+      const tokenProgramId = await CompressedTokenProgram.get_mint_program_id(
+        mintPublicKey,
+        rpc(),
+      );
 
       /// TODO: add explicit check that the ata is valid
       const sourceAta = getAssociatedTokenAddressSync(
         mintPublicKey,
         payer.publicKey,
+        undefined,
+        tokenProgramId,
       );
 
       txId = await compress(
@@ -69,6 +76,9 @@ class CompressSplCommand extends Command {
         payer,
         sourceAta,
         toPublicKey,
+        undefined,
+        undefined,
+        tokenProgramId,
       );
 
       loader.stop(false);

--- a/cli/src/commands/decompress-spl/index.ts
+++ b/cli/src/commands/decompress-spl/index.ts
@@ -8,6 +8,7 @@ import {
 import { PublicKey } from "@solana/web3.js";
 import { decompress } from "@lightprotocol/compressed-token";
 import { getOrCreateAssociatedTokenAccount } from "@solana/spl-token";
+import { CompressedTokenProgram } from "@lightprotocol/compressed-token";
 
 /// TODO: add ability to decompress from non-fee payer
 class DecompressSplCommand extends Command {
@@ -51,12 +52,20 @@ class DecompressSplCommand extends Command {
       const toPublicKey = new PublicKey(to);
       const mintPublicKey = new PublicKey(mint);
       const payer = defaultSolanaWalletKeypair();
+      const tokenProgramId = await CompressedTokenProgram.get_mint_program_id(
+        mintPublicKey,
+        rpc(),
+      );
 
       const recipientAta = await getOrCreateAssociatedTokenAccount(
         rpc(),
         payer,
         mintPublicKey,
         toPublicKey,
+        undefined,
+        undefined,
+        undefined,
+        tokenProgramId,
       );
 
       txId = await decompress(
@@ -66,6 +75,9 @@ class DecompressSplCommand extends Command {
         amount,
         payer,
         recipientAta.address,
+        undefined,
+        undefined,
+        tokenProgramId,
       );
 
       loader.stop(false);

--- a/js/compressed-token/src/actions/approve-and-mint-to.ts
+++ b/js/compressed-token/src/actions/approve-and-mint-to.ts
@@ -39,6 +39,7 @@ export async function approveAndMintTo(
     amount: number | BN,
     merkleTree?: PublicKey,
     confirmOptions?: ConfirmOptions,
+    tokenProgramId?: PublicKey,
 ): Promise<TransactionSignature> {
     const authorityTokenAccount = await getOrCreateAssociatedTokenAccount(
         rpc,
@@ -46,6 +47,7 @@ export async function approveAndMintTo(
         mint,
         authority.publicKey,
     );
+    const tokenProgram = tokenProgramId ? tokenProgramId : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
 
     const ixs = await CompressedTokenProgram.approveAndMintTo({
         feePayer: payer.publicKey,
@@ -55,6 +57,7 @@ export async function approveAndMintTo(
         amount,
         toPubkey: destination,
         merkleTree,
+        tokenProgram
     });
 
     const { blockhash } = await rpc.getLatestBlockhash();

--- a/js/compressed-token/src/actions/approve-and-mint-to.ts
+++ b/js/compressed-token/src/actions/approve-and-mint-to.ts
@@ -41,13 +41,20 @@ export async function approveAndMintTo(
     confirmOptions?: ConfirmOptions,
     tokenProgramId?: PublicKey,
 ): Promise<TransactionSignature> {
+    tokenProgramId = tokenProgramId
+        ? tokenProgramId
+        : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
+
     const authorityTokenAccount = await getOrCreateAssociatedTokenAccount(
         rpc,
         payer,
         mint,
         authority.publicKey,
+        undefined,
+        undefined,
+        confirmOptions,
+        tokenProgramId,
     );
-    const tokenProgram = tokenProgramId ? tokenProgramId : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
 
     const ixs = await CompressedTokenProgram.approveAndMintTo({
         feePayer: payer.publicKey,
@@ -57,7 +64,7 @@ export async function approveAndMintTo(
         amount,
         toPubkey: destination,
         merkleTree,
-        tokenProgram
+        tokenProgramId,
     });
 
     const { blockhash } = await rpc.getLatestBlockhash();

--- a/js/compressed-token/src/actions/compress-spl-token-account.ts
+++ b/js/compressed-token/src/actions/compress-spl-token-account.ts
@@ -41,7 +41,9 @@ export async function compressSplTokenAccount(
     confirmOptions?: ConfirmOptions,
     tokenProgramId?: PublicKey,
 ): Promise<TransactionSignature> {
-    const tokenProgram = tokenProgramId ? tokenProgramId : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
+    tokenProgramId = tokenProgramId
+        ? tokenProgramId
+        : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
 
     const compressIx = await CompressedTokenProgram.compressSplTokenAccount({
         feePayer: payer.publicKey,
@@ -50,7 +52,7 @@ export async function compressSplTokenAccount(
         mint,
         remainingAmount,
         outputStateTree,
-        tokenProgram
+        tokenProgramId,
     });
 
     const blockhashCtx = await rpc.getLatestBlockhash();

--- a/js/compressed-token/src/actions/compress-spl-token-account.ts
+++ b/js/compressed-token/src/actions/compress-spl-token-account.ts
@@ -39,7 +39,10 @@ export async function compressSplTokenAccount(
     outputStateTree: PublicKey,
     remainingAmount?: BN,
     confirmOptions?: ConfirmOptions,
+    tokenProgramId?: PublicKey,
 ): Promise<TransactionSignature> {
+    const tokenProgram = tokenProgramId ? tokenProgramId : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
+
     const compressIx = await CompressedTokenProgram.compressSplTokenAccount({
         feePayer: payer.publicKey,
         authority: owner.publicKey,
@@ -47,6 +50,7 @@ export async function compressSplTokenAccount(
         mint,
         remainingAmount,
         outputStateTree,
+        tokenProgram
     });
 
     const blockhashCtx = await rpc.getLatestBlockhash();

--- a/js/compressed-token/src/actions/compress.ts
+++ b/js/compressed-token/src/actions/compress.ts
@@ -46,7 +46,9 @@ export async function compress(
     confirmOptions?: ConfirmOptions,
     tokenProgramId?: PublicKey,
 ): Promise<TransactionSignature> {
-    const tokenProgram = tokenProgramId ? tokenProgramId : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
+    tokenProgramId = tokenProgramId
+        ? tokenProgramId
+        : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
 
     const compressIx = await CompressedTokenProgram.compress({
         payer: payer.publicKey,
@@ -56,7 +58,7 @@ export async function compress(
         amount,
         mint,
         outputStateTree: merkleTree,
-        tokenProgram
+        tokenProgramId,
     });
 
     const blockhashCtx = await rpc.getLatestBlockhash();

--- a/js/compressed-token/src/actions/compress.ts
+++ b/js/compressed-token/src/actions/compress.ts
@@ -44,7 +44,10 @@ export async function compress(
     toAddress: PublicKey | Array<PublicKey>,
     merkleTree?: PublicKey,
     confirmOptions?: ConfirmOptions,
+    tokenProgramId?: PublicKey,
 ): Promise<TransactionSignature> {
+    const tokenProgram = tokenProgramId ? tokenProgramId : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
+
     const compressIx = await CompressedTokenProgram.compress({
         payer: payer.publicKey,
         owner: owner.publicKey,
@@ -53,6 +56,7 @@ export async function compress(
         amount,
         mint,
         outputStateTree: merkleTree,
+        tokenProgram
     });
 
     const blockhashCtx = await rpc.getLatestBlockhash();

--- a/js/compressed-token/src/actions/create-mint.ts
+++ b/js/compressed-token/src/actions/create-mint.ts
@@ -6,7 +6,11 @@ import {
     TransactionSignature,
 } from '@solana/web3.js';
 import { CompressedTokenProgram } from '../program';
-import { MINT_SIZE, TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID } from '@solana/spl-token';
+import {
+    MINT_SIZE,
+    TOKEN_2022_PROGRAM_ID,
+    TOKEN_PROGRAM_ID,
+} from '@solana/spl-token';
 import {
     Rpc,
     buildAndSignTx,
@@ -37,8 +41,8 @@ export async function createMint(
 ): Promise<{ mint: PublicKey; transactionSignature: TransactionSignature }> {
     const rentExemptBalance =
         await rpc.getMinimumBalanceForRentExemption(MINT_SIZE);
-    
-    const tokenProgram = isToken22 ? TOKEN_2022_PROGRAM_ID : TOKEN_PROGRAM_ID;
+
+    const tokenProgramId = isToken22 ? TOKEN_2022_PROGRAM_ID : TOKEN_PROGRAM_ID;
 
     const ixs = await CompressedTokenProgram.createMint({
         feePayer: payer.publicKey,
@@ -47,7 +51,7 @@ export async function createMint(
         authority: mintAuthority,
         freezeAuthority: null, // TODO: add feature
         rentExemptBalance,
-        tokenProgram
+        tokenProgramId,
     });
 
     const { blockhash } = await rpc.getLatestBlockhash();

--- a/js/compressed-token/src/actions/create-mint.ts
+++ b/js/compressed-token/src/actions/create-mint.ts
@@ -6,7 +6,7 @@ import {
     TransactionSignature,
 } from '@solana/web3.js';
 import { CompressedTokenProgram } from '../program';
-import { MINT_SIZE } from '@solana/spl-token';
+import { MINT_SIZE, TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID } from '@solana/spl-token';
 import {
     Rpc,
     buildAndSignTx,
@@ -33,9 +33,12 @@ export async function createMint(
     decimals: number,
     keypair = Keypair.generate(),
     confirmOptions?: ConfirmOptions,
+    isToken22 = false,
 ): Promise<{ mint: PublicKey; transactionSignature: TransactionSignature }> {
     const rentExemptBalance =
         await rpc.getMinimumBalanceForRentExemption(MINT_SIZE);
+    
+    const tokenProgram = isToken22 ? TOKEN_2022_PROGRAM_ID : TOKEN_PROGRAM_ID;
 
     const ixs = await CompressedTokenProgram.createMint({
         feePayer: payer.publicKey,
@@ -44,6 +47,7 @@ export async function createMint(
         authority: mintAuthority,
         freezeAuthority: null, // TODO: add feature
         rentExemptBalance,
+        tokenProgram
     });
 
     const { blockhash } = await rpc.getLatestBlockhash();

--- a/js/compressed-token/src/actions/create-token-pool.ts
+++ b/js/compressed-token/src/actions/create-token-pool.ts
@@ -25,12 +25,16 @@ import {
 export async function createTokenPool(
     rpc: Rpc,
     payer: Signer,
-    mintAddress: PublicKey,
+    mint: PublicKey,
     confirmOptions?: ConfirmOptions,
+    tokenProgramId?: PublicKey,
 ): Promise<TransactionSignature> {
+    const tokenProgram = tokenProgramId ? tokenProgramId : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
+
     const ix = await CompressedTokenProgram.createTokenPool({
         feePayer: payer.publicKey,
-        mint: mintAddress,
+        mint,
+        tokenProgram
     });
 
     const { blockhash } = await rpc.getLatestBlockhash();

--- a/js/compressed-token/src/actions/create-token-pool.ts
+++ b/js/compressed-token/src/actions/create-token-pool.ts
@@ -29,12 +29,14 @@ export async function createTokenPool(
     confirmOptions?: ConfirmOptions,
     tokenProgramId?: PublicKey,
 ): Promise<TransactionSignature> {
-    const tokenProgram = tokenProgramId ? tokenProgramId : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
+    tokenProgramId = tokenProgramId
+        ? tokenProgramId
+        : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
 
     const ix = await CompressedTokenProgram.createTokenPool({
         feePayer: payer.publicKey,
         mint,
-        tokenProgram
+        tokenProgramId,
     });
 
     const { blockhash } = await rpc.getLatestBlockhash();

--- a/js/compressed-token/src/actions/decompress.ts
+++ b/js/compressed-token/src/actions/decompress.ts
@@ -46,7 +46,10 @@ export async function decompress(
     /// TODO: allow multiple
     merkleTree?: PublicKey,
     confirmOptions?: ConfirmOptions,
+    tokenProgramId?: PublicKey,
 ): Promise<TransactionSignature> {
+    const tokenProgram = tokenProgramId ? tokenProgramId : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
+
     amount = bn(amount);
 
     const compressedTokenAccounts = await rpc.getCompressedTokenAccountsByOwner(
@@ -74,6 +77,7 @@ export async function decompress(
         outputStateTree: merkleTree,
         recentInputStateRootIndices: proof.rootIndices,
         recentValidityProof: proof.compressedProof,
+        tokenProgram,
     });
 
     const { blockhash } = await rpc.getLatestBlockhash();

--- a/js/compressed-token/src/actions/decompress.ts
+++ b/js/compressed-token/src/actions/decompress.ts
@@ -48,7 +48,9 @@ export async function decompress(
     confirmOptions?: ConfirmOptions,
     tokenProgramId?: PublicKey,
 ): Promise<TransactionSignature> {
-    const tokenProgram = tokenProgramId ? tokenProgramId : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
+    tokenProgramId = tokenProgramId
+        ? tokenProgramId
+        : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
 
     amount = bn(amount);
 
@@ -77,7 +79,7 @@ export async function decompress(
         outputStateTree: merkleTree,
         recentInputStateRootIndices: proof.rootIndices,
         recentValidityProof: proof.compressedProof,
-        tokenProgram,
+        tokenProgramId,
     });
 
     const { blockhash } = await rpc.getLatestBlockhash();

--- a/js/compressed-token/src/actions/merge-token-accounts.ts
+++ b/js/compressed-token/src/actions/merge-token-accounts.ts
@@ -7,7 +7,6 @@ import {
 } from '@solana/web3.js';
 import {
     Rpc,
-    ParsedTokenAccount,
     dedupeSigner,
     buildAndSignTx,
     sendAndConfirmTx,

--- a/js/compressed-token/src/actions/mint-to.ts
+++ b/js/compressed-token/src/actions/mint-to.ts
@@ -40,7 +40,10 @@ export async function mintTo(
     amount: number | BN | number[] | BN[],
     merkleTree?: PublicKey,
     confirmOptions?: ConfirmOptions,
+    tokenProgramId?: PublicKey,
 ): Promise<TransactionSignature> {
+    const tokenProgram = tokenProgramId ? tokenProgramId : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
+
     const additionalSigners = dedupeSigner(payer, [authority]);
 
     const ix = await CompressedTokenProgram.mintTo({
@@ -50,6 +53,7 @@ export async function mintTo(
         amount: amount,
         toPubkey: destination,
         merkleTree,
+        tokenProgram
     });
 
     const { blockhash } = await rpc.getLatestBlockhash();

--- a/js/compressed-token/src/actions/mint-to.ts
+++ b/js/compressed-token/src/actions/mint-to.ts
@@ -42,7 +42,9 @@ export async function mintTo(
     confirmOptions?: ConfirmOptions,
     tokenProgramId?: PublicKey,
 ): Promise<TransactionSignature> {
-    const tokenProgram = tokenProgramId ? tokenProgramId : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
+    tokenProgramId = tokenProgramId
+        ? tokenProgramId
+        : await CompressedTokenProgram.get_mint_program_id(mint, rpc);
 
     const additionalSigners = dedupeSigner(payer, [authority]);
 
@@ -53,7 +55,7 @@ export async function mintTo(
         amount: amount,
         toPubkey: destination,
         merkleTree,
-        tokenProgram
+        tokenProgramId,
     });
 
     const { blockhash } = await rpc.getLatestBlockhash();

--- a/js/compressed-token/src/program.ts
+++ b/js/compressed-token/src/program.ts
@@ -27,6 +27,7 @@ import {
 } from '@lightprotocol/stateless.js';
 import {
     MINT_SIZE,
+    TOKEN_2022_PROGRAM_ID,
     TOKEN_PROGRAM_ID,
     createInitializeMint2Instruction,
     createMintToInstruction,
@@ -65,6 +66,10 @@ export type CompressParams = {
      * public state tree if unspecified.
      */
     outputStateTree?: PublicKey;
+    /**
+     * Optional: The token program ID. Default: SPL Token Program ID
+     */
+    tokenProgram?: PublicKey;
 };
 
 export type CompressSplTokenAccountParams = {
@@ -92,6 +97,10 @@ export type CompressSplTokenAccountParams = {
      * The state tree that the compressed token account should be inserted into.
      */
     outputStateTree: PublicKey;
+    /**
+     * Optional: The token program ID. Default: SPL Token Program ID
+     */
+    tokenProgram?: PublicKey;
 };
 
 export type DecompressParams = {
@@ -126,6 +135,10 @@ export type DecompressParams = {
      * Defaults to a public state tree if unspecified.
      */
     outputStateTree?: PublicKey;
+    /**
+     * Optional: The token program ID. Default: SPL Token Program ID
+     */
+    tokenProgram?: PublicKey;
 };
 
 export type TransferParams = {
@@ -192,6 +205,10 @@ export type CreateMintParams = {
      * lamport amount for mint account rent exemption
      */
     rentExemptBalance: number;
+    /**
+     * Optional: The token program ID. Default: SPL Token Program ID
+     */
+    tokenProgram?: PublicKey;
 };
 
 /**
@@ -257,6 +274,10 @@ export type MintToParams = {
      * tree if unspecified.
      */
     merkleTree?: PublicKey;
+    /**
+     * Optional: The token program ID. Default: SPL Token Program ID
+     */
+    tokenProgram?: PublicKey;
 };
 
 /**
@@ -268,6 +289,10 @@ export type RegisterMintParams = {
     feePayer: PublicKey;
     /** Mint public key */
     mint: PublicKey;
+    /**
+     * Optional: The token program ID. Default: SPL Token Program ID
+     */
+    tokenProgram?: PublicKey;
 };
 
 /**
@@ -303,6 +328,10 @@ export type ApproveAndMintToParams = {
      * tree if unspecified.
      */
     merkleTree?: PublicKey;
+    /**
+     * Optional: The token program ID. Default: SPL Token Program ID
+     */
+    tokenProgram?: PublicKey;
 };
 
 export type CreateTokenProgramLookupTableParams = {
@@ -548,14 +577,15 @@ export class CompressedTokenProgram {
     static async createMint(
         params: CreateMintParams,
     ): Promise<TransactionInstruction[]> {
-        const { mint, authority, feePayer, rentExemptBalance } = params;
+        const { mint, authority, feePayer, rentExemptBalance, tokenProgram } = params;
+        const tokenProgramInput = tokenProgram ?? TOKEN_PROGRAM_ID; 
 
         /// Create and initialize SPL Mint account
         const createMintAccountInstruction = SystemProgram.createAccount({
             fromPubkey: feePayer,
             lamports: rentExemptBalance,
             newAccountPubkey: mint,
-            programId: TOKEN_PROGRAM_ID,
+            programId: tokenProgramInput,
             space: MINT_SIZE,
         });
 
@@ -564,7 +594,7 @@ export class CompressedTokenProgram {
             params.decimals,
             authority,
             params.freezeAuthority,
-            TOKEN_PROGRAM_ID,
+            tokenProgramInput,
         );
 
         const ix = await this.createTokenPool({
@@ -582,7 +612,9 @@ export class CompressedTokenProgram {
     static async createTokenPool(
         params: RegisterMintParams,
     ): Promise<TransactionInstruction> {
-        const { mint, feePayer } = params;
+        const { mint, feePayer, tokenProgram } = params;
+
+        const tokenProgramInput = tokenProgram ?? TOKEN_PROGRAM_ID;
 
         const tokenPoolPda = this.deriveTokenPoolPda(mint);
 
@@ -593,7 +625,7 @@ export class CompressedTokenProgram {
                 feePayer,
                 tokenPoolPda,
                 systemProgram: SystemProgram.programId,
-                tokenProgram: TOKEN_PROGRAM_ID,
+                tokenProgram: tokenProgramInput,
                 cpiAuthorityPda: this.deriveCpiAuthorityPda,
             })
             .instruction();
@@ -607,8 +639,9 @@ export class CompressedTokenProgram {
     static async mintTo(params: MintToParams): Promise<TransactionInstruction> {
         const systemKeys = defaultStaticAccountsStruct();
 
-        const { mint, feePayer, authority, merkleTree, toPubkey, amount } =
+        const { mint, feePayer, authority, merkleTree, toPubkey, amount, tokenProgram } =
             params;
+        const tokenProgramInput = tokenProgram ?? TOKEN_PROGRAM_ID;
 
         const tokenPoolPda = this.deriveTokenPoolPda(mint);
 
@@ -630,7 +663,7 @@ export class CompressedTokenProgram {
                 cpiAuthorityPda: this.deriveCpiAuthorityPda,
                 mint,
                 tokenPoolPda,
-                tokenProgram: TOKEN_PROGRAM_ID,
+                tokenProgram: tokenProgramInput,
                 lightSystemProgram: LightSystemProgram.programId,
                 registeredProgramPda: systemKeys.registeredProgramPda,
                 noopProgram: systemKeys.noopProgram,
@@ -658,6 +691,7 @@ export class CompressedTokenProgram {
             authority,
             merkleTree,
             toPubkey,
+            tokenProgram,
         } = params;
 
         const amount: bigint = BigInt(params.amount.toString());
@@ -668,6 +702,8 @@ export class CompressedTokenProgram {
             authorityTokenAccount,
             authority,
             amount,
+             [],
+             tokenProgram,
         );
 
         /// 2. Compress from mint authority ATA to recipient compressed account
@@ -679,6 +715,7 @@ export class CompressedTokenProgram {
             mint,
             amount: params.amount,
             outputStateTree: merkleTree,
+            tokenProgram,
         });
 
         return [splMintToInstruction, compressInstruction];
@@ -807,6 +844,7 @@ export class CompressedTokenProgram {
                 defaultTestStateTreeAccounts().addressQueue,
                 this.programId,
                 TOKEN_PROGRAM_ID,
+                TOKEN_2022_PROGRAM_ID,
                 authority,
                 ...optionalMintKeys,
                 ...(remainingAccounts ?? []),
@@ -826,7 +864,7 @@ export class CompressedTokenProgram {
     static async compress(
         params: CompressParams,
     ): Promise<TransactionInstruction> {
-        const { payer, owner, source, toAddress, mint, outputStateTree } =
+        const { payer, owner, source, toAddress, mint, outputStateTree, tokenProgram } =
             params;
 
         if (Array.isArray(params.amount) !== Array.isArray(params.toAddress)) {
@@ -894,6 +932,7 @@ export class CompressedTokenProgram {
             'CompressedTokenInstructionDataTransfer',
             data,
         );
+        const tokenProgramInput = tokenProgram ?? TOKEN_PROGRAM_ID;
 
         const instruction = await this.program.methods
             .transfer(encodedData)
@@ -912,7 +951,7 @@ export class CompressedTokenProgram {
                 selfProgram: this.programId,
                 tokenPoolPda: this.deriveTokenPoolPda(mint),
                 compressOrDecompressTokenAccount: source, // token
-                tokenProgram: TOKEN_PROGRAM_ID,
+                tokenProgram: tokenProgramInput,
             })
             .remainingAccounts(remainingAccountMetas)
             .instruction();
@@ -933,6 +972,7 @@ export class CompressedTokenProgram {
             outputStateTree,
             recentValidityProof,
             recentInputStateRootIndices,
+            tokenProgram,
         } = params;
         const amount = bn(params.amount);
 
@@ -980,7 +1020,7 @@ export class CompressedTokenProgram {
             registeredProgramPda,
             accountCompressionProgram,
         } = defaultStaticAccountsStruct();
-
+        const tokenProgramInput = tokenProgram ?? TOKEN_PROGRAM_ID; 
         const instruction = await this.program.methods
             .transfer(encodedData)
             .accounts({
@@ -995,7 +1035,7 @@ export class CompressedTokenProgram {
                 selfProgram: this.programId,
                 tokenPoolPda: this.deriveTokenPoolPda(mint),
                 compressOrDecompressTokenAccount: toAddress,
-                tokenProgram: TOKEN_PROGRAM_ID,
+                tokenProgram: tokenProgramInput,
             })
             .remainingAccounts(remainingAccountMetas)
             .instruction();
@@ -1054,6 +1094,7 @@ export class CompressedTokenProgram {
                 isWritable: true,
             },
         ];
+        let tokenProgram = await CompressedTokenProgram.get_mint_program_id(mint, this._program?.provider.connection!);
 
         const instruction = await this.program.methods
             .compressSplTokenAccount(authority, remainingAmount ?? null, null)
@@ -1072,7 +1113,7 @@ export class CompressedTokenProgram {
                 selfProgram: this.programId,
                 tokenPoolPda: this.deriveTokenPoolPda(mint),
                 compressOrDecompressTokenAccount: tokenAccount,
-                tokenProgram: TOKEN_PROGRAM_ID,
+                tokenProgram,
                 systemProgram: SystemProgram.programId,
             })
             .remainingAccounts(remainingAccountMetas)
@@ -1080,4 +1121,11 @@ export class CompressedTokenProgram {
 
         return instruction;
     }
+
+    static async get_mint_program_id(mint: PublicKey, connection: Connection): Promise<PublicKey | undefined> {
+        return (await connection.getAccountInfo(
+             mint,
+         ))?.owner;
+     }
+
 }

--- a/js/compressed-token/tests/e2e/approve-and-mint-to.test.ts
+++ b/js/compressed-token/tests/e2e/approve-and-mint-to.test.ts
@@ -110,7 +110,7 @@ describe('approveAndMintTo', () => {
             token22MintAuthority,
             true,
         );
-        let mintAccountInfo = await rpc.getAccountInfo(token22Mint);
+        const mintAccountInfo = await rpc.getAccountInfo(token22Mint);
         assert(mintAccountInfo!.owner.equals(TOKEN_2022_PROGRAM_ID));
         /// Register mint
         await createTokenPool(rpc, payer, token22Mint);

--- a/js/compressed-token/tests/e2e/transfer.test.ts
+++ b/js/compressed-token/tests/e2e/transfer.test.ts
@@ -239,7 +239,7 @@ describe('transfer', () => {
                 true,
             )
         ).mint;
-        let mintAccountInfo = await rpc.getAccountInfo(mint);
+        const mintAccountInfo = await rpc.getAccountInfo(mint);
         assert.equal(
             mintAccountInfo!.owner.toBase58(),
             TOKEN_2022_PROGRAM_ID.toBase58(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,6 +398,10 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@22.5.5)(@vitest/browser@1.6.0)(terser@5.31.0)
 
+  hasher.rs/src/main/wasm: {}
+
+  hasher.rs/src/main/wasm-simd: {}
+
   js/compressed-token:
     dependencies:
       '@coral-xyz/anchor':


### PR DESCRIPTION
**Issue:**
- ts sdk is missing token 2022 support

**Changes:**
- add optional token program id for create instruction functions
-  fetch token program id if not provided for actions
- fetch token mint and determine owner in cli methods compress and decompress to determine token program id for ata derivation

**Tests Coverage:**
- create token pool
- mint to
- transfer
- compress
- decompress
- approve and mint to