### PR TITLE
refactor: restore name-service-without-macros example

### DIFF
--- a/.github/workflows/light-examples-tests.yml
+++ b/.github/workflows/light-examples-tests.yml
@@ -37,10 +37,10 @@ jobs:
             sub-tests: '[
               "cargo test-sbf -p token-escrow -- --test-threads=1"
             ]'
-          # - program: name-service-without-macros-test
-          #   sub-tests: '[
-          #     "cargo test-sbf -p name-service-without-macros -- --test-threads=1"
-          #   ]'
+          - program: name-service-without-macros-test
+            sub-tests: '[
+             "cargo test-sbf -p name-service-without-macros -- --test-threads=1"
+            ]'
 
     steps:
       - name: Checkout sources

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3562,12 +3562,12 @@ dependencies = [
  "light-hasher",
  "light-macros",
  "light-program-test",
+ "light-prover-client",
  "light-sdk",
  "light-sdk-macros",
  "light-test-utils",
  "light-utils",
  "light-verifier",
- "solana-program-test",
  "solana-sdk",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3553,6 +3553,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "name-service"
+version = "0.7.0"
+dependencies = [
+ "anchor-lang",
+ "borsh 0.10.3",
+ "light-client",
+ "light-hasher",
+ "light-macros",
+ "light-program-test",
+ "light-sdk",
+ "light-sdk-macros",
+ "light-test-utils",
+ "light-utils",
+ "light-verifier",
+ "solana-program-test",
+ "solana-sdk",
+ "tokio",
+]
+
+[[package]]
+name = "name-service-without-macros"
+version = "0.7.0"
+dependencies = [
+ "anchor-lang",
+ "borsh 0.10.3",
+ "light-client",
+ "light-hasher",
+ "light-macros",
+ "light-program-test",
+ "light-sdk",
+ "light-sdk-macros",
+ "light-test-utils",
+ "light-utils",
+ "light-verifier",
+ "solana-program-test",
+ "solana-sdk",
+ "tokio",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3553,26 +3553,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "name-service"
-version = "0.7.0"
-dependencies = [
- "anchor-lang",
- "borsh 0.10.3",
- "light-client",
- "light-hasher",
- "light-macros",
- "light-program-test",
- "light-sdk",
- "light-sdk-macros",
- "light-test-utils",
- "light-utils",
- "light-verifier",
- "solana-program-test",
- "solana-sdk",
- "tokio",
-]
-
-[[package]]
 name = "name-service-without-macros"
 version = "0.7.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "sdk-libs/program-test",
     "xtask",
     "examples/token-escrow/programs/*",
+    "examples/name-service/programs/*",
     "program-tests/account-compression-test/",
     "program-tests/compressed-token-test/",
     "program-tests/e2e-test/",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
     "sdk-libs/program-test",
     "xtask",
     "examples/token-escrow/programs/*",
-    "examples/name-service/programs/*",
+    "examples/name-service/programs/name-service-without-macros",
     "program-tests/account-compression-test/",
     "program-tests/compressed-token-test/",
     "program-tests/e2e-test/",

--- a/examples/name-service/package.json
+++ b/examples/name-service/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "lint:fix": "prettier \"*/**/*{.js,.ts}\" -w",
     "lint": "prettier  \"*/**/*{.js,.ts}\" --check",
-    "test": "cargo test-sbf -p name-service -- --test-threads 1"
+    "test": "cargo test-sbf -p name-service-without-macros -- --test-threads 1"
   },
   "dependencies": {
     "@coral-xyz/anchor": "^0.29.0"

--- a/examples/name-service/programs/name-service-without-macros/Cargo.toml
+++ b/examples/name-service/programs/name-service-without-macros/Cargo.toml
@@ -28,7 +28,7 @@ light-macros = { workspace = true }
 light-sdk = { workspace = true }
 light-sdk-macros = { workspace = true }
 light-utils = { workspace = true }
-light-verifier = { workspace = true }
+light-verifier = { workspace = true, features = ["solana"] }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 solana-sdk = { workspace = true }

--- a/examples/name-service/programs/name-service-without-macros/Cargo.toml
+++ b/examples/name-service/programs/name-service-without-macros/Cargo.toml
@@ -37,5 +37,5 @@ solana-sdk = { workspace = true }
 light-client = { workspace = true , features = ["devenv"]}
 light-test-utils = { workspace = true, features = ["devenv"] }
 light-program-test = { workspace = true, features = ["devenv"] }
-solana-program-test = { workspace = true }
+light-prover-client = { workspace = true, features = ["devenv"] }
 tokio = "1.36.0"

--- a/examples/name-service/programs/name-service-without-macros/tests/test.rs
+++ b/examples/name-service/programs/name-service-without-macros/tests/test.rs
@@ -12,6 +12,7 @@ use light_program_test::{
     test_env::{setup_test_programs_with_accounts_v2, EnvAccounts},
     test_rpc::ProgramTestRpcConnection,
 };
+use light_prover_client::gnark::helpers::{spawn_prover, ProverConfig, ProverMode};
 use light_sdk::{
     account_meta::LightAccountMeta,
     address::derive_address,
@@ -35,6 +36,15 @@ use solana_sdk::{
 
 #[tokio::test]
 async fn test_name_service() {
+    spawn_prover(
+        true,
+        ProverConfig {
+            run_mode: Some(ProverMode::Rpc),
+            circuits: vec![],
+        },
+    )
+    .await;
+
     let (mut rpc, env) = setup_test_programs_with_accounts_v2(Some(vec![(
         String::from("name_service_without_macros"),
         name_service_without_macros::ID,

--- a/forester/tests/test_utils.rs
+++ b/forester/tests/test_utils.rs
@@ -6,8 +6,10 @@ use forester::{
     ForesterConfig,
 };
 use light_client::{
-    indexer::{photon_indexer::PhotonIndexer, Indexer, IndexerError, NewAddressProofWithContext},
-    photon_rpc::Base58Conversions,
+    indexer::{
+        photon_indexer::PhotonIndexer, Base58Conversions, Indexer, IndexerError,
+        NewAddressProofWithContext,
+    },
     rpc::RpcConnection,
 };
 use light_program_test::{indexer::TestIndexerExtensions, test_env::get_test_env_accounts};
@@ -247,7 +249,7 @@ pub async fn assert_account_proofs_for_photon_and_test_indexer<
 
         let photon_result = photon_result.unwrap();
         let test_indexer_result = test_indexer_result.unwrap();
-        
+
         assert_eq!(photon_result.len(), test_indexer_result.len());
         for (photon_proof, test_indexer_proof) in
             photon_result.iter().zip(test_indexer_result.iter())

--- a/forester/tests/test_utils.rs
+++ b/forester/tests/test_utils.rs
@@ -6,14 +6,13 @@ use forester::{
     ForesterConfig,
 };
 use light_client::{
-    indexer::{
-        photon_indexer::PhotonIndexer, Base58Conversions, Hash, Indexer, IndexerError,
-        NewAddressProofWithContext,
-    },
+    indexer::{photon_indexer::PhotonIndexer, Indexer, IndexerError, NewAddressProofWithContext},
+    photon_rpc::Base58Conversions,
     rpc::RpcConnection,
 };
 use light_program_test::{indexer::TestIndexerExtensions, test_env::get_test_env_accounts};
 use light_prover_client::gnark::helpers::{spawn_validator, LightValidatorConfig};
+use light_sdk::compressed_account::CompressedAccountWithMerkleContext;
 use light_test_utils::e2e_test_env::{GeneralActionConfig, KeypairActionConfig, User};
 use solana_sdk::signature::{Keypair, Signer};
 use tracing::debug;
@@ -195,13 +194,13 @@ pub async fn assert_accounts_by_owner<
         .get_compressed_accounts_by_owner(&user.keypair.pubkey())
         .await
         .unwrap();
-    photon_accs.sort();
+    photon_accs.sort_by_key(|a| a.hash().unwrap().to_base58());
 
     let mut test_accs = indexer
         .get_compressed_accounts_by_owner(&user.keypair.pubkey())
         .await
         .unwrap();
-    test_accs.sort();
+    test_accs.sort_by_key(|a| a.hash().unwrap().to_base58());
 
     debug!(
         "asserting accounts for user: {} Test accs: {:?} Photon accs: {:?}",
@@ -228,14 +227,14 @@ pub async fn assert_account_proofs_for_photon_and_test_indexer<
     user_pubkey: &Pubkey,
     photon_indexer: &PhotonIndexer<R>,
 ) {
-    let accs: Result<Vec<Hash>, IndexerError> =
+    let accs: Result<Vec<CompressedAccountWithMerkleContext>, IndexerError> =
         indexer.get_compressed_accounts_by_owner(user_pubkey).await;
-    for account_hash in accs.unwrap() {
+    for account in accs.unwrap() {
         let photon_result = photon_indexer
-            .get_multiple_compressed_account_proofs(vec![account_hash.to_base58()])
+            .get_multiple_compressed_account_proofs(vec![account.hash().unwrap().to_base58()])
             .await;
         let test_indexer_result = indexer
-            .get_multiple_compressed_account_proofs(vec![account_hash.to_base58()])
+            .get_multiple_compressed_account_proofs(vec![account.hash().unwrap().to_base58()])
             .await;
 
         if photon_result.is_err() {
@@ -248,13 +247,7 @@ pub async fn assert_account_proofs_for_photon_and_test_indexer<
 
         let photon_result = photon_result.unwrap();
         let test_indexer_result = test_indexer_result.unwrap();
-        debug!(
-            "assert proofs for account: {} photon result: {:?} test indexer result: {:?}",
-            account_hash.to_base58(),
-            photon_result,
-            test_indexer_result
-        );
-
+        
         assert_eq!(photon_result.len(), test_indexer_result.len());
         for (photon_proof, test_indexer_proof) in
             photon_result.iter().zip(test_indexer_result.iter())

--- a/sdk-libs/client/src/indexer/mod.rs
+++ b/sdk-libs/client/src/indexer/mod.rs
@@ -124,7 +124,7 @@ pub trait Indexer<R: RpcConnection>: Sync + Send + Debug + 'static {
     async fn get_compressed_accounts_by_owner(
         &self,
         owner: &Pubkey,
-    ) -> Result<Vec<Hash>, IndexerError>;
+    ) -> Result<Vec<CompressedAccountWithMerkleContext>, IndexerError>;
 
     async fn get_compressed_account(
         &self,

--- a/sdk-libs/program-test/src/indexer/test_indexer.rs
+++ b/sdk-libs/program-test/src/indexer/test_indexer.rs
@@ -370,16 +370,11 @@ where
     async fn get_compressed_accounts_by_owner(
         &self,
         owner: &Pubkey,
-    ) -> Result<Vec<Hash>, IndexerError> {
-        let result = self.get_compressed_accounts_with_merkle_context_by_owner(owner);
-        let mut hashes: Vec<Hash> = Vec::new();
-        for account in result.iter() {
-            let hash = account.hash().unwrap();
-            hashes.push(hash);
-        }
-        Ok(hashes)
+    ) -> Result<Vec<CompressedAccountWithMerkleContext>, IndexerError> {
+        Ok(self.get_compressed_accounts_with_merkle_context_by_owner(owner))
     }
-
+    
+    
     async fn get_compressed_account(
         &self,
         address: Option<Address>,
@@ -540,6 +535,7 @@ where
     ) -> Result<Vec<String>, IndexerError> {
         todo!()
     }
+
 
     async fn get_multiple_new_address_proofs(
         &self,

--- a/sdk-libs/program-test/src/indexer/test_indexer.rs
+++ b/sdk-libs/program-test/src/indexer/test_indexer.rs
@@ -373,8 +373,7 @@ where
     ) -> Result<Vec<CompressedAccountWithMerkleContext>, IndexerError> {
         Ok(self.get_compressed_accounts_with_merkle_context_by_owner(owner))
     }
-    
-    
+
     async fn get_compressed_account(
         &self,
         address: Option<Address>,
@@ -535,7 +534,6 @@ where
     ) -> Result<Vec<String>, IndexerError> {
         todo!()
     }
-
 
     async fn get_multiple_new_address_proofs(
         &self,


### PR DESCRIPTION
1. Refactored `get_compressed_accounts_by_owner` method in `test_indexer.rs` and `photon_indexer.rs` to return structured data instead of raw hashes.
2. Adjusted test logic in name-service-without-macros example.