### PR TITLE
chore: cleanup & fix zero out bloom filter

### DIFF
--- a/forester/tests/batched_address_test.rs
+++ b/forester/tests/batched_address_test.rs
@@ -293,11 +293,14 @@ async fn test_address_batched() {
 
         let expected_sequence_number =
             initial_sequence_number + (num_zkp_batches * UPDATES_PER_BATCH);
-        let expected_root_history_len = (expected_sequence_number + 1) as usize;
+        let expected_root_history_len = expected_sequence_number as usize;
 
         assert_eq!(final_metadata.sequence_number, expected_sequence_number);
 
-        assert_eq!(merkle_tree.root_history.len(), expected_root_history_len);
+        assert_eq!(
+            merkle_tree.root_history.last_index(),
+            expected_root_history_len
+        );
 
         assert_ne!(
             pre_root,

--- a/forester/tests/batched_state_test.rs
+++ b/forester/tests/batched_state_test.rs
@@ -337,11 +337,13 @@ async fn test_state_batched() {
 
         let expected_sequence_number =
             initial_sequence_number + (num_zkp_batches * UPDATES_PER_BATCH);
-        let expected_root_history_len = (expected_sequence_number + 1) as usize;
 
         assert_eq!(final_metadata.sequence_number, expected_sequence_number);
 
-        assert_eq!(merkle_tree.root_history.len(), expected_root_history_len);
+        assert_eq!(
+            merkle_tree.root_history.last_index(),
+            expected_sequence_number as usize
+        );
 
         assert_ne!(
             pre_root,

--- a/program-libs/batched-merkle-tree/src/batch.rs
+++ b/program-libs/batched-merkle-tree/src/batch.rs
@@ -332,6 +332,11 @@ impl Batch {
             // When the batch is cleared check that sequence number is greater or equal than self.sequence_number
             // if not advance current root index to root index
             self.sequence_number = sequence_number + root_history_length as u64;
+            println!("root_history_length as u64: {}", root_history_length as u64);
+            println!("sequence_number: {}", sequence_number);
+            println!("recorded sequence_number: {}", self.sequence_number);
+            println!("current root index {}", root_index);
+
             self.root_index = root_index;
         }
 

--- a/program-libs/batched-merkle-tree/src/batch_metadata.rs
+++ b/program-libs/batched-merkle-tree/src/batch_metadata.rs
@@ -83,6 +83,14 @@ impl BatchMetadata {
         }
     }
 
+    /// Increment the currently_processing_batch_index if current state is full.
+    pub fn increment_currently_processing_batch_index_if_full(&mut self, state: BatchState) {
+        if state == BatchState::Full {
+            self.currently_processing_batch_index += 1;
+            self.currently_processing_batch_index %= self.num_batches;
+        }
+    }
+
     pub fn init(
         &mut self,
         num_batches: u64,

--- a/program-libs/batched-merkle-tree/src/batch_metadata.rs
+++ b/program-libs/batched-merkle-tree/src/batch_metadata.rs
@@ -75,7 +75,7 @@ impl BatchMetadata {
         })
     }
 
-    /// Increment the next full batch index if current state is inserted.
+    /// Increment the next full batch index if current state is BatchState::Inserted.
     pub fn increment_next_full_batch_index_if_inserted(&mut self, state: BatchState) {
         if state == BatchState::Inserted {
             self.next_full_batch_index += 1;
@@ -83,7 +83,7 @@ impl BatchMetadata {
         }
     }
 
-    /// Increment the currently_processing_batch_index if current state is full.
+    /// Increment the currently_processing_batch_index if current state is BatchState::Full.
     pub fn increment_currently_processing_batch_index_if_full(&mut self, state: BatchState) {
         if state == BatchState::Full {
             self.currently_processing_batch_index += 1;
@@ -134,7 +134,6 @@ impl BatchMetadata {
 
 #[test]
 fn test_increment_next_full_batch_index_if_inserted() {
-    // create a new metadata struct
     let mut metadata = BatchMetadata::new_input_queue(10, 10, 10, 2).unwrap();
     assert_eq!(metadata.next_full_batch_index, 0);
     // increment next full batch index
@@ -148,4 +147,21 @@ fn test_increment_next_full_batch_index_if_inserted() {
     assert_eq!(metadata.next_full_batch_index, 0);
     metadata.increment_next_full_batch_index_if_inserted(BatchState::Full);
     assert_eq!(metadata.next_full_batch_index, 0);
+}
+
+#[test]
+fn test_increment_currently_processing_batch_index_if_full() {
+    let mut metadata = BatchMetadata::new_input_queue(10, 10, 10, 2).unwrap();
+    assert_eq!(metadata.currently_processing_batch_index, 0);
+    // increment currently_processing_batch_index
+    metadata.increment_currently_processing_batch_index_if_full(BatchState::Full);
+    assert_eq!(metadata.currently_processing_batch_index, 1);
+    // increment currently_processing_batch_index
+    metadata.increment_currently_processing_batch_index_if_full(BatchState::Full);
+    assert_eq!(metadata.currently_processing_batch_index, 0);
+    // try incrementing next full batch index with state not full
+    metadata.increment_currently_processing_batch_index_if_full(BatchState::Fill);
+    assert_eq!(metadata.currently_processing_batch_index, 0);
+    metadata.increment_currently_processing_batch_index_if_full(BatchState::Inserted);
+    assert_eq!(metadata.currently_processing_batch_index, 0);
 }

--- a/program-libs/batched-merkle-tree/src/batch_metadata.rs
+++ b/program-libs/batched-merkle-tree/src/batch_metadata.rs
@@ -1,6 +1,7 @@
+use light_merkle_tree_metadata::{errors::MerkleTreeMetadataError, queue::QueueType};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
-use crate::{BorshDeserialize, BorshSerialize};
+use crate::{batch::BatchState, errors::BatchedMerkleTreeError, BorshDeserialize, BorshSerialize};
 
 #[repr(C)]
 #[derive(
@@ -17,12 +18,19 @@ use crate::{BorshDeserialize, BorshSerialize};
     Immutable,
 )]
 pub struct BatchMetadata {
+    /// Number of batches.
     pub num_batches: u64,
+    /// Number of elements in a batch.
     pub batch_size: u64,
+    /// Number of elements in a ZKP batch.
+    /// A batch has one or more ZKP batches.
     pub zkp_batch_size: u64,
-    pub currently_processing_batch_index: u64,
-    pub next_full_batch_index: u64,
+    /// Bloom filter capacity.
     pub bloom_filter_capacity: u64,
+    /// Batch elements are currently inserted in.
+    pub currently_processing_batch_index: u64,
+    /// Next batch to be inserted into the tree.
+    pub next_full_batch_index: u64,
 }
 
 impl BatchMetadata {
@@ -30,15 +38,22 @@ impl BatchMetadata {
         self.batch_size / self.zkp_batch_size
     }
 
-    pub fn new_output_queue(batch_size: u64, zkp_batch_size: u64, num_batches: u64) -> Self {
-        BatchMetadata {
+    pub fn new_output_queue(
+        batch_size: u64,
+        zkp_batch_size: u64,
+        num_batches: u64,
+    ) -> Result<Self, BatchedMerkleTreeError> {
+        if batch_size % zkp_batch_size != 0 {
+            return Err(BatchedMerkleTreeError::BatchSizeNotDivisibleByZkpBatchSize);
+        }
+        Ok(BatchMetadata {
             num_batches,
             zkp_batch_size,
             batch_size,
             currently_processing_batch_index: 0,
             next_full_batch_index: 0,
             bloom_filter_capacity: 0,
-        }
+        })
     }
 
     pub fn new_input_queue(
@@ -46,14 +61,83 @@ impl BatchMetadata {
         bloom_filter_capacity: u64,
         zkp_batch_size: u64,
         num_batches: u64,
-    ) -> Self {
-        BatchMetadata {
+    ) -> Result<Self, BatchedMerkleTreeError> {
+        if batch_size % zkp_batch_size != 0 {
+            return Err(BatchedMerkleTreeError::BatchSizeNotDivisibleByZkpBatchSize);
+        }
+        Ok(BatchMetadata {
             num_batches,
             zkp_batch_size,
             batch_size,
             currently_processing_batch_index: 0,
             next_full_batch_index: 0,
             bloom_filter_capacity,
+        })
+    }
+
+    /// Increment the next full batch index if current state is inserted.
+    pub fn increment_next_full_batch_index_if_inserted(&mut self, state: BatchState) {
+        if state == BatchState::Inserted {
+            self.next_full_batch_index += 1;
+            self.next_full_batch_index %= self.num_batches;
         }
     }
+
+    pub fn init(
+        &mut self,
+        num_batches: u64,
+        batch_size: u64,
+        zkp_batch_size: u64,
+    ) -> Result<(), BatchedMerkleTreeError> {
+        self.num_batches = num_batches;
+        self.batch_size = batch_size;
+        // Check that batch size is divisible by zkp_batch_size.
+        if batch_size % zkp_batch_size != 0 {
+            return Err(BatchedMerkleTreeError::BatchSizeNotDivisibleByZkpBatchSize);
+        }
+        self.zkp_batch_size = zkp_batch_size;
+        Ok(())
+    }
+
+    pub fn get_size_parameters(
+        &self,
+        queue_type: u64,
+    ) -> Result<(usize, usize, usize), MerkleTreeMetadataError> {
+        let num_batches = self.num_batches as usize;
+        // Input queues don't store values.
+        let num_value_stores = if queue_type == QueueType::BatchedOutput as u64 {
+            num_batches
+        } else if queue_type == QueueType::BatchedInput as u64 {
+            0
+        } else {
+            return Err(MerkleTreeMetadataError::InvalidQueueType);
+        };
+        // Output queues don't use bloom filters.
+        let num_stores = if queue_type == QueueType::BatchedInput as u64 {
+            num_batches
+        } else if queue_type == QueueType::BatchedOutput as u64 && self.bloom_filter_capacity == 0 {
+            0
+        } else {
+            return Err(MerkleTreeMetadataError::InvalidQueueType);
+        };
+        Ok((num_value_stores, num_stores, num_batches))
+    }
+}
+
+#[test]
+fn test_increment_next_full_batch_index_if_inserted() {
+    // create a new metadata struct
+    let mut metadata = BatchMetadata::new_input_queue(10, 10, 10, 2).unwrap();
+    assert_eq!(metadata.next_full_batch_index, 0);
+    // increment next full batch index
+    metadata.increment_next_full_batch_index_if_inserted(BatchState::Inserted);
+    assert_eq!(metadata.next_full_batch_index, 1);
+    // increment next full batch index
+    metadata.increment_next_full_batch_index_if_inserted(BatchState::Inserted);
+    assert_eq!(metadata.next_full_batch_index, 0);
+    // try incrementing next full batch index with state not inserted
+    metadata.increment_next_full_batch_index_if_inserted(BatchState::Fill);
+    assert_eq!(metadata.next_full_batch_index, 0);
+    metadata.increment_next_full_batch_index_if_inserted(BatchState::Full);
+    assert_eq!(metadata.next_full_batch_index, 0);
 }

--- a/program-libs/batched-merkle-tree/src/event.rs
+++ b/program-libs/batched-merkle-tree/src/event.rs
@@ -25,3 +25,5 @@ pub struct BatchNullifyEvent {
     pub sequence_number: u64,
     pub batch_size: u64,
 }
+
+pub type BatchAddressAppendEvent = BatchNullifyEvent;

--- a/program-libs/batched-merkle-tree/src/initialize_state_tree.rs
+++ b/program-libs/batched-merkle-tree/src/initialize_state_tree.rs
@@ -477,7 +477,8 @@ pub fn create_output_queue_account(params: CreateOutputQueueParams) -> BatchedQu
         params.batch_size,
         params.zkp_batch_size,
         params.num_batches,
-    );
+    )
+    .unwrap();
     BatchedQueueMetadata {
         metadata,
         batch_metadata,

--- a/program-libs/batched-merkle-tree/src/merkle_tree.rs
+++ b/program-libs/batched-merkle-tree/src/merkle_tree.rs
@@ -483,10 +483,10 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
     ///     3.3. If all zkps are inserted, set the state to inserted.
     /// 4. Increment next full batch index if inserted.
     /// 5. Return the batch append event.
+    ///     
     /// Note: when proving inclusion by index in
-    /// value array we need to insert the value into a bloom_filter once it is
-    /// inserted into the tree. Check this with get_num_inserted_zkps
-    #[cfg(not(target_os = "solana"))]
+    ///     value array we need to insert the value into a bloom_filter once it is
+    ///     inserted into the tree. Check this with get_num_inserted_zkps
     pub fn update_tree_from_output_queue_account(
         &mut self,
         queue_account: &mut BatchedQueueAccount,

--- a/program-libs/batched-merkle-tree/src/merkle_tree.rs
+++ b/program-libs/batched-merkle-tree/src/merkle_tree.rs
@@ -38,7 +38,7 @@ use crate::{
         BATCHED_STATE_TREE_TYPE, DEFAULT_BATCH_STATE_TREE_HEIGHT, TEST_DEFAULT_BATCH_SIZE,
     },
     errors::BatchedMerkleTreeError,
-    event::{BatchAppendEvent, BatchNullifyEvent},
+    event::{BatchAddressAppendEvent, BatchAppendEvent, BatchNullifyEvent},
     initialize_address_tree::InitAddressTreeAccountsInstructionData,
     initialize_state_tree::InitStateTreeAccountsInstructionData,
     queue::BatchedQueueAccount,
@@ -229,13 +229,13 @@ impl BatchedMerkleTreeMetadata {
                 bloom_filter_capacity,
                 zkp_batch_size,
                 num_batches,
-            ),
+            )
+            .unwrap(),
             capacity: 2u64.pow(height),
         }
     }
 }
 
-#[repr(C)]
 #[derive(Debug, PartialEq)]
 pub struct BatchedMerkleTreeAccount<'a> {
     metadata: Ref<&'a mut [u8], BatchedMerkleTreeMetadata>,
@@ -260,38 +260,34 @@ impl DerefMut for BatchedMerkleTreeAccount<'_> {
     }
 }
 
-/// Get batch from account.
-/// Hash all public inputs into one poseidon hash.
 /// Public inputs:
-/// 1. old root (get from account by index)
-/// 2. new root (send to chain and )
-/// 3. start index (get from batch)
-/// 4. end index (get from batch start index plus batch size)
+/// 1. old root (last root in root history)
+/// 2. new root (send to chain)
+/// 3. leaf hash chain (in hashchain store)
 #[repr(C)]
 #[derive(Debug, PartialEq, Clone, Copy, BorshDeserialize, BorshSerialize)]
 pub struct InstructionDataBatchNullifyInputs {
-    pub public_inputs: BatchProofInputsIx,
+    pub new_root: [u8; 32],
     pub compressed_proof: CompressedProof,
 }
 
-#[repr(C)]
-#[derive(Debug, PartialEq, Clone, Copy, BorshDeserialize, BorshSerialize)]
-pub struct BatchProofInputsIx {
-    pub new_root: [u8; 32],
-    pub old_root_index: u16,
-}
+/// Public inputs:
+/// 1. old root (last root in root history)
+/// 2. new root (send to chain)
+/// 3. leaf hash chain (in hashchain store)
+/// 4. next index (get from metadata)
+pub type InstructionDataAddressAppendInputs = InstructionDataBatchNullifyInputs;
 
+/// Public inputs:
+/// 1. old root (last root in root history)
+/// 2. new root (send to chain)
+/// 3. leaf hash chain (in hashchain store)
+/// 4. start index (get from batch)
 #[repr(C)]
 #[derive(Debug, PartialEq, Clone, Copy, BorshDeserialize, BorshSerialize)]
 pub struct InstructionDataBatchAppendInputs {
-    pub public_inputs: AppendBatchProofInputsIx,
-    pub compressed_proof: CompressedProof,
-}
-
-#[repr(C)]
-#[derive(Debug, PartialEq, Clone, Copy, BorshDeserialize, BorshSerialize)]
-pub struct AppendBatchProofInputsIx {
     pub new_root: [u8; 32],
+    pub compressed_proof: CompressedProof,
 }
 
 impl<'a> BatchedMerkleTreeAccount<'a> {
@@ -431,8 +427,9 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
         if tree_type == TreeType::BatchedState {
             root_history.push(light_hasher::Poseidon::zero_bytes()[height as usize]);
         } else if tree_type == TreeType::BatchedAddress {
-            // Initialized indexed Merkle tree root
+            // Initialized indexed Merkle tree root.
             root_history.push(ADDRESS_TREE_INIT_ROOT_40);
+            // The initialized indexed Merkle tree contains two elements.
             account_metadata.next_index = 2;
         }
         let (batches, value_vecs, bloom_filter_stores, hashchain_store) = init_queue(
@@ -453,210 +450,270 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
         })
     }
 
+    /// Update the tree from the output queue account.
+    /// 1. Checks that the tree and queue are associated.
+    /// 2. Updates the tree with the output queue account.
+    /// 3. Returns the batch append event.
     pub fn update_tree_from_output_queue_account_info(
         &mut self,
         queue_account_info: &AccountInfo<'_>,
         instruction_data: InstructionDataBatchAppendInputs,
         id: [u8; 32],
     ) -> Result<BatchAppendEvent, BatchedMerkleTreeError> {
+        if self.tree_type != TreeType::BatchedState as u64 {
+            return Err(MerkleTreeMetadataError::InvalidTreeType.into());
+        }
         if self.metadata.metadata.associated_queue != (*queue_account_info.key).into() {
             return Err(MerkleTreeMetadataError::MerkleTreeAndQueueNotAssociated.into());
         }
         let queue_account = &mut BatchedQueueAccount::output_from_account_info(queue_account_info)?;
-        self.update_output_queue_account(queue_account, instruction_data, id)
+        self.update_tree_from_output_queue_account(queue_account, instruction_data, id)
     }
 
-    // Note: when proving inclusion by index in
-    // value array we need to insert the value into a bloom_filter once it is
-    // inserted into the tree. Check this with get_num_inserted_zkps
-    pub fn update_output_queue_account(
+    /// Update the tree from the output queue account.
+    /// 1. Create public inputs hash.
+    /// 2. Verify update proof and update tree account.
+    ///     2.1. Verify proof.
+    ///     2.2. Increment sequence number.
+    ///     2.3. Increment next index.
+    ///     2.4. Append new root to root history.
+    /// 3. Mark batch as inserted in the merkle tree.
+    ///     3.1. Checks that the batch is ready.
+    ///     3.2. Increment the number of inserted zkps.
+    ///     3.3. If all zkps are inserted, set the state to inserted.
+    /// 4. Increment next full batch index if inserted.
+    /// 5. Return the batch append event.
+    /// Note: when proving inclusion by index in
+    /// value array we need to insert the value into a bloom_filter once it is
+    /// inserted into the tree. Check this with get_num_inserted_zkps
+    #[cfg(not(target_os = "solana"))]
+    pub fn update_tree_from_output_queue_account(
         &mut self,
         queue_account: &mut BatchedQueueAccount,
         instruction_data: InstructionDataBatchAppendInputs,
         id: [u8; 32],
     ) -> Result<BatchAppendEvent, BatchedMerkleTreeError> {
-        let batch_index = queue_account.batch_metadata.next_full_batch_index;
+        let full_batch_index = queue_account.batch_metadata.next_full_batch_index as usize;
+        let new_root = instruction_data.new_root;
         let circuit_batch_size = queue_account.batch_metadata.zkp_batch_size;
-        let batches = &mut queue_account.batches;
-        let full_batch = batches
-            .get_mut(batch_index as usize)
-            .ok_or(BatchedMerkleTreeError::InvalidBatchIndex)?;
-
-        let new_root = instruction_data.public_inputs.new_root;
+        let start_index = self.next_index;
+        let full_batch = &mut queue_account.batches[full_batch_index];
         let num_zkps = full_batch.get_first_ready_zkp_batch()?;
 
-        let leaves_hashchain = queue_account
-            .hashchain_store
-            .get(batch_index as usize)
-            .ok_or(BatchedMerkleTreeError::InvalidBatchIndex)?
-            .get(num_zkps as usize)
-            .ok_or(BatchedMerkleTreeError::InvalidIndex)?;
-        let old_root = self
-            .root_history
-            .last()
-            .ok_or(BatchedMerkleTreeError::InvalidIndex)?;
-        let start_index = self.next_index;
-        let mut start_index_bytes = [0u8; 32];
-        start_index_bytes[24..].copy_from_slice(&start_index.to_be_bytes());
-        let public_input_hash = create_hash_chain_from_array([
-            *old_root,
-            new_root,
-            *leaves_hashchain,
-            start_index_bytes,
-        ])?;
+        // 1. Create public inputs hash.
+        let public_input_hash = {
+            let leaves_hashchain =
+                queue_account.hashchain_store[full_batch_index][num_zkps as usize];
+            let old_root = self
+                .root_history
+                .last()
+                .ok_or(BatchedMerkleTreeError::InvalidIndex)?;
+            let mut start_index_bytes = [0u8; 32];
+            start_index_bytes[24..].copy_from_slice(&start_index.to_be_bytes());
+            create_hash_chain_from_array([
+                *old_root,
+                new_root,
+                leaves_hashchain,
+                start_index_bytes,
+            ])?
+        };
 
-        self.update::<5>(
-            circuit_batch_size as usize,
+        // 2. Verify update proof and update tree account.
+        self.verify_update::<5>(
+            circuit_batch_size,
             instruction_data.compressed_proof,
             public_input_hash,
+            new_root,
         )?;
 
-        self.metadata.next_index += circuit_batch_size;
-        let root_history_capacity = self.metadata.root_history_capacity;
-        let sequence_number = self.metadata.sequence_number;
-        self.root_history.push(new_root);
         let root_index = self.root_history.last_index() as u32;
-        full_batch.mark_as_inserted_in_merkle_tree(
-            sequence_number,
-            root_index,
-            root_history_capacity,
-        )?;
-        if full_batch.get_state() == BatchState::Inserted {
-            queue_account.batch_metadata.next_full_batch_index += 1;
-            queue_account.batch_metadata.next_full_batch_index %=
-                queue_account.batch_metadata.num_batches;
+
+        // Update queue metadata.
+        {
+            // 3. Mark batch as inserted in the merkle tree.
+            let full_batch_state = full_batch.mark_as_inserted_in_merkle_tree(
+                self.metadata.sequence_number,
+                root_index,
+                self.metadata.root_history_capacity,
+            )?;
+            // 4. Increment next full batch index if inserted.
+            queue_account
+                .batch_metadata
+                .increment_next_full_batch_index_if_inserted(full_batch_state);
         }
+        // 5. Return the batch append event.
         Ok(BatchAppendEvent {
             id,
-            batch_index,
-            batch_size: circuit_batch_size,
+            batch_index: full_batch_index as u64,
             zkp_batch_index: num_zkps,
             old_next_index: start_index,
             new_next_index: start_index + circuit_batch_size,
+            batch_size: circuit_batch_size,
             new_root,
             root_index,
             sequence_number: self.sequence_number,
         })
     }
 
+    /// Update the tree from the input queue account.
     pub fn update_tree_from_input_queue(
         &mut self,
         instruction_data: InstructionDataBatchNullifyInputs,
         id: [u8; 32],
     ) -> Result<BatchNullifyEvent, BatchedMerkleTreeError> {
-        self.private_update_input_queue::<3>(instruction_data, id)
+        if self.tree_type != TreeType::BatchedState as u64 {
+            return Err(MerkleTreeMetadataError::InvalidTreeType.into());
+        }
+        self.update_input_queue::<3>(instruction_data, id)
     }
 
+    /// Update the tree from the address queue account.
     pub fn update_tree_from_address_queue(
         &mut self,
-        instruction_data: InstructionDataBatchNullifyInputs,
+        instruction_data: InstructionDataAddressAppendInputs,
         id: [u8; 32],
-    ) -> Result<BatchNullifyEvent, BatchedMerkleTreeError> {
-        self.private_update_input_queue::<4>(instruction_data, id)
+    ) -> Result<BatchAddressAppendEvent, BatchedMerkleTreeError> {
+        if self.tree_type != TreeType::BatchedAddress as u64 {
+            return Err(MerkleTreeMetadataError::InvalidTreeType.into());
+        }
+        self.update_input_queue::<4>(instruction_data, id)
     }
 
-    fn private_update_input_queue<const QUEUE_TYPE: u64>(
+    /// Update the tree from the input/address queue account.
+    /// 1. Create public inputs hash.
+    /// 2. Verify update proof and update tree account.
+    ///     2.1. Verify proof.
+    ///     2.2. Increment sequence number.
+    ///     2.3. If address tree increment next index.
+    ///     2.4. Append new root to root history.
+    /// 3. Mark batch as inserted in the merkle tree.
+    ///     3.1. Checks that the batch is ready.
+    ///     3.2. Increment the number of inserted zkps.
+    ///     3.3. If all zkps are inserted, set the state to inserted.
+    /// 4. Wipe previous batch bloom filter if current batch is 50% inserted.
+    /// 5. Increment next full batch index if inserted.
+    /// 6. Return the batch nullify event.
+    fn update_input_queue<const QUEUE_TYPE: u64>(
         &mut self,
         instruction_data: InstructionDataBatchNullifyInputs,
         id: [u8; 32],
     ) -> Result<BatchNullifyEvent, BatchedMerkleTreeError> {
-        let batch_index = self.queue_metadata.next_full_batch_index;
-
-        let full_batch = self
-            .batches
-            .get(batch_index as usize)
-            .ok_or(BatchedMerkleTreeError::InvalidBatchIndex)?;
-
-        let num_zkps = full_batch.get_first_ready_zkp_batch()?;
-
-        let leaves_hashchain = self
-            .hashchain_store
-            .get(batch_index as usize)
-            .ok_or(BatchedMerkleTreeError::InvalidBatchIndex)?
-            .get(num_zkps as usize)
-            .ok_or(BatchedMerkleTreeError::InvalidIndex)?;
-        let old_root = self
-            .root_history
-            .get(instruction_data.public_inputs.old_root_index as usize)
-            .ok_or(BatchedMerkleTreeError::InvalidIndex)?;
-        let new_root = instruction_data.public_inputs.new_root;
-
-        let public_input_hash = if QUEUE_TYPE == QueueType::BatchedInput as u64 {
-            create_hash_chain_from_array([*old_root, new_root, *leaves_hashchain])?
-        } else if QUEUE_TYPE == QueueType::BatchedAddress as u64 {
-            let mut next_index_bytes = [0u8; 32];
-            next_index_bytes[24..].copy_from_slice(self.next_index.to_be_bytes().as_slice());
-            create_hash_chain_from_array([
-                *old_root,
-                new_root,
-                *leaves_hashchain,
-                next_index_bytes,
-            ])?
-        } else {
-            return Err(MerkleTreeMetadataError::InvalidQueueType.into());
-        };
+        let full_batch_index = self.queue_metadata.next_full_batch_index as usize;
+        let num_zkps = self.batches[full_batch_index].get_first_ready_zkp_batch()?;
+        let new_root = instruction_data.new_root;
         let circuit_batch_size = self.queue_metadata.zkp_batch_size;
-        self.update::<QUEUE_TYPE>(
-            circuit_batch_size as usize,
+
+        // 1. Create public inputs hash.
+        let public_input_hash = {
+            let leaves_hashchain = self.hashchain_store[full_batch_index][num_zkps as usize];
+            let old_root = self
+                .root_history
+                .last()
+                .ok_or(BatchedMerkleTreeError::InvalidIndex)?;
+
+            if QUEUE_TYPE == QueueType::BatchedInput as u64 {
+                create_hash_chain_from_array([*old_root, new_root, leaves_hashchain])?
+            } else if QUEUE_TYPE == QueueType::BatchedAddress as u64 {
+                let mut next_index_bytes = [0u8; 32];
+                next_index_bytes[24..].copy_from_slice(self.next_index.to_be_bytes().as_slice());
+                create_hash_chain_from_array([
+                    *old_root,
+                    new_root,
+                    leaves_hashchain,
+                    next_index_bytes,
+                ])?
+            } else {
+                return Err(MerkleTreeMetadataError::InvalidQueueType.into());
+            }
+        };
+
+        // 2. Verify update proof and update tree account.
+        self.verify_update::<QUEUE_TYPE>(
+            circuit_batch_size,
             instruction_data.compressed_proof,
             public_input_hash,
+            new_root,
         )?;
-        self.root_history.push(new_root);
 
-        let root_history_capacity = self.root_history_capacity;
-        let sequence_number = self.sequence_number;
-        let full_batch = self
-            .batches
-            .get_mut(batch_index as usize)
-            .ok_or(BatchedMerkleTreeError::InvalidBatchIndex)?;
-        full_batch.mark_as_inserted_in_merkle_tree(
-            sequence_number,
-            self.root_history.last_index() as u32,
-            root_history_capacity,
-        )?;
-        if full_batch.get_state() == BatchState::Inserted {
-            self.metadata.queue_metadata.next_full_batch_index += 1;
-            self.metadata.queue_metadata.next_full_batch_index %=
-                self.metadata.queue_metadata.num_batches;
+        let root_index = self.root_history.last_index() as u32;
+
+        // Update queue metadata.
+        {
+            let root_history_capacity = self.root_history_capacity;
+            let sequence_number = self.sequence_number;
+            // 3. Mark batch as inserted in the merkle tree.
+            let full_batch_state = self.batches[full_batch_index].mark_as_inserted_in_merkle_tree(
+                sequence_number,
+                root_index,
+                root_history_capacity,
+            )?;
+
+            // 4. Wipe previous batch bloom filter
+            //     if current batch is 50% inserted.
+            // Needs to be executed prior to
+            // incrementing next full batch index,
+            // but post mark_as_inserted_in_merkle_tree.
+            self.wipe_previous_batch_bloom_filter()?;
+
+            // 5. Increment next full batch index if inserted.
+            self.metadata
+                .queue_metadata
+                .increment_next_full_batch_index_if_inserted(full_batch_state);
         }
-        if QUEUE_TYPE == QueueType::BatchedAddress as u64 {
-            self.metadata.next_index += circuit_batch_size;
-        }
 
-        self.wipe_previous_batch_bloom_filter()?;
-
+        // 6. Return the batch nullify/address append event.
         Ok(BatchNullifyEvent {
             id,
-            batch_index,
+            batch_index: full_batch_index as u64,
             batch_size: circuit_batch_size,
             zkp_batch_index: num_zkps,
             new_root,
-            root_index: self.root_history.last_index() as u32,
+            root_index,
             sequence_number: self.sequence_number,
         })
     }
 
-    fn update<const QUEUE_TYPE: u64>(
+    /// Verify update proof and update the tree.
+    /// 1. Verify update proof.
+    /// 2. Increment next index (unless queue type is BatchedInput).
+    /// 3. Increment sequence number.
+    /// 4. Append new root to root history.
+    fn verify_update<const QUEUE_TYPE: u64>(
         &mut self,
-        batch_size: usize,
+        batch_size: u64,
         proof: CompressedProof,
         public_input_hash: [u8; 32],
+        new_root: [u8; 32],
     ) -> Result<(), BatchedMerkleTreeError> {
+        // 1. Verify update proof.
         if QUEUE_TYPE == QueueType::BatchedOutput as u64 {
             verify_batch_append_with_proofs(batch_size, public_input_hash, &proof)?;
+            // 2. Increment next index.
+            self.metadata.next_index += batch_size;
         } else if QUEUE_TYPE == QueueType::BatchedInput as u64 {
             verify_batch_update(batch_size, public_input_hash, &proof)?;
+            // 2. skip incrementing next index.
+            // The input queue update does not append new values
+            // hence no need to increment next_index.
         } else if QUEUE_TYPE == QueueType::BatchedAddress as u64 {
             verify_batch_address_update(batch_size, public_input_hash, &proof)?;
+            // 2. Increment next index.
+            self.metadata.next_index += batch_size;
         } else {
             return Err(MerkleTreeMetadataError::InvalidQueueType.into());
         }
+        // 3. Increment sequence number.
         self.metadata.sequence_number += 1;
+        // 4. Append new root to root history.
+        // root_history is a cyclic vec
+        // it will overwrite the oldest root
+        // once it is full.
+        self.root_history.push(new_root);
         Ok(())
     }
 
     /// State nullification:
-    /// - value is committed to bloom_filter for non-inclusion proof
+    /// - value is inserted into to a bloom_filter to prove non-inclusion in later txs.
     /// - nullifier is Hash(value, tx_hash), committed to leaves hashchain
     /// - tx_hash is hash of all inputs and outputs
     ///   -> we can access the history of how commitments are spent in zkps for example fraud proofs
@@ -668,7 +725,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
     ) -> Result<(), BatchedMerkleTreeError> {
         // Note, no need to check whether the tree is full
         // since nullifier insertions update existing values
-        // in the tree and not append a values.
+        // in the tree and do not append new values.
         if self.tree_type != TreeType::BatchedState as u64 {
             return Err(MerkleTreeMetadataError::InvalidTreeType.into());
         }
@@ -684,7 +741,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
         if self.tree_type != TreeType::BatchedAddress as u64 {
             return Err(MerkleTreeMetadataError::InvalidTreeType.into());
         }
-        // Check if the tree is full.
+        // Check that the tree is not full.
         self.check_tree_is_full()?;
 
         self.insert_into_current_batch(address, address)
@@ -755,28 +812,49 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
         Ok(())
     }
 
+    /// Zero out roots corresponding to sequence numbers < sequence_number.
+    /// 1. Check whether overlapping roots exist.
+    /// 2. If yes:
+    ///     2.1 Get, first safe root index.
+    ///     2.2 Zero out roots from the oldest root to first safe root.
     fn zero_out_roots(&mut self, sequence_number: u64, root_index: Option<u32>) {
-        if sequence_number > self.sequence_number {
-            // advance root history array current index from latest root
-            // to root_index and overwrite all roots with zeros
+        // 1. Check whether overlapping roots exist.
+        let overlapping_roots_exits = sequence_number > self.sequence_number;
+        if overlapping_roots_exits {
             if let Some(root_index) = root_index {
                 let root_index = root_index as usize;
-                let start = self.root_history.last_index();
-                let end = self.root_history.len() + root_index;
-                for index in start + 1..end {
+
+                let oldest_root_index = self.root_history.first_index();
+                // 2.1. Get, index of first root inserted after input queue batch was inserted.
+                let first_safe_root_index = self.root_history.len() + root_index;
+                // 2.2. Zero out roots oldest to first safe root index.
+                for index in oldest_root_index..first_safe_root_index {
                     let index = index % self.root_history.len();
+                    // TODO: test if needed
                     if index == root_index {
                         break;
                     }
-                    let root = self.root_history.get_mut(index).unwrap();
-                    *root = [0u8; 32];
+                    self.root_history[index] = [0u8; 32];
                 }
+            } else {
+                unreachable!("root_index must be Some(root_index) if overlapping roots exist");
             }
         }
     }
 
-    /// Wipe bloom filter after a batch has been inserted and 50% of the
-    /// subsequent batch been processed.
+    /// Wipe bloom filter of previous batch if 50% of the
+    /// current batch has been processed.
+    ///
+    /// Idea:
+    /// 1. Wiping the bloom filter of the previous batch is expensive
+    ///     -> the forester should do it.
+    /// 2. We don't want to wipe the bloom filter when inserting
+    ///     the last zkp of a batch for this might result in failing user tx.
+    /// 3. Wait until next batch is 50% full as grace period for clients
+    ///     to switch from proof by index to proof by zkp
+    ///     for values inserted in the previous batch.
+    ///
+    /// Steps:
     /// 1. Previous batch must be inserted and bloom filter must not be wiped.
     /// 2. Current batch must be 50% full
     /// 3. if yes
@@ -784,32 +862,65 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
     ///    3.2 mark bloom filter as wiped
     ///    3.3 zero out roots if needed
     pub fn wipe_previous_batch_bloom_filter(&mut self) -> Result<(), BatchedMerkleTreeError> {
-        let current_batch = self.queue_metadata.currently_processing_batch_index;
+        let current_batch = self.queue_metadata.next_full_batch_index as usize;
         let batch_size = self.queue_metadata.batch_size;
-        let previous_full_batch_index =
-            self.queue_metadata.next_full_batch_index.saturating_sub(1) as usize;
-        let num_inserted_elements = self
-            .batches
-            .get(current_batch as usize)
-            .ok_or(BatchedMerkleTreeError::InvalidBatchIndex)?
-            .get_num_inserted_elements();
+        let previous_full_batch_index = current_batch.saturating_sub(1);
+        let previous_full_batch_index = if previous_full_batch_index == current_batch {
+            self.queue_metadata.num_batches as usize - 1
+        } else {
+            previous_full_batch_index
+        };
+
+        let current_batch_is_half_full = {
+            let num_inserted_elements = self
+                .batches
+                .get(current_batch)
+                .ok_or(BatchedMerkleTreeError::InvalidBatchIndex)?
+                .get_num_inserted_elements();
+            // Keep for finegrained unit test
+            println!("current_batch: {}", current_batch);
+            println!("previous_full_batch_index: {}", previous_full_batch_index);
+            println!("num_inserted_elements: {}", num_inserted_elements);
+            println!("batch_size: {}", batch_size);
+            println!("batch_size / 2: {}", batch_size / 2);
+            println!(
+                "num_inserted_elements >= batch_size / 2: {}",
+                num_inserted_elements >= batch_size / 2
+            );
+            num_inserted_elements >= batch_size / 2
+        };
+
         let previous_full_batch = self
             .batches
             .get_mut(previous_full_batch_index)
             .ok_or(BatchedMerkleTreeError::InvalidBatchIndex)?;
-        if previous_full_batch.get_state() == BatchState::Inserted
-            && batch_size / 2 > num_inserted_elements
-            && !previous_full_batch.bloom_filter_is_wiped()
-        {
-            let bloom_filter = self
-                .bloom_filter_stores
-                .get_mut(previous_full_batch_index)
-                .ok_or(BatchedMerkleTreeError::InvalidBatchIndex)?;
-            bloom_filter.as_mut_slice().iter_mut().for_each(|x| *x = 0);
+
+        let previous_batch_is_ready = previous_full_batch.get_state() == BatchState::Inserted
+            && !previous_full_batch.bloom_filter_is_wiped();
+
+        if previous_batch_is_ready && current_batch_is_half_full {
+            // Keep for finegrained unit test
+            println!("Wiping bloom filter of previous batch");
+            println!("current_batch: {}", current_batch);
+            println!("previous_full_batch_index: {}", previous_full_batch_index);
+            // 3.1 Zero out bloom filter.
+            {
+                let bloom_filter = self
+                    .bloom_filter_stores
+                    .get_mut(previous_full_batch_index)
+                    .ok_or(BatchedMerkleTreeError::InvalidBatchIndex)?;
+                bloom_filter.as_mut_slice().iter_mut().for_each(|x| *x = 0);
+            }
+            // 3.2 Mark bloom filter wiped.
             previous_full_batch.set_bloom_filter_is_wiped();
-            let seq = previous_full_batch.sequence_number;
-            let root_index = previous_full_batch.root_index;
-            self.zero_out_roots(seq, Some(root_index));
+            // 3.3 Zero out roots if a root exists in root history
+            // which allows to prove inclusion of a value
+            // that was inserted into the bloom filter just wiped.
+            {
+                let seq = previous_full_batch.sequence_number;
+                let root_index = previous_full_batch.root_index;
+                self.zero_out_roots(seq, Some(root_index));
+            }
         }
 
         Ok(())

--- a/program-libs/batched-merkle-tree/src/queue.rs
+++ b/program-libs/batched-merkle-tree/src/queue.rs
@@ -257,7 +257,7 @@ impl<'a> BatchedQueueAccount<'a> {
 
     pub fn insert_into_current_batch(
         &mut self,
-        value: &[u8; 32],
+        hash_chain_value: &[u8; 32],
     ) -> Result<(), BatchedMerkleTreeError> {
         let current_index = self.next_index;
 
@@ -268,7 +268,7 @@ impl<'a> BatchedQueueAccount<'a> {
             &mut self.value_vecs,
             self.bloom_filter_stores.as_mut_slice(),
             &mut self.hashchain_store,
-            value,
+            hash_chain_value,
             None,
             Some(current_index),
         )?;
@@ -280,16 +280,16 @@ impl<'a> BatchedQueueAccount<'a> {
     pub fn prove_inclusion_by_index(
         &mut self,
         leaf_index: u64,
-        value: &[u8; 32],
+        hash_chain_value: &[u8; 32],
     ) -> Result<bool, BatchedMerkleTreeError> {
         for (batch_index, batch) in self.batches.iter().enumerate() {
-            if batch.value_is_inserted_in_batch(leaf_index)? {
+            if batch.leaf_index_could_exist_in_batch(leaf_index)? {
                 let index = batch.get_value_index_in_batch(leaf_index)?;
                 let element = self.value_vecs[batch_index]
                     .get_mut(index as usize)
                     .ok_or(BatchedMerkleTreeError::InclusionProofByIndexFailed)?;
 
-                if element == value {
+                if element == hash_chain_value {
                     return Ok(true);
                 } else {
                     return Err(BatchedMerkleTreeError::InclusionProofByIndexFailed);
@@ -304,7 +304,7 @@ impl<'a> BatchedQueueAccount<'a> {
         leaf_index: u64,
     ) -> Result<(), BatchedMerkleTreeError> {
         for batch in self.batches.iter() {
-            let res = batch.value_is_inserted_in_batch(leaf_index)?;
+            let res = batch.leaf_index_could_exist_in_batch(leaf_index)?;
             if res {
                 return Ok(());
             }
@@ -313,21 +313,21 @@ impl<'a> BatchedQueueAccount<'a> {
     }
 
     // TODO: add unit tests
-    /// Zero out a leaf by index if it exists in the queues value vec. If
+    /// Zero out a leaf by index if it exists in the queues hash_chain_value vec. If
     /// checked fail if leaf is not found.
     pub fn prove_inclusion_by_index_and_zero_out_leaf(
         &mut self,
         leaf_index: u64,
-        value: &[u8; 32],
+        hash_chain_value: &[u8; 32],
     ) -> Result<(), BatchedMerkleTreeError> {
         for (batch_index, batch) in self.batches.iter().enumerate() {
-            if batch.value_is_inserted_in_batch(leaf_index)? {
+            if batch.leaf_index_could_exist_in_batch(leaf_index)? {
                 let index = batch.get_value_index_in_batch(leaf_index)?;
                 let element = self.value_vecs[batch_index]
                     .get_mut(index as usize)
                     .ok_or(BatchedMerkleTreeError::InclusionProofByIndexFailed)?;
 
-                if element == value {
+                if element == hash_chain_value {
                     *element = [0u8; 32];
                     return Ok(());
                 } else {
@@ -338,18 +338,18 @@ impl<'a> BatchedQueueAccount<'a> {
         Ok(())
     }
 
-    pub fn get_batch_num_inserted_in_current_batch(&self) -> u64 {
+    pub fn get_num_inserted_in_current_batch(&self) -> u64 {
         let next_full_batch = self.batch_metadata.currently_processing_batch_index;
         let batch = self.batches.get(next_full_batch as usize).unwrap();
         batch.get_num_inserted() + batch.get_current_zkp_batch_index() * batch.zkp_batch_size
     }
 
-    pub fn is_associated(&self, account: &Pubkey) -> bool {
-        self.metadata.metadata.associated_merkle_tree == *account
+    pub fn is_associated(&self, pubkey: &Pubkey) -> bool {
+        self.metadata.metadata.associated_merkle_tree == *pubkey
     }
 
-    pub fn check_is_associated(&self, account: &Pubkey) -> Result<(), BatchedMerkleTreeError> {
-        if !self.is_associated(account) {
+    pub fn check_is_associated(&self, pubkey: &Pubkey) -> Result<(), BatchedMerkleTreeError> {
+        if !self.is_associated(pubkey) {
             return Err(MerkleTreeMetadataError::MerkleTreeAndQueueNotAssociated.into());
         }
         Ok(())
@@ -367,63 +367,61 @@ impl<'a> BatchedQueueAccount<'a> {
     }
 }
 
+/// Insert a value into the current batch.
+/// - Input&address queues: Insert into bloom filter & hash chain.
+/// - Output queue: Insert into value vec & hash chain.
+///
+/// Steps:
+/// 1. Check if the current batch is ready.
+///     1.1. If the current batch is inserted, clear the batch.
+/// 2. Insert value into the current batch.
+/// 3. If batch is full, increment currently_processing_batch_index.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 pub fn insert_into_current_batch(
     queue_type: u64,
-    account: &mut BatchMetadata,
+    batch_metadata: &mut BatchMetadata,
     batches: &mut ZeroCopySliceMutU64<Batch>,
     value_vecs: &mut [ZeroCopyVecU64<[u8; 32]>],
     bloom_filter_stores: &mut [ZeroCopySliceMutU64<u8>],
     hashchain_store: &mut [ZeroCopyVecU64<[u8; 32]>],
-    value: &[u8; 32],
-    leaves_hash_value: Option<&[u8; 32]>,
+    hash_chain_value: &[u8; 32],
+    bloom_filter_value: Option<&[u8; 32]>,
     current_index: Option<u64>,
 ) -> Result<(Option<u32>, Option<u64>), BatchedMerkleTreeError> {
-    let len = batches.len();
     let mut root_index = None;
     let mut sequence_number = None;
-    let currently_processing_batch_index = account.currently_processing_batch_index as usize;
-    // Insert value into current batch.
+    let batch_index = batch_metadata.currently_processing_batch_index as usize;
+    let mut value_store = value_vecs.get_mut(batch_index);
+    let mut hashchain_store = hashchain_store.get_mut(batch_index);
+    let current_batch = batches
+        .get_mut(batch_index)
+        .ok_or(BatchedMerkleTreeError::InvalidBatchIndex)?;
+    // 1. Check that the current batch is ready.
+    //      1.1. If the current batch is inserted, clear the batch.
     {
-        let mut bloom_filter_stores = bloom_filter_stores.get_mut(currently_processing_batch_index);
-        let mut value_store = value_vecs.get_mut(currently_processing_batch_index);
-        let mut hashchain_store = hashchain_store.get_mut(currently_processing_batch_index);
-
-        let current_batch = batches
-            .get_mut(currently_processing_batch_index)
-            .ok_or(BatchedMerkleTreeError::InvalidBatchIndex)?;
-        let mut wipe = false;
-        if current_batch.get_state() == BatchState::Inserted {
+        let clear_batch = current_batch.get_state() == BatchState::Inserted;
+        if current_batch.get_state() == BatchState::Fill {
+            // Do nothing, checking most often case first.
+        } else if clear_batch {
             current_batch.advance_state_to_fill()?;
-            if let Some(current_index) = current_index {
-                current_batch.start_index = current_index;
-            }
-            wipe = true;
-        }
+            msg!("clear_batch");
 
-        // We expect to insert into the current batch.
-        if current_batch.get_state() == BatchState::Full {
-            for batch in batches.iter_mut() {
-                msg!("batch {:?}", batch);
-            }
-            return Err(BatchedMerkleTreeError::BatchNotReady);
-        }
-        if wipe {
-            msg!("wipe");
-            if let Some(blomfilter_stores) = bloom_filter_stores.as_mut() {
-                if !current_batch.bloom_filter_is_wiped() {
+            if let Some(blomfilter_stores) = bloom_filter_stores.get_mut(batch_index) {
+                // Bloom filters should by default be zeroed by foresters
+                // because zeroing bytes is CU intensive.
+                // This is a safeguard to ensure queue lifeness
+                // in case foresters are behind.
+                if !current_batch.bloom_filter_is_zeroed() {
                     (*blomfilter_stores).iter_mut().for_each(|x| *x = 0);
                     // Saving sequence number and root index for the batch.
-                    // When the batch is cleared check that sequence number is greater or equal than self.sequence_number
+                    // When the batch is cleared check that sequence number
+                    // is greater or equal than self.sequence_number
                     // if not advance current root index to root index
-                    if current_batch.sequence_number != 0 {
-                        root_index = Some(current_batch.root_index);
-                        sequence_number = Some(current_batch.sequence_number);
-                    }
-                } else {
-                    current_batch.set_bloom_filter_is_not_wiped();
+                    root_index = Some(current_batch.root_index);
+                    sequence_number = Some(current_batch.sequence_number);
                 }
+                current_batch.set_bloom_filter_to_not_zeroed();
                 current_batch.sequence_number = 0;
             }
             if let Some(value_store) = value_store.as_mut() {
@@ -432,41 +430,39 @@ pub fn insert_into_current_batch(
             if let Some(hashchain_store) = hashchain_store.as_mut() {
                 (*hashchain_store).clear();
             }
-        }
-
-        let queue_type = QueueType::from(queue_type);
-        match queue_type {
-            QueueType::BatchedInput | QueueType::BatchedAddress => current_batch.insert(
-                value,
-                leaves_hash_value.unwrap(),
-                bloom_filter_stores.unwrap().as_mut_slice(),
-                hashchain_store.as_mut().unwrap(),
-            ),
-            QueueType::BatchedOutput => current_batch.store_and_hash_value(
-                value,
-                value_store.unwrap(),
-                hashchain_store.unwrap(),
-            ),
-            _ => Err(MerkleTreeMetadataError::InvalidQueueType.into()),
-        }?;
-    }
-
-    // If queue has bloom_filters check non-inclusion of value in bloom_filters of
-    // other batches. (Current batch is already checked by insertion.)
-    if !bloom_filter_stores.is_empty() {
-        for index in currently_processing_batch_index + 1..(len + currently_processing_batch_index)
-        {
-            let index = index % len;
-            let bloom_filter_stores = bloom_filter_stores.get_mut(index).unwrap().as_mut_slice();
-            let current_batch = batches.get_mut(index).unwrap();
-            current_batch.check_non_inclusion(value, bloom_filter_stores)?;
+            if let Some(current_index) = current_index {
+                current_batch.start_index = current_index;
+            }
+        } else {
+            // We expect to insert into the current batch.
+            for batch in batches.iter_mut() {
+                msg!("batch {:?}", batch);
+            }
+            return Err(BatchedMerkleTreeError::BatchNotReady);
         }
     }
 
-    if batches[account.currently_processing_batch_index as usize].get_state() == BatchState::Full {
-        account.currently_processing_batch_index += 1;
-        account.currently_processing_batch_index %= len as u64;
-    }
+    // 2. Insert value into the current batch.
+    let queue_type = QueueType::from(queue_type);
+    match queue_type {
+        QueueType::BatchedInput | QueueType::BatchedAddress => current_batch.insert(
+            bloom_filter_value.unwrap(),
+            hash_chain_value,
+            bloom_filter_stores,
+            hashchain_store.as_mut().unwrap(),
+            batch_index,
+        ),
+        QueueType::BatchedOutput => current_batch.store_and_hash_value(
+            hash_chain_value,
+            value_store.unwrap(),
+            hashchain_store.unwrap(),
+        ),
+        _ => Err(MerkleTreeMetadataError::InvalidQueueType.into()),
+    }?;
+
+    // 3. If batch is full, increment currently_processing_batch_index.
+    batch_metadata.increment_currently_processing_batch_index_if_full(current_batch.get_state());
+
     Ok((root_index, sequence_number))
 }
 
@@ -496,8 +492,8 @@ pub fn output_queue_from_bytes(
 }
 
 #[allow(clippy::type_complexity)]
-pub fn input_queue_bytes<'a>(
-    account: &BatchMetadata,
+pub fn input_queue_from_bytes<'a>(
+    batch_metadata: &BatchMetadata,
     account_data: &'a mut [u8],
     queue_type: u64,
 ) -> Result<
@@ -510,7 +506,7 @@ pub fn input_queue_bytes<'a>(
     BatchedMerkleTreeError,
 > {
     let (num_value_stores, num_stores, hashchain_store_capacity) =
-        account.get_size_parameters(queue_type)?;
+        batch_metadata.get_size_parameters(queue_type)?;
 
     let (batches, account_data) = ZeroCopySliceMutU64::from_bytes_at(account_data)?;
     let (value_vecs, account_data) =
@@ -526,7 +522,7 @@ pub fn input_queue_bytes<'a>(
 
 #[allow(clippy::type_complexity)]
 pub fn init_queue<'a>(
-    account: &BatchMetadata,
+    batch_metadata: &BatchMetadata,
     queue_type: u64,
     account_data: &'a mut [u8],
     num_iters: u64,
@@ -542,32 +538,32 @@ pub fn init_queue<'a>(
     BatchedMerkleTreeError,
 > {
     let (num_value_stores, num_stores, num_hashchain_stores) =
-        account.get_size_parameters(queue_type)?;
+        batch_metadata.get_size_parameters(queue_type)?;
 
     let (mut batches, account_data) =
-        ZeroCopySliceMutU64::new_at(account.num_batches, account_data)?;
+        ZeroCopySliceMutU64::new_at(batch_metadata.num_batches, account_data)?;
 
-    for i in 0..account.num_batches {
+    for i in 0..batch_metadata.num_batches {
         batches[i as usize] = Batch::new(
             num_iters,
             bloom_filter_capacity,
-            account.batch_size,
-            account.zkp_batch_size,
-            account.batch_size * i + batch_start_index,
+            batch_metadata.batch_size,
+            batch_metadata.zkp_batch_size,
+            batch_metadata.batch_size * i + batch_start_index,
         );
     }
     let (value_vecs, account_data) =
-        ZeroCopyVecU64::new_at_multiple(num_value_stores, account.batch_size, account_data)?;
+        ZeroCopyVecU64::new_at_multiple(num_value_stores, batch_metadata.batch_size, account_data)?;
 
     let (bloom_filter_stores, account_data) = ZeroCopySliceMutU64::new_at_multiple(
         num_stores,
-        account.bloom_filter_capacity / 8,
+        batch_metadata.bloom_filter_capacity / 8,
         account_data,
     )?;
 
     let (hashchain_store, _) = ZeroCopyVecU64::new_at_multiple(
         num_hashchain_stores,
-        account.get_num_zkp_batches(),
+        batch_metadata.get_num_zkp_batches(),
         account_data,
     )?;
 
@@ -575,7 +571,7 @@ pub fn init_queue<'a>(
 }
 
 pub fn get_output_queue_account_size_default() -> usize {
-    let account = BatchedQueueMetadata {
+    let batch_metadata = BatchedQueueMetadata {
         metadata: QueueMetadata::default(),
         next_index: 0,
         batch_metadata: BatchMetadata {
@@ -586,13 +582,17 @@ pub fn get_output_queue_account_size_default() -> usize {
         },
         ..Default::default()
     };
-    queue_account_size(&account.batch_metadata, QueueType::BatchedOutput as u64).unwrap()
+    queue_account_size(
+        &batch_metadata.batch_metadata,
+        QueueType::BatchedOutput as u64,
+    )
+    .unwrap()
 }
 
 pub fn get_output_queue_account_size_from_params(
     ix_data: InitStateTreeAccountsInstructionData,
 ) -> usize {
-    let account = BatchedQueueMetadata {
+    let metadata = BatchedQueueMetadata {
         metadata: QueueMetadata::default(),
         next_index: 0,
         batch_metadata: BatchMetadata {
@@ -603,7 +603,7 @@ pub fn get_output_queue_account_size_from_params(
         },
         ..Default::default()
     };
-    queue_account_size(&account.batch_metadata, QueueType::BatchedOutput as u64).unwrap()
+    queue_account_size(&metadata.batch_metadata, QueueType::BatchedOutput as u64).unwrap()
 }
 
 pub fn get_output_queue_account_size(
@@ -611,7 +611,7 @@ pub fn get_output_queue_account_size(
     zkp_batch_size: u64,
     num_batches: u64,
 ) -> usize {
-    let account = BatchedQueueMetadata {
+    let metadata = BatchedQueueMetadata {
         metadata: QueueMetadata::default(),
         next_index: 0,
         batch_metadata: BatchMetadata {
@@ -622,7 +622,7 @@ pub fn get_output_queue_account_size(
         },
         ..Default::default()
     };
-    queue_account_size(&account.batch_metadata, QueueType::BatchedOutput as u64).unwrap()
+    queue_account_size(&metadata.batch_metadata, QueueType::BatchedOutput as u64).unwrap()
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/program-libs/batched-merkle-tree/src/rollover_address_tree.rs
+++ b/program-libs/batched-merkle-tree/src/rollover_address_tree.rs
@@ -25,7 +25,7 @@ pub fn rollover_batched_address_tree<'a>(
     new_mt_pubkey: Pubkey,
     network_fee: Option<u64>,
 ) -> Result<BatchedMerkleTreeAccount<'a>, BatchedMerkleTreeError> {
-    // Check that old merkle tree is ready for rollover.
+    // 1. Check that old merkle tree is ready for rollover.
     batched_tree_is_ready_for_rollover(old_merkle_tree, &network_fee)?;
 
     // Rollover the old merkle tree.

--- a/program-libs/batched-merkle-tree/tests/merkle_tree.rs
+++ b/program-libs/batched-merkle-tree/tests/merkle_tree.rs
@@ -18,9 +18,8 @@ use light_batched_merkle_tree::{
     },
     merkle_tree::{
         assert_batch_append_event_event, assert_nullify_event,
-        get_merkle_tree_account_size_default, AppendBatchProofInputsIx, BatchProofInputsIx,
-        BatchedMerkleTreeAccount, BatchedMerkleTreeMetadata, InstructionDataBatchAppendInputs,
-        InstructionDataBatchNullifyInputs,
+        get_merkle_tree_account_size_default, BatchedMerkleTreeAccount, BatchedMerkleTreeMetadata,
+        InstructionDataBatchAppendInputs, InstructionDataBatchNullifyInputs,
     },
     queue::{
         get_output_queue_account_size_default, get_output_queue_account_size_from_params,
@@ -155,7 +154,7 @@ pub fn assert_input_queue_insert(
             println!("assert input queue batch update: clearing batch");
             pre_hashchains[inserted_batch_index].clear();
             expected_batch.sequence_number = 0;
-            expected_batch.advance_state_to_can_be_filled().unwrap();
+            expected_batch.advance_state_to_fill().unwrap();
             expected_batch.set_bloom_filter_is_not_wiped();
         }
         println!(
@@ -276,7 +275,7 @@ pub fn assert_output_queue_insert(
         let pre_value_store = pre_value_store.get_mut(inserted_batch_index).unwrap();
         let pre_hashchain = pre_hashchains.get_mut(inserted_batch_index).unwrap();
         if expected_batch.get_state() == BatchState::Inserted {
-            expected_batch.advance_state_to_can_be_filled().unwrap();
+            expected_batch.advance_state_to_fill().unwrap();
             pre_value_store.clear();
             pre_hashchain.clear();
             expected_batch.start_index = pre_account.next_index;
@@ -665,7 +664,6 @@ async fn test_simulate_transactions() {
                     BatchedMerkleTreeAccount::state_from_bytes(&mut pre_mt_account_data).unwrap();
                 println!("batches {:?}", account.batches);
 
-                let old_root_index = account.root_history.last_index();
                 let next_full_batch = account.get_metadata().queue_metadata.next_full_batch_index;
                 let batch = account.batches.get(next_full_batch as usize).unwrap();
                 println!(
@@ -693,10 +691,7 @@ async fn test_simulate_transactions() {
                     .await
                     .unwrap();
                 let instruction_data = InstructionDataBatchNullifyInputs {
-                    public_inputs: BatchProofInputsIx {
-                        new_root,
-                        old_root_index: old_root_index as u16,
-                    },
+                    new_root,
                     compressed_proof: CompressedProof {
                         a: proof.a,
                         b: proof.b,
@@ -769,7 +764,7 @@ async fn test_simulate_transactions() {
                 .unwrap();
 
             let instruction_data = InstructionDataBatchAppendInputs {
-                public_inputs: AppendBatchProofInputsIx { new_root },
+                new_root,
                 compressed_proof: CompressedProof {
                     a: proof.a,
                     b: proof.b,
@@ -782,7 +777,7 @@ async fn test_simulate_transactions() {
 
             let queue_account =
                 &mut BatchedQueueAccount::output_from_bytes(&mut pre_output_queue_state).unwrap();
-            let output_res = account.update_output_queue_account(
+            let output_res = account.update_tree_from_output_queue_account(
                 queue_account,
                 instruction_data,
                 mt_pubkey.to_bytes(),
@@ -1080,7 +1075,7 @@ async fn test_e2e() {
             }
 
             let instruction_data = InstructionDataBatchAppendInputs {
-                public_inputs: AppendBatchProofInputsIx { new_root },
+                new_root,
                 compressed_proof: CompressedProof {
                     a: proof.a,
                     b: proof.b,
@@ -1093,7 +1088,7 @@ async fn test_e2e() {
 
             let queue_account =
                 &mut BatchedQueueAccount::output_from_bytes(&mut pre_output_queue_state).unwrap();
-            let output_res = account.update_output_queue_account(
+            let output_res = account.update_tree_from_output_queue_account(
                 queue_account,
                 instruction_data,
                 mt_pubkey.to_bytes(),
@@ -1158,7 +1153,6 @@ pub async fn perform_input_update(
     let (input_res, root) = {
         let mut account = BatchedMerkleTreeAccount::state_from_bytes(mt_account_data).unwrap();
 
-        let old_root_index = account.root_history.last_index();
         let next_full_batch = account.get_metadata().queue_metadata.next_full_batch_index;
         let batch = account.batches.get(next_full_batch as usize).unwrap();
         let leaves_hashchain = account
@@ -1175,10 +1169,7 @@ pub async fn perform_input_update(
             .await
             .unwrap();
         let instruction_data = InstructionDataBatchNullifyInputs {
-            public_inputs: BatchProofInputsIx {
-                new_root,
-                old_root_index: old_root_index as u16,
-            },
+            new_root,
             compressed_proof: CompressedProof {
                 a: proof.a,
                 b: proof.b,
@@ -1221,7 +1212,6 @@ pub async fn perform_address_update(
     let (input_res, root, pre_next_full_batch) = {
         let mut account = BatchedMerkleTreeAccount::address_from_bytes(mt_account_data).unwrap();
 
-        let old_root_index = account.root_history.last_index();
         let next_full_batch = account.get_metadata().queue_metadata.next_full_batch_index;
         let next_index = account.get_metadata().next_index;
         println!("next index {:?}", next_index);
@@ -1246,10 +1236,7 @@ pub async fn perform_address_update(
             .await
             .unwrap();
         let instruction_data = InstructionDataBatchNullifyInputs {
-            public_inputs: BatchProofInputsIx {
-                new_root,
-                old_root_index: old_root_index as u16,
-            },
+            new_root,
             compressed_proof: CompressedProof {
                 a: proof.a,
                 b: proof.b,
@@ -1276,9 +1263,8 @@ pub async fn perform_address_update(
     let account = BatchedMerkleTreeAccount::address_from_bytes(mt_account_data).unwrap();
 
     {
-        let next_full_batch = account.get_metadata().queue_metadata.next_full_batch_index;
-        let batch = account.batches.get(next_full_batch as usize).unwrap();
-        if pre_next_full_batch != next_full_batch {
+        let batch = account.batches.get(pre_next_full_batch as usize).unwrap();
+        if batch.get_state() == BatchState::Inserted {
             mock_indexer.finalize_batch_address_update(batch.batch_size as usize);
         }
     }
@@ -1297,62 +1283,66 @@ fn assert_merkle_tree_update(
     let mut expected_account = *old_account.get_metadata();
     expected_account.sequence_number += 1;
     let actual_account = *account.get_metadata();
-
-    let (
-        batches,
-        previous_batchs,
-        _previous_processing,
-        expected_queue_account,
-        mut next_full_batch_index,
-    ) = if let Some(queue_account) = queue_account.as_ref() {
-        let expected_queue_account = *old_queue_account.as_ref().unwrap().get_metadata();
-
-        let previous_processing = if queue_account
-            .get_metadata()
-            .batch_metadata
-            .currently_processing_batch_index
-            == 0
-        {
-            queue_account.get_metadata().batch_metadata.num_batches - 1
-        } else {
-            queue_account
-                .get_metadata()
-                .batch_metadata
-                .currently_processing_batch_index
-                - 1
-        };
-        expected_account.next_index += queue_account.batches.get(0).unwrap().zkp_batch_size;
-        let next_full_batch_index = expected_queue_account.batch_metadata.next_full_batch_index;
-        (
-            queue_account.batches.to_vec(),
-            old_queue_account.as_ref().unwrap().batches.to_vec(),
-            previous_processing,
-            Some(expected_queue_account),
-            next_full_batch_index,
-        )
+    // We only have two batches.
+    let previous_full_batch_index = if expected_account.queue_metadata.next_full_batch_index == 0 {
+        1
     } else {
-        // We only have two batches.
-        let previous_processing = if expected_account
-            .queue_metadata
-            .currently_processing_batch_index
-            == 0
-        {
-            1
-        } else {
-            0
-        };
-        (
-            account.batches.to_vec(),
-            old_account.batches.to_vec(),
-            previous_processing,
-            None,
-            0,
-        )
+        0
     };
 
+    let (batches, mut previous_batches, expected_queue_account, mut next_full_batch_index) =
+        if let Some(queue_account) = queue_account.as_ref() {
+            let expected_queue_account = *old_queue_account.as_ref().unwrap().get_metadata();
+            expected_account.next_index += queue_account.batches.get(0).unwrap().zkp_batch_size;
+            let next_full_batch_index = expected_queue_account.batch_metadata.next_full_batch_index;
+            (
+                queue_account.batches.to_vec(),
+                old_queue_account.as_ref().unwrap().batches.to_vec(),
+                Some(expected_queue_account),
+                next_full_batch_index,
+            )
+        } else {
+            let mut batches = old_account.batches.to_vec();
+            println!("previous_full_batch_index: {:?}", previous_full_batch_index);
+            let previous_batch = batches.get_mut(previous_full_batch_index as usize).unwrap();
+            println!("previous_batch state: {:?}", previous_batch.get_state());
+            println!(
+                "previous_batch wiped?: {:?}",
+                previous_batch.bloom_filter_is_wiped()
+            );
+            let previous_batch_is_ready = previous_batch.get_state() == BatchState::Inserted
+                && !previous_batch.bloom_filter_is_wiped();
+            let batch = batches
+                .get_mut(old_account.queue_metadata.next_full_batch_index as usize)
+                .unwrap();
+
+            println!("previous_batch_is_ready: {:?}", previous_batch_is_ready);
+            println!(
+                "batch.bloom_filter_is_wiped(): {:?}",
+                batch.bloom_filter_is_wiped()
+            );
+            println!(
+                "batch.get_num_inserted_elements(): {:?}",
+                batch.get_num_inserted_elements() + batch.zkp_batch_size
+            );
+            println!("batch.batch_size: {:?}", batch.batch_size);
+            println!(" batch.get_num_inserted_elements() >= batch.batch_size / 2 && previous_batch_is_ready: {:?}", batch.get_num_inserted_elements()+ batch.zkp_batch_size >= batch.batch_size / 2);
+            let wiped_batch = batch.get_num_inserted_elements() + batch.zkp_batch_size
+                >= batch.batch_size / 2
+                && previous_batch_is_ready;
+            let previous_batch = batches.get_mut(previous_full_batch_index as usize).unwrap();
+
+            if wiped_batch {
+                previous_batch.set_bloom_filter_is_wiped();
+                println!("set bloom filter is wiped");
+            }
+            (account.batches.to_vec(), batches, None, 0)
+        };
+
     let mut checked_one = false;
+
     for (i, batch) in batches.iter().enumerate() {
-        let previous_batch = previous_batchs.get(i).unwrap();
+        let previous_batch = previous_batches.get_mut(i).unwrap();
 
         let expected_sequence_number =
             account.root_history.capacity() as u64 + account.get_metadata().sequence_number;
@@ -1360,6 +1350,7 @@ fn assert_merkle_tree_update(
             && batch.get_state() == BatchState::Inserted;
 
         let updated_batch = previous_batch.get_first_ready_zkp_batch().is_ok() && !checked_one;
+
         // Assert fully inserted batch
         if batch_fully_inserted {
             if queue_account.is_some() {
@@ -1571,7 +1562,7 @@ async fn test_fill_queues_completely() {
             }
 
             let instruction_data = InstructionDataBatchAppendInputs {
-                public_inputs: AppendBatchProofInputsIx { new_root },
+                new_root,
                 compressed_proof: CompressedProof {
                     a: proof.a,
                     b: proof.b,
@@ -1582,7 +1573,7 @@ async fn test_fill_queues_completely() {
             println!("Output update -----------------------------");
             let queue_account =
                 &mut BatchedQueueAccount::output_from_bytes(&mut pre_output_queue_state).unwrap();
-            let output_res = account.update_output_queue_account(
+            let output_res = account.update_tree_from_output_queue_account(
                 queue_account,
                 instruction_data,
                 mt_pubkey.to_bytes(),
@@ -1706,11 +1697,16 @@ async fn test_fill_queues_completely() {
         for i in 0..num_updates {
             println!("input update ----------------------------- {}", i);
             perform_input_update(&mut mt_account_data, &mut mock_indexer, false, mt_pubkey).await;
-            if i == 5 {
+            if i >= 7 {
                 let merkle_tree_account =
                     &mut BatchedMerkleTreeAccount::state_from_bytes(&mut mt_account_data).unwrap();
                 let batch = merkle_tree_account.batches.get(0).unwrap();
                 assert!(batch.bloom_filter_is_wiped());
+            } else {
+                let merkle_tree_account =
+                    &mut BatchedMerkleTreeAccount::state_from_bytes(&mut mt_account_data).unwrap();
+                let batch = merkle_tree_account.batches.get(0).unwrap();
+                assert!(!batch.bloom_filter_is_wiped());
             }
             println!(
                 "performed input queue batched update {} created root {:?}",
@@ -1757,7 +1753,7 @@ async fn test_fill_queues_completely() {
                 .unwrap();
             {
                 let post_batch = *merkle_tree_account.batches.get(0).unwrap();
-                assert_eq!(post_batch.get_state(), BatchState::CanBeFilled);
+                assert_eq!(post_batch.get_state(), BatchState::Fill);
                 assert_eq!(post_batch.get_num_inserted(), 1);
                 let bloom_filter_store =
                     merkle_tree_account.bloom_filter_stores.get_mut(0).unwrap();
@@ -1923,8 +1919,7 @@ async fn test_fill_address_tree_completely() {
         }
         // Root of the final batch of first input queue batch
         let mut first_input_batch_update_root_value = [0u8; 32];
-        let num_updates = params.input_queue_batch_size / params.input_queue_zkp_batch_size
-            * params.input_queue_num_batches;
+        let num_updates = 10;
         for i in 0..num_updates {
             println!("address update ----------------------------- {}", i);
             perform_address_update(&mut mt_account_data, &mut mock_indexer, false, mt_pubkey).await;
@@ -1937,7 +1932,7 @@ async fn test_fill_address_tree_completely() {
             let batch_one = merkle_tree_account.batches.get(1).unwrap();
             assert!(!batch_one.bloom_filter_is_wiped());
 
-            if i >= 4 {
+            if i >= 7 {
                 assert!(batch.bloom_filter_is_wiped());
             } else {
                 assert!(!batch.bloom_filter_is_wiped());
@@ -1972,7 +1967,7 @@ async fn test_fill_address_tree_completely() {
             //         .get(0)
             //         .unwrap()
             //         .clone();
-            //     assert_eq!(post_batch.get_state(), BatchState::CanBeFilled);
+            //     assert_eq!(post_batch.get_state(), BatchState::Fill);
             //     assert_eq!(post_batch.get_num_inserted(), 1);
             //     let mut bloom_filter_store = merkle_tree_account
             //         .bloom_filter_stores

--- a/program-libs/verifier/src/lib.rs
+++ b/program-libs/verifier/src/lib.rs
@@ -310,7 +310,7 @@ pub fn verify<const N: usize>(
 
 #[inline(never)]
 pub fn verify_batch_append_with_proofs(
-    batch_size: usize,
+    batch_size: u64,
     public_input_hash: [u8; 32],
     compressed_proof: &CompressedProof,
 ) -> Result<(), VerifierError> {
@@ -341,7 +341,7 @@ pub fn verify_batch_append_with_proofs(
 
 #[inline(never)]
 pub fn verify_batch_update(
-    batch_size: usize,
+    batch_size: u64,
     public_input_hash: [u8; 32],
     compressed_proof: &CompressedProof,
 ) -> Result<(), VerifierError> {
@@ -377,7 +377,7 @@ pub fn verify_batch_update(
 
 #[inline(never)]
 pub fn verify_batch_address_update(
-    batch_size: usize,
+    batch_size: u64,
     public_input_hash: [u8; 32],
     compressed_proof: &CompressedProof,
 ) -> Result<(), VerifierError> {

--- a/program-tests/account-compression-test/tests/batched_merkle_tree_test.rs
+++ b/program-tests/account-compression-test/tests/batched_merkle_tree_test.rs
@@ -1611,7 +1611,7 @@ async fn test_batch_address_merkle_trees() {
         UpdateBatchAddressTreeTestMode::UpdateTwice,
     ]
     .iter()
-    .zip(vec![0, 0, 0, 1])
+    .zip(vec![0, 0, 1])
     {
         let mut mock_indexer = mock_indexer.clone();
         let result = update_batch_address_tree(

--- a/program-tests/system-test/tests/test.rs
+++ b/program-tests/system-test/tests/test.rs
@@ -2569,7 +2569,7 @@ pub async fn create_compressed_accounts_in_batch_merkle_tree(
         .unwrap();
     let output_queue =
         BatchedQueueAccount::output_from_bytes(&mut output_queue_account.data).unwrap();
-    let fullness = output_queue.get_batch_num_inserted_in_current_batch();
+    let fullness = output_queue.get_num_inserted_in_current_batch();
     let remaining_leaves = output_queue.get_metadata().batch_metadata.batch_size - fullness;
     for _ in 0..remaining_leaves {
         create_output_accounts(context, &payer, test_indexer, output_queue_pubkey, 1, true).await?;

--- a/programs/system/src/invoke/verify_state_proof.rs
+++ b/programs/system/src/invoke/verify_state_proof.rs
@@ -245,7 +245,7 @@ fn fetch_root<const IS_READ_ONLY: bool, const IS_STATE: bool>(
 /// 1. prove inclusion by index in the output queue if leaf index should exist in the output queue.
 ///    1.1. if inclusion was proven by index, return Ok.
 /// 2. prove non-inclusion in the bloom filters
-///    2.1. skip wiped batches.
+///    2.1. skip cleared batches.
 ///    2.2. prove non-inclusion in the bloom filters for each batch.
 #[inline(always)]
 pub fn verify_read_only_account_inclusion_by_index<'a>(

--- a/programs/system/src/invoke_cpi/process_cpi_context.rs
+++ b/programs/system/src/invoke_cpi/process_cpi_context.rs
@@ -94,7 +94,7 @@ pub fn set_cpi_context(
 ) -> Result<()> {
     // SAFETY Assumptions:
     // -  previous data in cpi_context_account
-    //   -> we require the account to be wiped in the beginning of a
+    //   -> we require the account to be cleared in the beginning of a
     //   transaction
     // - leaf over data: There cannot be any leftover data in the
     //   account since if the transaction fails the account doesn't change.

--- a/programs/system/src/sdk/mod.rs
+++ b/programs/system/src/sdk/mod.rs
@@ -10,7 +10,7 @@ pub struct CompressedCpiContext {
     /// Is set by the program that is invoking the CPI to signal that is should
     /// set the cpi context.
     pub set_context: bool,
-    /// Is set to wipe the cpi context since someone could have set it before
+    /// Is set to clear the cpi context since someone could have set it before
     /// with unrelated data.
     pub first_set_context: bool,
     /// Index of cpi context account in remaining accounts.

--- a/prover/client/src/mock_batched_forester.rs
+++ b/prover/client/src/mock_batched_forester.rs
@@ -348,9 +348,11 @@ impl<const HEIGHT: usize> MockBatchedAddressForester<HEIGHT> {
     pub fn finalize_batch_address_update(&mut self, batch_size: usize) {
         println!("finalize batch address update");
         let new_element_values = self.queue_leaves[..batch_size].to_vec();
+        println!("removing leaves from queue {}", batch_size);
         for _ in 0..batch_size {
             self.queue_leaves.remove(0);
         }
+        println!("new queue length {}", self.queue_leaves.len());
         for new_element_value in &new_element_values {
             self.merkle_tree
                 .append(

--- a/sdk-libs/program-test/src/test_batch_forester.rs
+++ b/sdk-libs/program-test/src/test_batch_forester.rs
@@ -10,9 +10,8 @@ use light_batched_merkle_tree::{
         create_output_queue_account, CreateOutputQueueParams, InitStateTreeAccountsInstructionData,
     },
     merkle_tree::{
-        get_merkle_tree_account_size, AppendBatchProofInputsIx, BatchProofInputsIx,
-        BatchedMerkleTreeAccount, BatchedMerkleTreeMetadata, CreateTreeParams,
-        InstructionDataBatchAppendInputs, InstructionDataBatchNullifyInputs,
+        get_merkle_tree_account_size, BatchedMerkleTreeAccount, BatchedMerkleTreeMetadata,
+        CreateTreeParams, InstructionDataBatchAppendInputs, InstructionDataBatchNullifyInputs,
     },
     queue::{
         assert_queue_zero_copy_inited, get_output_queue_account_size, BatchedQueueAccount,
@@ -210,7 +209,7 @@ pub async fn create_append_batch_ix_data<Rpc: RpcConnection>(
     };
 
     InstructionDataBatchAppendInputs {
-        public_inputs: AppendBatchProofInputsIx { new_root },
+        new_root,
         compressed_proof: CompressedProof {
             a: proof.a,
             b: proof.b,
@@ -369,10 +368,7 @@ pub async fn get_batched_nullify_ix_data<Rpc: RpcConnection>(
     };
 
     Ok(InstructionDataBatchNullifyInputs {
-        public_inputs: BatchProofInputsIx {
-            new_root,
-            old_root_index: old_root_index as u16,
-        },
+        new_root,
         compressed_proof: CompressedProof {
             a: proof.a,
             b: proof.b,
@@ -804,7 +800,6 @@ pub async fn create_batch_update_address_tree_instruction_data_with_proof<
     let merkle_tree =
         BatchedMerkleTreeAccount::address_from_bytes(merkle_tree_account.data.as_mut_slice())
             .unwrap();
-    let old_root_index = merkle_tree.root_history.last_index();
     let full_batch_index = merkle_tree.queue_metadata.next_full_batch_index;
     let batch = &merkle_tree.batches[full_batch_index as usize];
     let zkp_batch_index = batch.get_num_inserted_zkps();
@@ -892,10 +887,8 @@ pub async fn create_batch_update_address_tree_instruction_data_with_proof<
         let (proof_a, proof_b, proof_c) = proof_from_json_struct(proof_json);
         let (proof_a, proof_b, proof_c) = compress_proof(&proof_a, &proof_b, &proof_c);
         let instruction_data = InstructionDataBatchNullifyInputs {
-            public_inputs: BatchProofInputsIx {
-                new_root: circuit_inputs_new_root,
-                old_root_index: old_root_index as u16,
-            },
+            new_root: circuit_inputs_new_root,
+
             compressed_proof: CompressedProof {
                 a: proof_a,
                 b: proof_b,

--- a/sdk-libs/sdk/src/verify.rs
+++ b/sdk-libs/sdk/src/verify.rs
@@ -26,7 +26,7 @@ pub struct CompressedCpiContext {
     /// Is set by the program that is invoking the CPI to signal that is should
     /// set the cpi context.
     pub set_context: bool,
-    /// Is set to wipe the cpi context since someone could have set it before
+    /// Is set to clear the cpi context since someone could have set it before
     /// with unrelated data.
     pub first_set_context: bool,
     /// Index of cpi context account in remaining accounts.


### PR DESCRIPTION
Changes:
1. rename `BatchState::CanBeFilled` -> `BatchState::Fill`
2. rename `*_wiped` -> `*_zeroed`
3. initializing root history with full length
    -> needed to adapt expected len assertion in batched forester tests 
4. 