### PR TITLE
feat: add generate photon test data script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ program-tests/e2e-test/**/*.txt
 output.txt
 .nx/cache
 .nx/workspace-data
+output1.txt
+test_state_batched_transactions

--- a/.gitignore
+++ b/.gitignore
@@ -82,4 +82,3 @@ output.txt
 .nx/cache
 .nx/workspace-data
 output1.txt
-test_state_batched_transactions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5481,9 +5481,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
  "itoa",
  "memchr",
@@ -8882,9 +8882,12 @@ dependencies = [
  "num-bigint 0.4.6",
  "quote",
  "rand 0.8.5",
+ "serde_json",
  "sha2 0.10.8",
+ "solana-client",
  "solana-program",
  "solana-sdk",
+ "solana-transaction-status",
  "tabled",
  "tokio",
 ]

--- a/program-libs/compressed-account/src/instruction_data/zero_copy.rs
+++ b/program-libs/compressed-account/src/instruction_data/zero_copy.rs
@@ -315,9 +315,8 @@ impl<'a> Deserialize<'a> for ZInstructionDataInvoke<'a> {
             Vec::<ZOutputCompressedAccountWithPackedContext>::zero_copy_at(bytes)?;
         let (relay_fee, bytes) = Option::<Ref<&'a [u8], U64>>::zero_copy_at(bytes)?;
         if relay_fee.is_some() {
-            unimplemented!("Relay fee not implemented");
+            return Err(ZeroCopyError::InvalidConversion);
         }
-
         let (new_address_params, bytes) = ZeroCopySliceBorsh::from_bytes_at(bytes)?;
         let (compress_or_decompress_lamports, bytes) =
             Option::<Ref<&'a [u8], U64>>::zero_copy_at(bytes)?;
@@ -403,7 +402,7 @@ impl<'a> Deserialize<'a> for ZInstructionDataInvokeCpi<'a> {
             Vec::<ZOutputCompressedAccountWithPackedContext>::zero_copy_at(bytes)?;
         let (option_relay_fee, bytes) = bytes.split_at(1);
         if option_relay_fee[0] == 1 {
-            unimplemented!(" Relay fee is unimplemented");
+            return Err(ZeroCopyError::InvalidConversion);
         }
         let (compress_or_decompress_lamports, bytes) =
             Option::<Ref<&'a [u8], U64>>::zero_copy_at(bytes)?;

--- a/program-libs/zero-copy/src/borsh.rs
+++ b/program-libs/zero-copy/src/borsh.rs
@@ -84,6 +84,8 @@ impl<'a, T: Deserialize<'a>> Deserialize<'a> for Vec<T> {
     fn zero_copy_at(bytes: &'a [u8]) -> Result<(Self::Output, &'a [u8]), ZeroCopyError> {
         let (num_slices, mut bytes) = Ref::<&[u8], U32>::from_prefix(bytes)?;
         let num_slices = u32::from(*num_slices) as usize;
+        // TODO: add check that remaining data is enough to read num_slices
+        // This prevents agains invalid data allocating a lot of heap memory
         let mut slices = Vec::with_capacity(num_slices);
         for _ in 0..num_slices {
             let (slice, _bytes) = T::zero_copy_at(bytes)?;

--- a/program-tests/compressed-token-test/tests/test.rs
+++ b/program-tests/compressed-token-test/tests/test.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "test-sbf")]
 
+use std::str::FromStr;
+
 use account_compression::errors::AccountCompressionErrorCode;
 use anchor_lang::{
     prelude::AccountMeta, system_program, AccountDeserialize, AnchorDeserialize, AnchorSerialize,
@@ -32,10 +34,12 @@ use light_compressed_token::{
 };
 use light_program_test::{
     indexer::{TestIndexer, TestIndexerExtensions},
-    test_env::setup_test_programs_with_accounts,
+    test_env::{setup_test_programs_with_accounts, EnvAccountKeypairs, EnvAccounts},
     test_rpc::ProgramTestRpcConnection,
 };
-use light_prover_client::gnark::helpers::{kill_prover, spawn_prover, ProofType, ProverConfig};
+use light_prover_client::gnark::helpers::{
+    kill_prover, spawn_prover, spawn_validator, LightValidatorConfig, ProofType, ProverConfig,
+};
 use light_sdk::token::{AccountState, TokenDataWithMerkleContext};
 use light_test_utils::{
     airdrop_lamports, assert_custom_error_or_program_error, assert_rpc_error,
@@ -50,12 +54,13 @@ use light_test_utils::{
         mint_tokens_helper_with_lamports, mint_wrapped_sol, perform_compress_spl_token_account,
         revoke_test, thaw_test, BurnInstructionMode,
     },
-    RpcConnection, RpcError,
+    RpcConnection, RpcError, SolanaRpcConnection, SolanaRpcUrl,
 };
 use light_verifier::VerifierError;
 use rand::{seq::SliceRandom, thread_rng, Rng};
 use serial_test::serial;
 use solana_sdk::{
+    commitment_config::CommitmentConfig,
     instruction::Instruction,
     pubkey::Pubkey,
     signature::{Keypair, Signature},
@@ -1401,6 +1406,7 @@ async fn perform_transfer_22_test(
     batched_tree: bool,
 ) {
     let (mut rpc, env) = setup_test_programs_with_accounts(None).await;
+
     let payer = rpc.get_payer().insecure_clone();
     let merkle_tree_pubkey = if batched_tree {
         env.batched_output_queue
@@ -1417,6 +1423,7 @@ async fn perform_transfer_22_test(
     };
     let mut test_indexer =
         TestIndexer::<ProgramTestRpcConnection>::init_from_env(&payer, &env, prover_config).await;
+
     let mint = if token_22 {
         create_mint_22_helper(&mut rpc, &payer).await
     } else {
@@ -5414,6 +5421,107 @@ async fn test_transfer_with_batched_tree() {
                 input_num, output_num
             );
             perform_transfer_22_test(input_num, output_num, 10_000, false, false, true).await
+        }
+    }
+}
+
+/// Used to generate photon test data
+/// Payer (En9a97stB3Ek2n6Ey3NJwCUJnmTzLMMEA5C69upGDuQP)
+/// has 3 token accounts with balance 12341 each.
+/// 4 recipients with hardcoded pubkeys the first 3 receive 9255 each and the last one 9258
+#[serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_transfer_with_photon_and_batched_tree() {
+    spawn_validator(LightValidatorConfig {
+        enable_indexer: false,
+        wait_time: 10,
+        prover_config: None,
+        sbf_programs: vec![],
+    })
+    .await;
+
+    let mut rpc =
+        SolanaRpcConnection::new(SolanaRpcUrl::Localnet, Some(CommitmentConfig::confirmed()));
+    let env = EnvAccounts::get_local_test_validator_accounts();
+    let keypairs = EnvAccountKeypairs::program_test_default();
+    // Deterministic keypair
+    let payer = keypairs.forester.insecure_clone();
+    println!("payer pubkey: {:?}", payer.pubkey());
+    rpc.airdrop_lamports(&payer.pubkey(), 10_000_000_000)
+        .await
+        .unwrap();
+
+    let possible_inputs = [3];
+    let batched_tree = true;
+    let token_22 = true;
+    let amount = 12341;
+    for inputs in possible_inputs {
+        for outputs in 4..5 {
+            if inputs == 8 && outputs > 5 {
+                // 8 inputs and 7 outputs is the max we can do
+                break;
+            }
+            println!("\n\ninput num: {}, output num: {}\n\n", inputs, outputs);
+
+            let merkle_tree_pubkey = if batched_tree {
+                env.batched_output_queue
+            } else {
+                env.merkle_tree_pubkey
+            };
+
+            let mut test_indexer: TestIndexer<SolanaRpcConnection> =
+                TestIndexer::init_from_env(&payer, &env, None).await;
+
+            let mint = if token_22 {
+                create_mint_22_helper(&mut rpc, &payer).await
+            } else {
+                create_mint_helper(&mut rpc, &payer).await
+            };
+            mint_tokens_22_helper_with_lamports(
+                &mut rpc,
+                &mut test_indexer,
+                &merkle_tree_pubkey,
+                &payer,
+                &mint,
+                vec![amount; inputs],
+                vec![payer.pubkey(); inputs],
+                Some(1_000_000),
+                token_22,
+            )
+            .await;
+            println!("mint to successful");
+            let recipients = [
+                Pubkey::from_str("DyRWDm81iYePWsdw1Yn2ue8CPcp7Lba6XsB8DVSGM7HK").unwrap(),
+                Pubkey::from_str("3YzfcCyqUPE9oubX2Ct9xWn1u5urqmGu6wfcFavHsCQZ").unwrap(),
+                Pubkey::from_str("2ShDKqkcMmacgYeSsEjwjLVJcoERZ9jgZ8tFyssxd82S").unwrap(),
+                Pubkey::from_str("24fLJv6tHmsxQg5vDD7XWy85TMhFzJdkqZ9Ta3LtVReU").unwrap(),
+            ];
+            println!("recipients {:?}", recipients);
+            let input_compressed_accounts = test_indexer
+                .get_compressed_token_accounts_by_owner(&payer.pubkey(), None)
+                .await
+                .unwrap();
+            let equal_amount = (amount * inputs as u64) / outputs as u64;
+            let rest_amount = (amount * inputs as u64) % outputs as u64;
+            let mut output_amounts = vec![equal_amount; outputs - 1];
+            output_amounts.push(equal_amount + rest_amount);
+            compressed_transfer_22_test(
+                &payer,
+                &mut rpc,
+                &mut test_indexer,
+                &mint,
+                &payer,
+                &recipients,
+                &output_amounts,
+                None,
+                input_compressed_accounts.as_slice(),
+                &vec![merkle_tree_pubkey; outputs],
+                None,
+                false,
+                None,
+                token_22,
+            )
+            .await;
         }
     }
 }

--- a/programs/system/src/processor/process.rs
+++ b/programs/system/src/processor/process.rs
@@ -89,7 +89,6 @@ pub fn process<
 ) -> Result<()> {
     #[cfg(feature = "bench-sbf")]
     bench_sbf_end!("cpda_process_compression");
-
     let num_input_compressed_accounts = inputs.input_compressed_accounts_with_merkle_context.len();
     let num_new_addresses = inputs.new_address_params.len();
     let num_output_compressed_accounts = inputs.output_compressed_accounts.len();

--- a/scripts/export-photon-test-transactions.sh
+++ b/scripts/export-photon-test-transactions.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Note generated data hasn't been in photon tests yet.
+# expected test results, 50 compressed accounts with 1_000_000 each owned by Pubkey::new_unique() (produces pubkeys deterministicly)
+# fully forested
+cargo test -p forester -- --test test_state_batched
+cargo xtask export-photon-test-data
+killall solana-test-validator;

--- a/scripts/export-photon-test-transactions.sh
+++ b/scripts/export-photon-test-transactions.sh
@@ -4,5 +4,9 @@
 # expected test results, 50 compressed accounts with 1_000_000 each owned by Pubkey::new_unique() (produces pubkeys deterministicly)
 # fully forested
 cargo test -p forester -- --test test_state_batched
-cargo xtask export-photon-test-data
+cargo xtask export-photon-test-data --test-name test_state_batched
+killall solana-test-validator;
+
+cargo test -p compressed-token-test -- --test test_transfer_with_photon_and_batched_tree
+cargo xtask export-photon-test-data --test-name test_batched_token
 killall solana-test-validator;

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -29,3 +29,6 @@ solana-sdk = { workspace = true }
 light-program-test = { workspace = true }
 light-client = { workspace = true }
 dirs = "6.0"
+serde_json = "1.0.139"
+solana-client = { workspace = true }
+solana-transaction-status = { workspace = true }

--- a/xtask/src/export_photon_test_data.rs
+++ b/xtask/src/export_photon_test_data.rs
@@ -1,0 +1,62 @@
+use clap::Parser;
+use serde_json::{json, Value};
+use solana_client::rpc_client::RpcClient;
+use solana_client::rpc_request::RpcRequest;
+use solana_sdk::signature::Signature;
+use solana_transaction_status::{EncodedConfirmedTransactionWithStatusMeta, UiTransactionEncoding};
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::Path;
+use std::str::FromStr;
+
+#[derive(Debug, Parser)]
+pub struct Options {
+    #[clap(long)]
+    test: Option<String>,
+}
+
+async fn export_transactions(
+    address: &str,
+    output_folder: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let rpc_url = "http://localhost:8899";
+    let client = RpcClient::new(rpc_url.to_string());
+
+    fs::create_dir_all(output_folder)?;
+
+    let transactions: Value = client.send(
+        RpcRequest::Custom {
+            method: "getSignaturesForAddress".into(),
+        },
+        json!([address]),
+    )?;
+
+    for tx in transactions.as_array().unwrap_or(&vec![]) {
+        let sig = tx["signature"].as_str().unwrap_or("");
+        if sig.is_empty() {
+            continue;
+        }
+
+        let tx_data: EncodedConfirmedTransactionWithStatusMeta = client
+            .get_transaction(
+                &Signature::from_str(sig).unwrap(),
+                UiTransactionEncoding::Base64,
+            )
+            .unwrap();
+
+        let file_path = format!("{}/{}", output_folder, sig);
+        let mut file = File::create(Path::new(&file_path))?;
+        file.write_all(serde_json::to_string_pretty(&tx_data)?.as_bytes())?;
+    }
+
+    Ok(())
+}
+
+pub async fn export_photon_test_data() {
+    let address = "compr6CUsB5m2jS4Y3831ztGSTnDpnKJTKS95d64XVq";
+    let output_folder = "./test_state_batched_transactions";
+
+    if let Err(e) = export_transactions(address, output_folder).await {
+        eprintln!("Error exporting transactions: {}", e);
+    }
+}

--- a/xtask/src/export_photon_test_data.rs
+++ b/xtask/src/export_photon_test_data.rs
@@ -1,18 +1,20 @@
+use std::{
+    fs::{self, File},
+    io::Write,
+    path::Path,
+    str::FromStr,
+};
+
 use clap::Parser;
 use serde_json::{json, Value};
-use solana_client::rpc_client::RpcClient;
-use solana_client::rpc_request::RpcRequest;
+use solana_client::{rpc_client::RpcClient, rpc_request::RpcRequest};
 use solana_sdk::signature::Signature;
 use solana_transaction_status::{EncodedConfirmedTransactionWithStatusMeta, UiTransactionEncoding};
-use std::fs::{self, File};
-use std::io::Write;
-use std::path::Path;
-use std::str::FromStr;
 
 #[derive(Debug, Parser)]
 pub struct Options {
     #[clap(long)]
-    test: Option<String>,
+    test_name: String,
 }
 
 async fn export_transactions(
@@ -26,7 +28,7 @@ async fn export_transactions(
 
     let transactions: Value = client.send(
         RpcRequest::Custom {
-            method: "getSignaturesForAddress".into(),
+            method: "getSignaturesForAddress",
         },
         json!([address]),
     )?;
@@ -52,11 +54,12 @@ async fn export_transactions(
     Ok(())
 }
 
-pub async fn export_photon_test_data() {
+pub async fn export_photon_test_data(opt: Options) -> anyhow::Result<()> {
     let address = "compr6CUsB5m2jS4Y3831ztGSTnDpnKJTKS95d64XVq";
-    let output_folder = "./test_state_batched_transactions";
+    let output_folder = format!("./target/{}", opt.test_name);
 
-    if let Err(e) = export_transactions(address, output_folder).await {
+    if let Err(e) = export_transactions(address, &output_folder).await {
         eprintln!("Error exporting transactions: {}", e);
     }
+    Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,6 +3,7 @@ use clap::{Parser, ValueEnum};
 mod bench;
 mod create_state_tree;
 mod create_vkeyrs_from_gnark_key;
+mod export_photon_test_data;
 mod fee;
 mod hash_set;
 mod type_sizes;
@@ -43,6 +44,7 @@ enum Command {
     /// Example:
     /// cargo xtask create-state-tree --mt-pubkey ./target/tree-keypairs/smtAvYA5UbTRyKAkAj5kHs1CmrA42t6WkVLi4c6mA1f.json --nfq-pubkey ./target/tree-keypairs/nfqAroCRkcZBgsAJDNkptKpsSWyM6cgB9XpWNNiCEC4.json --cpi-pubkey ./target/tree-keypairs/cpiAb2eNFf6MQeqMWEyEjSN3VJcD5hghujhmtdcMuZp.json --index 10 --network local
     CreateStateTree(create_state_tree::Options),
+    ExportPhotonTestData(export_photon_test_data::Options),
 }
 
 #[tokio::main]
@@ -62,5 +64,8 @@ async fn main() -> Result<(), anyhow::Error> {
         Command::Fee => fee::fees(),
         Command::HashSet(opts) => hash_set::hash_set(opts),
         Command::CreateStateTree(opts) => create_state_tree::create_state_tree(opts).await,
+        Command::ExportPhotonTestData(_opts) => {
+            Ok(export_photon_test_data::export_photon_test_data().await)
+        }
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -64,8 +64,8 @@ async fn main() -> Result<(), anyhow::Error> {
         Command::Fee => fee::fees(),
         Command::HashSet(opts) => hash_set::hash_set(opts),
         Command::CreateStateTree(opts) => create_state_tree::create_state_tree(opts).await,
-        Command::ExportPhotonTestData(_opts) => {
-            Ok(export_photon_test_data::export_photon_test_data().await)
+        Command::ExportPhotonTestData(opts) => {
+            export_photon_test_data::export_photon_test_data(opts).await
         }
     }
 }


### PR DESCRIPTION
Changes:
1. add xtask which exports transactions as json readable by photon tests from a running test ledger into a folder in target 
2. add a compressed token test to generate token test data in a batched tree
3. add a script to generate test data from forester test and compressed token test
4. `event_from_light_transaction` replace zero copy deserialization of system program instruction with borsh deserialization
5. replace relayer_fee unimplemented with error