### PR TITLE
feat: rate limiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2093,6 +2093,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,6 +2178,27 @@ dependencies = [
  "log",
  "plain",
  "scroll",
+]
+
+[[package]]
+name = "governor"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "842dc78579ce01e6a1576ad896edc92fca002dd60c9c3746b7fc2bec6fb429d0"
+dependencies = [
+ "cfg-if",
+ "dashmap 6.1.0",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.8.5",
+ "smallvec",
+ "spinning_top",
 ]
 
 [[package]]
@@ -2911,6 +2938,7 @@ dependencies = [
  "async-trait",
  "bb8",
  "borsh 0.10.3",
+ "governor",
  "light-compressed-token",
  "light-concurrent-merkle-tree",
  "light-hasher",
@@ -3547,6 +3575,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3555,6 +3589,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "normalize-line-endings"
@@ -4242,6 +4282,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd1fe6824cea6538803de3ff1bc0cf3949024db3d43c9643024bfb33a807c0e"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quinn"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4382,6 +4437,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6928fa44c097620b706542d428957635951bade7143269085389d42c8a4927e"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -6253,6 +6317,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"

--- a/forester/src/cli.rs
+++ b/forester/src/cli.rs
@@ -114,6 +114,12 @@ pub struct StartArgs {
 
     #[arg(long, env = "FORESTER_RPC_RATE_LIMIT")]
     pub rpc_rate_limit: Option<u32>,
+
+    #[arg(long, env = "FORESTER_PHOTON_RATE_LIMIT")]
+    pub photon_rate_limit: Option<u32>,
+
+    #[arg(long, env = "FORESTER_SEND_TRANSACTION_RATE_LIMIT")]
+    pub send_tx_rate_limit: Option<u32>,
 }
 
 #[derive(Parser, Clone, Debug)]

--- a/forester/src/cli.rs
+++ b/forester/src/cli.rs
@@ -66,7 +66,7 @@ pub struct StartArgs {
     #[arg(long, env = "FORESTER_CU_LIMIT", default_value = "1000000")]
     pub cu_limit: u32,
 
-    #[arg(long, env = "FORESTER_RPC_POOL_SIZE", default_value = "20")]
+    #[arg(long, env = "FORESTER_RPC_POOL_SIZE", default_value = "98")]
     pub rpc_pool_size: usize,
 
     #[arg(
@@ -112,11 +112,8 @@ pub struct StartArgs {
     )]
     pub address_queue_processing_length: u16,
 
-    #[arg(long, env = "FORESTER_ENABLE_RPC_RATE_LIMIT", default_value = "false")]
-    pub rpc_rate_limit_enabled: bool,
-
-    #[arg(long, env = "FORESTER_RPC_RATE_LIMIT", default_value = "100")]
-    pub rpc_rate_limit: u32,
+    #[arg(long, env = "FORESTER_RPC_RATE_LIMIT")]
+    pub rpc_rate_limit: Option<u32>,
 }
 
 #[derive(Parser, Clone, Debug)]

--- a/forester/src/cli.rs
+++ b/forester/src/cli.rs
@@ -111,6 +111,12 @@ pub struct StartArgs {
         default_value = "28807"
     )]
     pub address_queue_processing_length: u16,
+
+    #[arg(long, env = "FORESTER_ENABLE_RPC_RATE_LIMIT", default_value = "false")]
+    pub rpc_rate_limit_enabled: bool,
+
+    #[arg(long, env = "FORESTER_RPC_RATE_LIMIT", default_value = "100")]
+    pub rpc_rate_limit: u32,
 }
 
 #[derive(Parser, Clone, Debug)]

--- a/forester/src/config.rs
+++ b/forester/src/config.rs
@@ -41,6 +41,8 @@ pub struct ExternalServicesConfig {
     pub pushgateway_url: Option<String>,
     pub pagerduty_routing_key: Option<String>,
     pub rpc_rate_limit: Option<u32>,
+    pub photon_rate_limit: Option<u32>,
+    pub send_tx_rate_limit: Option<u32>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -153,6 +155,8 @@ impl ForesterConfig {
                 pushgateway_url: args.push_gateway_url.clone(),
                 pagerduty_routing_key: args.pagerduty_routing_key.clone(),
                 rpc_rate_limit: args.rpc_rate_limit,
+                photon_rate_limit: args.photon_rate_limit,
+                send_tx_rate_limit: args.send_tx_rate_limit,
             },
             retry_config: RetryConfig {
                 max_retries: args.max_retries,
@@ -206,6 +210,8 @@ impl ForesterConfig {
                 pushgateway_url: args.push_gateway_url.clone(),
                 pagerduty_routing_key: args.pagerduty_routing_key.clone(),
                 rpc_rate_limit: None,
+                photon_rate_limit: None,
+                send_tx_rate_limit: None,
             },
             retry_config: RetryConfig::default(),
             queue_config: QueueConfig::default(),

--- a/forester/src/config.rs
+++ b/forester/src/config.rs
@@ -40,6 +40,7 @@ pub struct ExternalServicesConfig {
     pub photon_api_key: Option<String>,
     pub pushgateway_url: Option<String>,
     pub pagerduty_routing_key: Option<String>,
+    pub rpc_rate_limit: Option<u32>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -142,6 +143,11 @@ impl ForesterConfig {
             .clone()
             .ok_or(ConfigError::MissingField { field: "rpc_url" })?;
 
+        let mut rpc_rate_limit = None;
+        if args.rpc_rate_limit_enabled {
+            rpc_rate_limit = Some(args.rpc_rate_limit);
+        }
+
         Ok(Self {
             external_services: ExternalServicesConfig {
                 rpc_url,
@@ -151,6 +157,7 @@ impl ForesterConfig {
                 photon_api_key: args.photon_api_key.clone(),
                 pushgateway_url: args.push_gateway_url.clone(),
                 pagerduty_routing_key: args.pagerduty_routing_key.clone(),
+                rpc_rate_limit,
             },
             retry_config: RetryConfig {
                 max_retries: args.max_retries,
@@ -203,6 +210,7 @@ impl ForesterConfig {
                 photon_api_key: None,
                 pushgateway_url: args.push_gateway_url.clone(),
                 pagerduty_routing_key: args.pagerduty_routing_key.clone(),
+                rpc_rate_limit: None,
             },
             retry_config: RetryConfig::default(),
             queue_config: QueueConfig::default(),

--- a/forester/src/config.rs
+++ b/forester/src/config.rs
@@ -143,11 +143,6 @@ impl ForesterConfig {
             .clone()
             .ok_or(ConfigError::MissingField { field: "rpc_url" })?;
 
-        let mut rpc_rate_limit = None;
-        if args.rpc_rate_limit_enabled {
-            rpc_rate_limit = Some(args.rpc_rate_limit);
-        }
-
         Ok(Self {
             external_services: ExternalServicesConfig {
                 rpc_url,
@@ -157,7 +152,7 @@ impl ForesterConfig {
                 photon_api_key: args.photon_api_key.clone(),
                 pushgateway_url: args.push_gateway_url.clone(),
                 pagerduty_routing_key: args.pagerduty_routing_key.clone(),
-                rpc_rate_limit,
+                rpc_rate_limit: args.rpc_rate_limit,
             },
             retry_config: RetryConfig {
                 max_retries: args.max_retries,
@@ -217,7 +212,7 @@ impl ForesterConfig {
             indexer_config: IndexerConfig::default(),
             transaction_config: TransactionConfig::default(),
             general_config: GeneralConfig {
-                rpc_pool_size: 1,
+                rpc_pool_size: 10,
                 slot_update_interval_seconds: 10,
                 tree_discovery_interval_seconds: 5,
                 enable_metrics: args.enable_metrics(),

--- a/forester/src/epoch_manager.rs
+++ b/forester/src/epoch_manager.rs
@@ -919,9 +919,9 @@ impl<R: RpcConnection, I: Indexer<R> + IndexerType<R>> EpochManager<R, I> {
                     // rate-limiting mechanism (with more control). Or rework
                     // the send logic to not await confirmations.
                     let batched_tx_config = SendBatchedTransactionsConfig {
-                        num_batches: 10,
+                        num_batches: 2,
                         build_transaction_batch_config: BuildTransactionBatchConfig {
-                            batch_size: 50, // TODO: make batch size configurable and or dynamic based on queue usage
+                            batch_size: 60, // TODO: make batch size configurable and or dynamic based on queue usage
                             compute_unit_price: Some(10_000), // Is dynamic. Sets max.
                             compute_unit_limit: Some(180_000),
                         },

--- a/forester/src/lib.rs
+++ b/forester/src/lib.rs
@@ -28,6 +28,7 @@ pub use config::{ForesterConfig, ForesterEpochInfo};
 use forester_utils::forester_epoch::{TreeAccounts, TreeType};
 use light_client::{
     indexer::Indexer,
+    rate_limiter::RateLimiter,
     rpc::{RpcConnection, SolanaRpcConnection},
     rpc_pool::SolanaRpcPool,
 };
@@ -83,6 +84,7 @@ pub async fn run_queue_info(
 
 pub async fn run_pipeline<R: RpcConnection, I: Indexer<R> + IndexerType<R>>(
     config: Arc<ForesterConfig>,
+    rate_limiter: Option<RateLimiter>,
     indexer: Arc<Mutex<I>>,
     shutdown: oneshot::Receiver<()>,
     work_report_sender: mpsc::Sender<WorkReport>,
@@ -91,6 +93,7 @@ pub async fn run_pipeline<R: RpcConnection, I: Indexer<R> + IndexerType<R>>(
         config.external_services.rpc_url.to_string(),
         CommitmentConfig::confirmed(),
         config.general_config.rpc_pool_size as u32,
+        rate_limiter.clone(),
     )
     .await?;
 

--- a/forester/src/lib.rs
+++ b/forester/src/lib.rs
@@ -84,7 +84,8 @@ pub async fn run_queue_info(
 
 pub async fn run_pipeline<R: RpcConnection, I: Indexer<R> + IndexerType<R>>(
     config: Arc<ForesterConfig>,
-    rate_limiter: Option<RateLimiter>,
+    rpc_rate_limiter: Option<RateLimiter>,
+    send_tx_rate_limiter: Option<RateLimiter>,
     indexer: Arc<Mutex<I>>,
     shutdown: oneshot::Receiver<()>,
     work_report_sender: mpsc::Sender<WorkReport>,
@@ -93,7 +94,8 @@ pub async fn run_pipeline<R: RpcConnection, I: Indexer<R> + IndexerType<R>>(
         config.external_services.rpc_url.to_string(),
         CommitmentConfig::confirmed(),
         config.general_config.rpc_pool_size as u32,
-        rate_limiter.clone(),
+        rpc_rate_limiter.clone(),
+        send_tx_rate_limiter.clone(),
     )
     .await?;
 

--- a/forester/tests/batched_address_test.rs
+++ b/forester/tests/batched_address_test.rs
@@ -59,6 +59,7 @@ async fn test_address_batched() {
         config.external_services.rpc_url.to_string(),
         CommitmentConfig::processed(),
         config.general_config.rpc_pool_size as u32,
+        None,
     )
     .await
     .unwrap();
@@ -217,6 +218,7 @@ async fn test_address_batched() {
 
     let service_handle = tokio::spawn(run_pipeline(
         config.clone(),
+        None,
         Arc::new(Mutex::new(env.indexer)),
         shutdown_receiver,
         work_report_sender,

--- a/forester/tests/batched_address_test.rs
+++ b/forester/tests/batched_address_test.rs
@@ -60,6 +60,7 @@ async fn test_address_batched() {
         CommitmentConfig::processed(),
         config.general_config.rpc_pool_size as u32,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -218,6 +219,7 @@ async fn test_address_batched() {
 
     let service_handle = tokio::spawn(run_pipeline(
         config.clone(),
+        None,
         None,
         Arc::new(Mutex::new(env.indexer)),
         shutdown_receiver,

--- a/forester/tests/batched_state_test.rs
+++ b/forester/tests/batched_state_test.rs
@@ -57,6 +57,7 @@ async fn test_state_batched() {
         config.external_services.rpc_url.to_string(),
         CommitmentConfig::processed(),
         config.general_config.rpc_pool_size as u32,
+        None,
     )
     .await
     .unwrap();
@@ -203,6 +204,7 @@ async fn test_state_batched() {
 
     let service_handle = tokio::spawn(run_pipeline(
         Arc::from(config.clone()),
+        None,
         Arc::new(Mutex::new(e2e_env.indexer)),
         shutdown_receiver,
         work_report_sender,

--- a/forester/tests/batched_state_test.rs
+++ b/forester/tests/batched_state_test.rs
@@ -58,6 +58,7 @@ async fn test_state_batched() {
         CommitmentConfig::processed(),
         config.general_config.rpc_pool_size as u32,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -204,6 +205,7 @@ async fn test_state_batched() {
 
     let service_handle = tokio::spawn(run_pipeline(
         Arc::from(config.clone()),
+        None,
         None,
         Arc::new(Mutex::new(e2e_env.indexer)),
         shutdown_receiver,

--- a/forester/tests/e2e_test.rs
+++ b/forester/tests/e2e_test.rs
@@ -65,6 +65,7 @@ async fn test_epoch_monitor_with_test_indexer_and_1_forester() {
         config.external_services.rpc_url.to_string(),
         CommitmentConfig::confirmed(),
         config.general_config.rpc_pool_size as u32,
+        None,
     )
     .await
     .unwrap();
@@ -174,6 +175,7 @@ async fn test_epoch_monitor_with_test_indexer_and_1_forester() {
     // Run the forester as pipeline
     let service_handle = tokio::spawn(run_pipeline(
         config.clone(),
+        None,
         Arc::new(Mutex::new(env.indexer)),
         shutdown_receiver,
         work_report_sender,
@@ -311,6 +313,7 @@ async fn test_epoch_monitor_with_2_foresters() {
         config1.external_services.rpc_url.to_string(),
         CommitmentConfig::confirmed(),
         config1.general_config.rpc_pool_size as u32,
+        None,
     )
     .await
     .unwrap();
@@ -463,12 +466,14 @@ async fn test_epoch_monitor_with_2_foresters() {
 
     let service_handle1 = tokio::spawn(run_pipeline(
         config1.clone(),
+        None,
         indexer.clone(),
         shutdown_receiver1,
         work_report_sender1,
     ));
     let service_handle2 = tokio::spawn(run_pipeline(
         config2.clone(),
+        None,
         indexer,
         shutdown_receiver2,
         work_report_sender2,
@@ -656,6 +661,7 @@ async fn test_epoch_double_registration() {
         config.external_services.rpc_url.to_string(),
         CommitmentConfig::confirmed(),
         config.general_config.rpc_pool_size as u32,
+        None,
     )
     .await
     .unwrap();
@@ -715,6 +721,7 @@ async fn test_epoch_double_registration() {
         // Run the forester pipeline
         let service_handle = tokio::spawn(run_pipeline(
             config.clone(),
+            None,
             indexer.clone(),
             shutdown_receiver,
             work_report_sender.clone(),

--- a/forester/tests/e2e_test.rs
+++ b/forester/tests/e2e_test.rs
@@ -66,6 +66,7 @@ async fn test_epoch_monitor_with_test_indexer_and_1_forester() {
         CommitmentConfig::confirmed(),
         config.general_config.rpc_pool_size as u32,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -175,6 +176,7 @@ async fn test_epoch_monitor_with_test_indexer_and_1_forester() {
     // Run the forester as pipeline
     let service_handle = tokio::spawn(run_pipeline(
         config.clone(),
+        None,
         None,
         Arc::new(Mutex::new(env.indexer)),
         shutdown_receiver,
@@ -313,6 +315,7 @@ async fn test_epoch_monitor_with_2_foresters() {
         config1.external_services.rpc_url.to_string(),
         CommitmentConfig::confirmed(),
         config1.general_config.rpc_pool_size as u32,
+        None,
         None,
     )
     .await
@@ -467,12 +470,14 @@ async fn test_epoch_monitor_with_2_foresters() {
     let service_handle1 = tokio::spawn(run_pipeline(
         config1.clone(),
         None,
+        None,
         indexer.clone(),
         shutdown_receiver1,
         work_report_sender1,
     ));
     let service_handle2 = tokio::spawn(run_pipeline(
         config2.clone(),
+        None,
         None,
         indexer,
         shutdown_receiver2,
@@ -662,6 +667,7 @@ async fn test_epoch_double_registration() {
         CommitmentConfig::confirmed(),
         config.general_config.rpc_pool_size as u32,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -721,6 +727,7 @@ async fn test_epoch_double_registration() {
         // Run the forester pipeline
         let service_handle = tokio::spawn(run_pipeline(
             config.clone(),
+            None,
             None,
             indexer.clone(),
             shutdown_receiver,

--- a/forester/tests/priority_fee_test.rs
+++ b/forester/tests/priority_fee_test.rs
@@ -61,6 +61,8 @@ async fn test_priority_fee_request() {
         address_queue_start_index: 0,
         address_queue_processing_length: 28807,
         rpc_rate_limit: None,
+        photon_rate_limit: None,
+        send_tx_rate_limit: None,
     };
 
     let config = ForesterConfig::new_for_start(&args).expect("Failed to create config");

--- a/forester/tests/priority_fee_test.rs
+++ b/forester/tests/priority_fee_test.rs
@@ -60,6 +60,7 @@ async fn test_priority_fee_request() {
         state_queue_processing_length: 28807,
         address_queue_start_index: 0,
         address_queue_processing_length: 28807,
+        rpc_rate_limit: None,
     };
 
     let config = ForesterConfig::new_for_start(&args).expect("Failed to create config");

--- a/forester/tests/priority_fee_test.rs
+++ b/forester/tests/priority_fee_test.rs
@@ -11,6 +11,7 @@ use crate::test_utils::init;
 mod test_utils;
 
 #[tokio::test]
+#[ignore]
 async fn test_priority_fee_request() {
     dotenvy::dotenv().ok();
 

--- a/forester/tests/test_utils.rs
+++ b/forester/tests/test_utils.rs
@@ -78,6 +78,8 @@ pub fn forester_config() -> ForesterConfig {
             pushgateway_url: None,
             pagerduty_routing_key: None,
             rpc_rate_limit: None,
+            photon_rate_limit: None,
+            send_tx_rate_limit: None,
         },
         retry_config: Default::default(),
         queue_config: Default::default(),

--- a/forester/tests/test_utils.rs
+++ b/forester/tests/test_utils.rs
@@ -77,6 +77,7 @@ pub fn forester_config() -> ForesterConfig {
             photon_api_key: None,
             pushgateway_url: None,
             pagerduty_routing_key: None,
+            rpc_rate_limit: None,
         },
         retry_config: Default::default(),
         queue_config: Default::default(),

--- a/program-tests/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/program-tests/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -225,7 +225,10 @@ async fn test_address_queue_and_tree_invalid_sizes() {
     program_test.add_program("account_compression", ID, None);
     program_test.add_program("spl_noop", NOOP_PROGRAM_ID, None);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection { context };
+    let mut context = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
     let payer = context.get_payer().insecure_clone();
 
     let address_merkle_tree_keypair = Keypair::new();
@@ -319,7 +322,10 @@ async fn test_address_queue_and_tree_invalid_config() {
     program_test.add_program("account_compression", ID, None);
     program_test.add_program("spl_noop", NOOP_PROGRAM_ID, None);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection { context };
+    let mut context = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
     let payer = context.get_payer().insecure_clone();
 
     let address_merkle_tree_keypair = Keypair::new();
@@ -1417,7 +1423,10 @@ pub async fn test_setup_with_address_merkle_tree(
     program_test.add_program("account_compression", ID, None);
     program_test.add_program("spl_noop", NOOP_PROGRAM_ID, None);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection { context };
+    let mut context = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
     let payer = context.get_payer().insecure_clone();
 
     let address_merkle_tree_keypair = Keypair::new();

--- a/program-tests/account-compression-test/tests/address_merkle_tree_tests.rs
+++ b/program-tests/account-compression-test/tests/address_merkle_tree_tests.rs
@@ -225,10 +225,7 @@ async fn test_address_queue_and_tree_invalid_sizes() {
     program_test.add_program("account_compression", ID, None);
     program_test.add_program("spl_noop", NOOP_PROGRAM_ID, None);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection {
-        context,
-        rate_limiter: None,
-    };
+    let mut context = ProgramTestRpcConnection::new(context);
     let payer = context.get_payer().insecure_clone();
 
     let address_merkle_tree_keypair = Keypair::new();
@@ -322,10 +319,7 @@ async fn test_address_queue_and_tree_invalid_config() {
     program_test.add_program("account_compression", ID, None);
     program_test.add_program("spl_noop", NOOP_PROGRAM_ID, None);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection {
-        context,
-        rate_limiter: None,
-    };
+    let mut context = ProgramTestRpcConnection::new(context);
     let payer = context.get_payer().insecure_clone();
 
     let address_merkle_tree_keypair = Keypair::new();
@@ -1423,10 +1417,7 @@ pub async fn test_setup_with_address_merkle_tree(
     program_test.add_program("account_compression", ID, None);
     program_test.add_program("spl_noop", NOOP_PROGRAM_ID, None);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection {
-        context,
-        rate_limiter: None,
-    };
+    let mut context = ProgramTestRpcConnection::new(context);
     let payer = context.get_payer().insecure_clone();
 
     let address_merkle_tree_keypair = Keypair::new();

--- a/program-tests/account-compression-test/tests/batched_merkle_tree_test.rs
+++ b/program-tests/account-compression-test/tests/batched_merkle_tree_test.rs
@@ -85,7 +85,10 @@ async fn test_batch_state_merkle_tree() {
     let output_queue_pubkey = nullifier_queue_keypair.pubkey();
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection { context };
+    let mut context = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
     let payer_pubkey = context.get_payer().pubkey();
     let payer = context.get_payer().insecure_clone();
     let params = InitStateTreeAccountsInstructionData::test_default();
@@ -853,7 +856,10 @@ async fn test_init_batch_state_merkle_trees() {
     );
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection { context };
+    let mut context = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
 
     let payer = context.get_payer().insecure_clone();
     let params = InitStateTreeAccountsInstructionData::test_default();
@@ -1001,7 +1007,10 @@ async fn test_rollover_batch_state_merkle_trees() {
     );
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection { context };
+    let mut context = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
     let payer = context.get_payer().insecure_clone();
     let mut params = InitStateTreeAccountsInstructionData::test_default();
     params.rollover_threshold = Some(0);
@@ -1385,7 +1394,10 @@ async fn test_init_batch_address_merkle_trees() {
     );
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection { context };
+    let mut context = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
 
     let params = InitAddressTreeAccountsInstructionData::test_default();
     let e2e_test_params = InitAddressTreeAccountsInstructionData::e2e_test_default();
@@ -1477,7 +1489,10 @@ async fn test_batch_address_merkle_trees() {
     );
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection { context };
+    let mut context = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
     let mut mock_indexer = mock_batched_forester::MockBatchedAddressForester::<40>::default();
     let payer = context.get_payer().insecure_clone();
     let mut params = InitAddressTreeAccountsInstructionData::test_default();

--- a/program-tests/account-compression-test/tests/group_authority_tests.rs
+++ b/program-tests/account-compression-test/tests/group_authority_tests.rs
@@ -36,7 +36,10 @@ async fn test_create_and_update_group() {
 
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection { context };
+    let mut context = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
 
     let seed = Keypair::new();
     let group_accounts = Pubkey::find_program_address(

--- a/program-tests/account-compression-test/tests/group_authority_tests.rs
+++ b/program-tests/account-compression-test/tests/group_authority_tests.rs
@@ -36,10 +36,7 @@ async fn test_create_and_update_group() {
 
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection {
-        context,
-        rate_limiter: None,
-    };
+    let mut context = ProgramTestRpcConnection::new(context);
 
     let seed = Keypair::new();
     let group_accounts = Pubkey::find_program_address(

--- a/program-tests/account-compression-test/tests/merkle_tree_tests.rs
+++ b/program-tests/account-compression-test/tests/merkle_tree_tests.rs
@@ -68,7 +68,10 @@ async fn test_init_and_insert_into_nullifier_queue(
     let nullifier_queue_pubkey = nullifier_queue_keypair.pubkey();
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut rpc = ProgramTestRpcConnection { context };
+    let mut rpc = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
     let payer_pubkey = rpc.get_payer().pubkey();
     fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_sizes(
         &mut rpc,
@@ -241,7 +244,10 @@ async fn test_full_nullifier_queue(
     let nullifier_queue_pubkey = nullifier_queue_keypair.pubkey();
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut rpc = ProgramTestRpcConnection { context };
+    let mut rpc = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
     let payer_pubkey = rpc.get_payer().pubkey();
     functional_1_initialize_state_merkle_tree_and_nullifier_queue(
         &mut rpc,
@@ -442,7 +448,10 @@ async fn failing_queue(
     let nullifier_queue_pubkey = nullifier_queue_keypair.pubkey();
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut rpc = ProgramTestRpcConnection { context };
+    let mut rpc = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
     let payer = rpc.get_payer().insecure_clone();
     let payer_pubkey = rpc.get_payer().pubkey();
     functional_1_initialize_state_merkle_tree_and_nullifier_queue(
@@ -623,7 +632,10 @@ async fn test_init_and_rollover_state_merkle_tree(
     let nullifier_queue_pubkey = nullifier_queue_keypair.pubkey();
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection { context };
+    let mut context = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
     let payer_pubkey = context.get_payer().pubkey();
     functional_1_initialize_state_merkle_tree_and_nullifier_queue(
         &mut context,
@@ -882,7 +894,10 @@ async fn test_append_functional_and_failing(
 
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection { context };
+    let mut context = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
     let payer_pubkey = context.get_payer().pubkey();
     let merkle_tree_keypair = Keypair::new();
     let queue_keypair = Keypair::new();
@@ -1012,7 +1027,10 @@ async fn test_nullify_leaves(
     let nullifier_queue_pubkey = nullifier_queue_keypair.pubkey();
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection { context };
+    let mut context = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
     let payer = context.get_payer().insecure_clone();
     let payer_pubkey = context.get_payer().pubkey();
     functional_1_initialize_state_merkle_tree_and_nullifier_queue(

--- a/program-tests/account-compression-test/tests/merkle_tree_tests.rs
+++ b/program-tests/account-compression-test/tests/merkle_tree_tests.rs
@@ -68,10 +68,7 @@ async fn test_init_and_insert_into_nullifier_queue(
     let nullifier_queue_pubkey = nullifier_queue_keypair.pubkey();
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut rpc = ProgramTestRpcConnection {
-        context,
-        rate_limiter: None,
-    };
+    let mut rpc = ProgramTestRpcConnection::new(context);
     let payer_pubkey = rpc.get_payer().pubkey();
     fail_initialize_state_merkle_tree_and_nullifier_queue_invalid_sizes(
         &mut rpc,
@@ -244,10 +241,7 @@ async fn test_full_nullifier_queue(
     let nullifier_queue_pubkey = nullifier_queue_keypair.pubkey();
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut rpc = ProgramTestRpcConnection {
-        context,
-        rate_limiter: None,
-    };
+    let mut rpc = ProgramTestRpcConnection::new(context);
     let payer_pubkey = rpc.get_payer().pubkey();
     functional_1_initialize_state_merkle_tree_and_nullifier_queue(
         &mut rpc,
@@ -448,10 +442,7 @@ async fn failing_queue(
     let nullifier_queue_pubkey = nullifier_queue_keypair.pubkey();
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut rpc = ProgramTestRpcConnection {
-        context,
-        rate_limiter: None,
-    };
+    let mut rpc = ProgramTestRpcConnection::new(context);
     let payer = rpc.get_payer().insecure_clone();
     let payer_pubkey = rpc.get_payer().pubkey();
     functional_1_initialize_state_merkle_tree_and_nullifier_queue(
@@ -632,10 +623,7 @@ async fn test_init_and_rollover_state_merkle_tree(
     let nullifier_queue_pubkey = nullifier_queue_keypair.pubkey();
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection {
-        context,
-        rate_limiter: None,
-    };
+    let mut context = ProgramTestRpcConnection::new(context);
     let payer_pubkey = context.get_payer().pubkey();
     functional_1_initialize_state_merkle_tree_and_nullifier_queue(
         &mut context,
@@ -894,10 +882,7 @@ async fn test_append_functional_and_failing(
 
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection {
-        context,
-        rate_limiter: None,
-    };
+    let mut context = ProgramTestRpcConnection::new(context);
     let payer_pubkey = context.get_payer().pubkey();
     let merkle_tree_keypair = Keypair::new();
     let queue_keypair = Keypair::new();
@@ -1027,10 +1012,7 @@ async fn test_nullify_leaves(
     let nullifier_queue_pubkey = nullifier_queue_keypair.pubkey();
     program_test.set_compute_max_units(1_400_000u64);
     let context = program_test.start_with_context().await;
-    let mut context = ProgramTestRpcConnection {
-        context,
-        rate_limiter: None,
-    };
+    let mut context = ProgramTestRpcConnection::new(context);
     let payer = context.get_payer().insecure_clone();
     let payer_pubkey = context.get_payer().pubkey();
     functional_1_initialize_state_merkle_tree_and_nullifier_queue(

--- a/program-tests/registry-test/tests/tests.rs
+++ b/program-tests/registry-test/tests/tests.rs
@@ -175,7 +175,7 @@ fn test_protocol_config_active_phase_continuity_for_config(config: ProtocolConfi
 #[tokio::test]
 async fn test_initialize_protocol_config() {
     let rpc = setup_test_programs(None).await;
-    let mut rpc = ProgramTestRpcConnection { context: rpc };
+    let mut rpc = ProgramTestRpcConnection { context: rpc, rate_limiter: None };
 
     let payer = rpc.get_payer().insecure_clone();
     let program_account_keypair = Keypair::from_bytes(&OLD_REGISTRY_ID_TEST_KEYPAIR).unwrap();

--- a/program-tests/registry-test/tests/tests.rs
+++ b/program-tests/registry-test/tests/tests.rs
@@ -175,7 +175,10 @@ fn test_protocol_config_active_phase_continuity_for_config(config: ProtocolConfi
 #[tokio::test]
 async fn test_initialize_protocol_config() {
     let rpc = setup_test_programs(None).await;
-    let mut rpc = ProgramTestRpcConnection { context: rpc, rate_limiter: None };
+    let mut rpc = ProgramTestRpcConnection {
+        context: rpc,
+        rate_limiter: None,
+    };
 
     let payer = rpc.get_payer().insecure_clone();
     let program_account_keypair = Keypair::from_bytes(&OLD_REGISTRY_ID_TEST_KEYPAIR).unwrap();

--- a/program-tests/registry-test/tests/tests.rs
+++ b/program-tests/registry-test/tests/tests.rs
@@ -175,11 +175,7 @@ fn test_protocol_config_active_phase_continuity_for_config(config: ProtocolConfi
 #[tokio::test]
 async fn test_initialize_protocol_config() {
     let rpc = setup_test_programs(None).await;
-    let mut rpc = ProgramTestRpcConnection {
-        context: rpc,
-        rate_limiter: None,
-    };
-
+    let mut rpc = ProgramTestRpcConnection::new(rpc);
     let payer = rpc.get_payer().insecure_clone();
     let program_account_keypair = Keypair::from_bytes(&OLD_REGISTRY_ID_TEST_KEYPAIR).unwrap();
     let protocol_config = ProtocolConfig::default();
@@ -711,11 +707,7 @@ async fn test_custom_forester_batched() {
             tree_params.input_queue_batch_size / tree_params.output_queue_zkp_batch_size;
         for i in 0..num_output_zkp_batches {
             // Simulate concurrency since instruction data has been created before
-            let instruction_data = if i == 0 {
-                instruction_data.clone()
-            } else {
-                None
-            };
+            let instruction_data = if i == 0 { instruction_data } else { None };
             perform_batch_append(
                 &mut rpc,
                 &mut state_merkle_tree_bundle,

--- a/program-tests/system-test/tests/test.rs
+++ b/program-tests/system-test/tests/test.rs
@@ -1669,7 +1669,10 @@ async fn regenerate_accounts() {
     };
 
     let context = setup_test_programs(None).await;
-    let mut context = ProgramTestRpcConnection { context, rate_limiter: None };
+    let mut context = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
     let keypairs = EnvAccountKeypairs::for_regenerate_accounts();
 
     airdrop_lamports(

--- a/program-tests/system-test/tests/test.rs
+++ b/program-tests/system-test/tests/test.rs
@@ -1669,7 +1669,7 @@ async fn regenerate_accounts() {
     };
 
     let context = setup_test_programs(None).await;
-    let mut context = ProgramTestRpcConnection { context };
+    let mut context = ProgramTestRpcConnection { context, rate_limiter: None };
     let keypairs = EnvAccountKeypairs::for_regenerate_accounts();
 
     airdrop_lamports(

--- a/programs/registry/src/utils.rs
+++ b/programs/registry/src/utils.rs
@@ -11,10 +11,6 @@ pub fn get_cpi_authority_pda() -> (Pubkey, u8) {
 }
 
 pub fn get_forester_epoch_pda_from_authority(authority: &Pubkey, epoch: u64) -> (Pubkey, u8) {
-    println!(
-        "get_forester_epoch_pda_from_authority: authority: {}, epoch: {}",
-        authority, epoch
-    );
     let forester_pda = get_forester_pda(authority);
     get_forester_epoch_pda(&forester_pda.0, epoch)
 }

--- a/sdk-libs/client/Cargo.toml
+++ b/sdk-libs/client/Cargo.toml
@@ -34,6 +34,9 @@ num-bigint = { workspace = true }
 num-traits = { workspace = true }
 reqwest = { workspace = true }
 
+governor = "0.8.0"
+
+
 [dev-dependencies]
 light-test-utils = { workspace = true, features=["devenv"]}
 light-program-test = { workspace = true }

--- a/sdk-libs/client/src/indexer/photon_indexer.rs
+++ b/sdk-libs/client/src/indexer/photon_indexer.rs
@@ -14,6 +14,7 @@ use crate::{
         AddressMerkleTreeBundle, Indexer, IndexerError, LeafIndexInfo, MerkleProof,
         NewAddressProofWithContext, ProofOfLeaf,
     },
+    rate_limiter::{RateLimiter, UseRateLimiter},
     rpc::RpcConnection,
 };
 
@@ -21,6 +22,17 @@ pub struct PhotonIndexer<R: RpcConnection> {
     configuration: Configuration,
     #[allow(dead_code)]
     rpc: R,
+    rate_limiter: Option<RateLimiter>,
+}
+
+impl<R: RpcConnection> UseRateLimiter for PhotonIndexer<R> {
+    fn set_rate_limiter(&mut self, rate_limiter: RateLimiter) {
+        self.rate_limiter = Some(rate_limiter);
+    }
+
+    fn rate_limiter(&self) -> Option<&RateLimiter> {
+        self.rate_limiter.as_ref()
+    }
 }
 
 impl<R: RpcConnection> PhotonIndexer<R> {
@@ -34,7 +46,22 @@ impl<R: RpcConnection> PhotonIndexer<R> {
             ..Default::default()
         };
 
-        PhotonIndexer { configuration, rpc }
+        PhotonIndexer {
+            configuration,
+            rpc,
+            rate_limiter: None,
+        }
+    }
+
+    async fn rate_limited_request<F, Fut, T>(&self, operation: F) -> Result<T, IndexerError>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<T, IndexerError>>,
+    {
+        if let Some(limiter) = &self.rate_limiter {
+            limiter.acquire_with_wait().await;
+        }
+        operation().await
     }
 }
 
@@ -77,81 +104,87 @@ impl<R: RpcConnection> Indexer<R> for PhotonIndexer<R> {
         &self,
         hashes: Vec<String>,
     ) -> Result<Vec<MerkleProof>, IndexerError> {
-        let request: photon_api::models::GetMultipleCompressedAccountProofsPostRequest =
-            photon_api::models::GetMultipleCompressedAccountProofsPostRequest {
-                params: hashes,
-                ..Default::default()
-            };
+        self.rate_limited_request(|| async {
+            let request: photon_api::models::GetMultipleCompressedAccountProofsPostRequest =
+                photon_api::models::GetMultipleCompressedAccountProofsPostRequest {
+                    params: hashes,
+                    ..Default::default()
+                };
 
-        let result = photon_api::apis::default_api::get_multiple_compressed_account_proofs_post(
-            &self.configuration,
-            request,
-        )
-        .await;
+            let result =
+                photon_api::apis::default_api::get_multiple_compressed_account_proofs_post(
+                    &self.configuration,
+                    request,
+                )
+                .await;
 
-        match result {
-            Ok(response) => {
-                match response.result {
-                    Some(result) => {
-                        let proofs = result
-                            .value
-                            .iter()
-                            .map(|x| {
-                                let mut proof_result_value = x.proof.clone();
-                                proof_result_value.truncate(proof_result_value.len() - 10); // Remove canopy
-                                let proof: Vec<[u8; 32]> =
-                                    proof_result_value.iter().map(|x| decode_hash(x)).collect();
-                                MerkleProof {
-                                    hash: x.hash.clone(),
-                                    leaf_index: x.leaf_index,
-                                    merkle_tree: x.merkle_tree.clone(),
-                                    proof,
-                                    root_seq: x.root_seq,
-                                }
-                            })
-                            .collect();
+            match result {
+                Ok(response) => {
+                    match response.result {
+                        Some(result) => {
+                            let proofs = result
+                                .value
+                                .iter()
+                                .map(|x| {
+                                    let mut proof_result_value = x.proof.clone();
+                                    proof_result_value.truncate(proof_result_value.len() - 10); // Remove canopy
+                                    let proof: Vec<[u8; 32]> =
+                                        proof_result_value.iter().map(|x| decode_hash(x)).collect();
+                                    MerkleProof {
+                                        hash: x.hash.clone(),
+                                        leaf_index: x.leaf_index,
+                                        merkle_tree: x.merkle_tree.clone(),
+                                        proof,
+                                        root_seq: x.root_seq,
+                                    }
+                                })
+                                .collect();
 
-                        Ok(proofs)
-                    }
-                    None => {
-                        let error = response.error.unwrap();
-                        Err(IndexerError::Custom(error.message.unwrap()))
+                            Ok(proofs)
+                        }
+                        None => {
+                            let error = response.error.unwrap();
+                            Err(IndexerError::Custom(error.message.unwrap()))
+                        }
                     }
                 }
+                Err(e) => Err(IndexerError::Custom(e.to_string())),
             }
-            Err(e) => Err(IndexerError::Custom(e.to_string())),
-        }
+        })
+        .await
     }
-
     async fn get_compressed_accounts_by_owner(
         &self,
         owner: &Pubkey,
     ) -> Result<Vec<String>, IndexerError> {
-        let request = photon_api::models::GetCompressedAccountsByOwnerPostRequest {
-            params: Box::from(GetCompressedAccountsByOwnerPostRequestParams {
-                cursor: None,
-                data_slice: None,
-                filters: None,
-                limit: None,
-                owner: owner.to_string(),
-            }),
-            ..Default::default()
-        };
+        self.rate_limited_request(|| async {
+            let request = photon_api::models::GetCompressedAccountsByOwnerPostRequest {
+                params: Box::from(GetCompressedAccountsByOwnerPostRequestParams {
+                    cursor: None,
+                    data_slice: None,
+                    filters: None,
+                    limit: None,
+                    owner: owner.to_string(),
+                }),
+                ..Default::default()
+            };
 
-        let result = photon_api::apis::default_api::get_compressed_accounts_by_owner_post(
-            &self.configuration,
-            request,
-        )
+            let result = photon_api::apis::default_api::get_compressed_accounts_by_owner_post(
+                &self.configuration,
+                request,
+            )
+            .await
+            .unwrap();
+
+            let accs = result.result.unwrap().value;
+            let mut hashes = Vec::new();
+            for acc in accs.items {
+                hashes.push(acc.hash);
+            }
+
+            Ok(hashes)
+        })
         .await
-        .unwrap();
-
-        let accs = result.result.unwrap().value;
-        let mut hashes = Vec::new();
-        for acc in accs.items {
-            hashes.push(acc.hash);
-        }
-
-        Ok(hashes)
     }
 
     async fn get_multiple_new_address_proofs(
@@ -159,63 +192,66 @@ impl<R: RpcConnection> Indexer<R> for PhotonIndexer<R> {
         merkle_tree_pubkey: [u8; 32],
         addresses: Vec<[u8; 32]>,
     ) -> Result<Vec<NewAddressProofWithContext<16>>, IndexerError> {
-        let params: Vec<AddressWithTree> = addresses
-            .iter()
-            .map(|x| AddressWithTree {
-                address: bs58::encode(x).into_string(),
-                tree: bs58::encode(&merkle_tree_pubkey).into_string(),
-            })
-            .collect();
+        self.rate_limited_request(|| async {
+            let params: Vec<AddressWithTree> = addresses
+                .iter()
+                .map(|x| AddressWithTree {
+                    address: bs58::encode(x).into_string(),
+                    tree: bs58::encode(&merkle_tree_pubkey).into_string(),
+                })
+                .collect();
 
-        let request = photon_api::models::GetMultipleNewAddressProofsV2PostRequest {
-            params,
-            ..Default::default()
-        };
-
-        let result = photon_api::apis::default_api::get_multiple_new_address_proofs_v2_post(
-            &self.configuration,
-            request,
-        )
-        .await;
-
-        if result.is_err() {
-            return Err(IndexerError::Custom(result.err().unwrap().to_string()));
-        }
-
-        let photon_proofs = result.unwrap().result.unwrap().value;
-        // net height 16 =  height(26) - canopy(10)
-        let mut proofs: Vec<NewAddressProofWithContext<16>> = Vec::new();
-        for photon_proof in photon_proofs {
-            let tree_pubkey = decode_hash(&photon_proof.merkle_tree);
-            let low_address_value = decode_hash(&photon_proof.lower_range_address);
-            let next_address_value = decode_hash(&photon_proof.higher_range_address);
-            let proof = NewAddressProofWithContext {
-                merkle_tree: tree_pubkey,
-                low_address_index: photon_proof.low_element_leaf_index as u64,
-                low_address_value,
-                low_address_next_index: photon_proof.next_index as u64,
-                low_address_next_value: next_address_value,
-                low_address_proof: {
-                    let mut proof_vec: Vec<[u8; 32]> = photon_proof
-                        .proof
-                        .iter()
-                        .map(|x: &String| decode_hash(x))
-                        .collect();
-                    proof_vec.truncate(proof_vec.len() - 10); // Remove canopy
-                    let mut proof_arr = [[0u8; 32]; 16];
-                    proof_arr.copy_from_slice(&proof_vec);
-                    proof_arr
-                },
-                root: decode_hash(&photon_proof.root),
-                root_seq: photon_proof.root_seq,
-                new_low_element: None,
-                new_element: None,
-                new_element_next_value: None,
+            let request = photon_api::models::GetMultipleNewAddressProofsV2PostRequest {
+                params,
+                ..Default::default()
             };
-            proofs.push(proof);
-        }
 
-        Ok(proofs)
+            let result = photon_api::apis::default_api::get_multiple_new_address_proofs_v2_post(
+                &self.configuration,
+                request,
+            )
+            .await;
+
+            if result.is_err() {
+                return Err(IndexerError::Custom(result.err().unwrap().to_string()));
+            }
+
+            let photon_proofs = result.unwrap().result.unwrap().value;
+            // net height 16 =  height(26) - canopy(10)
+            let mut proofs: Vec<NewAddressProofWithContext<16>> = Vec::new();
+            for photon_proof in photon_proofs {
+                let tree_pubkey = decode_hash(&photon_proof.merkle_tree);
+                let low_address_value = decode_hash(&photon_proof.lower_range_address);
+                let next_address_value = decode_hash(&photon_proof.higher_range_address);
+                let proof = NewAddressProofWithContext {
+                    merkle_tree: tree_pubkey,
+                    low_address_index: photon_proof.low_element_leaf_index as u64,
+                    low_address_value,
+                    low_address_next_index: photon_proof.next_index as u64,
+                    low_address_next_value: next_address_value,
+                    low_address_proof: {
+                        let mut proof_vec: Vec<[u8; 32]> = photon_proof
+                            .proof
+                            .iter()
+                            .map(|x: &String| decode_hash(x))
+                            .collect();
+                        proof_vec.truncate(proof_vec.len() - 10); // Remove canopy
+                        let mut proof_arr = [[0u8; 32]; 16];
+                        proof_arr.copy_from_slice(&proof_vec);
+                        proof_arr
+                    },
+                    root: decode_hash(&photon_proof.root),
+                    root_seq: photon_proof.root_seq,
+                    new_low_element: None,
+                    new_element: None,
+                    new_element_next_value: None,
+                };
+                proofs.push(proof);
+            }
+
+            Ok(proofs)
+        })
+        .await
     }
 
     async fn get_multiple_new_address_proofs_h40(

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod indexer;
 pub mod photon_rpc;
+pub mod rate_limiter;
 pub mod rpc;
 pub mod rpc_pool;
 pub mod transaction_params;

--- a/sdk-libs/client/src/photon_rpc/photon_client.rs
+++ b/sdk-libs/client/src/photon_rpc/photon_client.rs
@@ -10,18 +10,35 @@ use super::{
     Address, Base58Conversions, CompressedAccountResponse, Hash, PhotonClientError,
     TokenAccountBalanceResponse,
 };
-use crate::indexer::{MerkleProof, NewAddressProofWithContext};
+use crate::{
+    indexer::{MerkleProof, NewAddressProofWithContext},
+    rate_limiter::{RateLimiter, UseRateLimiter},
+};
 
 #[derive(Debug)]
 pub struct PhotonClient {
     config: Configuration,
+    rate_limiter: Option<RateLimiter>,
+}
+
+impl UseRateLimiter for PhotonClient {
+    fn set_rate_limiter(&mut self, rate_limiter: RateLimiter) {
+        self.rate_limiter = Some(rate_limiter);
+    }
+
+    fn rate_limiter(&self) -> Option<&RateLimiter> {
+        self.rate_limiter.as_ref()
+    }
 }
 
 impl PhotonClient {
     pub fn new(url: String) -> Self {
         let mut config = Configuration::new();
         config.base_path = url;
-        PhotonClient { config }
+        PhotonClient {
+            config,
+            rate_limiter: None,
+        }
     }
 
     pub fn new_with_auth(url: String, api_key: String) -> Self {
@@ -31,83 +48,104 @@ impl PhotonClient {
             key: api_key,
             prefix: None,
         });
-        PhotonClient { config }
+        PhotonClient {
+            config,
+            rate_limiter: None,
+        }
+    }
+
+    async fn rate_limited_request<F, Fut, T>(&self, operation: F) -> Result<T, PhotonClientError>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<T, PhotonClientError>>,
+    {
+        if let Some(limiter) = &self.rate_limiter {
+            limiter.acquire_with_wait().await;
+        }
+        operation().await
     }
 
     pub async fn get_multiple_compressed_account_proofs(
         &self,
         hashes: Vec<Hash>,
     ) -> Result<Vec<MerkleProof>, PhotonClientError> {
-        let request = photon_api::models::GetMultipleCompressedAccountProofsPostRequest {
-            params: hashes.iter().map(|h| h.to_base58()).collect(),
-            ..Default::default()
-        };
+        self.rate_limited_request(|| async {
+            let request = photon_api::models::GetMultipleCompressedAccountProofsPostRequest {
+                params: hashes.iter().map(|h| h.to_base58()).collect(),
+                ..Default::default()
+            };
 
-        let result = photon_api::apis::default_api::get_multiple_compressed_account_proofs_post(
-            &self.config,
-            request,
-        )
-        .await?;
+            let result =
+                photon_api::apis::default_api::get_multiple_compressed_account_proofs_post(
+                    &self.config,
+                    request,
+                )
+                .await?;
 
-        match result.result {
-            Some(result) => {
-                let proofs = result
-                    .value
-                    .iter()
-                    .map(|x| {
-                        let mut proof_result_value = x.proof.clone();
-                        proof_result_value.truncate(proof_result_value.len() - 10);
-                        let proof = proof_result_value
-                            .iter()
-                            .map(|x| Hash::from_base58(x).unwrap())
-                            .collect();
-                        MerkleProof {
-                            hash: x.hash.clone(),
-                            leaf_index: x.leaf_index,
-                            merkle_tree: x.merkle_tree.clone(),
-                            proof,
-                            root_seq: x.root_seq,
-                        }
-                    })
-                    .collect();
-                Ok(proofs)
+            match result.result {
+                Some(result) => {
+                    let proofs = result
+                        .value
+                        .iter()
+                        .map(|x| {
+                            let mut proof_result_value = x.proof.clone();
+                            proof_result_value.truncate(proof_result_value.len() - 10);
+                            let proof = proof_result_value
+                                .iter()
+                                .map(|x| Hash::from_base58(x).unwrap())
+                                .collect();
+                            MerkleProof {
+                                hash: x.hash.clone(),
+                                leaf_index: x.leaf_index,
+                                merkle_tree: x.merkle_tree.clone(),
+                                proof,
+                                root_seq: x.root_seq,
+                            }
+                        })
+                        .collect();
+                    Ok(proofs)
+                }
+                None => Err(PhotonClientError::DecodeError("Missing result".to_string())),
             }
-            None => Err(PhotonClientError::DecodeError("Missing result".to_string())),
-        }
+        })
+        .await
     }
 
     pub async fn get_rpc_compressed_accounts_by_owner(
         &self,
         owner: &Pubkey,
     ) -> Result<Vec<Hash>, PhotonClientError> {
-        let request = photon_api::models::GetCompressedAccountsByOwnerPostRequest {
-            params: Box::from(GetCompressedAccountsByOwnerPostRequestParams {
-                cursor: None,
-                data_slice: None,
-                filters: None,
-                limit: None,
-                owner: owner.to_string(),
-            }),
-            ..Default::default()
-        };
+        self.rate_limited_request(|| async {
+            let request = photon_api::models::GetCompressedAccountsByOwnerPostRequest {
+                params: Box::from(GetCompressedAccountsByOwnerPostRequestParams {
+                    cursor: None,
+                    data_slice: None,
+                    filters: None,
+                    limit: None,
+                    owner: owner.to_string(),
+                }),
+                ..Default::default()
+            };
 
-        let result = photon_api::apis::default_api::get_compressed_accounts_by_owner_post(
-            &self.config,
-            request,
-        )
+            let result = photon_api::apis::default_api::get_compressed_accounts_by_owner_post(
+                &self.config,
+                request,
+            )
+            .await
+            .unwrap();
+
+            let accs = result.result.unwrap().value;
+            let mut hashes = Vec::new();
+            for acc in accs.items {
+                hashes.push(acc.hash);
+            }
+
+            Ok(hashes
+                .iter()
+                .map(|x| Hash::from_base58(x).unwrap())
+                .collect())
+        })
         .await
-        .unwrap();
-
-        let accs = result.result.unwrap().value;
-        let mut hashes = Vec::new();
-        for acc in accs.items {
-            hashes.push(acc.hash);
-        }
-
-        Ok(hashes
-            .iter()
-            .map(|x| Hash::from_base58(x).unwrap())
-            .collect())
     }
 
     pub async fn get_multiple_new_address_proofs(
@@ -115,64 +153,69 @@ impl PhotonClient {
         merkle_tree_pubkey: Pubkey,
         addresses: Vec<Address>,
     ) -> Result<Vec<NewAddressProofWithContext<16>>, PhotonClientError> {
-        let params: Vec<photon_api::models::AddressWithTree> = addresses
-            .iter()
-            .map(|x| photon_api::models::AddressWithTree {
-                address: bs58::encode(x).into_string(),
-                tree: bs58::encode(&merkle_tree_pubkey).into_string(),
-            })
-            .collect();
+        self.rate_limited_request(|| async {
+            let params: Vec<photon_api::models::AddressWithTree> = addresses
+                .iter()
+                .map(|x| photon_api::models::AddressWithTree {
+                    address: bs58::encode(x).into_string(),
+                    tree: bs58::encode(&merkle_tree_pubkey).into_string(),
+                })
+                .collect();
 
-        let request = photon_api::models::GetMultipleNewAddressProofsV2PostRequest {
-            params,
-            ..Default::default()
-        };
-
-        let result = photon_api::apis::default_api::get_multiple_new_address_proofs_v2_post(
-            &self.config,
-            request,
-        )
-        .await;
-
-        if result.is_err() {
-            return Err(PhotonClientError::GetMultipleNewAddressProofsError(
-                result.err().unwrap(),
-            ));
-        }
-
-        let photon_proofs = result.unwrap().result.unwrap().value;
-        let mut proofs: Vec<NewAddressProofWithContext<16>> = Vec::new();
-        for photon_proof in photon_proofs {
-            let tree_pubkey = Hash::from_base58(&photon_proof.merkle_tree).unwrap();
-            let low_address_value = Hash::from_base58(&photon_proof.lower_range_address).unwrap();
-            let next_address_value = Hash::from_base58(&photon_proof.higher_range_address).unwrap();
-            let proof = NewAddressProofWithContext {
-                merkle_tree: tree_pubkey,
-                low_address_index: photon_proof.low_element_leaf_index as u64,
-                low_address_value,
-                low_address_next_index: photon_proof.next_index as u64,
-                low_address_next_value: next_address_value,
-                low_address_proof: {
-                    let mut proof_vec: Vec<[u8; 32]> = photon_proof
-                        .proof
-                        .iter()
-                        .map(|x: &String| Hash::from_base58(x).unwrap())
-                        .collect();
-                    proof_vec.truncate(proof_vec.len() - 10); // Remove canopy
-                    let mut proof_arr = [[0u8; 32]; 16];
-                    proof_arr.copy_from_slice(&proof_vec);
-                    proof_arr
-                },
-                root: Hash::from_base58(&photon_proof.root).unwrap(),
-                root_seq: photon_proof.root_seq,
-                new_low_element: None,
-                new_element: None,
-                new_element_next_value: None,
+            let request = photon_api::models::GetMultipleNewAddressProofsV2PostRequest {
+                params,
+                ..Default::default()
             };
-            proofs.push(proof);
-        }
 
-        Ok(proofs)
+            let result = photon_api::apis::default_api::get_multiple_new_address_proofs_v2_post(
+                &self.config,
+                request,
+            )
+            .await;
+
+            if result.is_err() {
+                return Err(PhotonClientError::GetMultipleNewAddressProofsError(
+                    result.err().unwrap(),
+                ));
+            }
+
+            let photon_proofs = result.unwrap().result.unwrap().value;
+            let mut proofs: Vec<NewAddressProofWithContext<16>> = Vec::new();
+            for photon_proof in photon_proofs {
+                let tree_pubkey = Hash::from_base58(&photon_proof.merkle_tree).unwrap();
+                let low_address_value =
+                    Hash::from_base58(&photon_proof.lower_range_address).unwrap();
+                let next_address_value =
+                    Hash::from_base58(&photon_proof.higher_range_address).unwrap();
+                let proof = NewAddressProofWithContext {
+                    merkle_tree: tree_pubkey,
+                    low_address_index: photon_proof.low_element_leaf_index as u64,
+                    low_address_value,
+                    low_address_next_index: photon_proof.next_index as u64,
+                    low_address_next_value: next_address_value,
+                    low_address_proof: {
+                        let mut proof_vec: Vec<[u8; 32]> = photon_proof
+                            .proof
+                            .iter()
+                            .map(|x: &String| Hash::from_base58(x).unwrap())
+                            .collect();
+                        proof_vec.truncate(proof_vec.len() - 10); // Remove canopy
+                        let mut proof_arr = [[0u8; 32]; 16];
+                        proof_arr.copy_from_slice(&proof_vec);
+                        proof_arr
+                    },
+                    root: Hash::from_base58(&photon_proof.root).unwrap(),
+                    root_seq: photon_proof.root_seq,
+                    new_low_element: None,
+                    new_element: None,
+                    new_element_next_value: None,
+                };
+                proofs.push(proof);
+            }
+
+            Ok(proofs)
+        })
+        .await
     }
 
     pub async fn get_validity_proof(
@@ -180,31 +223,35 @@ impl PhotonClient {
         hashes: Vec<Hash>,
         new_addresses_with_trees: Vec<AddressWithTree>,
     ) -> Result<photon_api::models::GetValidityProofPost200ResponseResult, PhotonClientError> {
-        let request = photon_api::models::GetValidityProofPostRequest {
-            params: Box::new(photon_api::models::GetValidityProofPostRequestParams {
-                hashes: Some(hashes.iter().map(|x| x.to_base58()).collect()),
-                new_addresses: None,
-                new_addresses_with_trees: Some(
-                    new_addresses_with_trees
-                        .iter()
-                        .map(|x| photon_api::models::AddressWithTree {
-                            address: x.address.to_base58(),
-                            tree: x.tree.to_string(),
-                        })
-                        .collect(),
-                ),
-            }),
-            ..Default::default()
-        };
+        self.rate_limited_request(|| async {
+            let request = photon_api::models::GetValidityProofPostRequest {
+                params: Box::new(photon_api::models::GetValidityProofPostRequestParams {
+                    hashes: Some(hashes.iter().map(|x| x.to_base58()).collect()),
+                    new_addresses: None,
+                    new_addresses_with_trees: Some(
+                        new_addresses_with_trees
+                            .iter()
+                            .map(|x| photon_api::models::AddressWithTree {
+                                address: x.address.to_base58(),
+                                tree: x.tree.to_string(),
+                            })
+                            .collect(),
+                    ),
+                }),
+                ..Default::default()
+            };
 
-        let result = photon_api::apis::default_api::get_validity_proof_post(&self.config, request)
-            .await
-            .map_err(|e| PhotonClientError::DecodeError(e.to_string()))?;
+            let result =
+                photon_api::apis::default_api::get_validity_proof_post(&self.config, request)
+                    .await
+                    .map_err(|e| PhotonClientError::DecodeError(e.to_string()))?;
 
-        match result.result {
-            Some(result) => Ok(*result),
-            None => Err(PhotonClientError::DecodeError("Missing result".to_string())),
-        }
+            match result.result {
+                Some(result) => Ok(*result),
+                None => Err(PhotonClientError::DecodeError("Missing result".to_string())),
+            }
+        })
+        .await
     }
 
     pub async fn get_compressed_account(
@@ -212,18 +259,22 @@ impl PhotonClient {
         address: Option<Address>,
         hash: Option<Hash>,
     ) -> Result<CompressedAccountResponse, PhotonClientError> {
-        let params = self.build_account_params(address, hash)?;
-        let request = photon_api::models::GetCompressedAccountPostRequest {
-            params: Box::new(params),
-            ..Default::default()
-        };
+        self.rate_limited_request(|| async {
+            let params = self.build_account_params(address, hash)?;
 
-        let result =
-            photon_api::apis::default_api::get_compressed_account_post(&self.config, request)
-                .await
-                .map_err(|e| PhotonClientError::DecodeError(e.to_string()))?;
+            let request = photon_api::models::GetCompressedAccountPostRequest {
+                params: Box::new(params),
+                ..Default::default()
+            };
 
-        Self::handle_result(result.result).map(|r| CompressedAccountResponse::from(*r))
+            let result =
+                photon_api::apis::default_api::get_compressed_account_post(&self.config, request)
+                    .await
+                    .map_err(|e| PhotonClientError::DecodeError(e.to_string()))?;
+
+            Self::handle_result(result.result).map(|r| CompressedAccountResponse::from(*r))
+        })
+        .await
     }
 
     pub async fn get_compressed_token_accounts_by_owner(
@@ -234,26 +285,30 @@ impl PhotonClient {
         photon_api::models::GetCompressedTokenAccountsByDelegatePost200ResponseResult,
         PhotonClientError,
     > {
-        let request = photon_api::models::GetCompressedTokenAccountsByOwnerPostRequest {
-            params: Box::new(
-                photon_api::models::GetCompressedTokenAccountsByOwnerPostRequestParams {
-                    owner: owner.to_string(),
-                    mint: mint.map(|x| Some(x.to_string())),
-                    cursor: None,
-                    limit: None,
-                },
-            ),
-            ..Default::default()
-        };
+        self.rate_limited_request(|| async {
+            let request = photon_api::models::GetCompressedTokenAccountsByOwnerPostRequest {
+                params: Box::new(
+                    photon_api::models::GetCompressedTokenAccountsByOwnerPostRequestParams {
+                        owner: owner.to_string(),
+                        mint: mint.map(|x| Some(x.to_string())),
+                        cursor: None,
+                        limit: None,
+                    },
+                ),
+                ..Default::default()
+            };
 
-        let result = photon_api::apis::default_api::get_compressed_token_accounts_by_owner_post(
-            &self.config,
-            request,
-        )
+            let result =
+                photon_api::apis::default_api::get_compressed_token_accounts_by_owner_post(
+                    &self.config,
+                    request,
+                )
+                .await
+                .map_err(|e| PhotonClientError::DecodeError(e.to_string()))?;
+
+            Self::handle_result(result.result).map(|r| *r)
+        })
         .await
-        .map_err(|e| PhotonClientError::DecodeError(e.to_string()))?;
-
-        Self::handle_result(result.result).map(|r| *r)
     }
 
     pub async fn get_compressed_account_balance(
@@ -261,20 +316,24 @@ impl PhotonClient {
         address: Option<Address>,
         hash: Option<Hash>,
     ) -> Result<AccountBalanceResponse, PhotonClientError> {
-        let params = self.build_account_params(address, hash)?;
-        let request = photon_api::models::GetCompressedAccountBalancePostRequest {
-            params: Box::new(params),
-            ..Default::default()
-        };
+        self.rate_limited_request(|| async {
+            let params = self.build_account_params(address, hash)?;
 
-        let result = photon_api::apis::default_api::get_compressed_account_balance_post(
-            &self.config,
-            request,
-        )
+            let request = photon_api::models::GetCompressedAccountBalancePostRequest {
+                params: Box::new(params),
+                ..Default::default()
+            };
+
+            let result = photon_api::apis::default_api::get_compressed_account_balance_post(
+                &self.config,
+                request,
+            )
+            .await
+            .map_err(|e| PhotonClientError::DecodeError(e.to_string()))?;
+
+            Self::handle_result(result.result).map(|r| AccountBalanceResponse::from(*r))
+        })
         .await
-        .map_err(|e| PhotonClientError::DecodeError(e.to_string()))?;
-
-        Self::handle_result(result.result).map(|r| AccountBalanceResponse::from(*r))
     }
 
     pub async fn get_compressed_token_account_balance(
@@ -282,22 +341,25 @@ impl PhotonClient {
         address: Option<Address>,
         hash: Option<Hash>,
     ) -> Result<TokenAccountBalanceResponse, PhotonClientError> {
-        let request = photon_api::models::GetCompressedTokenAccountBalancePostRequest {
-            params: Box::new(photon_api::models::GetCompressedAccountPostRequestParams {
-                address: address.map(|x| Some(x.to_base58())),
-                hash: hash.map(|x| Some(x.to_base58())),
-            }),
-            ..Default::default()
-        };
+        self.rate_limited_request(|| async {
+            let request = photon_api::models::GetCompressedTokenAccountBalancePostRequest {
+                params: Box::new(photon_api::models::GetCompressedAccountPostRequestParams {
+                    address: address.map(|x| Some(x.to_base58())),
+                    hash: hash.map(|x| Some(x.to_base58())),
+                }),
+                ..Default::default()
+            };
 
-        let result = photon_api::apis::default_api::get_compressed_token_account_balance_post(
-            &self.config,
-            request,
-        )
+            let result = photon_api::apis::default_api::get_compressed_token_account_balance_post(
+                &self.config,
+                request,
+            )
+            .await
+            .map_err(|e| PhotonClientError::DecodeError(e.to_string()))?;
+
+            Self::handle_result(result.result).map(|r| TokenAccountBalanceResponse::from(*r))
+        })
         .await
-        .map_err(|e| PhotonClientError::DecodeError(e.to_string()))?;
-
-        Self::handle_result(result.result).map(|r| TokenAccountBalanceResponse::from(*r))
     }
 
     pub async fn get_compressed_token_balances_by_owner(
@@ -308,26 +370,30 @@ impl PhotonClient {
         photon_api::models::GetCompressedTokenBalancesByOwnerPost200ResponseResult,
         PhotonClientError,
     > {
-        let request = photon_api::models::GetCompressedTokenBalancesByOwnerPostRequest {
-            params: Box::new(
-                photon_api::models::GetCompressedTokenAccountsByOwnerPostRequestParams {
-                    owner: owner.to_string(),
-                    mint: mint.map(|x| Some(x.to_string())),
-                    cursor: None,
-                    limit: None,
-                },
-            ),
-            ..Default::default()
-        };
+        self.rate_limited_request(|| async {
+            let request = photon_api::models::GetCompressedTokenBalancesByOwnerPostRequest {
+                params: Box::new(
+                    photon_api::models::GetCompressedTokenAccountsByOwnerPostRequestParams {
+                        owner: owner.to_string(),
+                        mint: mint.map(|x| Some(x.to_string())),
+                        cursor: None,
+                        limit: None,
+                    },
+                ),
+                ..Default::default()
+            };
 
-        let result = photon_api::apis::default_api::get_compressed_token_balances_by_owner_post(
-            &self.config,
-            request,
-        )
+            let result =
+                photon_api::apis::default_api::get_compressed_token_balances_by_owner_post(
+                    &self.config,
+                    request,
+                )
+                .await
+                .map_err(|e| PhotonClientError::DecodeError(e.to_string()))?;
+
+            Self::handle_result(result.result).map(|r| *r)
+        })
         .await
-        .map_err(|e| PhotonClientError::DecodeError(e.to_string()))?;
-
-        Self::handle_result(result.result).map(|r| *r)
     }
 
     pub async fn get_compression_signatures_for_account(
@@ -337,23 +403,27 @@ impl PhotonClient {
         photon_api::models::GetCompressionSignaturesForAccountPost200ResponseResult,
         PhotonClientError,
     > {
-        let request = photon_api::models::GetCompressionSignaturesForAccountPostRequest {
-            params: Box::new(
-                photon_api::models::GetCompressedAccountProofPostRequestParams {
-                    hash: hash.to_base58(),
-                },
-            ),
-            ..Default::default()
-        };
+        self.rate_limited_request(|| async {
+            let request = photon_api::models::GetCompressionSignaturesForAccountPostRequest {
+                params: Box::new(
+                    photon_api::models::GetCompressedAccountProofPostRequestParams {
+                        hash: hash.to_base58(),
+                    },
+                ),
+                ..Default::default()
+            };
 
-        let result = photon_api::apis::default_api::get_compression_signatures_for_account_post(
-            &self.config,
-            request,
-        )
+            let result =
+                photon_api::apis::default_api::get_compression_signatures_for_account_post(
+                    &self.config,
+                    request,
+                )
+                .await
+                .map_err(|e| PhotonClientError::DecodeError(e.to_string()))?;
+
+            Self::handle_result(result.result).map(|r| *r)
+        })
         .await
-        .map_err(|e| PhotonClientError::DecodeError(e.to_string()))?;
-
-        Self::handle_result(result.result).map(|r| *r)
     }
 
     pub async fn get_multiple_compressed_accounts(
@@ -361,24 +431,28 @@ impl PhotonClient {
         addresses: Option<Vec<Address>>,
         hashes: Option<Vec<Hash>>,
     ) -> Result<CompressedAccountsResponse, PhotonClientError> {
-        let request = photon_api::models::GetMultipleCompressedAccountsPostRequest {
-            params: Box::new(
-                photon_api::models::GetMultipleCompressedAccountsPostRequestParams {
-                    addresses: addresses.map(|x| Some(x.iter().map(|x| x.to_base58()).collect())),
-                    hashes: hashes.map(|x| Some(x.iter().map(|x| x.to_base58()).collect())),
-                },
-            ),
-            ..Default::default()
-        };
+        self.rate_limited_request(|| async {
+            let request = photon_api::models::GetMultipleCompressedAccountsPostRequest {
+                params: Box::new(
+                    photon_api::models::GetMultipleCompressedAccountsPostRequestParams {
+                        addresses: addresses
+                            .map(|x| Some(x.iter().map(|x| x.to_base58()).collect())),
+                        hashes: hashes.map(|x| Some(x.iter().map(|x| x.to_base58()).collect())),
+                    },
+                ),
+                ..Default::default()
+            };
 
-        let result = photon_api::apis::default_api::get_multiple_compressed_accounts_post(
-            &self.config,
-            request,
-        )
+            let result = photon_api::apis::default_api::get_multiple_compressed_accounts_post(
+                &self.config,
+                request,
+            )
+            .await
+            .map_err(|e| PhotonClientError::DecodeError(e.to_string()))?;
+
+            Self::handle_result(result.result).map(|r| CompressedAccountsResponse::from(*r))
+        })
         .await
-        .map_err(|e| PhotonClientError::DecodeError(e.to_string()))?;
-
-        Self::handle_result(result.result).map(|r| CompressedAccountsResponse::from(*r))
     }
 
     fn handle_result<T>(result: Option<T>) -> Result<T, PhotonClientError> {

--- a/sdk-libs/client/src/rate_limiter.rs
+++ b/sdk-libs/client/src/rate_limiter.rs
@@ -1,0 +1,182 @@
+use std::{num::NonZeroU32, sync::Arc, time::Duration};
+
+use governor::{
+    clock::DefaultClock,
+    state::{InMemoryState, NotKeyed},
+    Quota, RateLimiter as Governor,
+};
+use thiserror::Error;
+
+pub trait UseRateLimiter {
+    fn set_rate_limiter(&mut self, rate_limiter: RateLimiter);
+    fn rate_limiter(&self) -> Option<&RateLimiter>;
+}
+
+#[derive(Error, Debug)]
+pub enum RateLimiterError {
+    #[error("Rate limit exceeded")]
+    RateLimitExceeded,
+}
+
+#[derive(Clone, Debug)]
+pub struct RateLimiter {
+    governor: Arc<Governor<NotKeyed, InMemoryState, DefaultClock>>,
+}
+
+impl RateLimiter {
+    pub fn new(requests_per_second: u32) -> Self {
+        // Create a quota that allows exactly one request per 1/requests_per_second seconds
+        let quota = Quota::with_period(Duration::from_secs_f64(1.0 / requests_per_second as f64))
+            .unwrap()
+            .allow_burst(NonZeroU32::new(1).unwrap());
+        RateLimiter {
+            governor: Arc::new(Governor::new(
+                quota,
+                InMemoryState::default(),
+                DefaultClock::default(),
+            )),
+        }
+    }
+
+    pub async fn acquire(&self) -> Result<(), RateLimiterError> {
+        match self.governor.check() {
+            Ok(()) => Ok(()),
+            Err(_) => Err(RateLimiterError::RateLimitExceeded),
+        }
+    }
+
+    pub async fn acquire_with_wait(&self) {
+        let _start = self.governor.until_ready().await;
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+}
+
+pub struct RateLimitedClient<T> {
+    inner: T,
+    rate_limiter: RateLimiter,
+}
+
+impl<T> RateLimitedClient<T> {
+    pub fn new(inner: T, rate_limiter: RateLimiter) -> Self {
+        Self {
+            inner,
+            rate_limiter,
+        }
+    }
+
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    pub async fn execute<'a, F, Fut, R>(&'a self, f: F) -> Result<R, RateLimiterError>
+    where
+        F: FnOnce(&'a T) -> Fut + 'a,
+        Fut: std::future::Future<Output = R> + 'a,
+    {
+        self.rate_limiter.acquire().await?;
+        Ok(f(&self.inner).await)
+    }
+
+    pub async fn execute_with_wait<'a, F, Fut, R>(&'a self, f: F) -> R
+    where
+        F: FnOnce(&'a T) -> Fut + 'a,
+        Fut: std::future::Future<Output = R> + 'a,
+    {
+        self.rate_limiter.acquire_with_wait().await;
+        f(&self.inner).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::time::{Duration, Instant};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_rate_limiter_basic() {
+        let limiter = RateLimiter::new(10);
+        let mut successes = 0;
+
+        for _ in 0..20 {
+            if limiter.acquire().await.is_ok() {
+                successes += 1;
+            }
+        }
+
+        assert!(successes <= 11, "Allowed too many requests: {}", successes);
+    }
+
+    #[tokio::test]
+    async fn test_rate_limited_client() {
+        struct MockClient;
+        impl MockClient {
+            async fn make_request(&self) -> u32 {
+                42
+            }
+        }
+
+        let rate_limiter = RateLimiter::new(10);
+        let client = RateLimitedClient::new(MockClient, rate_limiter);
+
+        let result = client
+            .execute(|c| async move { c.make_request().await })
+            .await
+            .unwrap();
+        assert_eq!(result, 42);
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_concurrent() {
+        let rate_limiter = RateLimiter::new(10);
+        let test_duration = Duration::from_secs(3);
+        let start_time = Instant::now();
+        let mut total_successful = 0;
+
+        while start_time.elapsed() < test_duration {
+            rate_limiter.acquire_with_wait().await;
+            total_successful += 1;
+        }
+
+        let elapsed_secs = start_time.elapsed().as_secs_f64();
+        let requests_per_sec = total_successful as f64 / elapsed_secs;
+
+        println!("Total successful requests: {}", total_successful);
+        println!("Elapsed seconds: {:.2}", elapsed_secs);
+        println!("Requests per second: {:.2}", requests_per_sec);
+
+        assert!(
+            requests_per_sec <= 11.0,
+            "Rate should not exceed limit significantly: got {:.2} requests/sec",
+            requests_per_sec
+        );
+        assert!(
+            requests_per_sec >= 7.0,
+            "Rate should be close to limit: got {:.2} requests/sec",
+            requests_per_sec
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_with_wait() {
+        let rate_limiter = RateLimiter::new(10);
+        let start_time = Instant::now();
+
+        for _ in 0..15 {
+            rate_limiter.acquire_with_wait().await;
+        }
+
+        let elapsed = start_time.elapsed();
+        println!("Elapsed time: {:?}", elapsed);
+        
+        assert!(
+            elapsed >= Duration::from_millis(1400),
+            "Should take close to 1.5 seconds to process all requests, took {:?}",
+            elapsed
+        );
+    }
+}

--- a/sdk-libs/client/src/rate_limiter.rs
+++ b/sdk-libs/client/src/rate_limiter.rs
@@ -172,7 +172,7 @@ mod tests {
 
         let elapsed = start_time.elapsed();
         println!("Elapsed time: {:?}", elapsed);
-        
+
         assert!(
             elapsed >= Duration::from_millis(1400),
             "Should take close to 1.5 seconds to process all requests, took {:?}",

--- a/sdk-libs/client/src/rpc/rpc_connection.rs
+++ b/sdk-libs/client/src/rpc/rpc_connection.rs
@@ -25,11 +25,20 @@ pub trait RpcConnection: Send + Sync + Debug + 'static {
     where
         Self: Sized;
 
-    fn set_rate_limiter(&mut self, rate_limiter: RateLimiter);
-    fn rate_limiter(&self) -> Option<&RateLimiter>;
+    fn set_rpc_rate_limiter(&mut self, rate_limiter: RateLimiter);
+    fn set_send_tx_rate_limiter(&mut self, rate_limiter: RateLimiter);
 
-    async fn check_rate_limit(&self) {
-        if let Some(limiter) = self.rate_limiter() {
+    fn rpc_rate_limiter(&self) -> Option<&RateLimiter>;
+    fn send_tx_rate_limiter(&self) -> Option<&RateLimiter>;
+
+    async fn check_rpc_rate_limit(&self) {
+        if let Some(limiter) = self.rpc_rate_limiter() {
+            limiter.acquire_with_wait().await;
+        }
+    }
+
+    async fn check_send_tx_rrate_limit(&self) {
+        if let Some(limiter) = self.send_tx_rate_limiter() {
             limiter.acquire_with_wait().await;
         }
     }

--- a/sdk-libs/client/src/rpc_pool.rs
+++ b/sdk-libs/client/src/rpc_pool.rs
@@ -6,7 +6,10 @@ use solana_sdk::commitment_config::CommitmentConfig;
 use thiserror::Error;
 use tokio::time::sleep;
 
-use crate::rpc::{RpcConnection, RpcError};
+use crate::{
+    rate_limiter::RateLimiter,
+    rpc::{RpcConnection, RpcError},
+};
 
 #[derive(Error, Debug)]
 pub enum PoolError {
@@ -21,14 +24,20 @@ pub enum PoolError {
 pub struct SolanaConnectionManager<R: RpcConnection> {
     url: String,
     commitment: CommitmentConfig,
+    rate_limiter: Option<RateLimiter>,
     _phantom: std::marker::PhantomData<R>,
 }
 
 impl<R: RpcConnection> SolanaConnectionManager<R> {
-    pub fn new(url: String, commitment: CommitmentConfig) -> Self {
+    pub fn new(
+        url: String,
+        commitment: CommitmentConfig,
+        rate_limiter: Option<RateLimiter>,
+    ) -> Self {
         Self {
             url,
             commitment,
+            rate_limiter,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -40,7 +49,11 @@ impl<R: RpcConnection> bb8::ManageConnection for SolanaConnectionManager<R> {
     type Error = PoolError;
 
     async fn connect(&self) -> Result<Self::Connection, Self::Error> {
-        Ok(R::new(&self.url, Some(self.commitment)))
+        let mut conn = R::new(&self.url, Some(self.commitment));
+        if let Some(limiter) = &self.rate_limiter {
+            conn.set_rate_limiter(limiter.clone());
+        }
+        Ok(conn)
     }
 
     async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
@@ -62,8 +75,9 @@ impl<R: RpcConnection> SolanaRpcPool<R> {
         url: String,
         commitment: CommitmentConfig,
         max_size: u32,
+        rate_limiter: Option<RateLimiter>,
     ) -> Result<Self, PoolError> {
-        let manager = SolanaConnectionManager::new(url, commitment);
+        let manager = SolanaConnectionManager::new(url, commitment, rate_limiter);
         let pool = Pool::builder()
             .max_size(max_size)
             .connection_timeout(Duration::from_secs(15))

--- a/sdk-libs/program-test/src/test_env.rs
+++ b/sdk-libs/program-test/src/test_env.rs
@@ -570,7 +570,10 @@ pub async fn setup_test_programs_with_accounts_with_protocol_config_and_batched_
     batched_address_tree_init_params: InitAddressTreeAccountsInstructionData,
 ) -> (ProgramTestRpcConnection, EnvAccounts) {
     let context = setup_test_programs(additional_programs).await;
-    let mut context = ProgramTestRpcConnection { context };
+    let mut context = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
     let keypairs = EnvAccountKeypairs::program_test_default();
     airdrop_lamports(
         &mut context,
@@ -602,7 +605,10 @@ pub async fn setup_test_programs_with_accounts_with_protocol_config_v2(
     register_forester_and_advance_to_active_phase: bool,
 ) -> (ProgramTestRpcConnection, EnvAccounts) {
     let context = setup_test_programs(additional_programs).await;
-    let mut context = ProgramTestRpcConnection { context };
+    let mut context = ProgramTestRpcConnection {
+        context,
+        rate_limiter: None,
+    };
     let keypairs = EnvAccountKeypairs::program_test_default();
     airdrop_lamports(
         &mut context,

--- a/sdk-libs/program-test/src/test_env.rs
+++ b/sdk-libs/program-test/src/test_env.rs
@@ -570,11 +570,7 @@ pub async fn setup_test_programs_with_accounts_with_protocol_config_and_batched_
     batched_address_tree_init_params: InitAddressTreeAccountsInstructionData,
 ) -> (ProgramTestRpcConnection, EnvAccounts) {
     let context = setup_test_programs(additional_programs).await;
-    let mut context = ProgramTestRpcConnection {
-        context,
-        rpc_rate_limiter: None,
-        send_tx_rate_limiter: None,
-    };
+    let mut context = ProgramTestRpcConnection::new(context);
     let keypairs = EnvAccountKeypairs::program_test_default();
     airdrop_lamports(
         &mut context,
@@ -606,11 +602,7 @@ pub async fn setup_test_programs_with_accounts_with_protocol_config_v2(
     register_forester_and_advance_to_active_phase: bool,
 ) -> (ProgramTestRpcConnection, EnvAccounts) {
     let context = setup_test_programs(additional_programs).await;
-    let mut context = ProgramTestRpcConnection {
-        context,
-        rpc_rate_limiter: None,
-        send_tx_rate_limiter: None,
-    };
+    let mut context = ProgramTestRpcConnection::new(context);
     let keypairs = EnvAccountKeypairs::program_test_default();
     airdrop_lamports(
         &mut context,
@@ -1207,7 +1199,7 @@ pub async fn deregister_program_with_registry_program<R: RpcConnection>(
     governance_authority: &Keypair,
     group_pda: &Pubkey,
     program_id_keypair: &Keypair,
-) -> Result<Pubkey, light_client::rpc::errors::RpcError> {
+) -> Result<Pubkey, RpcError> {
     let governance_authority_pda = get_protocol_config_pda_address();
     let (instruction, token_program_registered_program_pda) = create_deregister_program_instruction(
         governance_authority.pubkey(),
@@ -1215,7 +1207,7 @@ pub async fn deregister_program_with_registry_program<R: RpcConnection>(
         *group_pda,
         program_id_keypair.pubkey(),
     );
-    let cpi_authority_pda = light_registry::utils::get_cpi_authority_pda();
+    let cpi_authority_pda = get_cpi_authority_pda();
     let transfer_instruction = system_instruction::transfer(
         &governance_authority.pubkey(),
         &cpi_authority_pda.0,

--- a/sdk-libs/program-test/src/test_env.rs
+++ b/sdk-libs/program-test/src/test_env.rs
@@ -572,7 +572,8 @@ pub async fn setup_test_programs_with_accounts_with_protocol_config_and_batched_
     let context = setup_test_programs(additional_programs).await;
     let mut context = ProgramTestRpcConnection {
         context,
-        rate_limiter: None,
+        rpc_rate_limiter: None,
+        send_tx_rate_limiter: None,
     };
     let keypairs = EnvAccountKeypairs::program_test_default();
     airdrop_lamports(
@@ -607,7 +608,8 @@ pub async fn setup_test_programs_with_accounts_with_protocol_config_v2(
     let context = setup_test_programs(additional_programs).await;
     let mut context = ProgramTestRpcConnection {
         context,
-        rate_limiter: None,
+        rpc_rate_limiter: None,
+        send_tx_rate_limiter: None,
     };
     let keypairs = EnvAccountKeypairs::program_test_default();
     airdrop_lamports(

--- a/sdk-libs/program-test/src/test_rpc.rs
+++ b/sdk-libs/program-test/src/test_rpc.rs
@@ -30,6 +30,16 @@ pub struct ProgramTestRpcConnection {
     pub send_tx_rate_limiter: Option<RateLimiter>,
 }
 
+impl ProgramTestRpcConnection {
+    pub fn new(context: ProgramTestContext) -> Self {
+        Self {
+            context,
+            rpc_rate_limiter: None,
+            send_tx_rate_limiter: None,
+        }
+    }
+}
+
 impl Debug for ProgramTestRpcConnection {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "ProgramTestRpcConnection")
@@ -49,12 +59,12 @@ impl RpcConnection for ProgramTestRpcConnection {
         self.rpc_rate_limiter = Some(rate_limiter);
     }
 
-    fn rpc_rate_limiter(&self) -> Option<&RateLimiter> {
-        self.rpc_rate_limiter.as_ref()
-    }
-
     fn set_send_tx_rate_limiter(&mut self, rate_limiter: RateLimiter) {
         self.send_tx_rate_limiter = Some(rate_limiter);
+    }
+
+    fn rpc_rate_limiter(&self) -> Option<&RateLimiter> {
+        self.rpc_rate_limiter.as_ref()
     }
 
     fn send_tx_rate_limiter(&self) -> Option<&RateLimiter> {

--- a/sdk-libs/program-test/src/test_rpc.rs
+++ b/sdk-libs/program-test/src/test_rpc.rs
@@ -26,7 +26,8 @@ use solana_transaction_status::TransactionStatus;
 
 pub struct ProgramTestRpcConnection {
     pub context: ProgramTestContext,
-    pub rate_limiter: Option<RateLimiter>,
+    pub rpc_rate_limiter: Option<RateLimiter>,
+    pub send_tx_rate_limiter: Option<RateLimiter>,
 }
 
 impl Debug for ProgramTestRpcConnection {
@@ -44,14 +45,21 @@ impl RpcConnection for ProgramTestRpcConnection {
         unimplemented!()
     }
 
-    fn set_rate_limiter(&mut self, rate_limiter: RateLimiter) {
-        self.rate_limiter = Some(rate_limiter);
+    fn set_rpc_rate_limiter(&mut self, rate_limiter: RateLimiter) {
+        self.rpc_rate_limiter = Some(rate_limiter);
     }
 
-    fn rate_limiter(&self) -> Option<&RateLimiter> {
-        self.rate_limiter.as_ref()
+    fn rpc_rate_limiter(&self) -> Option<&RateLimiter> {
+        self.rpc_rate_limiter.as_ref()
     }
 
+    fn set_send_tx_rate_limiter(&mut self, rate_limiter: RateLimiter) {
+        self.send_tx_rate_limiter = Some(rate_limiter);
+    }
+
+    fn send_tx_rate_limiter(&self) -> Option<&RateLimiter> {
+        self.send_tx_rate_limiter.as_ref()
+    }
     fn get_payer(&self) -> &Keypair {
         &self.context.payer
     }

--- a/sdk-libs/program-test/src/test_rpc.rs
+++ b/sdk-libs/program-test/src/test_rpc.rs
@@ -3,6 +3,7 @@ use std::fmt::{Debug, Formatter};
 use async_trait::async_trait;
 use borsh::BorshDeserialize;
 use light_client::{
+    rate_limiter::RateLimiter,
     rpc::{merkle_tree::MerkleTreeExt, RpcConnection, RpcError},
     transaction_params::TransactionParams,
 };
@@ -25,6 +26,7 @@ use solana_transaction_status::TransactionStatus;
 
 pub struct ProgramTestRpcConnection {
     pub context: ProgramTestContext,
+    pub rate_limiter: Option<RateLimiter>,
 }
 
 impl Debug for ProgramTestRpcConnection {
@@ -40,6 +42,14 @@ impl RpcConnection for ProgramTestRpcConnection {
         Self: Sized,
     {
         unimplemented!()
+    }
+
+    fn set_rate_limiter(&mut self, rate_limiter: RateLimiter) {
+        self.rate_limiter = Some(rate_limiter);
+    }
+
+    fn rate_limiter(&self) -> Option<&RateLimiter> {
+        self.rate_limiter.as_ref()
     }
 
     fn get_payer(&self) -> &Keypair {


### PR DESCRIPTION
Implemented rate limiter for rpc calls.
Forester can be run with 3 optional flags:
```
--rpc-rate-limit <RPC_RATE_LIMIT>
--photon-rate-limit <PHOTON_RATE_LIMIT>
--send-tx-rate-limit <SEND_TX_RATE_LIMIT>
```