### PR TITLE
refactor: removed redundant TreeType in forester_utils and improved forester `status` cli output.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,7 +1395,7 @@ version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
- "encode_unicode",
+ "encode_unicode 0.3.6",
  "lazy_static",
  "libc",
  "unicode-width 0.1.13",
@@ -1554,6 +1554,27 @@ checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1926,6 +1947,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,8 +2174,8 @@ dependencies = [
  "light-sdk",
  "light-system-program",
  "light-test-utils",
- "log",
  "photon-api",
+ "prettytable-rs",
  "prometheus",
  "reqwest",
  "scopeguard",
@@ -2183,10 +2210,10 @@ dependencies = [
  "light-hash-set",
  "light-hasher",
  "light-indexed-merkle-tree",
+ "light-merkle-tree-metadata",
  "light-prover-client",
  "light-registry",
  "light-system-program",
- "light-verifier",
  "log",
  "num-traits",
  "reqwest",
@@ -2538,6 +2565,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -2916,24 +2949,15 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.8"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
  "console",
- "instant",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.1.13",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
+ "unicode-width 0.2.0",
+ "web-time",
 ]
 
 [[package]]
@@ -2941,6 +2965,17 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
+dependencies = [
+ "hermit-abi 0.4.0",
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -4442,6 +4477,20 @@ checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "prettytable-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
+dependencies = [
+ "csv",
+ "encode_unicode 1.0.0",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -7368,6 +7417,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8194,6 +8254,16 @@ name = "web-sys"
 version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/forester-utils/Cargo.toml
+++ b/forester-utils/Cargo.toml
@@ -19,7 +19,7 @@ light-registry = { workspace = true }
 light-system-program = { workspace = true, features = ["cpi"] }
 light-compressed-account = { workspace = true }
 light-batched-merkle-tree = { workspace = true }
-light-verifier = { workspace = true }
+light-merkle-tree-metadata = { workspace = true }
 light-client = { workspace = true }
 light-account-checks = { workspace = true }
 

--- a/forester-utils/src/forester_epoch.rs
+++ b/forester-utils/src/forester_epoch.rs
@@ -1,10 +1,8 @@
-use std::fmt::Display;
-
-// TODO: move into separate forester utils crate
 use anchor_lang::{
     prelude::borsh, solana_program::pubkey::Pubkey, AnchorDeserialize, AnchorSerialize,
 };
 use light_client::rpc::{RpcConnection, RpcError};
+use light_merkle_tree_metadata::merkle_tree::TreeType;
 use light_registry::{
     protocol_config::state::{EpochState, ProtocolConfig},
     sdk::{create_register_forester_epoch_pda_instruction, create_report_work_instruction},
@@ -76,26 +74,6 @@ impl TreeAccounts {
             queue,
             tree_type,
             is_rolledover,
-        }
-    }
-}
-
-// TODO: unify with light-merkle-tree-metadata
-#[derive(Debug, Clone, PartialEq, Eq, Copy)]
-pub enum TreeType {
-    Address,
-    State,
-    BatchedState,
-    BatchedAddress,
-}
-
-impl Display for TreeType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TreeType::Address => write!(f, "address"),
-            TreeType::State => write!(f, "state"),
-            TreeType::BatchedState => write!(f, "batched state"),
-            TreeType::BatchedAddress => write!(f, "batched address"),
         }
     }
 }

--- a/forester/Cargo.toml
+++ b/forester/Cargo.toml
@@ -26,7 +26,6 @@ light-program-test = { workspace = true }
 solana-transaction-status = { workspace = true }
 url = "2.2"
 bb8 = { workspace = true }
-log = { workspace = true }
 
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -49,6 +48,7 @@ warp = "0.3"
 dashmap = "6.1.0"
 scopeguard = "1.2.0"
 itertools = "0.14.0"
+prettytable-rs = "0.10.0"
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/forester/src/batch_processor/common.rs
+++ b/forester/src/batch_processor/common.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
-use forester_utils::forester_epoch::TreeType;
 use light_batched_merkle_tree::{
     batch::{Batch, BatchState},
     merkle_tree::BatchedMerkleTreeAccount,
     queue::BatchedQueueAccount,
 };
 use light_client::{indexer::Indexer, rpc::RpcConnection, rpc_pool::SolanaRpcPool};
+use light_merkle_tree_metadata::merkle_tree::TreeType;
 use solana_program::pubkey::Pubkey;
 use solana_sdk::signature::Keypair;
 use tokio::sync::Mutex;

--- a/forester/src/batch_processor/error.rs
+++ b/forester/src/batch_processor/error.rs
@@ -1,5 +1,5 @@
-use forester_utils::forester_epoch::TreeType;
 use light_client::rpc_pool::PoolError;
+use light_merkle_tree_metadata::merkle_tree::TreeType;
 use solana_client::rpc_request::RpcError;
 use thiserror::Error;
 

--- a/forester/src/batch_processor/mod.rs
+++ b/forester/src/batch_processor/mod.rs
@@ -5,7 +5,6 @@ mod state;
 
 use common::BatchProcessor;
 use error::Result;
-use forester_utils::forester_epoch::TreeType;
 use light_client::rpc::RpcConnection;
 use tracing::{info, instrument};
 
@@ -29,5 +28,6 @@ pub async fn process_batched_operations<R: RpcConnection, I: Indexer<R> + Indexe
 pub use common::BatchContext;
 pub use error::BatchProcessError;
 use light_client::indexer::Indexer;
+use light_merkle_tree_metadata::merkle_tree::TreeType;
 
 use crate::indexer_type::IndexerType;

--- a/forester/src/epoch_manager.rs
+++ b/forester/src/epoch_manager.rs
@@ -9,15 +9,14 @@ use std::{
 
 use anyhow::Context;
 use dashmap::DashMap;
-use forester_utils::forester_epoch::{
-    get_epoch_phases, Epoch, TreeAccounts, TreeForesterSchedule, TreeType,
-};
+use forester_utils::forester_epoch::{get_epoch_phases, Epoch, TreeAccounts, TreeForesterSchedule};
 use futures::future::join_all;
 use light_client::{
     indexer::{Indexer, MerkleProof, NewAddressProofWithContext},
     rpc::{RetryConfig, RpcConnection, RpcError, SolanaRpcConnection},
     rpc_pool::SolanaRpcPool,
 };
+use light_merkle_tree_metadata::merkle_tree::TreeType;
 use light_registry::{
     protocol_config::state::ProtocolConfig,
     sdk::{create_finalize_registration_instruction, create_report_work_instruction},

--- a/forester/src/lib.rs
+++ b/forester/src/lib.rs
@@ -25,13 +25,14 @@ use std::{sync::Arc, time::Duration};
 
 use account_compression::utils::constants::{ADDRESS_QUEUE_VALUES, STATE_NULLIFIER_QUEUE_VALUES};
 pub use config::{ForesterConfig, ForesterEpochInfo};
-use forester_utils::forester_epoch::{TreeAccounts, TreeType};
+use forester_utils::forester_epoch::TreeAccounts;
 use light_client::{
     indexer::Indexer,
     rate_limiter::RateLimiter,
     rpc::{RpcConnection, SolanaRpcConnection},
     rpc_pool::SolanaRpcPool,
 };
+use light_merkle_tree_metadata::merkle_tree::TreeType;
 use solana_sdk::commitment_config::CommitmentConfig;
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tracing::debug;
@@ -76,8 +77,8 @@ pub async fn run_queue_info(
             .with_label_values(&[&*queue_type.to_string(), &tree_data.merkle_tree.to_string()])
             .set(queue_length as i64);
         println!(
-            "{:?} queue {} length: {}",
-            queue_type, tree_data.queue, queue_length
+            "{:?} queue {} tree {} length: {}",
+            queue_type, tree_data.queue, tree_data.merkle_tree, queue_length
         );
     }
 }

--- a/forester/src/rollover/operations.rs
+++ b/forester/src/rollover/operations.rs
@@ -4,9 +4,7 @@ use account_compression::{
 };
 use forester_utils::{
     address_merkle_tree_config::{get_address_bundle_config, get_state_bundle_config},
-    create_account_instruction,
-    forester_epoch::TreeType,
-    get_concurrent_merkle_tree, get_indexed_merkle_tree,
+    create_account_instruction, get_concurrent_merkle_tree, get_indexed_merkle_tree,
     registry::RentExemption,
 };
 use light_batched_merkle_tree::merkle_tree::BatchedMerkleTreeAccount;
@@ -15,6 +13,7 @@ use light_client::{
     rpc::{RpcConnection, RpcError},
 };
 use light_hasher::Poseidon;
+use light_merkle_tree_metadata::merkle_tree::TreeType;
 use light_registry::{
     account_compression_cpi::sdk::{
         create_rollover_address_merkle_tree_instruction,
@@ -287,7 +286,7 @@ pub async fn perform_state_merkle_tree_rollover_forester<R: RpcConnection>(
         epoch,
     )
     .await;
-    let blockhash = context.get_latest_blockhash().await.unwrap();
+    let blockhash = context.get_latest_blockhash().await?;
     let transaction = Transaction::new_signed_with_payer(
         &instructions,
         Some(&payer.pubkey()),
@@ -324,7 +323,7 @@ pub async fn perform_address_merkle_tree_rollover<R: RpcConnection>(
         epoch,
     )
     .await;
-    let blockhash = context.get_latest_blockhash().await.unwrap();
+    let blockhash = context.get_latest_blockhash().await?;
     let transaction = Transaction::new_signed_with_payer(
         &instructions,
         Some(&payer.pubkey()),
@@ -479,7 +478,7 @@ pub async fn get_rent_exemption_for_state_merkle_tree_and_queue<R: RpcConnection
         .get_minimum_balance_for_rent_exemption(queue_size)
         .await
         .unwrap();
-    let tree_size = account_compression::state::StateMerkleTreeAccount::size(
+    let tree_size = StateMerkleTreeAccount::size(
         merkle_tree_config.height as usize,
         merkle_tree_config.changelog_size as usize,
         merkle_tree_config.roots_size as usize,

--- a/forester/src/send_transaction.rs
+++ b/forester/src/send_transaction.rs
@@ -11,12 +11,13 @@ use account_compression::utils::constants::{
     STATE_MERKLE_TREE_CHANGELOG, STATE_NULLIFIER_QUEUE_VALUES,
 };
 use async_trait::async_trait;
-use forester_utils::forester_epoch::{TreeAccounts, TreeType};
+use forester_utils::forester_epoch::TreeAccounts;
 use light_client::{
     indexer::Indexer,
     rpc::{RetryConfig, RpcConnection, RpcError},
     rpc_pool::SolanaRpcPool,
 };
+use light_merkle_tree_metadata::merkle_tree::TreeType;
 use light_registry::{
     account_compression_cpi::sdk::{
         create_nullify_instruction, create_update_address_merkle_tree_instruction,

--- a/forester/src/tree_data_sync.rs
+++ b/forester/src/tree_data_sync.rs
@@ -3,10 +3,10 @@ use account_compression::{
     StateMerkleTreeAccount,
 };
 use borsh::BorshDeserialize;
-use forester_utils::forester_epoch::{TreeAccounts, TreeType};
+use forester_utils::forester_epoch::TreeAccounts;
 use light_batched_merkle_tree::merkle_tree::BatchedMerkleTreeAccount;
 use light_client::rpc::RpcConnection;
-use light_merkle_tree_metadata::merkle_tree::MerkleTreeMetadata;
+use light_merkle_tree_metadata::merkle_tree::{MerkleTreeMetadata, TreeType};
 use solana_sdk::{account::Account, pubkey::Pubkey};
 use tracing::debug;
 

--- a/program-libs/merkle-tree-metadata/src/merkle_tree.rs
+++ b/program-libs/merkle-tree-metadata/src/merkle_tree.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 #[cfg(feature = "anchor")]
 use anchor_lang::{AnchorDeserialize, AnchorSerialize};
 #[cfg(not(feature = "anchor"))]
@@ -9,7 +11,7 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use crate::{access::AccessMetadata, errors::MerkleTreeMetadataError, rollover::RolloverMetadata};
 
 #[repr(u64)]
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
 pub enum TreeType {
     State = 1,
     Address = 2,
@@ -26,6 +28,17 @@ impl From<u64> for TreeType {
             3 => TreeType::BatchedState,
             4 => TreeType::BatchedAddress,
             _ => panic!("Invalid TreeType"),
+        }
+    }
+}
+
+impl Display for TreeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TreeType::Address => write!(f, "address"),
+            TreeType::State => write!(f, "state"),
+            TreeType::BatchedState => write!(f, "batched state"),
+            TreeType::BatchedAddress => write!(f, "batched address"),
         }
     }
 }

--- a/program-tests/utils/src/e2e_test_env.rs
+++ b/program-tests/utils/src/e2e_test_env.rs
@@ -75,7 +75,7 @@ use create_address_test_program::create_invoke_cpi_instruction;
 use forester_utils::{
     address_merkle_tree_config::{address_tree_ready_for_rollover, state_tree_ready_for_rollover},
     airdrop_lamports,
-    forester_epoch::{Epoch, Forester, TreeAccounts, TreeType},
+    forester_epoch::{Epoch, Forester, TreeAccounts},
     registry::register_test_forester,
     AccountZeroCopy,
 };
@@ -118,6 +118,7 @@ use light_hasher::Poseidon;
 use light_indexed_merkle_tree::{
     array::IndexedArray, reference::IndexedMerkleTree, HIGHEST_ADDRESS_PLUS_ONE,
 };
+use light_merkle_tree_metadata::merkle_tree::TreeType;
 use light_program_test::{
     indexer::{TestIndexer, TestIndexerExtensions},
     test_batch_forester::{perform_batch_append, perform_batch_nullify},

--- a/program-tests/utils/src/lib.rs
+++ b/program-tests/utils/src/lib.rs
@@ -29,7 +29,7 @@ pub mod test_forester;
 pub use create_address_test_program::ID as CREATE_ADDRESS_TEST_PROGRAM_ID;
 pub use forester_utils::{
     airdrop_lamports, create_account_instruction,
-    forester_epoch::{Epoch, TreeAccounts, TreeType},
+    forester_epoch::{Epoch, TreeAccounts},
     get_concurrent_merkle_tree, get_hash_set, get_indexed_merkle_tree,
     registry::{
         create_rollover_address_merkle_tree_instructions,

--- a/sdk-libs/program-test/src/test_env.rs
+++ b/sdk-libs/program-test/src/test_env.rs
@@ -6,7 +6,7 @@ use account_compression::{
 };
 use forester_utils::{
     airdrop_lamports, create_account_instruction,
-    forester_epoch::{Epoch, TreeAccounts, TreeType},
+    forester_epoch::{Epoch, TreeAccounts},
     registry::register_test_forester,
 };
 use light_batched_merkle_tree::{
@@ -16,6 +16,7 @@ use light_batched_merkle_tree::{
 use light_client::rpc::{
     errors::RpcError, solana_rpc::SolanaRpcUrl, RpcConnection, SolanaRpcConnection,
 };
+use light_merkle_tree_metadata::merkle_tree::TreeType;
 use light_registry::{
     account_compression_cpi::sdk::get_registered_program_pda,
     protocol_config::state::ProtocolConfig,


### PR DESCRIPTION
1. [removed `TreeType` ](https://github.com/Lightprotocol/light-protocol/compare/sergey/forester-status-format?expand=1#diff-ad03c80df157caf124f67844af65516e24c82c1188719aa05dde149e5dd89224L83-L101) from forester-utils, its redudant, replaced it with the identical enum from light-merkle-tree-metadata.
2. cleaned up cli output for status cmd
