### PR TITLE
chore: remove name-service example from project Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3591,46 +3591,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "name-service"
-version = "0.7.0"
-dependencies = [
- "anchor-lang",
- "borsh 0.10.3",
- "light-client",
- "light-hasher",
- "light-macros",
- "light-program-test",
- "light-sdk",
- "light-sdk-macros",
- "light-test-utils",
- "light-utils",
- "light-verifier",
- "solana-program-test",
- "solana-sdk",
- "tokio",
-]
-
-[[package]]
-name = "name-service-without-macros"
-version = "0.7.0"
-dependencies = [
- "anchor-lang",
- "borsh 0.10.3",
- "light-client",
- "light-hasher",
- "light-macros",
- "light-program-test",
- "light-sdk",
- "light-sdk-macros",
- "light-test-utils",
- "light-utils",
- "light-verifier",
- "solana-program-test",
- "solana-sdk",
- "tokio",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ members = [
     "sdk-libs/photon-api",
     "sdk-libs/program-test",
     "xtask",
-    "examples/name-service/programs/*",
     "examples/token-escrow/programs/*",
     "program-tests/account-compression-test/",
     "program-tests/compressed-token-test/",


### PR DESCRIPTION
Issue:
- broken name-service example program prevents osec-api to recompile and verify latest compressed token program deployment

Changes:
- remove name-service example from project Cargo.toml until it is fixed
