### PR TITLE
fix: fallback to mac-compatible shasum command in `download_keys.sh`

### DIFF
--- a/light-prover/scripts/download_keys.sh
+++ b/light-prover/scripts/download_keys.sh
@@ -47,7 +47,6 @@ verify_checksum() {
     local expected
     local actual
     
-    # Determine which checksum command to use
     if command -v sha256sum >/dev/null 2>&1; then
         CHECKSUM_CMD="sha256sum"
     else

--- a/light-prover/scripts/download_keys.sh
+++ b/light-prover/scripts/download_keys.sh
@@ -47,8 +47,15 @@ verify_checksum() {
     local expected
     local actual
     
+    # Determine which checksum command to use
+    if command -v sha256sum >/dev/null 2>&1; then
+        CHECKSUM_CMD="sha256sum"
+    else
+        CHECKSUM_CMD="shasum -a 256"
+    fi
+    
     expected=$(grep "${file##*/}" "$checksum_file" | cut -d' ' -f1)
-    actual=$(sha256sum "$file" | cut -d' ' -f1)
+    actual=$($CHECKSUM_CMD "$file" | cut -d' ' -f1)
     
     echo "Expected checksum: $expected"
     echo "Actual checksum:   $actual"


### PR DESCRIPTION
mac does not have `sha256sum` installed by default. this causes `install.sh` to throw when checking proving keys on Mac

solution:

fallback to `shasum` if `sha256sum` isn't installed