### PR TITLE
Fixed URI format consistency

### DIFF
--- a/sdk-libs/photon-api/docs/DefaultApi.md
+++ b/sdk-libs/photon-api/docs/DefaultApi.md
@@ -1,6 +1,6 @@
 # \DefaultApi
 
-All URIs are relative to *https://devnet.helius-rpc.com?api-key=<api_key>*
+All URIs are relative to *https://devnet.helius-rpc.com/?api-key=<api_key>*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
@@ -228,7 +228,7 @@ No authorization required
 
 ## get_compressed_token_accounts_by_owner_post
 
-> models::GetCompressedTokenAccountsByDelegatePost200Response get_compressed_token_accounts_by_owner_post(get_compressed_token_accounts_by_owner_post_request)
+> models::GetCompressedTokenAccountsByOwnerPost200Response get_compressed_token_accounts_by_owner_post(get_compressed_token_accounts_by_owner_post_request)
 
 
 ### Parameters


### PR DESCRIPTION


Old: All URIs are relative to https://devnet.helius-rpc.com?api-key=<api_key>
New: All URIs are relative to https://devnet.helius-rpc.com/?api-key=<api_key>
Reason: Added a / before the query parameter to align with proper URL formatting standards and improve clarity.
Corrected return type for get_compressed_token_accounts_by_owner_post

Old: models::GetCompressedTokenAccountsByDelegatePost200Response
New: models::GetCompressedTokenAccountsByOwnerPost200Response
Reason: The original return type was incorrect. Since the function is meant to return compressed token accounts owned by a specific user,