### PR TITLE
chore: make light-zero-copy no-std, increase test coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3357,7 +3357,7 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
  "solana-program",
- "thiserror 1.0.64",
+ "thiserror 2.0.11",
  "zerocopy 0.8.14",
 ]
 

--- a/program-libs/batched-merkle-tree/Cargo.toml
+++ b/program-libs/batched-merkle-tree/Cargo.toml
@@ -14,7 +14,7 @@ solana = []
 [dependencies]
 aligned-sized = { workspace=true}
 solana-program = { workspace = true }
-light-zero-copy = { workspace=true, features = ["solana"] }
+light-zero-copy = { workspace=true, features = ["solana", "std"] }
 light-hasher = { workspace=true, features = ["solana"] }
 light-utils = { workspace=true }
 light-bloom-filter = { workspace=true, features = ["solana"] }

--- a/program-libs/batched-merkle-tree/src/merkle_tree.rs
+++ b/program-libs/batched-merkle-tree/src/merkle_tree.rs
@@ -245,7 +245,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
                 "account.get_account_size(): {}",
                 account_metadata.get_account_size()?
             );
-            return Err(ZeroCopyError::InvalidAccountSize.into());
+            return Err(ZeroCopyError::Size.into());
         }
 
         let (mut root_history, account_data) = ZeroCopyCyclicVecU64::new_at(
@@ -332,7 +332,7 @@ impl<'a> BatchedMerkleTreeAccount<'a> {
     ///     3.3. If all zkps are inserted, set batch state to inserted.
     /// 4. Increment next full batch index if inserted.
     /// 5. Return the batch append event.
-    ///     
+    ///
     /// Note: when proving inclusion by index in
     ///     value array we need to insert the value into a bloom_filter once it is
     ///     inserted into the tree. Check this with get_num_inserted_zkps

--- a/program-libs/batched-merkle-tree/src/queue.rs
+++ b/program-libs/batched-merkle-tree/src/queue.rs
@@ -236,7 +236,7 @@ impl<'a> BatchedQueueAccount<'a> {
                     .batch_metadata
                     .queue_account_size(account_metadata.metadata.queue_type)?
             );
-            return Err(ZeroCopyError::InvalidAccountSize.into());
+            return Err(ZeroCopyError::Size.into());
         }
 
         let (value_vecs, _bloom_filter_stores, hashchain_store, _) = init_queue(

--- a/program-libs/batched-merkle-tree/tests/rollover_state_tree.rs
+++ b/program-libs/batched-merkle-tree/tests/rollover_state_tree.rs
@@ -183,7 +183,7 @@ fn test_rollover() {
                 network_fee: params.network_fee,
             };
             let result = rollover_batched_state_tree(params);
-            assert_eq!(result, Err(ZeroCopyError::InvalidAccountSize.into()));
+            assert_eq!(result, Err(ZeroCopyError::Size.into()));
         }
         // 4. Failing: invalid queue size
         {
@@ -214,7 +214,7 @@ fn test_rollover() {
                 network_fee: params.network_fee,
             };
             let result = rollover_batched_state_tree(params);
-            assert_eq!(result, Err(ZeroCopyError::InvalidAccountSize.into()));
+            assert_eq!(result, Err(ZeroCopyError::Size.into()));
         }
         // 5. Functional: rollover address tree
         {

--- a/program-libs/zero-copy/Cargo.toml
+++ b/program-libs/zero-copy/Cargo.toml
@@ -7,15 +7,17 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
-default = []
+default = ["std"]
 solana = ["solana-program"]
+std = []
 
 [dependencies]
 solana-program = { workspace = true, optional = true }
-thiserror = "1.0"
+thiserror = {version="2.0", default-features = false}
 num-traits = { version = "0.2" }
-zerocopy = {version="0.8.14", features=["derive"]}
+zerocopy = {version="0.8.14"}
 
 [dev-dependencies]
 rand = "0.8"
 num-traits.workspace = true
+zerocopy = {version="0.8.14", features=["derive"]}

--- a/program-libs/zero-copy/src/lib.rs
+++ b/program-libs/zero-copy/src/lib.rs
@@ -1,9 +1,13 @@
+#![no_std]
+
 pub mod cyclic_vec;
 pub mod errors;
 pub mod slice_mut;
 pub mod vec;
+use core::mem::{align_of, size_of};
 
-use std::mem::{align_of, size_of};
+#[cfg(feature = "std")]
+extern crate std;
 
 pub fn add_padding<LEN, T>(offset: &mut usize) {
     let padding = align_of::<T>().saturating_sub(size_of::<LEN>());

--- a/program-libs/zero-copy/tests/cyclic_vec_tests.rs
+++ b/program-libs/zero-copy/tests/cyclic_vec_tests.rs
@@ -687,3 +687,49 @@ fn test_partial_eq() {
     }
     assert_eq!(vec, vec2);
 }
+
+#[test]
+fn test_new_memory_not_zeroed() {
+    let capacity = 5;
+    let mut data = vec![1; ZeroCopyCyclicVecU64::<u64>::required_size_for_capacity(capacity)];
+    let vec = ZeroCopyCyclicVecU64::<u64>::new(capacity, &mut data);
+    assert!(matches!(vec, Err(ZeroCopyError::MemoryNotZeroed)));
+}
+
+#[test]
+fn test_index() {
+    let length: u64 = 4;
+
+    let mut buffer = vec![0u8; ZeroCopyCyclicVecU64::<u32>::required_size_for_capacity(length)];
+    let values = [1u32, 2, 3, 4];
+    let (mut slice, _) = ZeroCopyCyclicVecU64::<u32>::new_at(length, &mut buffer)
+        .expect("Failed to create ZeroCopyVeceMut");
+    for value in &values {
+        slice.push(*value);
+    }
+    assert_eq!(slice[0], 1);
+    assert_eq!(slice[1], 2);
+    assert_eq!(slice[2], 3);
+    assert_eq!(slice[3], 4);
+    slice[0] = 10;
+    assert_eq!(slice[0], 10);
+    assert_eq!(slice[1], 2);
+    assert_eq!(slice[2], 3);
+    assert_eq!(slice[3], 4);
+    assert_eq!(slice.as_slice(), &[10, 2, 3, 4]);
+}
+
+#[test]
+fn test_debug_fmt() {
+    let length: u64 = 4;
+    let mut buffer = vec![0u8; ZeroCopyCyclicVecU64::<u32>::required_size_for_capacity(length)];
+    let values = [1u32, 2, 3, 4];
+
+    let (mut slice, _) = ZeroCopyCyclicVecU64::<u32>::new_at(length, &mut buffer)
+        .expect("Failed to create ZeroCopyVeceMut");
+    for value in values.iter() {
+        slice.push(*value);
+    }
+
+    assert_eq!(format!("{:?}", slice), "[1, 2, 3, 4]");
+}


### PR DESCRIPTION
changes:
1. make light-zero-copy no-std (default features includes std because we use vec for testing)
2. increase code coverage
3. improve zerocopy -> light-zero-copy error conversion