### PR TITLE
chore: batched handoff cleanup 2

### DIFF
--- a/forester-utils/src/address_merkle_tree_config.rs
+++ b/forester-utils/src/address_merkle_tree_config.rs
@@ -174,9 +174,9 @@ pub async fn state_tree_ready_for_rollover<R: RpcConnection>(
                     .unwrap();
 
             (
-                tree_meta_data.get_metadata().next_index as usize,
-                tree_meta_data.get_metadata().metadata,
-                tree_meta_data.get_metadata().height,
+                tree_meta_data.next_index as usize,
+                tree_meta_data.metadata,
+                tree_meta_data.height,
             )
         }
         _ => panic!("Invalid discriminator"),

--- a/forester-utils/src/instructions.rs
+++ b/forester-utils/src/instructions.rs
@@ -65,15 +65,12 @@ where
         .unwrap();
 
         let old_root_index = merkle_tree.root_history.last_index();
-        let full_batch_index = merkle_tree
-            .get_metadata()
-            .queue_metadata
-            .next_full_batch_index;
+        let full_batch_index = merkle_tree.queue_metadata.next_full_batch_index;
         let batch = &merkle_tree.batches[full_batch_index as usize];
         let zkp_batch_index = batch.get_num_inserted_zkps();
         let leaves_hashchain =
             merkle_tree.hashchain_store[full_batch_index as usize][zkp_batch_index as usize];
-        let start_index = merkle_tree.get_metadata().next_index;
+        let start_index = merkle_tree.next_index;
         let current_root = *merkle_tree.root_history.last().unwrap();
         let batch_size = batch.zkp_batch_size as usize;
 
@@ -227,7 +224,7 @@ pub async fn create_append_batch_ix_data<R: RpcConnection, I: Indexer<R>>(
         )
         .unwrap();
         (
-            merkle_tree.get_metadata().next_index,
+            merkle_tree.next_index,
             *merkle_tree.root_history.last().unwrap(),
         )
     };
@@ -239,9 +236,8 @@ pub async fn create_append_batch_ix_data<R: RpcConnection, I: Indexer<R>>(
         )
         .unwrap();
 
-        let queue_metadata = output_queue.get_metadata();
-        let full_batch_index = queue_metadata.batch_metadata.next_full_batch_index;
-        let zkp_batch_size = queue_metadata.batch_metadata.zkp_batch_size;
+        let full_batch_index = output_queue.batch_metadata.next_full_batch_index;
+        let zkp_batch_size = output_queue.batch_metadata.zkp_batch_size;
 
         let num_inserted_zkps =
             output_queue.batches[full_batch_index as usize].get_num_inserted_zkps();
@@ -352,9 +348,8 @@ pub async fn create_nullify_batch_ix_data<R: RpcConnection, I: Indexer<R>>(
         let merkle_tree =
             BatchedMerkleTreeAccount::state_tree_from_bytes_mut(account.data.as_mut_slice())
                 .unwrap();
-        let metadata = merkle_tree.get_metadata();
-        let batch_idx = metadata.queue_metadata.next_full_batch_index as usize;
-        let zkp_size = metadata.queue_metadata.zkp_batch_size;
+        let batch_idx = merkle_tree.queue_metadata.next_full_batch_index as usize;
+        let zkp_size = merkle_tree.queue_metadata.zkp_batch_size;
         let batch = &merkle_tree.batches[batch_idx];
         let zkp_idx = batch.get_num_inserted_zkps();
         let hashchain = merkle_tree.hashchain_store[batch_idx][zkp_idx as usize];

--- a/forester/src/batch_processor/common.rs
+++ b/forester/src/batch_processor/common.rs
@@ -125,7 +125,7 @@ impl<R: RpcConnection, I: Indexer<R> + IndexerType<R>> BatchProcessor<R, I> {
             Err(_) => return 0.0,
         };
 
-        let batch_index = tree.get_metadata().queue_metadata.next_full_batch_index;
+        let batch_index = tree.queue_metadata.next_full_batch_index;
         match tree.batches.get(batch_index as usize) {
             Some(batch) => Self::calculate_completion(batch),
             None => 0.0,
@@ -138,7 +138,7 @@ impl<R: RpcConnection, I: Indexer<R> + IndexerType<R>> BatchProcessor<R, I> {
             Err(_) => return 0.0,
         };
 
-        let batch_index = queue.get_metadata().batch_metadata.next_full_batch_index;
+        let batch_index = queue.batch_metadata.next_full_batch_index;
         match queue.batches.get(batch_index as usize) {
             Some(batch) => Self::calculate_completion(batch),
             None => 0.0,
@@ -178,11 +178,8 @@ impl<R: RpcConnection, I: Indexer<R> + IndexerType<R>> BatchProcessor<R, I> {
             )
             .map_err(|e| BatchProcessError::QueueParsing(e.to_string()))?;
 
-            let batch_index = output_queue
-                .get_metadata()
-                .batch_metadata
-                .next_full_batch_index;
-            let zkp_batch_size = output_queue.get_metadata().batch_metadata.zkp_batch_size;
+            let batch_index = output_queue.batch_metadata.next_full_batch_index;
+            let zkp_batch_size = output_queue.batch_metadata.zkp_batch_size;
 
             (
                 output_queue.batches[batch_index as usize].get_num_inserted_zkps(),
@@ -209,7 +206,7 @@ impl<R: RpcConnection, I: Indexer<R> + IndexerType<R>> BatchProcessor<R, I> {
         };
 
         if let Ok(tree) = merkle_tree {
-            let batch_index = tree.get_metadata().queue_metadata.next_full_batch_index;
+            let batch_index = tree.queue_metadata.next_full_batch_index;
             let full_batch = tree.batches.get(batch_index as usize).unwrap();
 
             full_batch.get_state() != BatchState::Inserted
@@ -233,7 +230,7 @@ impl<R: RpcConnection, I: Indexer<R> + IndexerType<R>> BatchProcessor<R, I> {
         };
 
         if let Ok(queue) = output_queue {
-            let batch_index = queue.get_metadata().batch_metadata.next_full_batch_index;
+            let batch_index = queue.batch_metadata.next_full_batch_index;
             let full_batch = queue.batches.get(batch_index as usize).unwrap();
 
             full_batch.get_state() != BatchState::Inserted

--- a/forester/src/batch_processor/state.rs
+++ b/forester/src/batch_processor/state.rs
@@ -111,8 +111,5 @@ async fn get_batch_index<R: RpcConnection, I: Indexer<R>>(
         account.data.as_mut_slice(),
     ).map_err(|e| BatchProcessError::MerkleTreeParsing(e.to_string()))?;
 
-    Ok(merkle_tree
-        .get_metadata()
-        .queue_metadata
-        .next_full_batch_index as usize)
+    Ok(merkle_tree.queue_metadata.next_full_batch_index as usize)
 }

--- a/forester/src/rollover/operations.rs
+++ b/forester/src/rollover/operations.rs
@@ -109,49 +109,37 @@ pub async fn get_tree_fullness<R: RpcConnection>(
                 BatchedMerkleTreeAccount::state_tree_from_bytes_mut(&mut account.data).unwrap();
             println!(
                 "merkle_tree.get_account().queue.batch_size: {:?}",
-                merkle_tree.get_metadata().queue_metadata.batch_size
+                merkle_tree.queue_metadata.batch_size
             );
 
             println!(
                 "queue currently_processing_batch_index: {:?}",
-                merkle_tree
-                    .get_metadata()
-                    .queue_metadata
-                    .currently_processing_batch_index as usize
+                merkle_tree.queue_metadata.currently_processing_batch_index as usize
             );
 
             println!(
                 "queue batch_size: {:?}",
-                merkle_tree.get_metadata().queue_metadata.batch_size
+                merkle_tree.queue_metadata.batch_size
             );
             println!(
                 "queue zkp_batch_size: {:?}",
-                merkle_tree.get_metadata().queue_metadata.zkp_batch_size
+                merkle_tree.queue_metadata.zkp_batch_size
             );
             println!(
                 "queue next_full_batch_index: {:?}",
-                merkle_tree
-                    .get_metadata()
-                    .queue_metadata
-                    .next_full_batch_index
+                merkle_tree.queue_metadata.next_full_batch_index
             );
             println!(
                 "queue bloom_filter_capacity: {:?}",
-                merkle_tree
-                    .get_metadata()
-                    .queue_metadata
-                    .bloom_filter_capacity
+                merkle_tree.queue_metadata.bloom_filter_capacity
             );
             println!(
                 "queue num_batches: {:?}",
-                merkle_tree.get_metadata().queue_metadata.num_batches
+                merkle_tree.queue_metadata.num_batches
             );
 
-            println!(
-                "tree next_index: {:?}",
-                merkle_tree.get_metadata().next_index
-            );
-            println!("tree height: {:?}", merkle_tree.get_metadata().height);
+            println!("tree next_index: {:?}", merkle_tree.next_index);
+            println!("tree height: {:?}", merkle_tree.height);
 
             // TODO: implement
             let threshold = 0;
@@ -171,49 +159,37 @@ pub async fn get_tree_fullness<R: RpcConnection>(
                 BatchedMerkleTreeAccount::state_tree_from_bytes_mut(&mut account.data).unwrap();
             println!(
                 "merkle_tree.get_account().queue.batch_size: {:?}",
-                merkle_tree.get_metadata().queue_metadata.batch_size
+                merkle_tree.queue_metadata.batch_size
             );
 
             println!(
                 "queue currently_processing_batch_index: {:?}",
-                merkle_tree
-                    .get_metadata()
-                    .queue_metadata
-                    .currently_processing_batch_index as usize
+                merkle_tree.queue_metadata.currently_processing_batch_index as usize
             );
 
             println!(
                 "queue batch_size: {:?}",
-                merkle_tree.get_metadata().queue_metadata.batch_size
+                merkle_tree.queue_metadata.batch_size
             );
             println!(
                 "queue zkp_batch_size: {:?}",
-                merkle_tree.get_metadata().queue_metadata.zkp_batch_size
+                merkle_tree.queue_metadata.zkp_batch_size
             );
             println!(
                 "queue next_full_batch_index: {:?}",
-                merkle_tree
-                    .get_metadata()
-                    .queue_metadata
-                    .next_full_batch_index
+                merkle_tree.queue_metadata.next_full_batch_index
             );
             println!(
                 "queue bloom_filter_capacity: {:?}",
-                merkle_tree
-                    .get_metadata()
-                    .queue_metadata
-                    .bloom_filter_capacity
+                merkle_tree.queue_metadata.bloom_filter_capacity
             );
             println!(
                 "queue num_batches: {:?}",
-                merkle_tree.get_metadata().queue_metadata.num_batches
+                merkle_tree.queue_metadata.num_batches
             );
 
-            println!(
-                "tree next_index: {:?}",
-                merkle_tree.get_metadata().next_index
-            );
-            println!("tree height: {:?}", merkle_tree.get_metadata().height);
+            println!("tree next_index: {:?}", merkle_tree.next_index);
+            println!("tree height: {:?}", merkle_tree.height);
 
             // TODO: implement
             let threshold = 0;

--- a/forester/src/tree_data_sync.rs
+++ b/forester/src/tree_data_sync.rs
@@ -58,7 +58,7 @@ fn process_batch_state_account(account: &mut Account, pubkey: Pubkey) -> Result<
         })?;
     Ok(create_tree_accounts(
         pubkey,
-        &tree_account.get_metadata().metadata,
+        &tree_account.metadata,
         TreeType::BatchedState,
     ))
 }
@@ -70,7 +70,7 @@ fn process_batch_address_account(account: &mut Account, pubkey: Pubkey) -> Resul
         })?;
     Ok(create_tree_accounts(
         pubkey,
-        &tree_account.get_metadata().metadata,
+        &tree_account.metadata,
         TreeType::BatchedAddress,
     ))
 }

--- a/program-libs/batched-merkle-tree/src/initialize_state_tree.rs
+++ b/program-libs/batched-merkle-tree/src/initialize_state_tree.rs
@@ -345,11 +345,11 @@ fn _assert_mt_zero_copy_inited<const TREE_TYPE: u64>(
 ) {
     use light_hasher::Hasher;
 
-    let queue = account.get_metadata().queue_metadata;
+    let queue = account.queue_metadata;
     let ref_queue = ref_account.queue_metadata;
     let num_batches = ref_queue.num_batches as usize;
-    let mut next_index = account.get_metadata().next_index;
-    assert_eq!(*account.get_metadata(), ref_account, "metadata mismatch");
+    let mut next_index = account.next_index;
+    assert_eq!(*account, ref_account, "metadata mismatch");
 
     assert_eq!(
         account.root_history.capacity(),

--- a/program-libs/batched-merkle-tree/src/initialize_state_tree.rs
+++ b/program-libs/batched-merkle-tree/src/initialize_state_tree.rs
@@ -204,7 +204,7 @@ pub fn init_batched_state_merkle_tree_accounts<'a>(
                 params.close_threshold,
                 Some(params.additional_bytes),
             ),
-            queue_type: QueueType::Output as u64,
+            queue_type: QueueType::BatchedOutput as u64,
             associated_merkle_tree: mt_pubkey,
         };
 
@@ -381,9 +381,9 @@ fn _assert_mt_zero_copy_inited<const TREE_TYPE: u64>(
     }
 
     let queue_type = if tree_type == TreeType::BatchedState as u64 {
-        QueueType::Input as u64
+        QueueType::BatchedInput as u64
     } else {
-        QueueType::Address as u64
+        QueueType::BatchedAddress as u64
     };
     crate::queue::assert_queue_inited(
         queue,
@@ -464,7 +464,7 @@ pub fn create_output_queue_account(params: CreateOutputQueueParams) -> BatchedQu
             network_fee: params.network_fee,
             additional_bytes: params.additional_bytes,
         },
-        queue_type: QueueType::Output as u64,
+        queue_type: QueueType::BatchedOutput as u64,
         associated_merkle_tree: params.associated_merkle_tree,
     };
     let batch_metadata = BatchMetadata::new_output_queue(

--- a/program-libs/batched-merkle-tree/src/merkle_tree.rs
+++ b/program-libs/batched-merkle-tree/src/merkle_tree.rs
@@ -295,11 +295,10 @@ pub struct AppendBatchProofInputsIx {
 }
 
 impl<'a> BatchedMerkleTreeAccount<'a> {
-    // TODO: remove
     pub fn get_metadata(&self) -> &BatchedMerkleTreeMetadata {
         &self.metadata
     }
-    // TODO: remove
+
     pub fn get_metadata_mut(&mut self) -> &mut BatchedMerkleTreeMetadata {
         &mut self.metadata
     }
@@ -459,7 +458,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
         instruction_data: InstructionDataBatchAppendInputs,
         id: [u8; 32],
     ) -> Result<BatchAppendEvent, BatchedMerkleTreeError> {
-        if self.get_metadata().metadata.associated_queue != (*queue_account_info.key).into() {
+        if self.metadata.metadata.associated_queue != (*queue_account_info.key).into() {
             return Err(MerkleTreeMetadataError::MerkleTreeAndQueueNotAssociated.into());
         }
         let queue_account =
@@ -477,7 +476,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
         id: [u8; 32],
     ) -> Result<BatchAppendEvent, BatchedMerkleTreeError> {
         let batch_index = queue_account.batch_metadata.next_full_batch_index;
-        let circuit_batch_size = queue_account.get_metadata().batch_metadata.zkp_batch_size;
+        let circuit_batch_size = queue_account.batch_metadata.zkp_batch_size;
         let batches = &mut queue_account.batches;
         let full_batch = batches
             .get_mut(batch_index as usize)
@@ -496,7 +495,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
             .root_history
             .last()
             .ok_or(BatchedMerkleTreeError::InvalidIndex)?;
-        let start_index = self.get_metadata().next_index;
+        let start_index = self.next_index;
         let mut start_index_bytes = [0u8; 32];
         start_index_bytes[24..].copy_from_slice(&start_index.to_be_bytes());
         let public_input_hash = create_hash_chain_from_array([
@@ -511,10 +510,10 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
             instruction_data.compressed_proof,
             public_input_hash,
         )?;
-        let account = self.get_metadata_mut();
-        account.next_index += circuit_batch_size;
-        let root_history_capacity = account.root_history_capacity;
-        let sequence_number = account.sequence_number;
+
+        self.metadata.next_index += circuit_batch_size;
+        let root_history_capacity = self.metadata.root_history_capacity;
+        let sequence_number = self.metadata.sequence_number;
         self.root_history.push(new_root);
         let root_index = self.root_history.last_index() as u32;
         full_batch.mark_as_inserted_in_merkle_tree(
@@ -523,15 +522,9 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
             root_history_capacity,
         )?;
         if full_batch.get_state() == BatchState::Inserted {
-            queue_account
-                .get_metadata_mut()
-                .batch_metadata
-                .next_full_batch_index += 1;
-            queue_account
-                .get_metadata_mut()
-                .batch_metadata
-                .next_full_batch_index %=
-                queue_account.get_metadata_mut().batch_metadata.num_batches;
+            queue_account.batch_metadata.next_full_batch_index += 1;
+            queue_account.batch_metadata.next_full_batch_index %=
+                queue_account.batch_metadata.num_batches;
         }
         Ok(BatchAppendEvent {
             id,
@@ -542,7 +535,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
             new_next_index: start_index + circuit_batch_size,
             new_root,
             root_index,
-            sequence_number: self.get_metadata().sequence_number,
+            sequence_number: self.sequence_number,
         })
     }
 
@@ -567,7 +560,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
         instruction_data: InstructionDataBatchNullifyInputs,
         id: [u8; 32],
     ) -> Result<BatchNullifyEvent, BatchedMerkleTreeError> {
-        let batch_index = self.get_metadata().queue_metadata.next_full_batch_index;
+        let batch_index = self.queue_metadata.next_full_batch_index;
 
         let full_batch = self
             .batches
@@ -592,8 +585,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
             create_hash_chain_from_array([*old_root, new_root, *leaves_hashchain])?
         } else if QUEUE_TYPE == QueueType::BatchedAddress as u64 {
             let mut next_index_bytes = [0u8; 32];
-            next_index_bytes[24..]
-                .copy_from_slice(self.get_metadata().next_index.to_be_bytes().as_slice());
+            next_index_bytes[24..].copy_from_slice(self.next_index.to_be_bytes().as_slice());
             create_hash_chain_from_array([
                 *old_root,
                 new_root,
@@ -603,7 +595,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
         } else {
             return Err(MerkleTreeMetadataError::InvalidQueueType.into());
         };
-        let circuit_batch_size = self.get_metadata().queue_metadata.zkp_batch_size;
+        let circuit_batch_size = self.queue_metadata.zkp_batch_size;
         self.update::<QUEUE_TYPE>(
             circuit_batch_size as usize,
             instruction_data.compressed_proof,
@@ -611,8 +603,8 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
         )?;
         self.root_history.push(new_root);
 
-        let root_history_capacity = self.get_metadata().root_history_capacity;
-        let sequence_number = self.get_metadata().sequence_number;
+        let root_history_capacity = self.root_history_capacity;
+        let sequence_number = self.sequence_number;
         let full_batch = self
             .batches
             .get_mut(batch_index as usize)
@@ -623,12 +615,12 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
             root_history_capacity,
         )?;
         if full_batch.get_state() == BatchState::Inserted {
-            let account = self.get_metadata_mut();
-            account.queue_metadata.next_full_batch_index += 1;
-            account.queue_metadata.next_full_batch_index %= account.queue_metadata.num_batches;
+            self.metadata.queue_metadata.next_full_batch_index += 1;
+            self.metadata.queue_metadata.next_full_batch_index %=
+                self.metadata.queue_metadata.num_batches;
         }
         if QUEUE_TYPE == QueueType::BatchedAddress as u64 {
-            self.get_metadata_mut().next_index += circuit_batch_size;
+            self.metadata.next_index += circuit_batch_size;
         }
 
         self.wipe_previous_batch_bloom_filter()?;
@@ -640,7 +632,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
             zkp_batch_index: num_zkps,
             new_root,
             root_index: self.root_history.last_index() as u32,
-            sequence_number: self.get_metadata().sequence_number,
+            sequence_number: self.sequence_number,
         })
     }
 
@@ -674,7 +666,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
         leaf_index: u64,
         tx_hash: &[u8; 32],
     ) -> Result<(), BatchedMerkleTreeError> {
-        if self.get_metadata().tree_type != TreeType::BatchedState as u64 {
+        if self.tree_type != TreeType::BatchedState as u64 {
             return Err(MerkleTreeMetadataError::InvalidTreeType.into());
         }
         let leaf_index_bytes = leaf_index.to_be_bytes();
@@ -686,7 +678,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
         &mut self,
         address: &[u8; 32],
     ) -> Result<(), BatchedMerkleTreeError> {
-        if self.get_metadata().tree_type != TreeType::BatchedAddress as u64 {
+        if self.tree_type != TreeType::BatchedAddress as u64 {
             return Err(MerkleTreeMetadataError::InvalidTreeType.into());
         }
         self.insert_into_current_batch(address, address)
@@ -758,7 +750,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
     }
 
     fn zero_out_roots(&mut self, sequence_number: u64, root_index: Option<u32>) {
-        if sequence_number > self.get_metadata().sequence_number {
+        if sequence_number > self.sequence_number {
             // advance root history array current index from latest root
             // to root_index and overwrite all roots with zeros
             if let Some(root_index) = root_index {
@@ -786,16 +778,10 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
     ///    3.2 mark bloom filter as wiped
     ///    3.3 zero out roots if needed
     pub fn wipe_previous_batch_bloom_filter(&mut self) -> Result<(), BatchedMerkleTreeError> {
-        let current_batch = self
-            .get_metadata()
-            .queue_metadata
-            .currently_processing_batch_index;
-        let batch_size = self.get_metadata().queue_metadata.batch_size;
-        let previous_full_batch_index = self
-            .get_metadata()
-            .queue_metadata
-            .next_full_batch_index
-            .saturating_sub(1) as usize;
+        let current_batch = self.queue_metadata.currently_processing_batch_index;
+        let batch_size = self.queue_metadata.batch_size;
+        let previous_full_batch_index =
+            self.queue_metadata.next_full_batch_index.saturating_sub(1) as usize;
         let num_inserted_elements = self
             .batches
             .get(current_batch as usize)
@@ -886,20 +872,16 @@ pub fn assert_nullify_event(
     old_account: &BatchedMerkleTreeAccount,
     mt_pubkey: Pubkey,
 ) {
-    let batch_index = old_account
-        .get_metadata()
-        .queue_metadata
-        .next_full_batch_index;
+    let batch_index = old_account.queue_metadata.next_full_batch_index;
     let batch = old_account.batches.get(batch_index as usize).unwrap();
     let ref_event = BatchNullifyEvent {
         id: mt_pubkey.to_bytes(),
         batch_index,
         zkp_batch_index: batch.get_num_inserted_zkps(),
         new_root,
-        root_index: (old_account.get_root_index() + 1)
-            % old_account.get_metadata().root_history_capacity,
-        sequence_number: old_account.get_metadata().sequence_number + 1,
-        batch_size: old_account.get_metadata().queue_metadata.zkp_batch_size,
+        root_index: (old_account.get_root_index() + 1) % old_account.root_history_capacity,
+        sequence_number: old_account.sequence_number + 1,
+        batch_size: old_account.queue_metadata.zkp_batch_size,
     };
     assert_eq!(event, ref_event);
 }
@@ -912,7 +894,6 @@ pub fn assert_batch_append_event_event(
     mt_pubkey: Pubkey,
 ) {
     let batch_index = old_output_queue_account
-        .get_metadata()
         .batch_metadata
         .next_full_batch_index;
     let batch = old_output_queue_account
@@ -924,16 +905,12 @@ pub fn assert_batch_append_event_event(
         batch_index,
         zkp_batch_index: batch.get_num_inserted_zkps(),
         new_root,
-        root_index: (old_account.get_root_index() + 1)
-            % old_account.get_metadata().root_history_capacity,
-        sequence_number: old_account.get_metadata().sequence_number + 1,
-        batch_size: old_account.get_metadata().queue_metadata.zkp_batch_size,
-        old_next_index: old_account.get_metadata().next_index,
-        new_next_index: old_account.get_metadata().next_index
-            + old_output_queue_account
-                .get_metadata()
-                .batch_metadata
-                .zkp_batch_size,
+        root_index: (old_account.get_root_index() + 1) % old_account.root_history_capacity,
+        sequence_number: old_account.sequence_number + 1,
+        batch_size: old_account.queue_metadata.zkp_batch_size,
+        old_next_index: old_account.next_index,
+        new_next_index: old_account.next_index
+            + old_output_queue_account.batch_metadata.zkp_batch_size,
     };
     assert_eq!(event, ref_event);
 }

--- a/program-libs/batched-merkle-tree/src/merkle_tree.rs
+++ b/program-libs/batched-merkle-tree/src/merkle_tree.rs
@@ -452,7 +452,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
         })
     }
 
-    pub fn update_output_queue_account_info(
+    pub fn update_tree_from_output_queue_account_info(
         &mut self,
         queue_account_info: &AccountInfo<'_>,
         instruction_data: InstructionDataBatchAppendInputs,
@@ -539,7 +539,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
         })
     }
 
-    pub fn update_input_queue(
+    pub fn update_tree_from_input_queue(
         &mut self,
         instruction_data: InstructionDataBatchNullifyInputs,
         id: [u8; 32],
@@ -547,7 +547,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
         self.private_update_input_queue::<3>(instruction_data, id)
     }
 
-    pub fn update_address_queue(
+    pub fn update_tree_from_address_queue(
         &mut self,
         instruction_data: InstructionDataBatchNullifyInputs,
         id: [u8; 32],

--- a/program-libs/batched-merkle-tree/src/queue.rs
+++ b/program-libs/batched-merkle-tree/src/queue.rs
@@ -175,12 +175,10 @@ impl DerefMut for BatchedQueueAccount<'_> {
 }
 
 impl<'a> BatchedQueueAccount<'a> {
-    // TODO: remove
     pub fn get_metadata(&self) -> &BatchedQueueMetadata {
         &self.metadata
     }
 
-    // TODO: remove
     pub fn get_metadata_mut(&mut self) -> &mut BatchedQueueMetadata {
         &mut self.metadata
     }

--- a/program-libs/batched-merkle-tree/src/rollover_address_tree.rs
+++ b/program-libs/batched-merkle-tree/src/rollover_address_tree.rs
@@ -18,22 +18,16 @@ pub fn rollover_batched_address_tree<'a>(
     network_fee: Option<u64>,
 ) -> Result<BatchedMerkleTreeAccount<'a>, BatchedMerkleTreeError> {
     // Check that old merkle tree is ready for rollover.
-    let old_merkle_tree_metadata = old_merkle_tree.get_metadata();
-    batched_tree_is_ready_for_rollover(old_merkle_tree_metadata, &network_fee)?;
+    batched_tree_is_ready_for_rollover(old_merkle_tree, &network_fee)?;
 
     // Rollover the old merkle tree.
     old_merkle_tree
-        .get_metadata_mut()
         .metadata
         .rollover(Pubkey::default(), new_mt_pubkey)?;
 
     // Initialize the new address merkle tree.
     let params = create_batched_address_tree_init_params(old_merkle_tree, network_fee);
-    let owner = old_merkle_tree
-        .get_metadata()
-        .metadata
-        .access_metadata
-        .owner;
+    let owner = old_merkle_tree.metadata.access_metadata.owner;
     init_batched_address_merkle_tree_account(owner, params, new_mt_data, new_mt_rent)
 }
 
@@ -41,44 +35,35 @@ fn create_batched_address_tree_init_params(
     old_merkle_tree: &mut BatchedMerkleTreeAccount,
     network_fee: Option<u64>,
 ) -> InitAddressTreeAccountsInstructionData {
-    let old_merkle_tree_metadata = old_merkle_tree.get_metadata();
     InitAddressTreeAccountsInstructionData {
-        index: old_merkle_tree_metadata.metadata.rollover_metadata.index,
+        index: old_merkle_tree.metadata.rollover_metadata.index,
         program_owner: if_equals_none(
-            old_merkle_tree_metadata
-                .metadata
-                .access_metadata
-                .program_owner,
+            old_merkle_tree.metadata.access_metadata.program_owner,
             Pubkey::default(),
         ),
         forester: if_equals_none(
-            old_merkle_tree_metadata.metadata.access_metadata.forester,
+            old_merkle_tree.metadata.access_metadata.forester,
             Pubkey::default(),
         ),
-        height: old_merkle_tree_metadata.height,
-        input_queue_batch_size: old_merkle_tree_metadata.queue_metadata.batch_size,
-        input_queue_zkp_batch_size: old_merkle_tree_metadata.queue_metadata.zkp_batch_size,
-        bloom_filter_capacity: old_merkle_tree_metadata
-            .queue_metadata
-            .bloom_filter_capacity,
+        height: old_merkle_tree.height,
+        input_queue_batch_size: old_merkle_tree.queue_metadata.batch_size,
+        input_queue_zkp_batch_size: old_merkle_tree.queue_metadata.zkp_batch_size,
+        bloom_filter_capacity: old_merkle_tree.queue_metadata.bloom_filter_capacity,
         bloom_filter_num_iters: old_merkle_tree.batches[0].num_iters,
-        root_history_capacity: old_merkle_tree_metadata.root_history_capacity,
+        root_history_capacity: old_merkle_tree.root_history_capacity,
         network_fee,
         rollover_threshold: if_equals_none(
-            old_merkle_tree_metadata
+            old_merkle_tree
                 .metadata
                 .rollover_metadata
                 .rollover_threshold,
             u64::MAX,
         ),
         close_threshold: if_equals_none(
-            old_merkle_tree_metadata
-                .metadata
-                .rollover_metadata
-                .close_threshold,
+            old_merkle_tree.metadata.rollover_metadata.close_threshold,
             u64::MAX,
         ),
-        input_queue_num_batches: old_merkle_tree_metadata.queue_metadata.num_batches,
+        input_queue_num_batches: old_merkle_tree.queue_metadata.num_batches,
     }
 }
 
@@ -99,8 +84,7 @@ pub fn assert_address_mt_roll_over(
 
     let old_mt_account =
         BatchedMerkleTreeAccount::address_tree_from_bytes_mut(&mut old_mt_account_data).unwrap();
-    assert_eq!(old_mt_account.get_metadata(), &old_ref_mt_account);
-
+    assert_eq!(*old_mt_account.get_metadata(), old_ref_mt_account);
     crate::initialize_state_tree::assert_address_mt_zero_copy_inited(
         &mut new_mt_account_data,
         new_ref_mt_account,

--- a/program-libs/batched-merkle-tree/src/rollover_address_tree.rs
+++ b/program-libs/batched-merkle-tree/src/rollover_address_tree.rs
@@ -10,6 +10,14 @@ use crate::{
     rollover_state_tree::batched_tree_is_ready_for_rollover,
 };
 
+/// Checks:
+/// 1. Merkle tree is ready to be rolled over
+/// 2. Merkle tree is not already rolled over
+/// 3. Rollover threshold is configured, if not tree cannot be rolled over
+///
+/// Actions:
+/// 1. mark Merkle tree as rolled over in this slot
+/// 2. initialize new Merkle tree and nullifier queue with the same parameters
 pub fn rollover_batched_address_tree<'a>(
     old_merkle_tree: &mut BatchedMerkleTreeAccount<'a>,
     new_mt_data: &'a mut [u8],

--- a/program-libs/batched-merkle-tree/src/rollover_state_tree.rs
+++ b/program-libs/batched-merkle-tree/src/rollover_state_tree.rs
@@ -28,6 +28,14 @@ pub struct RolloverBatchStateTreeParams<'a> {
     pub network_fee: Option<u64>,
 }
 
+/// Checks:
+/// 1. Merkle tree is ready to be rolled over
+/// 2. Merkle tree is not already rolled over
+/// 3. Rollover threshold is configured, if not tree cannot be rolled over
+///
+/// Actions:
+/// 1. mark Merkle tree as rolled over in this slot
+/// 2. initialize new Merkle tree and output queue with the same parameters
 pub fn rollover_batched_state_tree(
     params: RolloverBatchStateTreeParams,
 ) -> Result<(), BatchedMerkleTreeError> {

--- a/program-libs/batched-merkle-tree/src/rollover_state_tree.rs
+++ b/program-libs/batched-merkle-tree/src/rollover_state_tree.rs
@@ -36,29 +36,19 @@ pub fn rollover_batched_state_tree(
         .check_is_associated(&params.old_mt_pubkey)?;
 
     // Check that old merkle tree is ready for rollover.
-    batched_tree_is_ready_for_rollover(
-        params.old_merkle_tree.get_metadata_mut(),
-        &params.network_fee,
-    )?;
+    batched_tree_is_ready_for_rollover(params.old_merkle_tree, &params.network_fee)?;
     // Rollover the old merkle tree.
     params
         .old_merkle_tree
-        .get_metadata_mut()
         .metadata
         .rollover(params.old_queue_pubkey, params.new_mt_pubkey)?;
     // Rollover the old output queue.
     params
         .old_output_queue
-        .get_metadata_mut()
         .metadata
         .rollover(params.old_mt_pubkey, params.new_output_queue_pubkey)?;
     let init_params = InitStateTreeAccountsInstructionData::from(&params);
-    let owner = params
-        .old_merkle_tree
-        .get_metadata()
-        .metadata
-        .access_metadata
-        .owner;
+    let owner = params.old_merkle_tree.metadata.access_metadata.owner;
 
     // Initialize the new merkle tree and output queue.
     init_batched_state_merkle_tree_accounts(
@@ -78,54 +68,47 @@ pub fn rollover_batched_state_tree(
 impl From<&RolloverBatchStateTreeParams<'_>> for InitStateTreeAccountsInstructionData {
     #[inline(always)]
     fn from(params: &RolloverBatchStateTreeParams<'_>) -> Self {
-        let old_merkle_tree_account = params.old_merkle_tree.get_metadata();
-
         InitStateTreeAccountsInstructionData {
-            index: old_merkle_tree_account.metadata.rollover_metadata.index,
+            index: params.old_merkle_tree.metadata.rollover_metadata.index,
             program_owner: if_equals_none(
-                old_merkle_tree_account
+                params
+                    .old_merkle_tree
                     .metadata
                     .access_metadata
                     .program_owner,
                 Pubkey::default(),
             ),
             forester: if_equals_none(
-                old_merkle_tree_account.metadata.access_metadata.forester,
+                params.old_merkle_tree.metadata.access_metadata.forester,
                 Pubkey::default(),
             ),
-            height: old_merkle_tree_account.height,
-            input_queue_batch_size: old_merkle_tree_account.queue_metadata.batch_size,
-            input_queue_zkp_batch_size: old_merkle_tree_account.queue_metadata.zkp_batch_size,
-            bloom_filter_capacity: old_merkle_tree_account.queue_metadata.bloom_filter_capacity,
+            height: params.old_merkle_tree.height,
+            input_queue_batch_size: params.old_merkle_tree.queue_metadata.batch_size,
+            input_queue_zkp_batch_size: params.old_merkle_tree.queue_metadata.zkp_batch_size,
+            bloom_filter_capacity: params.old_merkle_tree.queue_metadata.bloom_filter_capacity,
             bloom_filter_num_iters: params.old_merkle_tree.batches[0].num_iters,
-            root_history_capacity: old_merkle_tree_account.root_history_capacity,
+            root_history_capacity: params.old_merkle_tree.root_history_capacity,
             network_fee: params.network_fee,
             rollover_threshold: if_equals_none(
-                old_merkle_tree_account
+                params
+                    .old_merkle_tree
                     .metadata
                     .rollover_metadata
                     .rollover_threshold,
                 u64::MAX,
             ),
             close_threshold: if_equals_none(
-                old_merkle_tree_account
+                params
+                    .old_merkle_tree
                     .metadata
                     .rollover_metadata
                     .close_threshold,
                 u64::MAX,
             ),
-            input_queue_num_batches: old_merkle_tree_account.queue_metadata.num_batches,
+            input_queue_num_batches: params.old_merkle_tree.queue_metadata.num_batches,
             additional_bytes: params.additional_bytes,
-            output_queue_batch_size: params
-                .old_output_queue
-                .get_metadata()
-                .batch_metadata
-                .batch_size,
-            output_queue_zkp_batch_size: params
-                .old_output_queue
-                .get_metadata()
-                .batch_metadata
-                .zkp_batch_size,
+            output_queue_batch_size: params.old_output_queue.batch_metadata.batch_size,
+            output_queue_zkp_batch_size: params.old_output_queue.batch_metadata.zkp_batch_size,
             output_queue_num_batches: params.old_output_queue.batches.len() as u64,
         }
     }
@@ -133,7 +116,7 @@ impl From<&RolloverBatchStateTreeParams<'_>> for InitStateTreeAccountsInstructio
 
 // TODO: add unit test
 pub fn batched_tree_is_ready_for_rollover(
-    metadata: &BatchedMerkleTreeMetadata,
+    metadata: &BatchedMerkleTreeAccount<'_>,
     network_fee: &Option<u64>,
 ) -> Result<(), BatchedMerkleTreeError> {
     if metadata.metadata.rollover_metadata.rollover_threshold == u64::MAX {
@@ -201,10 +184,7 @@ pub fn assert_state_mt_roll_over(params: StateMtRollOverAssertParams) {
 
     let zero_copy_queue =
         BatchedQueueAccount::output_queue_from_bytes_mut(&mut queue_account_data).unwrap();
-    assert_eq!(
-        zero_copy_queue.get_metadata().metadata,
-        ref_rolledover_queue.metadata
-    );
+    assert_eq!(zero_copy_queue.metadata, ref_rolledover_queue.metadata);
     let params = MtRollOverAssertParams {
         mt_account_data,
         ref_mt_account,

--- a/program-libs/batched-merkle-tree/tests/merkle_tree.rs
+++ b/program-libs/batched-merkle-tree/tests/merkle_tree.rs
@@ -711,7 +711,7 @@ async fn test_simulate_transactions() {
                 };
 
                 (
-                    account.update_input_queue(instruction_data, mt_pubkey.to_bytes()),
+                    account.update_tree_from_input_queue(instruction_data, mt_pubkey.to_bytes()),
                     new_root,
                 )
             };
@@ -1213,7 +1213,7 @@ pub async fn perform_input_update(
         };
 
         (
-            account.update_input_queue(instruction_data, mt_pubkey.to_bytes()),
+            account.update_tree_from_input_queue(instruction_data, mt_pubkey.to_bytes()),
             new_root,
         )
     };
@@ -1286,7 +1286,7 @@ pub async fn perform_address_update(
         };
 
         (
-            account.update_address_queue(instruction_data, mt_pubkey.to_bytes()),
+            account.update_tree_from_address_queue(instruction_data, mt_pubkey.to_bytes()),
             new_root,
             next_full_batch,
         )

--- a/program-libs/batched-merkle-tree/tests/queue.rs
+++ b/program-libs/batched-merkle-tree/tests/queue.rs
@@ -52,7 +52,7 @@ fn test_output_queue_account() {
     let bloom_filter_capacity = 0;
     let bloom_filter_num_iters = 0;
     {
-        let queue_type = QueueType::Output;
+        let queue_type = QueueType::BatchedOutput;
         let (ref_account, mut account_data) = get_test_account_and_account_data(
             batch_size,
             num_batches,
@@ -76,7 +76,7 @@ fn test_output_queue_account() {
         let value = [1u8; 32];
         account.insert_into_current_batch(&value).unwrap();
         // assert!(account.insert_into_current_batch(&value).is_ok());
-        if queue_type != QueueType::Output {
+        if queue_type != QueueType::BatchedOutput {
             assert!(account.insert_into_current_batch(&value).is_err());
         }
     }
@@ -85,7 +85,7 @@ fn test_output_queue_account() {
 #[test]
 fn test_value_exists_in_value_vec_present() {
     let (account, mut account_data) =
-        get_test_account_and_account_data(100, 2, QueueType::Output, 0);
+        get_test_account_and_account_data(100, 2, QueueType::BatchedOutput, 0);
     let mut account =
         BatchedQueueAccount::init(&mut account_data, account.metadata, 2, 100, 10, 0, 0).unwrap();
 

--- a/program-libs/merkle-tree-metadata/src/queue.rs
+++ b/program-libs/merkle-tree-metadata/src/queue.rs
@@ -40,9 +40,9 @@ pub struct QueueMetadata {
 pub enum QueueType {
     NullifierQueue = 1,
     AddressQueue = 2,
-    Input = 3,
-    Address = 4,
-    Output = 5,
+    BatchedInput = 3,
+    BatchedAddress = 4,
+    BatchedOutput = 5,
 }
 
 impl From<u64> for QueueType {
@@ -50,9 +50,9 @@ impl From<u64> for QueueType {
         match value {
             1 => QueueType::NullifierQueue,
             2 => QueueType::AddressQueue,
-            3 => QueueType::Input,
-            4 => QueueType::Address,
-            5 => QueueType::Output,
+            3 => QueueType::BatchedInput,
+            4 => QueueType::BatchedAddress,
+            5 => QueueType::BatchedOutput,
             _ => panic!("Invalid queue type"),
         }
     }

--- a/program-tests/account-compression-test/tests/batched_merkle_tree_test.rs
+++ b/program-tests/account-compression-test/tests/batched_merkle_tree_test.rs
@@ -1389,7 +1389,7 @@ pub async fn perform_init_batch_address_merkle_tree(
     let instruction = account_compression::instruction::IntializeBatchedAddressMerkleTree {
         bytes: params.try_to_vec().unwrap(),
     };
-    let accounts = account_compression::accounts::InitializeBatchAddressMerkleTree {
+    let accounts = account_compression::accounts::InitializeBatchedAddressMerkleTree {
         authority: context.get_payer().pubkey(),
         merkle_tree: merkle_tree_pubkey,
         registered_program_pda: None,

--- a/program-tests/account-compression-test/tests/batched_merkle_tree_test.rs
+++ b/program-tests/account-compression-test/tests/batched_merkle_tree_test.rs
@@ -1205,7 +1205,7 @@ pub async fn perform_rollover_batch_state_merkle_tree<R: RpcConnection>(
         } else {
             old_output_queue_pubkey
         };
-    let accounts = account_compression::accounts::RolloverBatchStateMerkleTree {
+    let accounts = account_compression::accounts::RolloverBatchedStateMerkleTree {
         fee_payer: payer_pubkey,
         authority: payer_pubkey,
         old_state_merkle_tree,
@@ -1214,7 +1214,7 @@ pub async fn perform_rollover_batch_state_merkle_tree<R: RpcConnection>(
         new_output_queue: new_output_queue_keypair.pubkey(),
         registered_program_pda: None,
     };
-    let instruction_data = account_compression::instruction::RolloverBatchStateMerkleTree {
+    let instruction_data = account_compression::instruction::RolloverBatchedStateMerkleTree {
         additional_bytes,
         network_fee,
     };
@@ -1631,7 +1631,7 @@ async fn test_batch_address_merkle_trees() {
     }
     // 12. functional: rollover
     let (_, new_address_merkle_tree) = {
-        rollover_batch_address_merkle_tree(
+        rollover_batched_address_merkle_tree(
             &mut context,
             address_merkle_tree_pubkey,
             &payer,
@@ -1646,7 +1646,7 @@ async fn test_batch_address_merkle_trees() {
         .unwrap();
     // 13. Failing: already rolled over
     {
-        let result = rollover_batch_address_merkle_tree(
+        let result = rollover_batched_address_merkle_tree(
             &mut context,
             address_merkle_tree_pubkey,
             &payer,
@@ -1662,7 +1662,7 @@ async fn test_batch_address_merkle_trees() {
     }
     // 14. Failing: invalid authority
     {
-        let result = rollover_batch_address_merkle_tree(
+        let result = rollover_batched_address_merkle_tree(
             &mut context,
             new_address_merkle_tree,
             &invalid_authority,
@@ -1678,7 +1678,7 @@ async fn test_batch_address_merkle_trees() {
     }
     // 15. Failing: account too small
     {
-        let result = rollover_batch_address_merkle_tree(
+        let result = rollover_batched_address_merkle_tree(
             &mut context,
             new_address_merkle_tree,
             &payer,
@@ -1689,7 +1689,7 @@ async fn test_batch_address_merkle_trees() {
     }
     // 15. Failing: Account too large
     {
-        let result = rollover_batch_address_merkle_tree(
+        let result = rollover_batched_address_merkle_tree(
             &mut context,
             new_address_merkle_tree,
             &payer,
@@ -1711,7 +1711,7 @@ async fn test_batch_address_merkle_trees() {
         perform_init_batch_address_merkle_tree(&mut context, &params, &merkle_tree_keypair)
             .await
             .unwrap();
-        let result = rollover_batch_address_merkle_tree(
+        let result = rollover_batched_address_merkle_tree(
             &mut context,
             address_merkle_tree_pubkey,
             &payer,
@@ -1728,7 +1728,7 @@ pub enum RolloverBatchAddressTreeTestMode {
     InvalidNewAccountSizeLarge,
 }
 
-pub async fn rollover_batch_address_merkle_tree(
+pub async fn rollover_batched_address_merkle_tree(
     context: &mut ProgramTestRpcConnection,
     address_merkle_tree_pubkey: Pubkey,
     payer: &Keypair,
@@ -1761,10 +1761,10 @@ pub async fn rollover_batch_address_merkle_tree(
         &ID,
         Some(&new_address_merkle_tree_keypair),
     );
-    let instruction_data = account_compression::instruction::RolloverBatchAddressMerkleTree {
+    let instruction_data = account_compression::instruction::RolloverBatchedAddressMerkleTree {
         network_fee: params.network_fee,
     };
-    let accounts = account_compression::accounts::RolloverBatchAddressMerkleTree {
+    let accounts = account_compression::accounts::RolloverBatchedAddressMerkleTree {
         authority: payer_pubkey,
         old_address_merkle_tree: address_merkle_tree_pubkey,
         new_address_merkle_tree: new_address_merkle_tree_keypair.pubkey(),

--- a/program-tests/account-compression-test/tests/batched_merkle_tree_test.rs
+++ b/program-tests/account-compression-test/tests/batched_merkle_tree_test.rs
@@ -88,26 +88,36 @@ async fn test_batch_state_merkle_tree() {
     let mut context = ProgramTestRpcConnection { context };
     let payer_pubkey = context.get_payer().pubkey();
     let payer = context.get_payer().insecure_clone();
+    let params = InitStateTreeAccountsInstructionData::test_default();
+    let queue_account_size = get_output_queue_account_size(
+        params.output_queue_batch_size,
+        params.output_queue_zkp_batch_size,
+        params.output_queue_num_batches,
+    );
+    let mt_account_size = get_merkle_tree_account_size(
+        params.input_queue_batch_size,
+        params.bloom_filter_capacity,
+        params.input_queue_zkp_batch_size,
+        params.root_history_capacity,
+        params.height,
+        params.input_queue_num_batches,
+    );
+    let queue_rent = context
+        .get_minimum_balance_for_rent_exemption(queue_account_size)
+        .await
+        .unwrap();
+    let mt_rent = context
+        .get_minimum_balance_for_rent_exemption(mt_account_size)
+        .await
+        .unwrap();
+    let additional_bytes_rent = context
+        .get_minimum_balance_for_rent_exemption(params.additional_bytes as usize)
+        .await
+        .unwrap();
+    let total_rent = queue_rent + mt_rent + additional_bytes_rent;
+
     // 1. Functional initialize a batched Merkle tree and output queue
     {
-        let params = InitStateTreeAccountsInstructionData::test_default();
-        let queue_account_size = get_output_queue_account_size(
-            params.output_queue_batch_size,
-            params.output_queue_zkp_batch_size,
-            params.output_queue_num_batches,
-        );
-        let mt_account_size = get_merkle_tree_account_size(
-            params.input_queue_batch_size,
-            params.bloom_filter_capacity,
-            params.input_queue_zkp_batch_size,
-            params.root_history_capacity,
-            params.height,
-            params.input_queue_num_batches,
-        );
-        let queue_rent = context
-            .get_minimum_balance_for_rent_exemption(queue_account_size)
-            .await
-            .unwrap();
         let create_queue_account_ix = create_account_instruction(
             &payer_pubkey,
             queue_account_size,
@@ -115,15 +125,7 @@ async fn test_batch_state_merkle_tree() {
             &ID,
             Some(&nullifier_queue_keypair),
         );
-        let mt_rent = context
-            .get_minimum_balance_for_rent_exemption(mt_account_size)
-            .await
-            .unwrap();
-        let additional_bytes_rent = context
-            .get_minimum_balance_for_rent_exemption(params.additional_bytes as usize)
-            .await
-            .unwrap();
-        let total_rent = queue_rent + mt_rent + additional_bytes_rent;
+
         let create_mt_account_ix = create_account_instruction(
             &payer_pubkey,
             mt_account_size,
@@ -210,6 +212,7 @@ async fn test_batch_state_merkle_tree() {
         )
         .unwrap();
     }
+    println!("post 2");
     // 3. Functional: insert 10 leaves into output queue
     let num_of_leaves = 10;
     let num_tx = 5;
@@ -345,6 +348,52 @@ async fn test_batch_state_merkle_tree() {
         .unwrap();
     }
 
+    let invalid_merkle_tree = Keypair::new();
+    let invalid_output_queue = Keypair::new();
+
+    // create 2nd merkle tree and output queue
+    {
+        let create_queue_account_ix = create_account_instruction(
+            &payer_pubkey,
+            queue_account_size,
+            queue_rent,
+            &ID,
+            Some(&invalid_output_queue),
+        );
+
+        let create_mt_account_ix = create_account_instruction(
+            &payer_pubkey,
+            mt_account_size,
+            mt_rent,
+            &ID,
+            Some(&invalid_merkle_tree),
+        );
+
+        let instruction = account_compression::instruction::InitializeBatchedStateMerkleTree {
+            bytes: params.try_to_vec().unwrap(),
+        };
+        let accounts = account_compression::accounts::InitializeBatchedStateMerkleTreeAndQueue {
+            authority: context.get_payer().pubkey(),
+            merkle_tree: invalid_merkle_tree.pubkey(),
+            queue: invalid_output_queue.pubkey(),
+            registered_program_pda: None,
+        };
+
+        let instruction = Instruction {
+            program_id: ID,
+            accounts: accounts.to_account_metas(Some(true)),
+            data: instruction.data(),
+        };
+        context
+            .create_and_send_transaction(
+                &[create_queue_account_ix, create_mt_account_ix, instruction],
+                &payer_pubkey,
+                &[&payer, &invalid_output_queue, &invalid_merkle_tree],
+            )
+            .await
+            .unwrap();
+    }
+    println!("created 2nd merkle tree and output queue");
     // 10. Failing Invalid Merkle tree - association (insert into nullifier queue)
     {
         let mut mock_indexer = mock_indexer.clone();
@@ -354,8 +403,26 @@ async fn test_batch_state_merkle_tree() {
             &mut 0,
             10,
             output_queue_pubkey,
-            output_queue_pubkey,
-            &invalid_payer,
+            invalid_merkle_tree.pubkey(),
+            &payer,
+        )
+        .await;
+        assert_rpc_error(
+            result,
+            0,
+            MerkleTreeMetadataError::MerkleTreeAndQueueNotAssociated.into(),
+        )
+        .unwrap();
+
+        let mut mock_indexer = mock_indexer.clone();
+        let result = perform_insert_into_input_queue(
+            &mut context,
+            &mut mock_indexer,
+            &mut 0,
+            10,
+            invalid_output_queue.pubkey(),
+            merkle_tree_pubkey,
+            &payer,
         )
         .await;
         assert_rpc_error(
@@ -1574,7 +1641,6 @@ async fn test_batch_address_merkle_trees() {
     // 9. Failing: invalid tree account (state tree account)
     {
         let mut mock_indexer = mock_indexer.clone();
-        println!("invalid tree account");
         let result = update_batch_address_tree(
             &mut context,
             &mut mock_indexer,

--- a/program-tests/utils/src/e2e_test_env.rs
+++ b/program-tests/utils/src/e2e_test_env.rs
@@ -531,10 +531,8 @@ where
                                 merkle_tree_account_data.as_mut_slice(),
                             )
                             .unwrap();
-                            let next_full_batch_index = merkle_tree
-                                .get_metadata()
-                                .queue_metadata
-                                .next_full_batch_index;
+                            let next_full_batch_index =
+                                merkle_tree.queue_metadata.next_full_batch_index;
                             let batch = merkle_tree
                                 .batches
                                 .get(next_full_batch_index as usize)
@@ -582,10 +580,8 @@ where
                                 queue_account_data.as_mut_slice(),
                             )
                             .unwrap();
-                            let next_full_batch_index = output_queue
-                                .get_metadata()
-                                .batch_metadata
-                                .next_full_batch_index;
+                            let next_full_batch_index =
+                                output_queue.batch_metadata.next_full_batch_index;
                             let batch = output_queue
                                 .batches
                                 .get(next_full_batch_index as usize)

--- a/programs/account-compression/src/instructions/batch_append.rs
+++ b/programs/account-compression/src/instructions/batch_append.rs
@@ -18,10 +18,10 @@ pub struct BatchAppend<'info> {
     pub registered_program_pda: Option<Account<'info, RegisteredProgram>>,
     /// CHECK: when emitting event.
     pub log_wrapper: UncheckedAccount<'info>,
-    /// CHECK: in from_account_info.
+    /// CHECK: in state_tree_from_account_info_mut.
     #[account(mut)]
     pub merkle_tree: AccountInfo<'info>,
-    /// CHECK: in from_account_info.
+    /// CHECK: in update_output_queue_account_info.
     #[account(mut)]
     pub output_queue: AccountInfo<'info>,
 }
@@ -35,18 +35,30 @@ impl<'info> GroupAccounts<'info> for BatchAppend<'info> {
     }
 }
 
+/// Append a batch of leaves from the output queue
+/// to the state Merkle tree.
+/// 1. Check Merkle tree account discriminator and program ownership.
+/// 2. Check that signer is registered or authority.
+/// 3. Append leaves from the output queue to the state Merkle tree.
+///     3.1 Checks that output queue is associated with the Merkle tree.
+///     3.2 Checks output queue discriminator, program ownership.
+///     3.3 Verifies batch zkp and updates root.
+/// 4. Emit indexer event.
 pub fn process_batch_append_leaves<'a, 'b, 'c: 'info, 'info>(
     ctx: &'a Context<'a, 'b, 'c, 'info, BatchAppend<'info>>,
     instruction_data: InstructionDataBatchAppendInputs,
 ) -> Result<()> {
+    // 1. Check Merkle tree account discriminator and program ownership.
     let merkle_tree =
         &mut BatchedMerkleTreeAccount::state_tree_from_account_info_mut(&ctx.accounts.merkle_tree)
             .map_err(ProgramError::from)?;
+    // 2. Check that signer is registered or authority.
     check_signer_is_registered_or_authority::<BatchAppend, BatchedMerkleTreeAccount>(
         ctx,
         merkle_tree,
     )?;
 
+    // 3. Append leaves and check output queue account.
     let event = merkle_tree
         .update_output_queue_account_info(
             &ctx.accounts.output_queue,
@@ -54,5 +66,6 @@ pub fn process_batch_append_leaves<'a, 'b, 'c: 'info, 'info>(
             ctx.accounts.merkle_tree.key().to_bytes(),
         )
         .map_err(ProgramError::from)?;
+    // 4. Emit indexer event.
     emit_indexer_event(event.try_to_vec()?, &ctx.accounts.log_wrapper)
 }

--- a/programs/account-compression/src/instructions/batch_append.rs
+++ b/programs/account-compression/src/instructions/batch_append.rs
@@ -21,7 +21,7 @@ pub struct BatchAppend<'info> {
     /// CHECK: in state_tree_from_account_info_mut.
     #[account(mut)]
     pub merkle_tree: AccountInfo<'info>,
-    /// CHECK: in update_output_queue_account_info.
+    /// CHECK: in update_tree_from_output_queue_account_info.
     #[account(mut)]
     pub output_queue: AccountInfo<'info>,
 }
@@ -37,7 +37,7 @@ impl<'info> GroupAccounts<'info> for BatchAppend<'info> {
 
 /// Append a batch of leaves from the output queue
 /// to the state Merkle tree.
-/// 1. Check Merkle tree account discriminator and program ownership.
+/// 1. Check Merkle tree account discriminator, tree type, and program ownership.
 /// 2. Check that signer is registered or authority.
 /// 3. Append leaves from the output queue to the state Merkle tree.
 ///     3.1 Checks that output queue is associated with the Merkle tree.
@@ -48,7 +48,7 @@ pub fn process_batch_append_leaves<'a, 'b, 'c: 'info, 'info>(
     ctx: &'a Context<'a, 'b, 'c, 'info, BatchAppend<'info>>,
     instruction_data: InstructionDataBatchAppendInputs,
 ) -> Result<()> {
-    // 1. Check Merkle tree account discriminator and program ownership.
+    // 1. Check Merkle tree account discriminator, tree type, and program ownership.
     let merkle_tree =
         &mut BatchedMerkleTreeAccount::state_tree_from_account_info_mut(&ctx.accounts.merkle_tree)
             .map_err(ProgramError::from)?;
@@ -60,7 +60,7 @@ pub fn process_batch_append_leaves<'a, 'b, 'c: 'info, 'info>(
 
     // 3. Append leaves and check output queue account.
     let event = merkle_tree
-        .update_output_queue_account_info(
+        .update_tree_from_output_queue_account_info(
             &ctx.accounts.output_queue,
             instruction_data,
             ctx.accounts.merkle_tree.key().to_bytes(),

--- a/programs/account-compression/src/instructions/batch_nullify.rs
+++ b/programs/account-compression/src/instructions/batch_nullify.rs
@@ -36,7 +36,7 @@ impl<'info> GroupAccounts<'info> for BatchNullify<'info> {
 /// to the state Merkle tree.
 /// Nullify means updating the leaf index with a nullifier.
 /// The input queue is part of the state Merkle tree account.
-/// 1. Check Merkle tree account discriminator and program ownership.
+/// 1. Check Merkle tree account discriminator, tree type, and program ownership.
 /// 2. Check that signer is registered or authority.
 /// 3. Nullify leaves from the input queue to the state Merkle tree.
 ///     3.1 Verifies batch zkp and updates root.
@@ -45,7 +45,7 @@ pub fn process_batch_nullify<'a, 'b, 'c: 'info, 'info>(
     ctx: &'a Context<'a, 'b, 'c, 'info, BatchNullify<'info>>,
     instruction_data: InstructionDataBatchNullifyInputs,
 ) -> Result<()> {
-    // 1. Check Merkle tree account discriminator and program ownership.
+    // 1. Check Merkle tree account discriminator, tree type, and program ownership.
     let merkle_tree =
         &mut BatchedMerkleTreeAccount::state_tree_from_account_info_mut(&ctx.accounts.merkle_tree)
             .map_err(ProgramError::from)?;
@@ -56,7 +56,7 @@ pub fn process_batch_nullify<'a, 'b, 'c: 'info, 'info>(
     )?;
     // 3. Nullify leaves from the input queue to the state Merkle tree.
     let event = merkle_tree
-        .update_input_queue(instruction_data, ctx.accounts.merkle_tree.key().to_bytes())
+        .update_tree_from_input_queue(instruction_data, ctx.accounts.merkle_tree.key().to_bytes())
         .map_err(ProgramError::from)?;
     // 4. Emit indexer event.
     emit_indexer_event(event.try_to_vec()?, &ctx.accounts.log_wrapper)

--- a/programs/account-compression/src/instructions/insert_into_queues.rs
+++ b/programs/account-compression/src/instructions/insert_into_queues.rs
@@ -81,7 +81,7 @@ pub fn process_insert_into_queues<'a, 'b, 'c: 'info, 'info>(
                 ctx.remaining_accounts,
             )?,
             // V2 nullifier (input state) queue
-            BatchedQueueAccount::DISCRIMINATOR => add_state_queue_bundle_v2(
+            BatchedQueueAccount::DISCRIMINATOR => add_nullifier_queue_bundle_v2(
                 &mut current_index,
                 queue_type,
                 &mut queue_map,
@@ -333,7 +333,7 @@ fn add_queue_bundle_v1<'a, 'info>(
 /// 2. Get or create a queue bundle.
 /// 3. Add the element to the queue bundle.
 /// 4. Add the index to the queue bundle.
-fn add_state_queue_bundle_v2<'a, 'info>(
+fn add_nullifier_queue_bundle_v2<'a, 'info>(
     remaining_accounts_index: &mut usize,
     queue_type: QueueType,
     queue_map: &mut HashMap<Pubkey, QueueBundle<'a, 'info>>,

--- a/programs/account-compression/src/instructions/intialize_batched_address_merkle_tree.rs
+++ b/programs/account-compression/src/instructions/intialize_batched_address_merkle_tree.rs
@@ -69,14 +69,10 @@ pub fn process_initialize_batched_address_merkle_tree<'info>(
 
 impl GroupAccess for BatchedMerkleTreeAccount<'_> {
     fn get_owner(&self) -> Pubkey {
-        self.get_metadata().metadata.access_metadata.owner.into()
+        self.metadata.access_metadata.owner.into()
     }
 
     fn get_program_owner(&self) -> Pubkey {
-        self.get_metadata()
-            .metadata
-            .access_metadata
-            .program_owner
-            .into()
+        self.metadata.access_metadata.program_owner.into()
     }
 }

--- a/programs/account-compression/src/instructions/intialize_batched_address_merkle_tree.rs
+++ b/programs/account-compression/src/instructions/intialize_batched_address_merkle_tree.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[derive(Accounts)]
-pub struct InitializeBatchAddressMerkleTree<'info> {
+pub struct InitializeBatchedAddressMerkleTree<'info> {
     #[account(mut)]
     pub authority: Signer<'info>,
     /// CHECK: is initialized in this instruction.
@@ -24,7 +24,7 @@ pub struct InitializeBatchAddressMerkleTree<'info> {
     pub registered_program_pda: Option<Account<'info, RegisteredProgram>>,
 }
 
-impl<'info> GroupAccounts<'info> for InitializeBatchAddressMerkleTree<'info> {
+impl<'info> GroupAccounts<'info> for InitializeBatchedAddressMerkleTree<'info> {
     fn get_authority(&self) -> &Signer<'info> {
         &self.authority
     }
@@ -36,7 +36,7 @@ impl<'info> GroupAccounts<'info> for InitializeBatchAddressMerkleTree<'info> {
 /// 1. checks signer
 /// 2. initializes merkle tree
 pub fn process_initialize_batched_address_merkle_tree<'info>(
-    ctx: Context<'_, '_, '_, 'info, InitializeBatchAddressMerkleTree<'info>>,
+    ctx: Context<'_, '_, '_, 'info, InitializeBatchedAddressMerkleTree<'info>>,
     params: InitAddressTreeAccountsInstructionData,
 ) -> Result<()> {
     #[cfg(feature = "test")]
@@ -52,7 +52,7 @@ pub fn process_initialize_batched_address_merkle_tree<'info>(
     let owner = match ctx.accounts.registered_program_pda.as_ref() {
         Some(registered_program_pda) => {
             check_signer_is_registered_or_authority::<
-                InitializeBatchAddressMerkleTree,
+                InitializeBatchedAddressMerkleTree,
                 RegisteredProgram,
             >(&ctx, registered_program_pda)?;
             registered_program_pda.group_authority_pda

--- a/programs/account-compression/src/instructions/migrate_state.rs
+++ b/programs/account-compression/src/instructions/migrate_state.rs
@@ -409,7 +409,7 @@ mod migrate_state_test {
             light_merkle_tree_reference::MerkleTree::<Poseidon>::new(HEIGHT, 10);
         let mut queue_account = get_output_queue();
         let output_queue = &mut queue_account.account.as_mut().unwrap();
-        let batch_size = output_queue.get_metadata().batch_metadata.batch_size as usize;
+        let batch_size = output_queue.batch_metadata.batch_size as usize;
         // insert two test leaves into the merkle tree
 
         let num_leaves = 2000;
@@ -443,10 +443,7 @@ mod migrate_state_test {
                     .to_array()
                     .unwrap(),
             };
-            let current_batch = output_queue
-                .get_metadata()
-                .batch_metadata
-                .currently_processing_batch_index;
+            let current_batch = output_queue.batch_metadata.currently_processing_batch_index;
 
             let event = migrate_state(
                 input,

--- a/programs/account-compression/src/instructions/migrate_state.rs
+++ b/programs/account-compression/src/instructions/migrate_state.rs
@@ -151,7 +151,7 @@ mod migrate_state_test {
             next_queue: Pubkey::new_unique().into(),
             access_metadata: AccessMetadata::default(),
             rollover_metadata: RolloverMetadata::default(),
-            queue_type: QueueType::Output as u64,
+            queue_type: QueueType::BatchedOutput as u64,
             associated_merkle_tree: Pubkey::new_unique().into(),
         };
 

--- a/programs/account-compression/src/instructions/rollover_batched_state_merkle_tree.rs
+++ b/programs/account-compression/src/instructions/rollover_batched_state_merkle_tree.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 #[derive(Accounts)]
-pub struct RolloverBatchStateMerkleTree<'info> {
+pub struct RolloverBatchedStateMerkleTree<'info> {
     #[account(mut)]
     /// Signer used to receive rollover accounts rentexemption reimbursement.
     pub fee_payer: Signer<'info>,
@@ -37,7 +37,7 @@ pub struct RolloverBatchStateMerkleTree<'info> {
     pub old_output_queue: AccountInfo<'info>,
 }
 
-impl<'info> GroupAccounts<'info> for RolloverBatchStateMerkleTree<'info> {
+impl<'info> GroupAccounts<'info> for RolloverBatchedStateMerkleTree<'info> {
     fn get_authority(&self) -> &Signer<'info> {
         &self.authority
     }
@@ -54,8 +54,8 @@ impl<'info> GroupAccounts<'info> for RolloverBatchStateMerkleTree<'info> {
 /// Actions:
 /// 1. mark Merkle tree as rolled over in this slot
 /// 2. initialize new Merkle tree and output queue with the same parameters
-pub fn process_rollover_batch_state_merkle_tree<'a, 'b, 'c: 'info, 'info>(
-    ctx: Context<'a, 'b, 'c, 'info, RolloverBatchStateMerkleTree<'info>>,
+pub fn process_rollover_batched_state_merkle_tree<'a, 'b, 'c: 'info, 'info>(
+    ctx: Context<'a, 'b, 'c, 'info, RolloverBatchedStateMerkleTree<'info>>,
     additional_bytes: u64,
     network_fee: Option<u64>,
 ) -> Result<()> {
@@ -68,7 +68,7 @@ pub fn process_rollover_batch_state_merkle_tree<'a, 'b, 'c: 'info, 'info>(
     )
     .map_err(ProgramError::from)?;
     check_signer_is_registered_or_authority::<
-        RolloverBatchStateMerkleTree,
+        RolloverBatchedStateMerkleTree,
         BatchedMerkleTreeAccount,
     >(&ctx, old_merkle_tree_account)?;
 

--- a/programs/account-compression/src/lib.rs
+++ b/programs/account-compression/src/lib.rs
@@ -237,6 +237,8 @@ pub mod account_compression {
         process_batch_append_leaves(&ctx, instruction_data)
     }
 
+    /// Insert a batch of addresses into a
+    /// batched address Merkle tree with a zkp.
     pub fn batch_update_address_tree<'a, 'b, 'c: 'info, 'info>(
         ctx: Context<'a, 'b, 'c, 'info, BatchUpdateAddressTree<'info>>,
         data: Vec<u8>,

--- a/programs/account-compression/src/lib.rs
+++ b/programs/account-compression/src/lib.rs
@@ -257,19 +257,21 @@ pub mod account_compression {
         process_initialize_batched_address_merkle_tree(ctx, params)
     }
 
-    pub fn rollover_batch_address_merkle_tree<'a, 'b, 'c: 'info, 'info>(
-        ctx: Context<'a, 'b, 'c, 'info, RolloverBatchAddressMerkleTree<'info>>,
+    /// Rollover batched address Merkle tree.
+    pub fn rollover_batched_address_merkle_tree<'a, 'b, 'c: 'info, 'info>(
+        ctx: Context<'a, 'b, 'c, 'info, RolloverBatchedAddressMerkleTree<'info>>,
         network_fee: Option<u64>,
     ) -> Result<()> {
-        process_rollover_batch_address_merkle_tree(ctx, network_fee)
+        process_rollover_batched_address_merkle_tree(ctx, network_fee)
     }
 
-    pub fn rollover_batch_state_merkle_tree<'a, 'b, 'c: 'info, 'info>(
-        ctx: Context<'a, 'b, 'c, 'info, RolloverBatchStateMerkleTree<'info>>,
+    /// Rollover batched state Merkle tree.
+    pub fn rollover_batched_state_merkle_tree<'a, 'b, 'c: 'info, 'info>(
+        ctx: Context<'a, 'b, 'c, 'info, RolloverBatchedStateMerkleTree<'info>>,
         additional_bytes: u64,
         network_fee: Option<u64>,
     ) -> Result<()> {
-        process_rollover_batch_state_merkle_tree(ctx, additional_bytes, network_fee)
+        process_rollover_batched_state_merkle_tree(ctx, additional_bytes, network_fee)
     }
 
     /// Migrate state from a v1 state Merkle tree

--- a/programs/account-compression/src/lib.rs
+++ b/programs/account-compression/src/lib.rs
@@ -215,6 +215,8 @@ pub mod account_compression {
         process_rollover_state_merkle_tree_nullifier_queue_pair(ctx)
     }
 
+    /// Nullify a batch of leaves from the input queue
+    /// to a batched Merkle tree with a zkp.
     pub fn batch_nullify<'a, 'b, 'c: 'info, 'info>(
         ctx: Context<'a, 'b, 'c, 'info, BatchNullify<'info>>,
         data: Vec<u8>,
@@ -268,6 +270,8 @@ pub mod account_compression {
         process_rollover_batch_state_merkle_tree(ctx, additional_bytes, network_fee)
     }
 
+    /// Migrate state from a v1 state Merkle tree
+    /// to a v2 state Merkle tree.
     pub fn migrate_state<'a, 'b, 'c: 'info, 'info>(
         ctx: Context<'a, 'b, 'c, 'info, MigrateState<'info>>,
         input: MigrateLeafParams,

--- a/programs/account-compression/src/lib.rs
+++ b/programs/account-compression/src/lib.rs
@@ -258,6 +258,9 @@ pub mod account_compression {
     }
 
     /// Rollover batched address Merkle tree.
+    /// Rollover means creating a new Merkle tree accounts
+    /// with the parameters of the old account.
+    /// Rent is reimbursed from the old account to the payer.
     pub fn rollover_batched_address_merkle_tree<'a, 'b, 'c: 'info, 'info>(
         ctx: Context<'a, 'b, 'c, 'info, RolloverBatchedAddressMerkleTree<'info>>,
         network_fee: Option<u64>,
@@ -266,6 +269,9 @@ pub mod account_compression {
     }
 
     /// Rollover batched state Merkle tree.
+    /// Rollover means creating new queue and Merkle tree accounts
+    /// with the parameters of the old accounts.
+    /// Rent is reimbursed from the old output queue account to the payer.
     pub fn rollover_batched_state_merkle_tree<'a, 'b, 'c: 'info, 'info>(
         ctx: Context<'a, 'b, 'c, 'info, RolloverBatchedStateMerkleTree<'info>>,
         additional_bytes: u64,

--- a/programs/account-compression/src/lib.rs
+++ b/programs/account-compression/src/lib.rs
@@ -224,6 +224,8 @@ pub mod account_compression {
         process_batch_nullify(&ctx, instruction_data)
     }
 
+    /// Append a batch of leaves from an output queue
+    /// to a batched Merkle tree with a zkp.
     pub fn batch_append<'a, 'b, 'c: 'info, 'info>(
         ctx: Context<'a, 'b, 'c, 'info, BatchAppend<'info>>,
         data: Vec<u8>,

--- a/programs/registry/src/account_compression_cpi/initialize_batched_address_tree.rs
+++ b/programs/registry/src/account_compression_cpi/initialize_batched_address_tree.rs
@@ -27,7 +27,7 @@ pub fn process_initialize_batched_address_merkle_tree(
     let bump = &[bump];
     let seeds = [CPI_AUTHORITY_PDA_SEED, bump];
     let signer_seeds = &[&seeds[..]];
-    let accounts = account_compression::cpi::accounts::InitializeBatchAddressMerkleTree {
+    let accounts = account_compression::cpi::accounts::InitializeBatchedAddressMerkleTree {
         authority: ctx.accounts.cpi_authority.to_account_info(),
         merkle_tree: ctx.accounts.merkle_tree.to_account_info(),
         registered_program_pda: Some(ctx.accounts.registered_program_pda.clone()),

--- a/programs/registry/src/account_compression_cpi/initialize_batched_state_tree.rs
+++ b/programs/registry/src/account_compression_cpi/initialize_batched_state_tree.rs
@@ -22,6 +22,7 @@ pub struct InitializeBatchedStateMerkleTreeAndQueue<'info> {
     pub account_compression_program: Program<'info, AccountCompression>,
     pub protocol_config_pda: Account<'info, ProtocolConfigPda>,
     /// CHECK: (system program) new cpi context account.
+    #[account(zero)]
     pub cpi_context_account: AccountInfo<'info>,
     pub light_system_program: Program<'info, LightSystemProgram>,
 }

--- a/programs/registry/src/account_compression_cpi/rollover_batched_address_tree.rs
+++ b/programs/registry/src/account_compression_cpi/rollover_batched_address_tree.rs
@@ -5,7 +5,7 @@ use light_merkle_tree_metadata::utils::if_equals_zero_u64;
 use crate::{protocol_config::state::ProtocolConfigPda, ForesterEpochPda};
 
 #[derive(Accounts)]
-pub struct RolloverBatchAddressMerkleTree<'info> {
+pub struct RolloverBatchedAddressMerkleTree<'info> {
     /// CHECK: only eligible foresters can nullify leaves. Is checked in ix.
     #[account(mut)]
     pub registered_forester_pda: Option<Account<'info, ForesterEpochPda>>,
@@ -26,14 +26,14 @@ pub struct RolloverBatchAddressMerkleTree<'info> {
     pub protocol_config_pda: Account<'info, ProtocolConfigPda>,
 }
 
-pub fn process_rollover_batch_address_merkle_tree(
-    ctx: &Context<RolloverBatchAddressMerkleTree>,
+pub fn process_rollover_batched_address_merkle_tree(
+    ctx: &Context<RolloverBatchedAddressMerkleTree>,
     bump: u8,
 ) -> Result<()> {
     let bump = &[bump];
     let seeds = [CPI_AUTHORITY_PDA_SEED, bump];
     let signer_seeds = &[&seeds[..]];
-    let accounts = account_compression::cpi::accounts::RolloverBatchAddressMerkleTree {
+    let accounts = account_compression::cpi::accounts::RolloverBatchedAddressMerkleTree {
         fee_payer: ctx.accounts.authority.to_account_info(),
         authority: ctx.accounts.cpi_authority.to_account_info(),
         old_address_merkle_tree: ctx.accounts.old_address_merkle_tree.to_account_info(),
@@ -47,7 +47,7 @@ pub fn process_rollover_batch_address_merkle_tree(
         signer_seeds,
     );
 
-    account_compression::cpi::rollover_batch_address_merkle_tree(
+    account_compression::cpi::rollover_batched_address_merkle_tree(
         cpi_ctx,
         if_equals_zero_u64(ctx.accounts.protocol_config_pda.config.network_fee),
     )

--- a/programs/registry/src/account_compression_cpi/rollover_batched_state_tree.rs
+++ b/programs/registry/src/account_compression_cpi/rollover_batched_state_tree.rs
@@ -5,7 +5,7 @@ use light_merkle_tree_metadata::utils::if_equals_zero_u64;
 use crate::{protocol_config::state::ProtocolConfigPda, ForesterEpochPda};
 
 #[derive(Accounts)]
-pub struct RolloverBatchStateMerkleTree<'info> {
+pub struct RolloverBatchedStateMerkleTree<'info> {
     /// CHECK: only eligible foresters can nullify leaves. Is checked in ix.
     #[account(mut)]
     pub registered_forester_pda: Option<Account<'info, ForesterEpochPda>>,
@@ -35,14 +35,14 @@ pub struct RolloverBatchStateMerkleTree<'info> {
     pub light_system_program: Program<'info, light_system_program::program::LightSystemProgram>,
 }
 
-pub fn process_rollover_batch_state_merkle_tree(
-    ctx: &Context<RolloverBatchStateMerkleTree>,
+pub fn process_rollover_batched_state_merkle_tree(
+    ctx: &Context<RolloverBatchedStateMerkleTree>,
     bump: u8,
 ) -> Result<()> {
     let bump = &[bump];
     let seeds = [CPI_AUTHORITY_PDA_SEED, bump];
     let signer_seeds = &[&seeds[..]];
-    let accounts = account_compression::cpi::accounts::RolloverBatchStateMerkleTree {
+    let accounts = account_compression::cpi::accounts::RolloverBatchedStateMerkleTree {
         fee_payer: ctx.accounts.authority.to_account_info(),
         authority: ctx.accounts.cpi_authority.to_account_info(),
         old_state_merkle_tree: ctx.accounts.old_state_merkle_tree.to_account_info(),
@@ -63,7 +63,7 @@ pub fn process_rollover_batch_state_merkle_tree(
         None
     };
 
-    account_compression::cpi::rollover_batch_state_merkle_tree(
+    account_compression::cpi::rollover_batched_state_merkle_tree(
         cpi_ctx,
         ctx.accounts.protocol_config_pda.config.cpi_context_size,
         network_fee,

--- a/programs/registry/src/account_compression_cpi/rollover_batched_state_tree.rs
+++ b/programs/registry/src/account_compression_cpi/rollover_batched_state_tree.rs
@@ -24,6 +24,7 @@ pub struct RolloverBatchedStateMerkleTree<'info> {
     #[account(mut)]
     pub old_output_queue: AccountInfo<'info>,
     /// CHECK: (system program) new cpi context account.
+    #[account(zero)]
     pub cpi_context_account: AccountInfo<'info>,
     /// CHECK: (account compression program) access control.
     pub registered_program_pda: AccountInfo<'info>,

--- a/programs/registry/src/account_compression_cpi/sdk.rs
+++ b/programs/registry/src/account_compression_cpi/sdk.rs
@@ -431,14 +431,14 @@ pub fn create_rollover_batch_state_tree_instruction(
     let registered_forester_pda =
         get_forester_epoch_pda_from_authority(&derivation_pubkey, epoch).0;
     let (cpi_authority, bump) = get_cpi_authority_pda();
-    let instruction_data = crate::instruction::RolloverBatchStateMerkleTree { bump };
+    let instruction_data = crate::instruction::RolloverBatchedStateMerkleTree { bump };
     let registered_forester_pda = if !light_forester {
         None
     } else {
         Some(registered_forester_pda)
     };
 
-    let accounts = crate::accounts::RolloverBatchStateMerkleTree {
+    let accounts = crate::accounts::RolloverBatchedStateMerkleTree {
         authority: forester,
         registered_forester_pda,
         registered_program_pda: register_program_pda,
@@ -526,7 +526,7 @@ pub fn create_rollover_batch_address_tree_instruction(
     let registered_program_pda = get_registered_program_pda(&crate::ID);
 
     let (cpi_authority_pda, bump) = get_cpi_authority_pda();
-    let accounts = crate::accounts::RolloverBatchAddressMerkleTree {
+    let accounts = crate::accounts::RolloverBatchedAddressMerkleTree {
         authority: forester,
         new_address_merkle_tree: new_merkle_tree,
         old_address_merkle_tree: old_merkle_tree,
@@ -536,7 +536,7 @@ pub fn create_rollover_batch_address_tree_instruction(
         account_compression_program: account_compression::ID,
         protocol_config_pda: get_protocol_config_pda_address().0,
     };
-    let instruction_data = crate::instruction::RolloverBatchAddressMerkleTree { bump };
+    let instruction_data = crate::instruction::RolloverBatchedAddressMerkleTree { bump };
     Instruction {
         program_id: crate::ID,
         accounts: accounts.to_account_metas(Some(true)),

--- a/programs/registry/src/lib.rs
+++ b/programs/registry/src/lib.rs
@@ -595,8 +595,8 @@ pub mod light_registry {
         process_batch_update_address_tree(&ctx, bump, data)
     }
 
-    pub fn rollover_batch_address_merkle_tree<'info>(
-        ctx: Context<'_, '_, '_, 'info, RolloverBatchAddressMerkleTree<'info>>,
+    pub fn rollover_batched_address_merkle_tree<'info>(
+        ctx: Context<'_, '_, '_, 'info, RolloverBatchedAddressMerkleTree<'info>>,
         bump: u8,
     ) -> Result<()> {
         let account = BatchedMerkleTreeAccount::address_tree_from_account_info_mut(
@@ -610,11 +610,11 @@ pub mod light_registry {
             &mut ctx.accounts.registered_forester_pda,
             DEFAULT_WORK_V1,
         )?;
-        process_rollover_batch_address_merkle_tree(&ctx, bump)
+        process_rollover_batched_address_merkle_tree(&ctx, bump)
     }
 
-    pub fn rollover_batch_state_merkle_tree<'info>(
-        ctx: Context<'_, '_, '_, 'info, RolloverBatchStateMerkleTree<'info>>,
+    pub fn rollover_batched_state_merkle_tree<'info>(
+        ctx: Context<'_, '_, '_, 'info, RolloverBatchedStateMerkleTree<'info>>,
         bump: u8,
     ) -> Result<()> {
         let account = BatchedMerkleTreeAccount::state_tree_from_account_info_mut(
@@ -633,7 +633,7 @@ pub mod light_registry {
             &ctx.accounts.protocol_config_pda.config,
         )?;
 
-        process_rollover_batch_state_merkle_tree(&ctx, bump)?;
+        process_rollover_batched_state_merkle_tree(&ctx, bump)?;
 
         process_initialize_cpi_context(
             bump,

--- a/programs/registry/src/lib.rs
+++ b/programs/registry/src/lib.rs
@@ -517,13 +517,12 @@ pub mod light_registry {
                 &ctx.accounts.merkle_tree,
             )
             .map_err(ProgramError::from)?;
-            let metadata = account.get_metadata().metadata;
             check_forester(
-                &metadata,
+                &account.metadata,
                 ctx.accounts.authority.key(),
                 ctx.accounts.merkle_tree.key(),
                 &mut ctx.accounts.registered_forester_pda,
-                account.get_metadata().queue_metadata.batch_size,
+                account.queue_metadata.batch_size,
             )?;
         }
         process_batch_nullify(&ctx, bump, data)
@@ -542,13 +541,12 @@ pub mod light_registry {
                 &ctx.accounts.merkle_tree,
             )
             .map_err(ProgramError::from)?;
-            let metadata = merkle_tree.get_metadata().metadata;
             check_forester(
-                &metadata,
+                &merkle_tree.metadata,
                 ctx.accounts.authority.key(),
                 ctx.accounts.merkle_tree.key(),
                 &mut ctx.accounts.registered_forester_pda,
-                queue_account.get_metadata().batch_metadata.batch_size,
+                queue_account.batch_metadata.batch_size,
             )?;
         }
         process_batch_append(&ctx, bump, data)
@@ -586,10 +584,8 @@ pub mod light_registry {
                 &ctx.accounts.merkle_tree,
             )
             .map_err(ProgramError::from)?;
-            let account = account.get_metadata();
-            let metadata = account.metadata;
             check_forester(
-                &metadata,
+                &account.metadata,
                 ctx.accounts.authority.key(),
                 ctx.accounts.merkle_tree.key(),
                 &mut ctx.accounts.registered_forester_pda,
@@ -608,7 +604,7 @@ pub mod light_registry {
         )
         .map_err(ProgramError::from)?;
         check_forester(
-            &account.get_metadata().metadata,
+            &account.metadata,
             ctx.accounts.authority.key(),
             ctx.accounts.old_address_merkle_tree.key(),
             &mut ctx.accounts.registered_forester_pda,
@@ -626,7 +622,7 @@ pub mod light_registry {
         )
         .map_err(ProgramError::from)?;
         check_forester(
-            &account.get_metadata().metadata,
+            &account.metadata,
             ctx.accounts.authority.key(),
             ctx.accounts.old_state_merkle_tree.key(),
             &mut ctx.accounts.registered_forester_pda,

--- a/programs/system/src/invoke/verify_state_proof.rs
+++ b/programs/system/src/invoke/verify_state_proof.rs
@@ -202,13 +202,13 @@ fn fetch_root<const IS_READ_ONLY: bool, const IS_STATE: bool>(
                 )
                 .map_err(ProgramError::from)?;
                 (*roots).push(merkle_tree.root_history[root_index as usize]);
-                height = merkle_tree.get_metadata().height as u8;
+                height = merkle_tree.height as u8;
             } else {
                 let merkle_tree = BatchedMerkleTreeAccount::address_tree_from_account_info_mut(
                     merkle_tree_account_info,
                 )
                 .map_err(ProgramError::from)?;
-                height = merkle_tree.get_metadata().height as u8;
+                height = merkle_tree.height as u8;
                 (*roots).push(merkle_tree.root_history[root_index as usize]);
             }
         }

--- a/programs/system/src/invoke_cpi/verify_signer.rs
+++ b/programs/system/src/invoke_cpi/verify_signer.rs
@@ -164,15 +164,14 @@ pub fn check_program_owner_state_merkle_tree<'a, 'b: 'a, const IS_NULLIFY: bool>
                     merkle_tree_acc_info,
                 )
                 .map_err(ProgramError::from)?;
-                let account = merkle_tree.get_metadata();
-                let seq = account.sequence_number + 1;
-                let next_index: u32 = account.next_index.try_into().unwrap();
+                let seq = merkle_tree.sequence_number + 1;
+                let next_index: u32 = merkle_tree.next_index.try_into().unwrap();
 
                 (
                     seq,
                     next_index,
-                    account.metadata.rollover_metadata.network_fee,
-                    account.metadata.access_metadata.program_owner,
+                    merkle_tree.metadata.rollover_metadata.network_fee,
+                    merkle_tree.metadata.access_metadata.program_owner,
                     merkle_tree_acc_info.key(),
                 )
             }
@@ -185,15 +184,14 @@ pub fn check_program_owner_state_merkle_tree<'a, 'b: 'a, const IS_NULLIFY: bool>
                 let merkle_tree =
                     BatchedQueueAccount::output_queue_from_account_info_mut(merkle_tree_acc_info)
                         .map_err(ProgramError::from)?;
-                let account = merkle_tree.get_metadata();
                 let seq = u64::MAX;
-                let next_index: u32 = account.next_index.try_into().unwrap();
+                let next_index: u32 = merkle_tree.next_index.try_into().unwrap();
                 (
                     seq,
                     next_index,
-                    account.metadata.rollover_metadata.network_fee,
-                    account.metadata.access_metadata.program_owner,
-                    account.metadata.associated_merkle_tree.into(),
+                    merkle_tree.metadata.rollover_metadata.network_fee,
+                    merkle_tree.metadata.access_metadata.program_owner,
+                    merkle_tree.metadata.associated_merkle_tree.into(),
                 )
             }
             _ => {
@@ -245,8 +243,7 @@ pub fn check_program_owner_address_merkle_tree<'a, 'b: 'a>(
             let merkle_tree =
                 BatchedMerkleTreeAccount::address_tree_from_account_info_mut(merkle_tree_acc_info)
                     .map_err(ProgramError::from)?;
-            let account = merkle_tree.get_metadata();
-            account.metadata
+            merkle_tree.metadata
         }
         _ => {
             return err!(

--- a/sdk-libs/program-test/src/indexer/test_indexer.rs
+++ b/sdk-libs/program-test/src/indexer/test_indexer.rs
@@ -764,7 +764,7 @@ where
             )
             .unwrap();
             (
-                merkle_tree.get_metadata().next_index as usize,
+                merkle_tree.next_index as usize,
                 *merkle_tree.root_history.last().unwrap(),
             )
         };
@@ -777,9 +777,8 @@ where
             )
             .unwrap();
 
-            let output_queue_account = output_queue.get_metadata();
-            let max_num_zkp_updates = output_queue_account.batch_metadata.get_num_zkp_batches();
-            let zkp_batch_size = output_queue_account.batch_metadata.zkp_batch_size;
+            let max_num_zkp_updates = output_queue.batch_metadata.get_num_zkp_batches();
+            let zkp_batch_size = output_queue.batch_metadata.zkp_batch_size;
             (max_num_zkp_updates, zkp_batch_size)
         };
 
@@ -876,7 +875,7 @@ where
             .find(|x| x.accounts.merkle_tree == merkle_tree_pubkey)
             .unwrap();
         let address_tree_index = address_tree.merkle_tree.merkle_tree.rightmost_index;
-        let onchain_next_index = onchain_account.get_metadata().next_index;
+        let onchain_next_index = onchain_account.next_index;
         let diff_onchain_indexer = onchain_next_index - address_tree_index as u64;
         let addresses = address_tree.queue_elements[0..diff_onchain_indexer as usize].to_vec();
 

--- a/sdk-libs/program-test/src/test_batch_forester.rs
+++ b/sdk-libs/program-test/src/test_batch_forester.rs
@@ -110,16 +110,15 @@ pub async fn create_append_batch_ix_data<Rpc: RpcConnection>(
         merkle_tree_account.data.as_mut_slice(),
     )
     .unwrap();
-    let merkle_tree_next_index = merkle_tree.get_metadata().next_index as usize;
+    let merkle_tree_next_index = merkle_tree.next_index as usize;
 
     let mut output_queue_account = rpc.get_account(output_queue_pubkey).await.unwrap().unwrap();
     let output_queue =
         BatchedQueueAccount::output_queue_from_bytes_mut(output_queue_account.data.as_mut_slice())
             .unwrap();
-    let output_queue_account = output_queue.get_metadata();
-    let full_batch_index = output_queue_account.batch_metadata.next_full_batch_index;
-    let zkp_batch_size = output_queue_account.batch_metadata.zkp_batch_size;
-    let max_num_zkp_updates = output_queue_account.batch_metadata.get_num_zkp_batches();
+    let full_batch_index = output_queue.batch_metadata.next_full_batch_index;
+    let zkp_batch_size = output_queue.batch_metadata.zkp_batch_size;
+    let max_num_zkp_updates = output_queue.batch_metadata.get_num_zkp_batches();
 
     let leaves = bundle.output_queue_elements.to_vec();
 
@@ -276,11 +275,8 @@ pub async fn get_batched_nullify_ix_data<Rpc: RpcConnection>(
         merkle_tree_account.data.as_mut_slice(),
     )
     .unwrap();
-    let zkp_batch_size = merkle_tree.get_metadata().queue_metadata.zkp_batch_size;
-    let full_batch_index = merkle_tree
-        .get_metadata()
-        .queue_metadata
-        .next_full_batch_index;
+    let zkp_batch_size = merkle_tree.queue_metadata.zkp_batch_size;
+    let full_batch_index = merkle_tree.queue_metadata.next_full_batch_index;
     let full_batch = &merkle_tree.batches[full_batch_index as usize];
     let zkp_batch_index = full_batch.get_num_inserted_zkps();
     let leaves_hashchain =
@@ -574,7 +570,6 @@ pub async fn perform_rollover_batch_state_merkle_tree<R: RpcConnection>(
         BatchedMerkleTreeAccount::state_tree_from_bytes_mut(account.data.as_mut_slice()).unwrap();
     let batch_zero = &old_merkle_tree.batches[0];
     let num_batches = old_merkle_tree.batches.len();
-    let old_merkle_tree = old_merkle_tree.get_metadata();
     let mt_account_size = get_merkle_tree_account_size(
         batch_zero.batch_size,
         batch_zero.bloom_filter_capacity,
@@ -814,10 +809,7 @@ pub async fn create_batch_update_address_tree_instruction_data_with_proof<
     )
     .unwrap();
     let old_root_index = merkle_tree.root_history.last_index();
-    let full_batch_index = merkle_tree
-        .get_metadata()
-        .queue_metadata
-        .next_full_batch_index;
+    let full_batch_index = merkle_tree.queue_metadata.next_full_batch_index;
     let batch = &merkle_tree.batches[full_batch_index as usize];
     let zkp_batch_index = batch.get_num_inserted_zkps();
     let leaves_hashchain =
@@ -843,7 +835,7 @@ pub async fn create_batch_update_address_tree_instruction_data_with_proof<
     // // local_leaves_hashchain is only used for a test assertion.
     // let local_nullifier_hashchain = create_hash_chain_from_array(&addresses);
     // assert_eq!(leaves_hashchain, local_nullifier_hashchain);
-    let start_index = merkle_tree.get_metadata().next_index as usize;
+    let start_index = merkle_tree.next_index as usize;
     assert!(
         start_index >= 2,
         "start index should be greater than 2 else tree is not inited"
@@ -936,7 +928,6 @@ pub async fn perform_rollover_batch_address_merkle_tree<R: RpcConnection>(
         BatchedMerkleTreeAccount::address_tree_from_bytes_mut(account.data.as_mut_slice()).unwrap();
     let batch_zero = &old_merkle_tree.batches[0];
     let num_batches = old_merkle_tree.batches.len();
-    let old_merkle_tree = old_merkle_tree.get_metadata();
     let mt_account_size = get_merkle_tree_account_size(
         batch_zero.batch_size,
         batch_zero.bloom_filter_capacity,


### PR DESCRIPTION
Changes:
1. add comments to new account compression program instructions
2. remove usage of `get_metadata()` and `get_metadata_mut()` except in tests
3. renamed `QueueType`
    1.  `QueueType::Output` -> `QueueType::BatchedOutput` 
    2. `QueueType::Input` -> `QueueType::BatchedInput` 
    3. `QueueType::Address` -> `QueueType::BatchedAddress` 
4. renamed `update_output_queue_account_info` -> `update_tree_from_output_queue_account_info`
5. renamed `update_input_queue` -> `update_tree_from_input_queue`
6. renamed `update_address_queue` -> `update_tree_from_address_queue`