### PR TITLE
Fix parameter naming in invoke_cpi to match Solana conventions

### DIFF
--- a/sdk-libs/sdk/src/verify.rs
+++ b/sdk-libs/sdk/src/verify.rs
@@ -169,7 +169,7 @@ pub struct InvokeCpi {
 #[inline(always)]
 pub fn invoke_cpi(
     account_infos: &[AccountInfo],
-    accounts_metas: Vec<AccountMeta>,
+    account_metas: Vec<AccountMeta>,
     inputs: Vec<u8>,
     signer_seeds: &[&[&[u8]]],
 ) -> Result<()> {
@@ -181,7 +181,7 @@ pub fn invoke_cpi(
 
     let instruction = Instruction {
         program_id: PROGRAM_ID_LIGHT_SYSTEM,
-        accounts: accounts_metas,
+        accounts: account_metas,
         data,
     };
     invoke_signed(&instruction, account_infos, signer_seeds)?;


### PR DESCRIPTION
Renamed `accounts_metas` parameter to `account_metas` in invoke_cpi function to align with standard Solana naming conventions for AccountMeta collections.