### PR TITLE
refactor: light-sdk, Light Account and LightAccountInfo

### DIFF
--- a/examples/anchor/counter/tests/test.rs
+++ b/examples/anchor/counter/tests/test.rs
@@ -17,7 +17,7 @@ use light_sdk::{
     account_meta::LightAccountMeta,
     address::derive_address,
     instruction_data::LightInstructionData,
-    merkle_context::{AddressMerkleContext, RemainingAccounts},
+    merkle_context::{AddressMerkleContext, CpiAccounts},
     utils::get_cpi_authority_pda,
     verify::find_cpi_signer,
     PROGRAM_ID_ACCOUNT_COMPRESSION, PROGRAM_ID_LIGHT_SYSTEM, PROGRAM_ID_NOOP,
@@ -61,7 +61,7 @@ async fn test_counter() {
     )
     .await;
 
-    let mut remaining_accounts = RemainingAccounts::default();
+    let mut remaining_accounts = CpiAccounts::default();
 
     let address_merkle_context = AddressMerkleContext {
         address_merkle_tree_pubkey: env.address_merkle_tree_pubkey,
@@ -208,7 +208,7 @@ async fn create_counter<R>(
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
-    remaining_accounts: &mut RemainingAccounts,
+    remaining_accounts: &mut CpiAccounts,
     payer: &Keypair,
     address: &[u8; 32],
     account_compression_authority: &Pubkey,
@@ -287,7 +287,7 @@ where
 async fn increment_counter<R>(
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
-    remaining_accounts: &mut RemainingAccounts,
+    remaining_accounts: &mut CpiAccounts,
     payer: &Keypair,
     compressed_account: &CompressedAccountWithMerkleContext,
     account_compression_authority: &Pubkey,
@@ -364,7 +364,7 @@ where
 async fn decrement_counter<R>(
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
-    remaining_accounts: &mut RemainingAccounts,
+    remaining_accounts: &mut CpiAccounts,
     payer: &Keypair,
     compressed_account: &CompressedAccountWithMerkleContext,
     account_compression_authority: &Pubkey,
@@ -440,7 +440,7 @@ where
 async fn reset_counter<R>(
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
-    remaining_accounts: &mut RemainingAccounts,
+    remaining_accounts: &mut CpiAccounts,
     payer: &Keypair,
     compressed_account: &CompressedAccountWithMerkleContext,
     account_compression_authority: &Pubkey,

--- a/examples/anchor/memo/tests/test.rs
+++ b/examples/anchor/memo/tests/test.rs
@@ -16,7 +16,7 @@ use light_sdk::{
     account_meta::LightAccountMeta,
     address::derive_address,
     instruction_data::LightInstructionData,
-    merkle_context::{AddressMerkleContext, RemainingAccounts},
+    merkle_context::{AddressMerkleContext, CpiAccounts},
     utils::get_cpi_authority_pda,
     verify::find_cpi_signer,
     PROGRAM_ID_ACCOUNT_COMPRESSION, PROGRAM_ID_LIGHT_SYSTEM, PROGRAM_ID_NOOP,
@@ -60,7 +60,7 @@ async fn test_memo_program() {
     )
     .await;
 
-    let mut remaining_accounts = RemainingAccounts::default();
+    let mut remaining_accounts = CpiAccounts::default();
 
     let address_merkle_context = AddressMerkleContext {
         address_merkle_tree_pubkey: env.address_merkle_tree_pubkey,
@@ -169,7 +169,7 @@ async fn create_memo<R>(
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
-    remaining_accounts: &mut RemainingAccounts,
+    remaining_accounts: &mut CpiAccounts,
     payer: &Keypair,
     address: &[u8; 32],
     account_compression_authority: &Pubkey,
@@ -252,7 +252,7 @@ async fn update_memo<R>(
     new_message: &str,
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
-    remaining_accounts: &mut RemainingAccounts,
+    remaining_accounts: &mut CpiAccounts,
     payer: &Keypair,
     compressed_account: &CompressedAccountWithMerkleContext,
     account_compression_authority: &Pubkey,
@@ -332,7 +332,7 @@ where
 async fn delete_memo<R>(
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
-    remaining_accounts: &mut RemainingAccounts,
+    remaining_accounts: &mut CpiAccounts,
     payer: &Keypair,
     compressed_account: &CompressedAccountWithMerkleContext,
     account_compression_authority: &Pubkey,

--- a/examples/anchor/name-service-without-macros/tests/test.rs
+++ b/examples/anchor/name-service-without-macros/tests/test.rs
@@ -19,7 +19,7 @@ use light_sdk::{
     address::derive_address,
     error::LightSdkError,
     instruction_data::LightInstructionData,
-    merkle_context::{AddressMerkleContext, RemainingAccounts},
+    merkle_context::{AddressMerkleContext, CpiAccounts},
     utils::get_cpi_authority_pda,
     verify::find_cpi_signer,
     PROGRAM_ID_ACCOUNT_COMPRESSION, PROGRAM_ID_LIGHT_SYSTEM, PROGRAM_ID_NOOP,
@@ -70,7 +70,7 @@ async fn test_name_service() {
 
     let name = "example.io";
 
-    let mut remaining_accounts = RemainingAccounts::default();
+    let mut remaining_accounts = CpiAccounts::default();
 
     let address_merkle_context = AddressMerkleContext {
         address_merkle_tree_pubkey: env.address_merkle_tree_pubkey,
@@ -295,7 +295,7 @@ async fn create_record<R>(
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
-    remaining_accounts: &mut RemainingAccounts,
+    remaining_accounts: &mut CpiAccounts,
     payer: &Keypair,
     address: &[u8; 32],
     account_compression_authority: &Pubkey,
@@ -377,7 +377,7 @@ where
 async fn update_record<R>(
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
-    remaining_accounts: &mut RemainingAccounts,
+    remaining_accounts: &mut CpiAccounts,
     new_rdata: &RData,
     payer: &Keypair,
     compressed_account: &CompressedAccountWithMerkleContext,
@@ -457,7 +457,7 @@ where
 async fn delete_record<R>(
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
-    remaining_accounts: &mut RemainingAccounts,
+    remaining_accounts: &mut CpiAccounts,
     payer: &Keypair,
     compressed_account: &CompressedAccountWithMerkleContext,
     account_compression_authority: &Pubkey,

--- a/examples/anchor/name-service/tests/test.rs
+++ b/examples/anchor/name-service/tests/test.rs
@@ -18,7 +18,7 @@ use light_sdk::{
     error::LightSdkError,
     merkle_context::{
         pack_address_merkle_context, pack_merkle_context, AddressMerkleContext, MerkleContext,
-        PackedAddressMerkleContext, PackedMerkleContext, RemainingAccounts,
+        PackedAddressMerkleContext, PackedMerkleContext, CpiAccounts,
     },
     utils::get_cpi_authority_pda,
     verify::find_cpi_signer,
@@ -60,7 +60,7 @@ async fn test_name_service() {
 
     let name = "example.io";
 
-    let mut remaining_accounts = RemainingAccounts::default();
+    let mut remaining_accounts = CpiAccounts::default();
 
     let merkle_context = MerkleContext {
         merkle_tree_pubkey: env.merkle_tree_pubkey,
@@ -299,7 +299,7 @@ async fn create_record<R>(
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
-    remaining_accounts: &mut RemainingAccounts,
+    remaining_accounts: &mut CpiAccounts,
     payer: &Keypair,
     address: &[u8; 32],
     merkle_context: &PackedMerkleContext,
@@ -365,7 +365,7 @@ where
 async fn update_record<R>(
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
-    remaining_accounts: &mut RemainingAccounts,
+    remaining_accounts: &mut CpiAccounts,
     new_rdata: &RData,
     payer: &Keypair,
     compressed_account: &CompressedAccountWithMerkleContext,
@@ -445,7 +445,7 @@ where
 async fn delete_record<R>(
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
-    remaining_accounts: &mut RemainingAccounts,
+    remaining_accounts: &mut CpiAccounts,
     payer: &Keypair,
     compressed_account: &CompressedAccountWithMerkleContext,
     address_merkle_context: &PackedAddressMerkleContext,

--- a/examples/anchor/token-escrow/src/escrow_with_compressed_pda/escrow.rs
+++ b/examples/anchor/token-escrow/src/escrow_with_compressed_pda/escrow.rs
@@ -22,7 +22,7 @@ use light_sdk::{
     light_system_accounts,
     system_accounts::{LightCpiAccounts, SystemAccountInfoConfig},
     traits::*,
-    verify::verify,
+    verify::verify_borsh,
     LightTraits,
 };
 
@@ -109,9 +109,6 @@ fn cpi_compressed_pda_transfer<'info>(
     compressed_pda: OutputCompressedAccountWithPackedContext,
     mut cpi_context: CompressedCpiContext,
 ) -> Result<()> {
-    let bump = Pubkey::find_program_address(&[b"cpi_authority"], &crate::ID).1;
-    let bump = [bump];
-    let signer_seeds = [CPI_AUTHORITY_PDA_SEED, &bump];
     cpi_context.first_set_context = false;
     // Create inputs struct
     let inputs_struct = create_cpi_inputs_for_new_account(
@@ -146,7 +143,7 @@ fn cpi_compressed_pda_transfer<'info>(
     )
     .unwrap();
 
-    verify(&light_accounts, &inputs_struct, &[&signer_seeds]).map_err(ProgramError::from)?;
+    verify_borsh(&light_accounts, &inputs_struct).map_err(ProgramError::from)?;
 
     Ok(())
 }

--- a/examples/anchor/token-escrow/src/escrow_with_compressed_pda/withdrawal.rs
+++ b/examples/anchor/token-escrow/src/escrow_with_compressed_pda/withdrawal.rs
@@ -1,4 +1,3 @@
-use account_compression::utils::constants::CPI_AUTHORITY_PDA_SEED;
 use anchor_lang::prelude::*;
 use light_compressed_account::{
     compressed_account::{
@@ -17,7 +16,7 @@ use light_hasher::{DataHasher, Poseidon};
 use light_sdk::{
     system_accounts::{LightCpiAccounts, SystemAccountInfoConfig},
     traits::*,
-    verify::verify,
+    verify::verify_borsh,
 };
 
 use crate::{
@@ -135,10 +134,6 @@ fn cpi_compressed_pda_withdrawal<'info>(
     compressed_pda: OutputCompressedAccountWithPackedContext,
     mut cpi_context: CompressedCpiContext,
 ) -> Result<()> {
-    // Create CPI signer seed
-    let bump = Pubkey::find_program_address(&[b"cpi_authority"], &crate::ID).1;
-    let bump = [bump];
-    let signer_seeds = [CPI_AUTHORITY_PDA_SEED, &bump];
     cpi_context.first_set_context = false;
 
     // Create CPI inputs
@@ -177,7 +172,7 @@ fn cpi_compressed_pda_withdrawal<'info>(
         },
     )
     .unwrap();
-    verify(&light_accounts, &inputs_struct, &[&signer_seeds]).map_err(ProgramError::from)?;
+    verify_borsh(&light_accounts, &inputs_struct).map_err(ProgramError::from)?;
 
     Ok(())
 }

--- a/program-libs/batched-merkle-tree/src/queue.rs
+++ b/program-libs/batched-merkle-tree/src/queue.rs
@@ -329,6 +329,14 @@ impl<'a> BatchedQueueAccount<'a> {
                     }
                     return Ok(true);
                 } else {
+                    #[cfg(target_os = "solana")]
+                    {
+                        solana_program::msg!(
+                            "Index found but value doesn't match leaf_index {} compressed account hash: {:?} expected compressed account hash {:?}. (If the expected element is [0u8;32] it was already spent. Other possibly causes, data hash, discriminator, leaf index, or Merkle tree mismatch.)",
+                            leaf_index,
+                            hash_chain_value,*element
+                        );
+                    }
                     return Err(BatchedMerkleTreeError::InclusionProofByIndexFailed);
                 }
             }
@@ -352,6 +360,14 @@ impl<'a> BatchedQueueAccount<'a> {
         }
         // If no value is found and a check is not enforced return ok.
         if prove_by_index {
+            #[cfg(target_os = "solana")]
+            {
+                solana_program::msg!(
+                    "leaf_index {} compressed account hash: {:?}. Possibly causes, leaf index, or Merkle tree mismatch.)",
+                    leaf_index,
+                    hash_chain_value
+                );
+            }
             Err(BatchedMerkleTreeError::InclusionProofByIndexFailed)
         } else {
             Ok(())

--- a/program-tests/sdk-anchor-test/programs/sdk-anchor-test/Cargo.toml
+++ b/program-tests/sdk-anchor-test/programs/sdk-anchor-test/Cargo.toml
@@ -23,7 +23,7 @@ idl-build = ["anchor-lang/idl-build", "light-sdk/idl-build"]
 [dependencies]
 anchor-lang = { workspace = true }
 light-hasher = { workspace = true, features = ["solana"] }
-light-sdk = { workspace = true }
+light-sdk = { workspace = true, features = ["anchor"] }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 solana-sdk = { workspace = true }

--- a/program-tests/sdk-test/src/create_pda.rs
+++ b/program-tests/sdk-test/src/create_pda.rs
@@ -1,0 +1,116 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use light_compressed_account::{
+    hashv_to_bn254_field_size_be, instruction_data::data::NewAddressParamsPacked,
+};
+use light_sdk::{
+    account::CBorshAccount,
+    error::LightSdkError,
+    instruction_data::LightInstructionData,
+    program_merkle_context::unpack_address_merkle_context,
+    system_accounts::{LightCpiAccounts, SystemAccountInfoConfig},
+    verify::verify_light_account_infos,
+    LightDiscriminator, LightHasher,
+};
+use solana_program::account_info::AccountInfo;
+
+/// CU usage:
+/// - sdk pre system program cpi 10,942 CU
+/// - total with V1 tree: 307,784 CU
+/// - total with V2 tree: 181,932 CU
+pub fn create_pda<const BATCHED: bool>(
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> Result<(), LightSdkError> {
+    let mut instruction_data = instruction_data;
+    let instruction_data = CreatePdaInstructionData::deserialize(&mut instruction_data)
+        .map_err(|_| LightSdkError::Borsh)?;
+
+    let address_merkle_context = unpack_address_merkle_context(
+        instruction_data
+            .light_ix_data
+            .new_addresses
+            .as_ref()
+            .unwrap()[0],
+        &accounts[9..],
+    );
+
+    let (address, address_seed) = if BATCHED {
+        let address_seed =
+            hashv_to_bn254_field_size_be(&[b"compressed", instruction_data.data.as_slice()]);
+        let address = light_compressed_account::address::derive_address(
+            &address_seed,
+            &address_merkle_context.address_merkle_tree_pubkey.to_bytes(),
+            &crate::ID.to_bytes(),
+        );
+        (address, address_seed)
+    } else {
+        light_sdk::address::derive_address(
+            &[b"compressed", instruction_data.data.as_slice()],
+            &address_merkle_context,
+            &crate::ID,
+        )
+    };
+    let new_address_params = NewAddressParamsPacked {
+        seed: address_seed,
+        address_queue_account_index: instruction_data
+            .light_ix_data
+            .new_addresses
+            .as_ref()
+            .unwrap()[0]
+            .address_queue_pubkey_index,
+        address_merkle_tree_root_index: instruction_data
+            .light_ix_data
+            .new_addresses
+            .as_ref()
+            .unwrap()[0]
+            .root_index,
+        address_merkle_tree_account_index: instruction_data
+            .light_ix_data
+            .new_addresses
+            .as_ref()
+            .unwrap()[0]
+            .address_merkle_tree_pubkey_index,
+    };
+
+    let program_id = crate::ID.into();
+    let mut my_compressed_account = CBorshAccount::<'_, MyCompressedAccount>::new_init(
+        &program_id,
+        Some(address),
+        instruction_data.output_merkle_tree_index,
+    );
+
+    my_compressed_account.data = instruction_data.data;
+
+    let config = SystemAccountInfoConfig {
+        self_program: crate::ID,
+        cpi_context: false,
+        sol_pool_pda: false,
+        sol_compression_recipient: false,
+    };
+    let light_cpi_accounts =
+        LightCpiAccounts::new_with_config(&accounts[0], &accounts[1..], config)?;
+
+    verify_light_account_infos(
+        &light_cpi_accounts,
+        instruction_data.light_ix_data.proof,
+        &[my_compressed_account.to_account_info()?],
+        Some(vec![new_address_params]),
+        None,
+        false,
+        None,
+    )
+}
+
+#[derive(
+    Clone, Debug, Default, LightHasher, LightDiscriminator, BorshDeserialize, BorshSerialize,
+)]
+pub struct MyCompressedAccount {
+    pub data: [u8; 31],
+}
+
+#[derive(Clone, Debug, Default, BorshDeserialize, BorshSerialize)]
+pub struct CreatePdaInstructionData {
+    pub light_ix_data: LightInstructionData,
+    pub output_merkle_tree_index: u8,
+    pub data: [u8; 31],
+}

--- a/program-tests/sdk-test/src/lib.rs
+++ b/program-tests/sdk-test/src/lib.rs
@@ -84,7 +84,7 @@ pub fn create_pda(accounts: &[AccountInfo], instruction_data: &[u8]) -> Result<(
         .map_err(ProgramError::from)?;
 
     my_compressed_account.data = account_data.try_into().unwrap();
-
+    let new_address_params = my_compressed_account.new_address_params().unwrap();
     let config = SystemAccountInfoConfig {
         self_program: crate::ID,
         cpi_context: false,
@@ -98,6 +98,7 @@ pub fn create_pda(accounts: &[AccountInfo], instruction_data: &[u8]) -> Result<(
         &light_cpi_accounts,
         inputs.proof,
         &[my_compressed_account],
+        Some(vec![new_address_params]),
         None,
         false,
         None,

--- a/program-tests/sdk-test/src/lib.rs
+++ b/program-tests/sdk-test/src/lib.rs
@@ -1,20 +1,12 @@
-use borsh::{BorshDeserialize, BorshSerialize};
-use light_hasher::Discriminator;
 use light_macros::pubkey;
-use light_sdk::{
-    account::LightAccount,
-    address::derive_address,
-    error::LightSdkError,
-    instruction_data::LightInstructionData,
-    program_merkle_context::unpack_address_merkle_context,
-    system_accounts::{LightCpiAccounts, SystemAccountInfoConfig},
-    verify::verify_light_accounts,
-    LightDiscriminator, LightHasher,
-};
+use light_sdk::error::LightSdkError;
 use solana_program::{
-    account_info::AccountInfo, entrypoint, log::sol_log_compute_units, program_error::ProgramError,
-    pubkey::Pubkey,
+    account_info::AccountInfo, entrypoint, program_error::ProgramError, pubkey::Pubkey,
 };
+
+pub mod create_pda;
+pub mod update_pda;
+
 pub const ID: Pubkey = pubkey!("FNt7byTHev1k5x2cXZLBr8TdWiC3zoP5vcnZR4P682Uy");
 
 entrypoint!(process_instruction);
@@ -22,7 +14,7 @@ entrypoint!(process_instruction);
 #[repr(u8)]
 pub enum InstructionType {
     CreatePdaBorsh = 0,
-    // TODO: add CreatePdaZeroCopy
+    UpdatePdaBorsh = 1,
 }
 
 impl TryFrom<u8> for InstructionType {
@@ -31,6 +23,7 @@ impl TryFrom<u8> for InstructionType {
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(InstructionType::CreatePdaBorsh),
+            1 => Ok(InstructionType::UpdatePdaBorsh),
             _ => panic!("Invalid instruction discriminator."),
         }
     }
@@ -41,74 +34,14 @@ pub fn process_instruction(
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> Result<(), ProgramError> {
-    sol_log_compute_units();
     let discriminator = InstructionType::try_from(instruction_data[0]).unwrap();
     match discriminator {
-        InstructionType::CreatePdaBorsh => create_pda(accounts, &instruction_data[1..]),
+        InstructionType::CreatePdaBorsh => {
+            create_pda::create_pda::<true>(accounts, &instruction_data[1..])
+        }
+        InstructionType::UpdatePdaBorsh => {
+            update_pda::update_pda::<false>(accounts, &instruction_data[1..])
+        }
     }?;
     Ok(())
-}
-
-pub fn create_pda(accounts: &[AccountInfo], instruction_data: &[u8]) -> Result<(), LightSdkError> {
-    let (instruction_data, inputs) = LightInstructionData::deserialize(instruction_data)?;
-    let account_data = &instruction_data[..31];
-
-    let address_merkle_context = unpack_address_merkle_context(
-        inputs.accounts.as_ref().unwrap()[0]
-            .address_merkle_context
-            .unwrap(),
-        &accounts[9..],
-    );
-    solana_program::msg!(
-        "create_pda address_merkle_context {:?}",
-        address_merkle_context
-    );
-    solana_program::msg!("create_pda account_data {:?}", account_data);
-    let (address, address_seed) = derive_address(
-        &[b"compressed", account_data],
-        &address_merkle_context,
-        &crate::ID,
-    );
-    solana_program::msg!("create_pda address {:?}", address);
-    solana_program::msg!("create_pda address_seed {:?}", address_seed);
-
-    let account_meta = &inputs.accounts.unwrap()[0];
-    let mut my_compressed_account: LightAccount<'_, MyCompressedAccount> =
-        LightAccount::from_meta_init(
-            account_meta,
-            MyCompressedAccount::discriminator(),
-            address,
-            address_seed,
-            &crate::ID,
-        )
-        .map_err(ProgramError::from)?;
-
-    my_compressed_account.data = account_data.try_into().unwrap();
-    let new_address_params = my_compressed_account.new_address_params().unwrap();
-    let config = SystemAccountInfoConfig {
-        self_program: crate::ID,
-        cpi_context: false,
-        sol_pool_pda: false,
-        sol_compression_recipient: false,
-    };
-    let light_cpi_accounts =
-        LightCpiAccounts::new_with_config(&accounts[0], &accounts[1..], config)?;
-    solana_program::msg!("my_compressed_account {:?}", my_compressed_account);
-    verify_light_accounts(
-        &light_cpi_accounts,
-        inputs.proof,
-        &[my_compressed_account],
-        Some(vec![new_address_params]),
-        None,
-        false,
-        None,
-    )
-}
-
-// TODO: add account traits
-#[derive(
-    Clone, Debug, Default, LightHasher, LightDiscriminator, BorshDeserialize, BorshSerialize,
-)]
-pub struct MyCompressedAccount {
-    data: [u8; 31],
 }

--- a/program-tests/sdk-test/src/update_pda.rs
+++ b/program-tests/sdk-test/src/update_pda.rs
@@ -1,0 +1,67 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use light_sdk::{
+    account::CBorshAccount,
+    account_meta::InputAccountMeta,
+    error::LightSdkError,
+    instruction_data::LightInstructionData,
+    system_accounts::{LightCpiAccounts, SystemAccountInfoConfig},
+    verify::verify_light_account_infos,
+};
+use solana_program::account_info::AccountInfo;
+
+use crate::create_pda::MyCompressedAccount;
+
+/// CU usage:
+/// - sdk pre system program  10,902k CU
+/// - total with V2 tree: 78,074 CU (proof by index)
+pub fn update_pda<const BATCHED: bool>(
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> Result<(), LightSdkError> {
+    let mut instruction_data = instruction_data;
+    let instruction_data = UpdatePdaInstructionData::deserialize(&mut instruction_data)
+        .map_err(|_| LightSdkError::Borsh)?;
+
+    let program_id = crate::ID.into();
+    let mut my_compressed_account = CBorshAccount::<'_, MyCompressedAccount>::new_mut(
+        &program_id,
+        &instruction_data.my_compressed_account.meta,
+        MyCompressedAccount {
+            data: instruction_data.my_compressed_account.data,
+        },
+    )?;
+
+    my_compressed_account.data = instruction_data.new_data;
+
+    let config = SystemAccountInfoConfig {
+        self_program: crate::ID,
+        cpi_context: false,
+        sol_pool_pda: false,
+        sol_compression_recipient: false,
+    };
+    let light_cpi_accounts =
+        LightCpiAccounts::new_with_config(&accounts[0], &accounts[1..], config)?;
+
+    verify_light_account_infos(
+        &light_cpi_accounts,
+        instruction_data.light_ix_data.proof,
+        &[my_compressed_account.to_account_info()?],
+        None,
+        None,
+        false,
+        None,
+    )
+}
+
+#[derive(Clone, Debug, Default, BorshDeserialize, BorshSerialize)]
+pub struct UpdatePdaInstructionData {
+    pub light_ix_data: LightInstructionData,
+    pub my_compressed_account: UpdateMyCompressedAccount,
+    pub new_data: [u8; 31],
+}
+
+#[derive(Clone, Debug, Default, BorshDeserialize, BorshSerialize)]
+pub struct UpdateMyCompressedAccount {
+    pub meta: InputAccountMeta,
+    pub data: [u8; 31],
+}

--- a/program-tests/sdk-test/tests/test.rs
+++ b/program-tests/sdk-test/tests/test.rs
@@ -1,9 +1,13 @@
 #![cfg(feature = "test-sbf")]
-use std::{println, vec};
 
+use borsh::BorshSerialize;
 use light_client::{
-    indexer::{AddressMerkleTreeAccounts, Indexer, StateMerkleTreeAccounts},
-    rpc::RpcConnection,
+    indexer::Indexer,
+    rpc::{RpcConnection, RpcError},
+};
+use light_compressed_account::{
+    address::derive_address, compressed_account::CompressedAccountWithMerkleContext,
+    hashv_to_bn254_field_size_be,
 };
 use light_program_test::{
     indexer::{TestIndexer, TestIndexerExtensions},
@@ -12,13 +16,20 @@ use light_program_test::{
 };
 use light_prover_client::gnark::helpers::{ProofType, ProverConfig};
 use light_sdk::{
-    account_meta::LightAccountMeta,
-    address::derive_address,
+    account_meta::InputAccountMeta,
     instruction_data::LightInstructionData,
-    merkle_context::{AddressMerkleContext, RemainingAccounts},
+    merkle_context::{pack_address_merkle_context, AddressMerkleContext, CpiAccounts},
     system_accounts::SystemAccountMetaConfig,
 };
-use solana_sdk::{instruction::Instruction, signature::Signer};
+use sdk_test::{
+    create_pda::CreatePdaInstructionData,
+    update_pda::{UpdateMyCompressedAccount, UpdatePdaInstructionData},
+};
+use solana_sdk::{
+    instruction::Instruction,
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+};
 
 #[tokio::test]
 async fn test_sdk_test() {
@@ -27,96 +38,205 @@ async fn test_sdk_test() {
             .await;
     let payer = rpc.get_payer().insecure_clone();
 
-    let mut test_indexer: TestIndexer<ProgramTestRpcConnection> = TestIndexer::new(
-        vec![StateMerkleTreeAccounts {
-            merkle_tree: env.merkle_tree_pubkey,
-            nullifier_queue: env.nullifier_queue_pubkey,
-            cpi_context: env.cpi_context_account_pubkey,
-        }],
-        vec![AddressMerkleTreeAccounts {
-            merkle_tree: env.address_merkle_tree_pubkey,
-            queue: env.address_merkle_tree_queue_pubkey,
-        }],
-        payer.insecure_clone(),
-        env.group_pda,
+    let mut test_indexer: TestIndexer<ProgramTestRpcConnection> = TestIndexer::init_from_env(
+        &payer,
+        &env,
+        // None,
         Some(ProverConfig {
             circuits: vec![ProofType::Inclusion, ProofType::NonInclusion],
             run_mode: None,
         }),
     )
     .await;
-    let system_account_meta_config = SystemAccountMetaConfig {
-        self_program: sdk_test::ID,
-        ..SystemAccountMetaConfig::default()
-    };
-    let mut accounts = RemainingAccounts::default();
-    accounts.insert_or_get_signer_mut(payer.pubkey());
-    accounts.add_system_accounts(system_account_meta_config);
-
-    let mut remaining_accounts = RemainingAccounts::default();
 
     let address_merkle_context = AddressMerkleContext {
-        address_merkle_tree_pubkey: env.address_merkle_tree_pubkey,
-        address_queue_pubkey: env.address_merkle_tree_queue_pubkey,
+        address_merkle_tree_pubkey: env.batch_address_merkle_tree,
+        address_queue_pubkey: env.batch_address_merkle_tree,
     };
 
     let account_data = [1u8; 31];
 
-    let (address, _) = derive_address(
-        &[b"compressed", &account_data],
-        &address_merkle_context,
-        &sdk_test::ID,
+    // // V1 trees
+    // let (address, _) = light_sdk::address::derive_address(
+    //     &[b"compressed", &account_data],
+    //     &address_merkle_context,
+    //     &sdk_test::ID,
+    // );
+    // Batched trees
+    let address_seed = hashv_to_bn254_field_size_be(&[b"compressed", account_data.as_slice()]);
+    let address = derive_address(
+        &address_seed,
+        &address_merkle_context.address_merkle_tree_pubkey.to_bytes(),
+        &sdk_test::ID.to_bytes(),
     );
-    println!("offchain address {:?}", address);
-    {
-        let rpc_result = test_indexer
-            .create_proof_for_compressed_accounts(
-                None,
-                None,
-                Some(&[address]),
-                Some(vec![env.address_merkle_tree_pubkey]),
-                &mut rpc,
-            )
-            .await
-            .unwrap();
 
-        let address_merkle_context = AddressMerkleContext {
-            address_merkle_tree_pubkey: env.address_merkle_tree_pubkey,
-            address_queue_pubkey: env.address_merkle_tree_queue_pubkey,
-        };
-        let account = LightAccountMeta::new_init(
-            &env.merkle_tree_pubkey,
-            Some(&address_merkle_context),
-            Some(rpc_result.address_root_indices[0]),
-            &mut remaining_accounts,
+    create_pda(
+        &payer,
+        &mut rpc,
+        &mut test_indexer,
+        &env.batched_output_queue,
+        account_data,
+        address_merkle_context,
+        address,
+    )
+    .await
+    .unwrap();
+
+    let compressed_pda = test_indexer
+        .get_compressed_accounts_by_owner_v2(&sdk_test::ID)
+        .await
+        .unwrap()[0]
+        .clone();
+    assert_eq!(compressed_pda.compressed_account.address.unwrap(), address);
+
+    update_pda(
+        &payer,
+        &mut rpc,
+        &mut test_indexer,
+        [2u8; 31],
+        compressed_pda,
+        env.batched_output_queue,
+    )
+    .await
+    .unwrap();
+}
+
+pub async fn create_pda(
+    payer: &Keypair,
+    rpc: &mut ProgramTestRpcConnection,
+    test_indexer: &mut TestIndexer<ProgramTestRpcConnection>,
+    merkle_tree_pubkey: &Pubkey,
+    account_data: [u8; 31],
+    address_merkle_context: AddressMerkleContext,
+    address: [u8; 32],
+) -> Result<(), RpcError> {
+    let system_account_meta_config = SystemAccountMetaConfig::new(sdk_test::ID);
+    let mut accounts = CpiAccounts::default();
+    accounts.insert_or_get_signer_mut(payer.pubkey());
+    accounts.add_system_accounts(system_account_meta_config);
+
+    let mut light_cpi_accounts = CpiAccounts::default();
+
+    let rpc_result = test_indexer
+        .create_proof_for_compressed_accounts(
+            None,
+            None,
+            Some(&[address]),
+            Some(vec![address_merkle_context.address_merkle_tree_pubkey]),
+            rpc,
         )
+        .await
         .unwrap();
 
-        let inputs = LightInstructionData {
-            proof: Some(rpc_result),
-            accounts: Some(vec![account]),
-        };
-        let inputs = inputs.serialize().unwrap();
+    let output_merkle_tree_index = light_cpi_accounts.insert_or_get(*merkle_tree_pubkey);
+    let packed_address_merkle_context = pack_address_merkle_context(
+        &address_merkle_context,
+        &mut light_cpi_accounts,
+        rpc_result.address_root_indices[0],
+    );
+    let light_ix_data = LightInstructionData {
+        proof: Some(rpc_result.proof),
+        new_addresses: Some(vec![packed_address_merkle_context]),
+    };
+    let instruction_data = CreatePdaInstructionData {
+        light_ix_data,
+        data: account_data,
+        output_merkle_tree_index,
+    };
+    let inputs = instruction_data.try_to_vec().unwrap();
 
-        let system_accounts = accounts.to_account_metas();
-        let remaining_accounts = remaining_accounts.to_account_metas();
-        let accounts = vec![system_accounts, remaining_accounts].concat();
-        let instruction = Instruction {
-            program_id: sdk_test::ID,
-            accounts,
-            data: [&[0u8][..], &inputs[..], &account_data[..]].concat(),
-        };
+    let system_accounts = accounts.to_account_metas();
+    let light_cpi_accounts = light_cpi_accounts.to_account_metas();
+    let accounts = [system_accounts, light_cpi_accounts].concat();
+    let instruction = Instruction {
+        program_id: sdk_test::ID,
+        accounts,
+        data: [&[0u8][..], &inputs[..]].concat(),
+    };
 
-        let (event, _, slot) = rpc
-            .create_and_send_transaction_with_public_event(
-                &[instruction],
-                &payer.pubkey(),
-                &[&payer],
-                None,
+    let (event, _, slot) = rpc
+        .create_and_send_transaction_with_public_event(
+            &[instruction],
+            &payer.pubkey(),
+            &[payer],
+            None,
+        )
+        .await?
+        .unwrap();
+    test_indexer.add_event_and_compressed_accounts(slot, &event);
+    Ok(())
+}
+
+pub async fn update_pda(
+    payer: &Keypair,
+    rpc: &mut ProgramTestRpcConnection,
+    test_indexer: &mut TestIndexer<ProgramTestRpcConnection>,
+    new_account_data: [u8; 31],
+    compressed_account: CompressedAccountWithMerkleContext,
+    output_merkle_tree: Pubkey,
+) -> Result<(), RpcError> {
+    let system_account_meta_config = SystemAccountMetaConfig::new(sdk_test::ID);
+    let mut accounts = CpiAccounts::default();
+    accounts.insert_or_get_signer_mut(payer.pubkey());
+    accounts.add_system_accounts(system_account_meta_config);
+
+    let mut light_cpi_accounts = CpiAccounts::default();
+
+    let rpc_result = test_indexer
+        .create_proof_for_compressed_accounts2(
+            Some(vec![compressed_account.hash().unwrap()]),
+            Some(vec![compressed_account.merkle_context.merkle_tree_pubkey]),
+            None,
+            None,
+            rpc,
+        )
+        .await;
+
+    let light_ix_data = LightInstructionData {
+        proof: rpc_result.proof,
+        new_addresses: None,
+    };
+
+    let instruction_data = UpdatePdaInstructionData {
+        my_compressed_account: UpdateMyCompressedAccount {
+            meta: InputAccountMeta::from_compressed_account(
+                &compressed_account,
+                &mut light_cpi_accounts,
+                rpc_result.root_indices[0],
+                &output_merkle_tree,
             )
-            .await
-            .unwrap()
-            .unwrap();
-        test_indexer.add_compressed_accounts_with_token_data(slot, &event);
-    }
+            .unwrap(),
+            data: compressed_account
+                .compressed_account
+                .data
+                .unwrap()
+                .data
+                .try_into()
+                .unwrap(),
+        },
+        light_ix_data,
+        new_data: new_account_data,
+    };
+    let inputs = instruction_data.try_to_vec().unwrap();
+
+    let system_accounts = accounts.to_account_metas();
+    let light_cpi_accounts = light_cpi_accounts.to_account_metas();
+    let accounts = [system_accounts, light_cpi_accounts].concat();
+    let instruction = Instruction {
+        program_id: sdk_test::ID,
+        accounts,
+        data: [&[1u8][..], &inputs[..]].concat(),
+    };
+
+    let (event, _, slot) = rpc
+        .create_and_send_transaction_with_public_event(
+            &[instruction],
+            &payer.pubkey(),
+            &[payer],
+            None,
+        )
+        .await?
+        .unwrap();
+    test_indexer.add_compressed_accounts_with_token_data(slot, &event);
+    Ok(())
 }

--- a/sdk-libs/sdk/src/account.rs
+++ b/sdk-libs/sdk/src/account.rs
@@ -1,180 +1,180 @@
-use std::{
-    fmt::Debug,
-    ops::{Deref, DerefMut},
-};
+use std::ops::{Deref, DerefMut};
 
-use light_compressed_account::{
-    compressed_account::{
-        CompressedAccount, CompressedAccountData, PackedCompressedAccountWithMerkleContext,
-    },
-    instruction_data::data::{
-        NewAddressParamsPacked as PackedNewAddressParams, OutputCompressedAccountWithPackedContext,
-    },
-};
+use borsh::{BorshDeserialize, BorshSerialize};
+use light_compressed_account::pubkey::Pubkey;
 use light_hasher::{DataHasher, Discriminator, Poseidon};
-use solana_program::pubkey::Pubkey;
 
 use crate::{
-    account_info::LightAccountInfo,
-    account_meta::LightAccountMeta,
-    error::{LightSdkError, Result},
-    BorshDeserialize, BorshSerialize,
+    account_info::{CAccountInfo, CInAccountInfo, COutAccountInfo},
+    account_meta::InputAccountMetaTrait,
+    error::LightSdkError,
 };
-pub trait LightAccounts<'a>: Sized {
-    fn try_light_accounts(accounts: &'a [LightAccountInfo]) -> Result<Self>;
+
+#[derive(Debug, PartialEq)]
+pub struct CBorshAccount<
+    'a,
+    A: BorshSerialize + BorshDeserialize + Discriminator + DataHasher + Default,
+> {
+    owner: &'a Pubkey,
+    pub account: A,
+    account_info: CAccountInfo,
 }
 
-// TODO: replace Borsh trait bound with custom deserialize that can be implemented and can be borsh
-/// A wrapper which abstracts away the UTXO model.
-#[derive(Debug)]
-pub struct LightAccount<'info, T>
-where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Default + Discriminator + Debug,
+impl<'a, A: BorshSerialize + BorshDeserialize + Discriminator + DataHasher + Default>
+    CBorshAccount<'a, A>
 {
-    /// State of the output account which can be modified by the developer in
-    /// the program code.
-    account_state: T,
-    /// Account information.
-    account_info: LightAccountInfo<'info>,
-}
-
-impl<'info, T> LightAccount<'info, T>
-where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Default + Discriminator + Debug,
-{
-    pub fn from_meta_init(
-        meta: &'info LightAccountMeta,
-        discriminator: [u8; 8],
-        new_address: [u8; 32],
-        new_address_seed: [u8; 32],
-        owner: &'info Pubkey,
-    ) -> Result<Self> {
-        let account_state = T::default();
-        let account_info = LightAccountInfo::from_meta_init_without_output_data(
-            meta,
-            discriminator,
-            new_address,
-            new_address_seed,
+    pub fn new_init(
+        owner: &'a Pubkey,
+        address: Option<[u8; 32]>,
+        output_merkle_tree_index: u8,
+    ) -> Self {
+        let output_account_info = COutAccountInfo {
+            output_merkle_tree_index,
+            ..Default::default()
+        };
+        Self {
             owner,
-        )?;
-        Ok(Self {
-            account_state,
-            account_info,
-        })
-    }
-
-    pub fn from_meta_mut(
-        meta: &'info LightAccountMeta,
-        discriminator: [u8; 8],
-        owner: &'info Pubkey,
-    ) -> Result<Self> {
-        let mut account_info =
-            LightAccountInfo::from_meta_without_output_data(meta, discriminator, owner)?;
-        let account_state = T::try_from_slice(
-            meta.data
-                .as_ref()
-                .ok_or(LightSdkError::ExpectedData)?
-                .as_slice(),
-        )
-        .map_err(|_| LightSdkError::Borsh)?;
-        let input_hash = account_state.hash::<Poseidon>()?;
-
-        // Set the input account hash.
-        //
-        // PANICS: At this point we are sure `input` is `Some`
-        account_info.input.as_mut().unwrap().data_hash = Some(input_hash);
-
-        Ok(Self {
-            account_state,
-            account_info,
-        })
-    }
-
-    pub fn from_meta_close(
-        meta: &'info LightAccountMeta,
-        discriminator: [u8; 8],
-        owner: &'info Pubkey,
-    ) -> Result<Self> {
-        let mut account_info =
-            LightAccountInfo::from_meta_without_output_data(meta, discriminator, owner)?;
-        let account_state = T::try_from_slice(
-            meta.data
-                .as_ref()
-                .ok_or(LightSdkError::ExpectedData)?
-                .as_slice(),
-        )
-        .map_err(|_| LightSdkError::Borsh)?;
-        let input_hash = account_state.hash::<Poseidon>()?;
-
-        // Set the input account hash.
-        //
-        // PANICS: At this point we are sure `input` is `Some`
-        account_info.input.as_mut().unwrap().data_hash = Some(input_hash);
-
-        Ok(Self {
-            account_state,
-            account_info,
-        })
-    }
-
-    pub fn new_address_params(&self) -> Option<PackedNewAddressParams> {
-        self.account_info.new_address_params
-    }
-
-    pub fn input_compressed_account(
-        &self,
-    ) -> Result<Option<PackedCompressedAccountWithMerkleContext>> {
-        self.account_info.input_compressed_account()
-    }
-
-    pub fn output_compressed_account(
-        &self,
-    ) -> Result<Option<OutputCompressedAccountWithPackedContext>> {
-        match self.account_info.output_merkle_tree_index {
-            Some(merkle_tree_index) => {
-                let data = {
-                    let discriminator = T::discriminator();
-                    let data_hash = self.account_state.hash::<Poseidon>()?;
-                    Some(CompressedAccountData {
-                        discriminator,
-                        data: self
-                            .account_state
-                            .try_to_vec()
-                            .map_err(|_| LightSdkError::Borsh)?,
-                        data_hash,
-                    })
-                };
-                Ok(Some(OutputCompressedAccountWithPackedContext {
-                    compressed_account: CompressedAccount {
-                        owner: *self.account_info.owner,
-                        lamports: self.account_info.lamports.unwrap_or(0),
-                        address: self.account_info.address,
-                        data,
-                    },
-                    merkle_tree_index,
-                }))
-            }
-            None => Ok(None),
+            account: A::default(),
+            account_info: CAccountInfo {
+                discriminator: A::discriminator(),
+                address,
+                input: None,
+                output: Some(output_account_info),
+            },
         }
     }
-}
 
-impl<T> Deref for LightAccount<'_, T>
-where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Default + Discriminator + Debug,
-{
-    type Target = T;
+    pub fn new_mut(
+        owner: &'a Pubkey,
+        input_account_meta: &impl InputAccountMetaTrait,
+        input_account: A,
+    ) -> Result<Self, LightSdkError> {
+        let input_account_info = {
+            let input_data_hash = input_account.hash::<Poseidon>()?;
+            CInAccountInfo {
+                data_hash: input_data_hash,
+                lamports: input_account_meta.get_lamports().unwrap_or_default(),
+                merkle_context: *input_account_meta.get_merkle_context(),
+                root_index: input_account_meta.get_root_index().unwrap_or_default(),
+            }
+        };
+        let output_account_info = {
+            COutAccountInfo {
+                lamports: input_account_meta.get_lamports().unwrap_or_default(),
+                output_merkle_tree_index: input_account_meta.get_output_merkle_tree_index(),
+                ..Default::default()
+            }
+        };
 
-    fn deref(&self) -> &Self::Target {
-        &self.account_state
+        Ok(Self {
+            owner,
+            account: input_account,
+            account_info: CAccountInfo {
+                discriminator: A::discriminator(),
+                address: input_account_meta.get_address(),
+                input: Some(input_account_info),
+                output: Some(output_account_info),
+            },
+        })
+    }
+
+    pub fn new_close(
+        owner: &'a Pubkey,
+        input_account_meta: &impl InputAccountMetaTrait,
+        input_account: A,
+    ) -> Result<Self, LightSdkError> {
+        let input_account_info = {
+            let input_data_hash = input_account.hash::<Poseidon>()?;
+            CInAccountInfo {
+                data_hash: input_data_hash,
+                lamports: input_account_meta.get_lamports().unwrap_or_default(),
+                merkle_context: *input_account_meta.get_merkle_context(),
+                root_index: input_account_meta.get_root_index().unwrap_or_default(),
+            }
+        };
+        Ok(Self {
+            owner,
+            account: input_account,
+            account_info: CAccountInfo {
+                discriminator: A::discriminator(),
+                address: input_account_meta.get_address(),
+                input: Some(input_account_info),
+                output: None,
+            },
+        })
+    }
+
+    pub fn discriminator(&self) -> &[u8; 8] {
+        &self.account_info.discriminator
+    }
+
+    pub fn lamports(&self) -> u64 {
+        if let Some(output) = self.account_info.output.as_ref() {
+            output.lamports
+        } else if let Some(input) = self.account_info.input.as_ref() {
+            input.lamports
+        } else {
+            0
+        }
+    }
+
+    pub fn lamports_mut(&mut self) -> &mut u64 {
+        if let Some(output) = self.account_info.output.as_mut() {
+            &mut output.lamports
+        } else if let Some(input) = self.account_info.input.as_mut() {
+            &mut input.lamports
+        } else {
+            panic!("No lamports field available in account_info")
+        }
+    }
+
+    pub fn address(&self) -> &Option<[u8; 32]> {
+        &self.account_info.address
+    }
+
+    pub fn owner(&self) -> &Pubkey {
+        self.owner
+    }
+
+    pub fn in_account_info(&self) -> &Option<CInAccountInfo> {
+        &self.account_info.input
+    }
+
+    pub fn out_account_info(&mut self) -> &Option<COutAccountInfo> {
+        &self.account_info.output
+    }
+
+    /// 1. Serializes the account data and sets the output data hash.
+    /// 2. Returns CAccountInfo.
+    ///
+    /// Note this is an expensive operation
+    /// that should only be called once per instruction.
+    pub fn to_account_info(mut self) -> Result<CAccountInfo, LightSdkError> {
+        if let Some(output) = self.account_info.output.as_mut() {
+            output.data_hash = self.account.hash::<Poseidon>()?;
+            output.data = self
+                .account
+                .try_to_vec()
+                .map_err(|_| LightSdkError::Borsh)?;
+        }
+        Ok(self.account_info)
     }
 }
 
-impl<T> DerefMut for LightAccount<'_, T>
-where
-    T: BorshDeserialize + BorshSerialize + Clone + DataHasher + Default + Discriminator + Debug,
+impl<A: BorshSerialize + BorshDeserialize + Discriminator + DataHasher + Default> Deref
+    for CBorshAccount<'_, A>
 {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.account_state
+    type Target = A;
+
+    fn deref(&self) -> &Self::Target {
+        &self.account
+    }
+}
+
+impl<A: BorshSerialize + BorshDeserialize + Discriminator + DataHasher + Default> DerefMut
+    for CBorshAccount<'_, A>
+{
+    fn deref_mut(&mut self) -> &mut <Self as Deref>::Target {
+        &mut self.account
     }
 }

--- a/sdk-libs/sdk/src/account_info.rs
+++ b/sdk-libs/sdk/src/account_info.rs
@@ -1,318 +1,219 @@
-use std::{cell::RefCell, rc::Rc};
-
+use borsh::{BorshDeserialize, BorshSerialize};
 use light_compressed_account::{
     compressed_account::{
         CompressedAccount, CompressedAccountData, PackedCompressedAccountWithMerkleContext,
-        PackedMerkleContext,
+        PackedMerkleContext, PackedReadOnlyCompressedAccount,
     },
-    instruction_data::data::{
-        NewAddressParamsPacked as PackedNewAddressParams, OutputCompressedAccountWithPackedContext,
+    instruction_data::{
+        compressed_proof::CompressedProof,
+        cpi_context::CompressedCpiContext,
+        data::{
+            NewAddressParamsPacked, OutputCompressedAccountWithPackedContext, PackedReadOnlyAddress,
+        },
     },
-};
-use solana_program::pubkey::Pubkey;
-
-use crate::{
-    account_meta::LightAccountMeta,
-    error::{LightSdkError, Result},
+    pubkey::Pubkey,
+    CompressedAccountError,
 };
 
-/// Information about compressed account which is being initialized.
-#[derive(Debug)]
-pub struct LightInputAccountInfo<'a> {
-    /// Lamports.
-    pub lamports: Option<u64>,
-    /// Address.
-    pub address: Option<[u8; 32]>,
-    /// Account data.
-    pub data: Option<&'a [u8]>,
-    /// Data hash.
-    pub data_hash: Option<[u8; 32]>,
+use crate::{account_meta::InputAccountMetaTrait, error::LightSdkError};
+
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
+pub struct SystemInfoInstructionData {
+    pub bump: u8,
+    pub invoking_program_id: Pubkey,
+    pub is_compress: bool,
+    pub compress_or_decompress_lamports: u64,
+    pub cpi_context: CompressedCpiContext,
+    pub proof: Option<CompressedProof>,
+    pub new_addresses: Vec<NewAddressParamsPacked>,
+    pub read_only_accounts: Vec<PackedReadOnlyCompressedAccount>,
+    pub read_only_addresses: Vec<PackedReadOnlyAddress>,
+    pub light_account_infos: Vec<CAccountInfo>,
+}
+
+#[derive(Debug, Default, PartialEq, BorshSerialize, BorshDeserialize)]
+pub struct CInAccountInfo {
+    /// Data hash
+    pub data_hash: [u8; 32],
     /// Merkle tree context.
     pub merkle_context: PackedMerkleContext,
     /// Root index.
     pub root_index: u16,
-}
-
-/// Information about compressed account which is being mutated.
-#[derive(Debug)]
-pub struct LightAccountInfo<'a> {
-    /// Input account.
-    pub(crate) input: Option<LightInputAccountInfo<'a>>,
-    /// Owner of the account.
-    ///
-    /// Defaults to the program ID.
-    pub owner: &'a Pubkey,
     /// Lamports.
-    pub lamports: Option<u64>,
-    /// Discriminator.
-    pub discriminator: Option<[u8; 8]>,
-    /// Account data.
-    pub data: Option<Rc<RefCell<Vec<u8>>>>,
-    /// Data hash.
-    pub data_hash: Option<[u8; 32]>,
-    /// Address.
-    pub address: Option<[u8; 32]>,
-    /// New Merkle tree index. Set `None` for `close` account infos.
-    pub output_merkle_tree_index: Option<u8>,
-    /// New address parameters.
-    pub new_address_params: Option<PackedNewAddressParams>,
+    pub lamports: u64,
 }
 
-impl<'a> LightAccountInfo<'a> {
-    pub fn from_meta_init(
-        meta: &'a LightAccountMeta,
+#[derive(Debug, Default, PartialEq, BorshSerialize, BorshDeserialize)]
+pub struct COutAccountInfo {
+    /// Data hash
+    pub data_hash: [u8; 32],
+    pub output_merkle_tree_index: u8,
+    /// Lamports.
+    pub lamports: u64,
+    /// Account data.
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Default, PartialEq, BorshSerialize, BorshDeserialize)]
+pub struct CAccountInfo {
+    // TODO: optimize parsing by manually implementing ZeroCopy and using the bitmask.
+    // bitmask: u8,
+    pub discriminator: [u8; 8], // 1
+    /// Address.
+    pub address: Option<[u8; 32]>, // 2
+    /// Input account.
+    pub input: Option<CInAccountInfo>, // 3
+    /// Output account.
+    pub output: Option<COutAccountInfo>, // 5
+}
+
+impl CInAccountInfo {
+    pub fn from_input_meta<T: InputAccountMetaTrait>(&mut self, meta: &T, data_hash: [u8; 32]) {
+        if let Some(input_lamports) = meta.get_lamports() {
+            self.lamports = input_lamports;
+        }
+        self.data_hash = data_hash;
+        if let Some(root_index) = meta.get_root_index().as_ref() {
+            self.root_index = *root_index;
+        }
+        self.merkle_context = *meta.get_merkle_context();
+    }
+}
+
+impl CAccountInfo {
+    /// Initializes a compressed account info with address.
+    /// 1. The account is zeroed, data has to be added in a separate step.
+    /// 2. Once data is added the data hash has to be added.
+    pub fn init(
+        &mut self,
         discriminator: [u8; 8],
-        new_address: [u8; 32],
-        new_address_seed: [u8; 32],
-        space: Option<usize>,
-        owner: &'a Pubkey,
-    ) -> Result<Self> {
-        let address_merkle_context = meta
-            .address_merkle_context
-            .as_ref()
-            .ok_or(LightSdkError::ExpectedAddressMerkleContext)?;
-
-        let new_address_params = PackedNewAddressParams {
-            seed: new_address_seed,
-            address_queue_account_index: address_merkle_context.address_queue_pubkey_index,
-            address_merkle_tree_account_index: address_merkle_context
-                .address_merkle_tree_pubkey_index,
-            address_merkle_tree_root_index: meta
-                .address_merkle_tree_root_index
-                .ok_or(LightSdkError::ExpectedAddressRootIndex)?,
-        };
-
-        let data = match space {
-            Some(space) => Vec::with_capacity(space),
-            None => Vec::new(),
-        };
-        let data = Some(Rc::new(RefCell::new(data)));
-
-        let account_info = LightAccountInfo {
-            input: None,
-            owner,
-            // Needs to be assigned by the program.
-            lamports: None,
-            // Needs to be assigned by the program.
-            discriminator: Some(discriminator),
-            data,
-            // Needs to be assigned by the program.
-            data_hash: None,
-            address: Some(new_address),
-            output_merkle_tree_index: meta.output_merkle_tree_index,
-            new_address_params: Some(new_address_params),
-        };
-        Ok(account_info)
+        address: Option<[u8; 32]>,
+        output_merkle_tree_index: u8,
+    ) -> Result<(), CompressedAccountError> {
+        self.discriminator = discriminator;
+        if let Some(self_address) = self.address.as_mut() {
+            if let Some(address) = address {
+                self_address.copy_from_slice(&address);
+            } else {
+                solana_program::msg!("init: address is none");
+                return Err(CompressedAccountError::InvalidAccountSize);
+            }
+        } else {
+            solana_program::msg!("init_with_address: address is none");
+            return Err(CompressedAccountError::InvalidAccountSize);
+        }
+        if let Some(output) = self.output.as_mut() {
+            output.output_merkle_tree_index = output_merkle_tree_index;
+        } else {
+            solana_program::msg!("init_with_address: output is none");
+            return Err(CompressedAccountError::InvalidAccountSize);
+        }
+        Ok(())
     }
 
-    pub fn from_meta_mut(
-        meta: &'a LightAccountMeta,
+    /// Initializes a compressed account info with address.
+    /// 1. The account is zeroed, data has to be added in a separate step.
+    /// 2. Once data is added the data hash has to be added.
+    pub fn from_meta_mut<M: InputAccountMetaTrait>(
+        &mut self,
+        // Input
+        input_account_meta: &M,
+        input_data_hash: [u8; 32],
         discriminator: [u8; 8],
-        owner: &'a Pubkey,
-    ) -> Result<Self> {
-        let input = LightInputAccountInfo {
-            lamports: meta.lamports,
-            address: meta.address,
-            data: meta.data.as_deref(),
-            // Needs to be assigned by the program.
-            data_hash: None,
-            merkle_context: meta
-                .merkle_context
-                .ok_or(LightSdkError::ExpectedMerkleContext)?,
-            root_index: meta
-                .merkle_tree_root_index
-                .ok_or(LightSdkError::ExpectedRootIndex)?,
-        };
+        output_merkle_tree_index: u8,
+    ) -> Result<(), CompressedAccountError> {
+        if self.discriminator != [0; 8] {
+            solana_program::msg!(
+                "from_z_meta_mut: discriminator is not zeroed. Account already loaded."
+            );
+            return Err(CompressedAccountError::InvalidAccountSize);
+        }
+        self.discriminator = discriminator;
 
-        let account_info = LightAccountInfo {
-            input: Some(input),
-            owner,
-            // Needs to be assigned by the program.
-            lamports: None,
-            // Needs to be assigned by the program.
-            discriminator: Some(discriminator),
-            // NOTE(vadorovsky): A `clone()` here is unavoidable.
-            // What we have here is an immutable reference to `LightAccountMeta`,
-            // from which we can take an immutable reference to `data`.
-            //
-            // - That immutable reference can be used in the input account,
-            //   since we don't make modifications there.
-            // - In the most cases, we intend to make modifications for the
-            //   output account. We make a copy, which then we try not to
-            //   copy again until the moment of creating a CPI call.
-            //
-            // The reason why `solana_account_info::AccountInfo` stores data as
-            // `Rc<RefCell<&'a mut [u8]>>` is that the reference points to
-            // runtime's memory region which provides the accout and is mutable
-            // by design.
-            //
-            // In our case, compressed accounts are part of instruction data.
-            // Instruction data is immutable (`&[u8]`). There is no way to
-            // mutate instruction data without copy.
-            data: meta
-                .data
-                .as_ref()
-                .map(|data| Rc::new(RefCell::new(data.clone()))),
-            // Needs to be assigned by the program.
-            data_hash: None,
-            address: meta.address,
-            output_merkle_tree_index: meta.output_merkle_tree_index,
-            new_address_params: None,
-        };
-        Ok(account_info)
+        if let Some(self_address) = self.address.as_mut() {
+            if let Some(address) = input_account_meta.get_address().as_ref() {
+                *self_address = *address;
+            } else {
+                solana_program::msg!("from_z_meta_mut: address is none");
+                return Err(CompressedAccountError::InvalidAccountSize);
+            }
+        } else {
+            solana_program::msg!("from_z_meta_mut: address is none");
+            return Err(CompressedAccountError::InvalidAccountSize);
+        }
+
+        if let Some(input) = self.input.as_mut() {
+            input.from_input_meta(input_account_meta, input_data_hash);
+        } else {
+            solana_program::msg!("from_z_meta_mut: input is none");
+            return Err(CompressedAccountError::InvalidAccountSize);
+        }
+
+        if let Some(output) = self.output.as_mut() {
+            output.output_merkle_tree_index = output_merkle_tree_index;
+
+            if let Some(input_lamports) = input_account_meta.get_lamports() {
+                output.lamports = input_lamports;
+            } else {
+                solana_program::msg!("from_z_meta_mut: output lamports is none");
+                return Err(CompressedAccountError::InvalidAccountSize);
+            }
+        } else {
+            solana_program::msg!("from_z_meta_mut: output is none");
+            return Err(CompressedAccountError::InvalidAccountSize);
+        }
+        Ok(())
     }
 
-    pub fn from_meta_close(
-        meta: &'a LightAccountMeta,
+    /// Initializes a compressed account info with address.
+    /// 1. The account is zeroed, data has to be added in a separate step.
+    /// 2. Once data is added the data hash has to be added.
+    pub fn from_meta_close<M: InputAccountMetaTrait>(
+        &mut self,
+        input_account_meta: &M,
+        input_data_hash: [u8; 32],
         discriminator: [u8; 8],
-        owner: &'a Pubkey,
-    ) -> Result<Self> {
-        let input = LightInputAccountInfo {
-            lamports: meta.lamports,
-            address: meta.address,
-            data: meta.data.as_deref(),
-            // Needs to be assigned by the program.
-            data_hash: None,
-            merkle_context: meta
-                .merkle_context
-                .ok_or(LightSdkError::ExpectedMerkleContext)?,
-            root_index: meta
-                .merkle_tree_root_index
-                .ok_or(LightSdkError::ExpectedRootIndex)?,
-        };
+    ) -> Result<(), CompressedAccountError> {
+        self.discriminator = discriminator;
 
-        let account_info = LightAccountInfo {
-            input: Some(input),
-            owner,
-            // Needs to be assigned by the program.
-            lamports: None,
-            // Needs to be assigned by the program.
-            discriminator: Some(discriminator),
-            data: None,
-            // Needs to be assigned by the program.
-            data_hash: None,
-            address: meta.address,
-            output_merkle_tree_index: None,
-            new_address_params: None,
-        };
-        Ok(account_info)
+        if let Some(self_address) = self.address.as_mut() {
+            if let Some(address) = input_account_meta.get_address() {
+                self_address.copy_from_slice(&address);
+            } else {
+                solana_program::msg!("from_z_meta_mut: address is none");
+                return Err(CompressedAccountError::InvalidAccountSize);
+            }
+        } else {
+            solana_program::msg!("from_z_meta_mut: address is none");
+            return Err(CompressedAccountError::InvalidAccountSize);
+        }
+
+        if let Some(input) = self.input.as_mut() {
+            input.from_input_meta(input_account_meta, input_data_hash);
+        } else {
+            solana_program::msg!("from_z_meta_mut: input is none");
+            return Err(CompressedAccountError::InvalidAccountSize);
+        }
+
+        Ok(())
     }
 
-    pub(crate) fn from_meta_init_without_output_data(
-        meta: &'a LightAccountMeta,
-        discriminator: [u8; 8],
-        new_address: [u8; 32],
-        new_address_seed: [u8; 32],
-        owner: &'a Pubkey,
-    ) -> Result<Self> {
-        let address_merkle_context = meta
-            .address_merkle_context
-            .as_ref()
-            .ok_or(LightSdkError::ExpectedAddressMerkleContext)?;
-
-        let new_address_params = PackedNewAddressParams {
-            seed: new_address_seed,
-            address_queue_account_index: address_merkle_context.address_queue_pubkey_index,
-            address_merkle_tree_account_index: address_merkle_context
-                .address_merkle_tree_pubkey_index,
-            address_merkle_tree_root_index: meta
-                .address_merkle_tree_root_index
-                .ok_or(LightSdkError::ExpectedAddressRootIndex)?,
-        };
-
-        let account_info = LightAccountInfo {
-            input: None,
-            owner,
-            // Needs to be assigned by the program.
-            lamports: None,
-            // Needs to be assigned by the program.
-            discriminator: Some(discriminator),
-            data: None,
-            data_hash: None,
-            address: Some(new_address),
-            output_merkle_tree_index: meta.output_merkle_tree_index,
-            new_address_params: Some(new_address_params),
-        };
-        Ok(account_info)
-    }
-
-    /// Converts [`LightAcccountMeta`], representing either a `mut` or `close`
-    /// account, to a `LightAccountInfo` without output data set.
-    ///
-    /// Not intended for external use, intended for building upper abstraction
-    /// layers which handle data serialization on their own.
-    pub(crate) fn from_meta_without_output_data(
-        meta: &'a LightAccountMeta,
-        discriminator: [u8; 8],
-        owner: &'a Pubkey,
-    ) -> Result<Self> {
-        let input = LightInputAccountInfo {
-            lamports: meta.lamports,
-            address: meta.address,
-            data: meta.data.as_deref(),
-            // Needs to be assigned by the program.
-            data_hash: None,
-            merkle_context: meta
-                .merkle_context
-                .ok_or(LightSdkError::ExpectedMerkleContext)?,
-            root_index: meta
-                .merkle_tree_root_index
-                .ok_or(LightSdkError::ExpectedRootIndex)?,
-        };
-
-        let account_info = LightAccountInfo {
-            input: Some(input),
-            owner,
-            // Needs to be assigned by the program.
-            lamports: None,
-            discriminator: Some(discriminator),
-            // Needs to be assigned by the program.
-            data: None,
-            data_hash: None,
-            address: meta.address,
-            output_merkle_tree_index: meta.output_merkle_tree_index,
-            new_address_params: None,
-        };
-        Ok(account_info)
-    }
-
-    pub fn compress_and_add_sol(&mut self, lamports: u64) {
-        self.lamports = Some(lamports);
-    }
-
-    /// Returns the original data sent by the client, before any potential
-    /// modifications made by the program.
-    pub fn initial_data(&self) -> Option<&[u8]> {
-        self.input.as_ref().and_then(|input| input.data)
-    }
-
-    /// Converts the given [LightAccountInfo] into a
-    /// [PackedCompressedAccountWithMerkleContext] which can be sent to the
-    /// light-system program.
-    pub fn input_compressed_account(
+    pub(crate) fn input_compressed_account(
         &self,
-    ) -> Result<Option<PackedCompressedAccountWithMerkleContext>> {
+        owner: solana_program::pubkey::Pubkey,
+    ) -> Result<Option<PackedCompressedAccountWithMerkleContext>, LightSdkError> {
         match self.input.as_ref() {
             Some(input) => {
-                let data = match input.data {
-                    Some(_) => {
-                        let discriminator = self
-                            .discriminator
-                            .ok_or(LightSdkError::ExpectedDiscriminator)?;
-                        let data_hash = input.data_hash.ok_or(LightSdkError::ExpectedHash)?;
-                        Some(CompressedAccountData {
-                            discriminator,
-                            data: Vec::new(),
-                            data_hash,
-                        })
-                    }
-                    None => None,
-                };
+                let data = Some(CompressedAccountData {
+                    discriminator: self.discriminator,
+                    data: Vec::new(),
+                    data_hash: input.data_hash,
+                });
                 Ok(Some(PackedCompressedAccountWithMerkleContext {
                     compressed_account: CompressedAccount {
-                        owner: *self.owner,
-                        lamports: input.lamports.unwrap_or(0),
-                        address: input.address,
+                        owner,
+                        lamports: input.lamports,
+                        address: self.address,
                         data,
                     },
                     merkle_context: input.merkle_context,
@@ -326,31 +227,23 @@ impl<'a> LightAccountInfo<'a> {
 
     pub fn output_compressed_account(
         &self,
-    ) -> Result<Option<OutputCompressedAccountWithPackedContext>> {
-        match self.output_merkle_tree_index {
-            Some(merkle_tree_index) => {
-                let data = match self.data {
-                    Some(_) => {
-                        let discriminator = self
-                            .discriminator
-                            .ok_or(LightSdkError::ExpectedDiscriminator)?;
-                        let data_hash = self.data_hash.ok_or(LightSdkError::ExpectedHash)?;
-                        Some(CompressedAccountData {
-                            discriminator,
-                            data: Vec::new(),
-                            data_hash,
-                        })
-                    }
-                    None => None,
-                };
+        owner: solana_program::pubkey::Pubkey,
+    ) -> Result<Option<OutputCompressedAccountWithPackedContext>, LightSdkError> {
+        match self.output.as_ref() {
+            Some(output) => {
+                let data = Some(CompressedAccountData {
+                    discriminator: self.discriminator,
+                    data: output.data.clone(),
+                    data_hash: output.data_hash,
+                });
                 Ok(Some(OutputCompressedAccountWithPackedContext {
                     compressed_account: CompressedAccount {
-                        owner: *self.owner,
-                        lamports: self.lamports.unwrap_or(0),
+                        owner,
+                        lamports: output.lamports,
                         address: self.address,
                         data,
                     },
-                    merkle_tree_index,
+                    merkle_tree_index: output.output_merkle_tree_index,
                 }))
             }
             None => Ok(None),

--- a/sdk-libs/sdk/src/account_meta.rs
+++ b/sdk-libs/sdk/src/account_meta.rs
@@ -1,118 +1,250 @@
-//! Types used
-use borsh::{BorshDeserialize, BorshSerialize};
 use light_compressed_account::compressed_account::{
     CompressedAccountWithMerkleContext, PackedMerkleContext,
 };
-use solana_program::pubkey::Pubkey;
 
 use crate::{
-    error::Result,
-    merkle_context::{
-        pack_address_merkle_context, pack_merkle_context, AddressMerkleContext,
-        PackedAddressMerkleContext, RemainingAccounts,
-    },
+    error::LightSdkError,
+    merkle_context::{pack_merkle_context, CpiAccounts},
+    BorshDeserialize, BorshSerialize,
 };
 
-#[derive(Debug, Clone, BorshDeserialize, BorshSerialize, PartialEq, Default)]
-pub struct LightAccountMeta {
-    /// Lamports.
-    pub lamports: Option<u64>,
-    /// Address of the account (the address can change).
-    pub address: Option<[u8; 32]>,
-    /// Data of the account.
-    pub data: Option<Vec<u8>>,
-    /// Merkle tree.
-    pub merkle_context: Option<PackedMerkleContext>,
-    /// Merkle tree root index.
-    pub merkle_tree_root_index: Option<u16>,
-    /// Output Merkle tree.
-    pub output_merkle_tree_index: Option<u8>,
-    /// Address Merkle tree. Set only when adding or updating the address.
-    pub address_merkle_context: Option<PackedAddressMerkleContext>,
-    /// Address Merkle tree root index. Set only when adding or updating the
-    /// address.
-    pub address_merkle_tree_root_index: Option<u16>,
-    /// Account is read only.
-    /// (not used for now, just a placeholder)
-    pub read_only: bool,
+/// InputAccountMeta (context, address, root_index, output_merkle_tree_index)
+/// InputAccountMetaNoLamportsNoAddress (context, root_index, output_merkle_tree_index)
+/// InputAccountMetaWithLamportsNoAddress (context, root_index, output_merkle_tree_index)
+/// InputAccountMetaWithLamports (context, lamports, address, root_index, output_merkle_tree_index)
+pub trait InputAccountMetaTrait {
+    fn get_merkle_context(&self) -> &PackedMerkleContext;
+    fn get_lamports(&self) -> Option<u64>;
+    fn get_root_index(&self) -> Option<u16>;
+    fn get_address(&self) -> Option<[u8; 32]>;
+    fn get_output_merkle_tree_index(&self) -> u8;
 }
 
-impl LightAccountMeta {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_init(
-        output_merkle_tree: &Pubkey,
-        address_merkle_context: Option<&AddressMerkleContext>,
-        address_merkle_tree_root_index: Option<u16>,
-        remaining_accounts: &mut RemainingAccounts,
-    ) -> Result<Self> {
-        let output_merkle_tree_index = remaining_accounts.insert_or_get(*output_merkle_tree);
-        let address_merkle_context =
-            address_merkle_context.map(|ctx| pack_address_merkle_context(ctx, remaining_accounts));
-        Ok(Self {
-            lamports: None,
-            address: None,
-            data: None,
-            merkle_context: None,
-            merkle_tree_root_index: None,
-            output_merkle_tree_index: Some(output_merkle_tree_index),
-            address_merkle_context,
-            address_merkle_tree_root_index,
-            read_only: false,
+#[derive(Default, Debug, Clone, Copy, PartialEq, BorshSerialize, BorshDeserialize)]
+pub struct InputAccountMetaNoLamportsNoAddress {
+    pub merkle_context: PackedMerkleContext,
+    pub output_merkle_tree_index: u8,
+    pub root_index: Option<u16>,
+}
+
+impl InputAccountMetaTrait for InputAccountMetaNoLamportsNoAddress {
+    fn get_merkle_context(&self) -> &PackedMerkleContext {
+        &self.merkle_context
+    }
+
+    fn get_lamports(&self) -> Option<u64> {
+        None
+    }
+
+    fn get_root_index(&self) -> Option<u16> {
+        self.root_index
+    }
+
+    fn get_address(&self) -> Option<[u8; 32]> {
+        None
+    }
+
+    fn get_output_merkle_tree_index(&self) -> u8 {
+        self.output_merkle_tree_index
+    }
+}
+
+impl InputAccountMetaNoLamportsNoAddress {
+    pub fn from_compressed_account(
+        compressed_account: &CompressedAccountWithMerkleContext,
+        cpi_accounts: &mut CpiAccounts,
+        root_index: Option<u16>,
+        output_merkle_tree: &solana_program::pubkey::Pubkey,
+    ) -> Self {
+        let mut merkle_context =
+            pack_merkle_context(&compressed_account.merkle_context, cpi_accounts);
+        let output_merkle_tree_index = cpi_accounts.insert_or_get(*output_merkle_tree);
+        if root_index.is_none() {
+            merkle_context.prove_by_index = true;
+        }
+        InputAccountMetaNoLamportsNoAddress {
+            merkle_context,
+            root_index,
+            output_merkle_tree_index,
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, BorshSerialize, BorshDeserialize)]
+pub struct InputAccountMetaNoAddress {
+    pub merkle_context: PackedMerkleContext,
+    pub output_merkle_tree_index: u8,
+    pub lamports: u64,
+    pub root_index: Option<u16>,
+}
+
+impl InputAccountMetaTrait for InputAccountMetaNoAddress {
+    fn get_merkle_context(&self) -> &PackedMerkleContext {
+        &self.merkle_context
+    }
+
+    fn get_lamports(&self) -> Option<u64> {
+        Some(self.lamports)
+    }
+
+    fn get_root_index(&self) -> Option<u16> {
+        self.root_index
+    }
+
+    fn get_address(&self) -> Option<[u8; 32]> {
+        None
+    }
+
+    fn get_output_merkle_tree_index(&self) -> u8 {
+        self.output_merkle_tree_index
+    }
+}
+
+impl InputAccountMetaNoAddress {
+    pub fn from_compressed_account(
+        compressed_account: &CompressedAccountWithMerkleContext,
+        cpi_accounts: &mut CpiAccounts,
+        root_index: Option<u16>,
+        output_merkle_tree: &solana_program::pubkey::Pubkey,
+    ) -> Self {
+        let mut merkle_context =
+            pack_merkle_context(&compressed_account.merkle_context, cpi_accounts);
+
+        let output_merkle_tree_index = cpi_accounts.insert_or_get(*output_merkle_tree);
+        if root_index.is_none() {
+            merkle_context.prove_by_index = true;
+        }
+        InputAccountMetaNoAddress {
+            merkle_context,
+            root_index,
+            output_merkle_tree_index,
+            lamports: compressed_account.compressed_account.lamports,
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, BorshSerialize, BorshDeserialize)]
+pub struct InputAccountMeta {
+    /// Merkle tree context.
+    pub merkle_context: PackedMerkleContext,
+    /// Address.
+    pub address: [u8; 32],
+    /// Root index.
+    pub root_index: Option<u16>,
+    pub output_merkle_tree_index: u8,
+}
+
+impl InputAccountMetaTrait for InputAccountMeta {
+    fn get_merkle_context(&self) -> &PackedMerkleContext {
+        &self.merkle_context
+    }
+
+    fn get_lamports(&self) -> Option<u64> {
+        None
+    }
+
+    fn get_root_index(&self) -> Option<u16> {
+        self.root_index
+    }
+
+    fn get_address(&self) -> Option<[u8; 32]> {
+        Some(self.address)
+    }
+
+    fn get_output_merkle_tree_index(&self) -> u8 {
+        self.output_merkle_tree_index
+    }
+}
+
+impl InputAccountMeta {
+    pub fn from_compressed_account(
+        compressed_account: &CompressedAccountWithMerkleContext,
+        cpi_accounts: &mut CpiAccounts,
+        root_index: Option<u16>,
+        output_merkle_tree: &solana_program::pubkey::Pubkey,
+    ) -> Result<Self, LightSdkError> {
+        let mut merkle_context =
+            pack_merkle_context(&compressed_account.merkle_context, cpi_accounts);
+
+        let address = compressed_account
+            .compressed_account
+            .address
+            .ok_or(LightSdkError::MissingField("address".to_string()))?;
+
+        let output_merkle_tree_index = cpi_accounts.insert_or_get(*output_merkle_tree);
+
+        if root_index.is_none() {
+            merkle_context.prove_by_index = true;
+        }
+        Ok(InputAccountMeta {
+            merkle_context,
+            address,
+            root_index,
+            output_merkle_tree_index,
         })
     }
+}
 
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_mut(
-        compressed_account: &CompressedAccountWithMerkleContext,
-        merkle_tree_root_index: u16,
-        output_merkle_tree: &Pubkey,
-        remaining_accounts: &mut RemainingAccounts,
-    ) -> Self {
-        let merkle_context =
-            pack_merkle_context(&compressed_account.merkle_context, remaining_accounts);
+#[derive(Default, Debug, Clone, Copy, PartialEq, BorshSerialize, BorshDeserialize)]
+pub struct InputAccountMetaWithLamports {
+    /// Merkle tree context.
+    pub merkle_context: PackedMerkleContext,
+    /// Lamports.
+    pub lamports: u64,
+    /// Address.
+    pub address: [u8; 32],
+    /// Root index.
+    pub output_merkle_tree_index: u8,
+    pub root_index: Option<u16>,
+}
 
-        // If no output Merkle tree was specified, use the one used for the
-        // input account.
-        let output_merkle_tree_index = remaining_accounts.insert_or_get(*output_merkle_tree);
-
-        Self {
-            lamports: Some(compressed_account.compressed_account.lamports),
-            address: compressed_account.compressed_account.address,
-            data: compressed_account
-                .compressed_account
-                .data
-                .as_ref()
-                .map(|data| data.data.clone()),
-            merkle_context: Some(merkle_context),
-            merkle_tree_root_index: Some(merkle_tree_root_index),
-            output_merkle_tree_index: Some(output_merkle_tree_index),
-            address_merkle_context: None,
-            address_merkle_tree_root_index: None,
-            read_only: false,
-        }
+impl InputAccountMetaTrait for InputAccountMetaWithLamports {
+    fn get_merkle_context(&self) -> &PackedMerkleContext {
+        &self.merkle_context
     }
 
-    pub fn new_close(
+    fn get_lamports(&self) -> Option<u64> {
+        Some(self.lamports)
+    }
+
+    fn get_root_index(&self) -> Option<u16> {
+        self.root_index
+    }
+
+    fn get_address(&self) -> Option<[u8; 32]> {
+        Some(self.address)
+    }
+
+    fn get_output_merkle_tree_index(&self) -> u8 {
+        self.output_merkle_tree_index
+    }
+}
+
+impl InputAccountMetaWithLamports {
+    pub fn from_compressed_account(
         compressed_account: &CompressedAccountWithMerkleContext,
-        merkle_tree_root_index: u16,
-        remaining_accounts: &mut RemainingAccounts,
-    ) -> Self {
-        let merkle_context =
-            pack_merkle_context(&compressed_account.merkle_context, remaining_accounts);
-        Self {
-            lamports: Some(compressed_account.compressed_account.lamports),
-            address: compressed_account.compressed_account.address,
-            data: compressed_account
-                .compressed_account
-                .data
-                .as_ref()
-                .map(|data| data.data.clone()),
-            merkle_context: Some(merkle_context),
-            merkle_tree_root_index: Some(merkle_tree_root_index),
-            output_merkle_tree_index: None,
-            address_merkle_context: None,
-            address_merkle_tree_root_index: None,
-            read_only: false,
+        cpi_accounts: &mut CpiAccounts,
+        root_index: Option<u16>,
+        output_merkle_tree: &solana_program::pubkey::Pubkey,
+    ) -> Result<Self, LightSdkError> {
+        let mut merkle_context =
+            pack_merkle_context(&compressed_account.merkle_context, cpi_accounts);
+
+        // Use the address if available, otherwise default
+        let address = compressed_account
+            .compressed_account
+            .address
+            .ok_or(LightSdkError::MissingField("address".to_string()))?;
+        let output_merkle_tree_index = cpi_accounts.insert_or_get(*output_merkle_tree);
+        if root_index.is_none() {
+            merkle_context.prove_by_index = true;
         }
+        Ok(InputAccountMetaWithLamports {
+            merkle_context,
+            lamports: compressed_account.compressed_account.lamports,
+            address,
+            root_index,
+            output_merkle_tree_index,
+        })
     }
 }

--- a/sdk-libs/sdk/src/address.rs
+++ b/sdk-libs/sdk/src/address.rs
@@ -5,7 +5,7 @@ use light_compressed_account::{
 use light_hasher::{Hasher, Keccak};
 use solana_program::{account_info::AccountInfo, pubkey::Pubkey};
 
-use crate::merkle_context::{AddressMerkleContext, RemainingAccounts};
+use crate::merkle_context::{AddressMerkleContext, CpiAccounts};
 
 pub struct AddressWithMerkleContext {
     pub address: [u8; 32],
@@ -14,7 +14,7 @@ pub struct AddressWithMerkleContext {
 
 pub fn pack_new_addresses_params(
     addresses_params: &[NewAddressParams],
-    remaining_accounts: &mut RemainingAccounts,
+    remaining_accounts: &mut CpiAccounts,
 ) -> Vec<PackedNewAddressParams> {
     addresses_params
         .iter()
@@ -35,7 +35,7 @@ pub fn pack_new_addresses_params(
 
 pub fn pack_new_address_params(
     address_params: NewAddressParams,
-    remaining_accounts: &mut RemainingAccounts,
+    remaining_accounts: &mut CpiAccounts,
 ) -> PackedNewAddressParams {
     pack_new_addresses_params(&[address_params], remaining_accounts)[0]
 }

--- a/sdk-libs/sdk/src/error.rs
+++ b/sdk-libs/sdk/src/error.rs
@@ -42,6 +42,8 @@ pub enum LightSdkError {
     FewerAccountsThanSystemAccounts,
     #[error("InvalidCpiSignerAccount")]
     InvalidCpiSignerAccount,
+    #[error("Missing meta field: {0}")]
+    MissingField(String),
     #[error(transparent)]
     Hasher(#[from] HasherError),
     #[error("Program error: {0}")]
@@ -69,6 +71,7 @@ impl From<LightSdkError> for u32 {
             LightSdkError::Borsh => 14016,
             LightSdkError::FewerAccountsThanSystemAccounts => 14017,
             LightSdkError::InvalidCpiSignerAccount => 14018,
+            LightSdkError::MissingField(_) => 14019,
             LightSdkError::Hasher(e) => e.into(),
             LightSdkError::ProgramError(e) => u32::try_from(u64::from(e)).unwrap(),
         }

--- a/sdk-libs/sdk/src/error.rs
+++ b/sdk-libs/sdk/src/error.rs
@@ -40,6 +40,8 @@ pub enum LightSdkError {
     Borsh,
     #[error("Fewer accounts than number of system accounts.")]
     FewerAccountsThanSystemAccounts,
+    #[error("InvalidCpiSignerAccount")]
+    InvalidCpiSignerAccount,
     #[error(transparent)]
     Hasher(#[from] HasherError),
     #[error("Program error: {0}")]
@@ -66,6 +68,7 @@ impl From<LightSdkError> for u32 {
             LightSdkError::TransferIntegerOverflow => 14015,
             LightSdkError::Borsh => 14016,
             LightSdkError::FewerAccountsThanSystemAccounts => 14017,
+            LightSdkError::InvalidCpiSignerAccount => 14018,
             LightSdkError::Hasher(e) => e.into(),
             LightSdkError::ProgramError(e) => u32::try_from(u64::from(e)).unwrap(),
         }

--- a/sdk-libs/sdk/src/instruction_data.rs
+++ b/sdk-libs/sdk/src/instruction_data.rs
@@ -1,53 +1,9 @@
-use std::io::Cursor;
+use light_compressed_account::instruction_data::compressed_proof::CompressedProof;
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use crate::{merkle_context::PackedAddressMerkleContext, BorshDeserialize, BorshSerialize};
 
-use crate::{
-    account_meta::LightAccountMeta,
-    error::{LightSdkError, Result},
-    proof::ProofRpcResult,
-};
-
+#[derive(Debug, Default, Clone, BorshSerialize, PartialEq, BorshDeserialize)]
 pub struct LightInstructionData {
-    pub proof: Option<ProofRpcResult>,
-    pub accounts: Option<Vec<LightAccountMeta>>,
-    // TODO: refactor addresses in separate pr
-    // pub new_addresses: Option<Vec<PackedAddressMerkleContext>>,
-}
-
-impl LightInstructionData {
-    pub fn deserialize(bytes: &[u8]) -> Result<(&[u8], Self)> {
-        let mut inputs = Cursor::new(bytes);
-
-        let proof = Option::<ProofRpcResult>::deserialize_reader(&mut inputs)
-            .map_err(|_| LightSdkError::Borsh)?;
-        let accounts = Option::<Vec<LightAccountMeta>>::deserialize_reader(&mut inputs)
-            .map_err(|_| LightSdkError::Borsh)?;
-        // let new_addresses =
-        //     Option::<Vec<PackedAddressMerkleContext>>::deserialize_reader(&mut inputs)
-        //         .map_err(|_| LightSdkError::Borsh)?;
-        let (_, remaining_bytes) = bytes.split_at(inputs.position() as usize);
-        Ok((
-            remaining_bytes,
-            LightInstructionData {
-                proof,
-                accounts,
-                // new_addresses,
-            },
-        ))
-    }
-
-    pub fn serialize(&self) -> Result<Vec<u8>> {
-        let mut bytes = Vec::new();
-        self.proof
-            .serialize(&mut bytes)
-            .map_err(|_| LightSdkError::Borsh)?;
-        self.accounts
-            .serialize(&mut bytes)
-            .map_err(|_| LightSdkError::Borsh)?;
-        // self.new_addresses
-        //     .serialize(&mut bytes)
-        //     .map_err(|_| LightSdkError::Borsh)?;
-        Ok(bytes)
-    }
+    pub proof: Option<CompressedProof>,
+    pub new_addresses: Option<Vec<PackedAddressMerkleContext>>,
 }

--- a/sdk-libs/sdk/src/lib.rs
+++ b/sdk-libs/sdk/src/lib.rs
@@ -3,11 +3,10 @@ pub use light_sdk_macros::*;
 
 pub mod account;
 pub mod account_info;
-pub mod account_meta;
 pub mod address;
 pub mod constants;
 pub use constants::*;
-// pub mod context;
+pub mod account_meta;
 pub mod error;
 pub mod instruction_data;
 pub mod legacy;
@@ -26,4 +25,5 @@ pub mod verify;
 use anchor_lang::{AnchorDeserialize as BorshDeserialize, AnchorSerialize as BorshSerialize};
 #[cfg(not(feature = "anchor"))]
 use borsh::{BorshDeserialize, BorshSerialize};
+pub use light_compressed_account::instruction_data::data::*;
 pub use light_verifier;

--- a/sdk-libs/sdk/src/merkle_context.rs
+++ b/sdk-libs/sdk/src/merkle_context.rs
@@ -167,239 +167,246 @@ pub fn pack_address_merkle_context(
     }
 }
 
-// #[cfg(test)]
-// mod test {
-//     use super::*;
+#[cfg(test)]
+mod test {
+    use super::*;
 
-//     #[test]
-//     fn test_remaining_accounts() {
-//         let mut remaining_accounts = CpiAccounts::default();
+    #[test]
+    fn test_remaining_accounts() {
+        let mut remaining_accounts = CpiAccounts::default();
 
-//         let pubkey_1 = Pubkey::new_unique();
-//         let pubkey_2 = Pubkey::new_unique();
-//         let pubkey_3 = Pubkey::new_unique();
-//         let pubkey_4 = Pubkey::new_unique();
+        let pubkey_1 = Pubkey::new_unique();
+        let pubkey_2 = Pubkey::new_unique();
+        let pubkey_3 = Pubkey::new_unique();
+        let pubkey_4 = Pubkey::new_unique();
 
-//         // Initial insertion.
-//         assert_eq!(remaining_accounts.insert_or_get(pubkey_1), 0);
-//         assert_eq!(remaining_accounts.insert_or_get(pubkey_2), 1);
-//         assert_eq!(remaining_accounts.insert_or_get(pubkey_3), 2);
+        // Initial insertion.
+        assert_eq!(remaining_accounts.insert_or_get(pubkey_1), 0);
+        assert_eq!(remaining_accounts.insert_or_get(pubkey_2), 1);
+        assert_eq!(remaining_accounts.insert_or_get(pubkey_3), 2);
 
-//         assert_eq!(
-//             remaining_accounts.to_account_metas().as_slice(),
-//             &[
-//                 AccountMeta {
-//                     pubkey: pubkey_1,
-//                     is_signer: false,
-//                     is_writable: true,
-//                 },
-//                 AccountMeta {
-//                     pubkey: pubkey_2,
-//                     is_signer: false,
-//                     is_writable: true,
-//                 },
-//                 AccountMeta {
-//                     pubkey: pubkey_3,
-//                     is_signer: false,
-//                     is_writable: true,
-//                 }
-//             ]
-//         );
+        assert_eq!(
+            remaining_accounts.to_account_metas().as_slice(),
+            &[
+                AccountMeta {
+                    pubkey: pubkey_1,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: pubkey_2,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: pubkey_3,
+                    is_signer: false,
+                    is_writable: true,
+                }
+            ]
+        );
 
-//         // Insertion of already existing pubkeys.
-//         assert_eq!(remaining_accounts.insert_or_get(pubkey_1), 0);
-//         assert_eq!(remaining_accounts.insert_or_get(pubkey_2), 1);
-//         assert_eq!(remaining_accounts.insert_or_get(pubkey_3), 2);
+        // Insertion of already existing pubkeys.
+        assert_eq!(remaining_accounts.insert_or_get(pubkey_1), 0);
+        assert_eq!(remaining_accounts.insert_or_get(pubkey_2), 1);
+        assert_eq!(remaining_accounts.insert_or_get(pubkey_3), 2);
 
-//         assert_eq!(
-//             remaining_accounts.to_account_metas().as_slice(),
-//             &[
-//                 AccountMeta {
-//                     pubkey: pubkey_1,
-//                     is_signer: false,
-//                     is_writable: true,
-//                 },
-//                 AccountMeta {
-//                     pubkey: pubkey_2,
-//                     is_signer: false,
-//                     is_writable: true,
-//                 },
-//                 AccountMeta {
-//                     pubkey: pubkey_3,
-//                     is_signer: false,
-//                     is_writable: true,
-//                 }
-//             ]
-//         );
+        assert_eq!(
+            remaining_accounts.to_account_metas().as_slice(),
+            &[
+                AccountMeta {
+                    pubkey: pubkey_1,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: pubkey_2,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: pubkey_3,
+                    is_signer: false,
+                    is_writable: true,
+                }
+            ]
+        );
 
-//         // Again, initial insertion.
-//         assert_eq!(remaining_accounts.insert_or_get(pubkey_4), 3);
+        // Again, initial insertion.
+        assert_eq!(remaining_accounts.insert_or_get(pubkey_4), 3);
 
-//         assert_eq!(
-//             remaining_accounts.to_account_metas().as_slice(),
-//             &[
-//                 AccountMeta {
-//                     pubkey: pubkey_1,
-//                     is_signer: false,
-//                     is_writable: true,
-//                 },
-//                 AccountMeta {
-//                     pubkey: pubkey_2,
-//                     is_signer: false,
-//                     is_writable: true,
-//                 },
-//                 AccountMeta {
-//                     pubkey: pubkey_3,
-//                     is_signer: false,
-//                     is_writable: true,
-//                 },
-//                 AccountMeta {
-//                     pubkey: pubkey_4,
-//                     is_signer: false,
-//                     is_writable: true,
-//                 }
-//             ]
-//         );
-//     }
+        assert_eq!(
+            remaining_accounts.to_account_metas().as_slice(),
+            &[
+                AccountMeta {
+                    pubkey: pubkey_1,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: pubkey_2,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: pubkey_3,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                AccountMeta {
+                    pubkey: pubkey_4,
+                    is_signer: false,
+                    is_writable: true,
+                }
+            ]
+        );
+    }
 
-//     #[test]
-//     fn test_pack_merkle_context() {
-//         let mut remaining_accounts = CpiAccounts::default();
+    #[test]
+    fn test_pack_merkle_context() {
+        let mut remaining_accounts = CpiAccounts::default();
 
-//         let merkle_tree_pubkey = Pubkey::new_unique();
-//         let nullifier_queue_pubkey = Pubkey::new_unique();
-//         let merkle_context = MerkleContext {
-//             merkle_tree_pubkey,
-//             nullifier_queue_pubkey,
-//             leaf_index: 69,
-//             prove_by_index: false,
-//             ..Default::default()
-//         };
+        let merkle_tree_pubkey = Pubkey::new_unique();
+        let nullifier_queue_pubkey = Pubkey::new_unique();
+        let merkle_context = MerkleContext {
+            merkle_tree_pubkey,
+            nullifier_queue_pubkey,
+            leaf_index: 69,
+            prove_by_index: false,
+            ..Default::default()
+        };
 
-//         let packed_merkle_context = pack_merkle_context(&merkle_context, &mut remaining_accounts);
-//         assert_eq!(
-//             packed_merkle_context,
-//             PackedMerkleContext {
-//                 merkle_tree_pubkey_index: 0,
-//                 nullifier_queue_pubkey_index: 1,
-//                 leaf_index: 69,
-//                 prove_by_index: false,
-//             }
-//         )
-//     }
+        let packed_merkle_context = pack_merkle_context(&merkle_context, &mut remaining_accounts);
+        assert_eq!(
+            packed_merkle_context,
+            PackedMerkleContext {
+                merkle_tree_pubkey_index: 0,
+                nullifier_queue_pubkey_index: 1,
+                leaf_index: 69,
+                prove_by_index: false,
+            }
+        )
+    }
 
-//     #[test]
-//     fn test_pack_merkle_contexts() {
-//         let mut remaining_accounts = CpiAccounts::default();
+    #[test]
+    fn test_pack_merkle_contexts() {
+        let mut remaining_accounts = CpiAccounts::default();
 
-//         let merkle_contexts = &[
-//             MerkleContext {
-//                 merkle_tree_pubkey: Pubkey::new_unique(),
-//                 nullifier_queue_pubkey: Pubkey::new_unique(),
-//                 leaf_index: 10,
-//                 prove_by_index: false,
-//                 ..Default::default()
-//             },
-//             MerkleContext {
-//                 merkle_tree_pubkey: Pubkey::new_unique(),
-//                 nullifier_queue_pubkey: Pubkey::new_unique(),
-//                 leaf_index: 11,
-//                 prove_by_index: true,
-//                 ..Default::default()
-//             },
-//             MerkleContext {
-//                 merkle_tree_pubkey: Pubkey::new_unique(),
-//                 nullifier_queue_pubkey: Pubkey::new_unique(),
-//                 leaf_index: 12,
-//                 prove_by_index: false,
-//                 ..Default::default()
-//             },
-//         ];
+        let merkle_contexts = &[
+            MerkleContext {
+                merkle_tree_pubkey: Pubkey::new_unique(),
+                nullifier_queue_pubkey: Pubkey::new_unique(),
+                leaf_index: 10,
+                prove_by_index: false,
+                ..Default::default()
+            },
+            MerkleContext {
+                merkle_tree_pubkey: Pubkey::new_unique(),
+                nullifier_queue_pubkey: Pubkey::new_unique(),
+                leaf_index: 11,
+                prove_by_index: true,
+                ..Default::default()
+            },
+            MerkleContext {
+                merkle_tree_pubkey: Pubkey::new_unique(),
+                nullifier_queue_pubkey: Pubkey::new_unique(),
+                leaf_index: 12,
+                prove_by_index: false,
+                ..Default::default()
+            },
+        ];
 
-//         let packed_merkle_contexts =
-//             pack_merkle_contexts(merkle_contexts.iter(), &mut remaining_accounts);
-//         assert_eq!(
-//             packed_merkle_contexts.collect::<Vec<_>>(),
-//             &[
-//                 PackedMerkleContext {
-//                     merkle_tree_pubkey_index: 0,
-//                     nullifier_queue_pubkey_index: 1,
-//                     leaf_index: 10,
-//                     prove_by_index: false
-//                 },
-//                 PackedMerkleContext {
-//                     merkle_tree_pubkey_index: 2,
-//                     nullifier_queue_pubkey_index: 3,
-//                     leaf_index: 11,
-//                     prove_by_index: true
-//                 },
-//                 PackedMerkleContext {
-//                     merkle_tree_pubkey_index: 4,
-//                     nullifier_queue_pubkey_index: 5,
-//                     leaf_index: 12,
-//                     prove_by_index: false,
-//                 }
-//             ]
-//         );
-//     }
+        let packed_merkle_contexts =
+            pack_merkle_contexts(merkle_contexts.iter(), &mut remaining_accounts);
+        assert_eq!(
+            packed_merkle_contexts.collect::<Vec<_>>(),
+            &[
+                PackedMerkleContext {
+                    merkle_tree_pubkey_index: 0,
+                    nullifier_queue_pubkey_index: 1,
+                    leaf_index: 10,
+                    prove_by_index: false
+                },
+                PackedMerkleContext {
+                    merkle_tree_pubkey_index: 2,
+                    nullifier_queue_pubkey_index: 3,
+                    leaf_index: 11,
+                    prove_by_index: true
+                },
+                PackedMerkleContext {
+                    merkle_tree_pubkey_index: 4,
+                    nullifier_queue_pubkey_index: 5,
+                    leaf_index: 12,
+                    prove_by_index: false,
+                }
+            ]
+        );
+    }
 
-//     #[test]
-//     fn test_pack_address_merkle_context() {
-//         let mut remaining_accounts = CpiAccounts::default();
+    #[test]
+    fn test_pack_address_merkle_context() {
+        let mut remaining_accounts = CpiAccounts::default();
 
-//         let address_merkle_context = AddressMerkleContext {
-//             address_merkle_tree_pubkey: Pubkey::new_unique(),
-//             address_queue_pubkey: Pubkey::new_unique(),
-//         };
+        let address_merkle_context = AddressMerkleContext {
+            address_merkle_tree_pubkey: Pubkey::new_unique(),
+            address_queue_pubkey: Pubkey::new_unique(),
+        };
 
-//         let packed_address_merkle_context =
-//             pack_address_merkle_context(&address_merkle_context, &mut remaining_accounts);
-//         assert_eq!(
-//             packed_address_merkle_context,
-//             PackedAddressMerkleContext {
-//                 address_merkle_tree_pubkey_index: 0,
-//                 address_queue_pubkey_index: 1,
-//             }
-//         )
-//     }
+        let packed_address_merkle_context =
+            pack_address_merkle_context(&address_merkle_context, &mut remaining_accounts, 2);
+        assert_eq!(
+            packed_address_merkle_context,
+            PackedAddressMerkleContext {
+                address_merkle_tree_pubkey_index: 0,
+                address_queue_pubkey_index: 1,
+                root_index: 2,
+            }
+        )
+    }
 
-//     #[test]
-//     fn test_pack_address_merkle_contexts() {
-//         let mut remaining_accounts = CpiAccounts::default();
+    #[test]
+    fn test_pack_address_merkle_contexts() {
+        let mut remaining_accounts = CpiAccounts::default();
 
-//         let address_merkle_contexts = &[
-//             AddressMerkleContext {
-//                 address_merkle_tree_pubkey: Pubkey::new_unique(),
-//                 address_queue_pubkey: Pubkey::new_unique(),
-//             },
-//             AddressMerkleContext {
-//                 address_merkle_tree_pubkey: Pubkey::new_unique(),
-//                 address_queue_pubkey: Pubkey::new_unique(),
-//             },
-//             AddressMerkleContext {
-//                 address_merkle_tree_pubkey: Pubkey::new_unique(),
-//                 address_queue_pubkey: Pubkey::new_unique(),
-//             },
-//         ];
+        let address_merkle_contexts = &[
+            AddressMerkleContext {
+                address_merkle_tree_pubkey: Pubkey::new_unique(),
+                address_queue_pubkey: Pubkey::new_unique(),
+            },
+            AddressMerkleContext {
+                address_merkle_tree_pubkey: Pubkey::new_unique(),
+                address_queue_pubkey: Pubkey::new_unique(),
+            },
+            AddressMerkleContext {
+                address_merkle_tree_pubkey: Pubkey::new_unique(),
+                address_queue_pubkey: Pubkey::new_unique(),
+            },
+        ];
 
-//         let packed_address_merkle_contexts =
-//             pack_address_merkle_contexts(address_merkle_contexts.iter(), &mut remaining_accounts);
-//         assert_eq!(
-//             packed_address_merkle_contexts.collect::<Vec<_>>(),
-//             &[
-//                 PackedAddressMerkleContext {
-//                     address_merkle_tree_pubkey_index: 0,
-//                     address_queue_pubkey_index: 1,
-//                 },
-//                 PackedAddressMerkleContext {
-//                     address_merkle_tree_pubkey_index: 2,
-//                     address_queue_pubkey_index: 3,
-//                 },
-//                 PackedAddressMerkleContext {
-//                     address_merkle_tree_pubkey_index: 4,
-//                     address_queue_pubkey_index: 5,
-//                 }
-//             ]
-//         );
-//     }
-// }
+        let packed_address_merkle_contexts = pack_address_merkle_contexts(
+            address_merkle_contexts.iter(),
+            &[6, 7, 8],
+            &mut remaining_accounts,
+        );
+        assert_eq!(
+            packed_address_merkle_contexts.collect::<Vec<_>>(),
+            &[
+                PackedAddressMerkleContext {
+                    address_merkle_tree_pubkey_index: 0,
+                    address_queue_pubkey_index: 1,
+                    root_index: 6,
+                },
+                PackedAddressMerkleContext {
+                    address_merkle_tree_pubkey_index: 2,
+                    address_queue_pubkey_index: 3,
+                    root_index: 7,
+                },
+                PackedAddressMerkleContext {
+                    address_merkle_tree_pubkey_index: 4,
+                    address_queue_pubkey_index: 5,
+                    root_index: 8,
+                }
+            ]
+        );
+    }
+}

--- a/sdk-libs/sdk/src/program_merkle_context.rs
+++ b/sdk-libs/sdk/src/program_merkle_context.rs
@@ -4,11 +4,13 @@ use crate::merkle_context::{AddressMerkleContext, PackedAddressMerkleContext};
 
 pub fn pack_address_merkle_contexts(
     address_merkle_contexts: &[AddressMerkleContext],
+    address_root_indices: &[u16],
     remaining_accounts: &[AccountInfo],
 ) -> Vec<PackedAddressMerkleContext> {
     address_merkle_contexts
         .iter()
-        .map(|x| {
+        .zip(address_root_indices.iter())
+        .map(|(x, root_index)| {
             let address_merkle_tree_pubkey_index = remaining_accounts
                 .iter()
                 .position(|account| *account.key == x.address_merkle_tree_pubkey)
@@ -20,6 +22,7 @@ pub fn pack_address_merkle_contexts(
             PackedAddressMerkleContext {
                 address_merkle_tree_pubkey_index,
                 address_queue_pubkey_index,
+                root_index: *root_index,
             }
         })
         .collect::<Vec<_>>()
@@ -27,9 +30,14 @@ pub fn pack_address_merkle_contexts(
 
 pub fn pack_address_merkle_context(
     address_merkle_context: AddressMerkleContext,
+    address_root_index: u16,
     remaining_accounts: &[AccountInfo],
 ) -> PackedAddressMerkleContext {
-    pack_address_merkle_contexts(&[address_merkle_context], remaining_accounts)[0]
+    pack_address_merkle_contexts(
+        &[address_merkle_context],
+        &[address_root_index],
+        remaining_accounts,
+    )[0]
 }
 
 pub fn unpack_address_merkle_contexts(

--- a/sdk-libs/sdk/src/system_accounts.rs
+++ b/sdk-libs/sdk/src/system_accounts.rs
@@ -1,14 +1,12 @@
 use solana_program::{account_info::AccountInfo, instruction::AccountMeta, pubkey::Pubkey};
 
 use crate::{
-    error::{LightSdkError, Result},
-    find_cpi_signer_macro, CPI_AUTHORITY_PDA_SEED, PROGRAM_ID_ACCOUNT_COMPRESSION,
+    error::Result, find_cpi_signer_macro, CPI_AUTHORITY_PDA_SEED, PROGRAM_ID_ACCOUNT_COMPRESSION,
     PROGRAM_ID_LIGHT_SYSTEM, PROGRAM_ID_NOOP,
 };
 
 #[repr(usize)]
 pub enum LightSystemAccountIndex {
-    // FeePayer,
     LightSystemProgram,
     Authority,
     RegisteredProgramPda,
@@ -38,10 +36,10 @@ impl<'c, 'info> LightCpiAccounts<'c, 'info> {
         accounts: &'c [AccountInfo<'info>],
         program_id: Pubkey,
     ) -> Result<Self> {
-        if accounts.len() < SYSTEM_ACCOUNTS_LEN {
-            solana_program::msg!("accounts len {}", accounts.len());
-            return Err(LightSdkError::FewerAccountsThanSystemAccounts);
-        }
+        // if accounts.len() < SYSTEM_ACCOUNTS_LEN {
+        //     solana_program::msg!("accounts len {}", accounts.len());
+        //     return Err(LightSdkError::FewerAccountsThanSystemAccounts);
+        // }
         Ok(Self {
             fee_payer,
             accounts,
@@ -57,10 +55,10 @@ impl<'c, 'info> LightCpiAccounts<'c, 'info> {
         accounts: &'c [AccountInfo<'info>],
         config: SystemAccountInfoConfig,
     ) -> Result<Self> {
-        if accounts.len() < SYSTEM_ACCOUNTS_LEN {
-            solana_program::msg!("accounts len {}", accounts.len());
-            return Err(LightSdkError::FewerAccountsThanSystemAccounts);
-        }
+        // if accounts.len() < SYSTEM_ACCOUNTS_LEN {
+        //     solana_program::msg!("accounts len {}", accounts.len());
+        //     return Err(LightSdkError::FewerAccountsThanSystemAccounts);
+        // }
         Ok(Self {
             fee_payer,
             accounts,
@@ -184,6 +182,10 @@ impl<'c, 'info> LightCpiAccounts<'c, 'info> {
             len -= 1;
         }
         len
+    }
+
+    pub fn account_infos(&self) -> &'c [AccountInfo<'info>] {
+        self.accounts
     }
 }
 

--- a/sdk-libs/sdk/src/system_accounts.rs
+++ b/sdk-libs/sdk/src/system_accounts.rs
@@ -278,7 +278,7 @@ impl Default for SystemAccountPubkeys {
 }
 
 pub fn get_light_system_account_metas(config: SystemAccountMetaConfig) -> Vec<AccountMeta> {
-    let cpi_signer = find_cpi_signer_macro!(&config.self_program);
+    let cpi_signer = find_cpi_signer_macro!(&config.self_program).0;
     let default_pubkeys = SystemAccountPubkeys::default();
     let mut vec = vec![
         AccountMeta::new_readonly(default_pubkeys.light_sytem_program, false),

--- a/sdk-libs/sdk/src/verify.rs
+++ b/sdk-libs/sdk/src/verify.rs
@@ -1,11 +1,7 @@
-use light_compressed_account::{
-    compressed_account::PackedCompressedAccountWithMerkleContext,
-    instruction_data::{
-        compressed_proof::CompressedProof,
-        data::{NewAddressParamsPacked, OutputCompressedAccountWithPackedContext},
-    },
+use light_compressed_account::instruction_data::{
+    compressed_proof::CompressedProof, cpi_context::CompressedCpiContext,
+    data::NewAddressParamsPacked, invoke_cpi::InstructionDataInvokeCpi,
 };
-use light_hasher::{DataHasher, Discriminator};
 use solana_program::{
     account_info::AccountInfo,
     instruction::{AccountMeta, Instruction},
@@ -14,12 +10,10 @@ use solana_program::{
 };
 
 use crate::{
-    account::LightAccount,
-    account_info::LightAccountInfo,
+    account_info::CAccountInfo,
     error::{LightSdkError, Result},
-    proof::ProofRpcResult,
     system_accounts::LightCpiAccounts,
-    BorshDeserialize, BorshSerialize, CPI_AUTHORITY_PDA_SEED, PROGRAM_ID_LIGHT_SYSTEM,
+    BorshSerialize, CPI_AUTHORITY_PDA_SEED, PROGRAM_ID_LIGHT_SYSTEM,
 };
 
 pub fn find_cpi_signer(program_id: &Pubkey) -> Pubkey {
@@ -33,35 +27,10 @@ macro_rules! find_cpi_signer_macro {
     };
 }
 
-#[derive(BorshDeserialize, BorshSerialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct CompressedCpiContext {
-    /// Is set by the program that is invoking the CPI to signal that is should
-    /// set the cpi context.
-    pub set_context: bool,
-    /// Is set to wipe the cpi context since someone could have set it before
-    /// with unrelated data.
-    pub first_set_context: bool,
-    /// Index of cpi context account in remaining accounts.
-    pub cpi_context_account_index: u8,
-}
-
-#[derive(Debug, PartialEq, Default, Clone, BorshDeserialize, BorshSerialize)]
-pub struct InstructionDataInvokeCpi {
-    pub proof: Option<CompressedProof>,
-    pub new_address_params: Vec<NewAddressParamsPacked>,
-    pub input_compressed_accounts_with_merkle_context:
-        Vec<PackedCompressedAccountWithMerkleContext>,
-    pub output_compressed_accounts: Vec<OutputCompressedAccountWithPackedContext>,
-    pub relay_fee: Option<u64>,
-    pub compress_or_decompress_lamports: Option<u64>,
-    pub is_compress: bool,
-    pub cpi_context: Option<CompressedCpiContext>,
-}
-
 pub fn verify_light_account_infos(
     light_cpi_accounts: &LightCpiAccounts,
-    proof: Option<ProofRpcResult>,
-    light_accounts: &[LightAccountInfo],
+    proof: Option<CompressedProof>,
+    light_accounts: &[CAccountInfo],
     new_address_params: Option<Vec<NewAddressParamsPacked>>,
     compress_or_decompress_lamports: Option<u64>,
     is_compress: bool,
@@ -70,19 +39,18 @@ pub fn verify_light_account_infos(
     let mut input_compressed_accounts_with_merkle_context =
         Vec::with_capacity(light_accounts.len());
     let mut output_compressed_accounts = Vec::with_capacity(light_accounts.len());
-
+    let owner = *light_cpi_accounts.invoking_program().key;
     for light_account in light_accounts.iter() {
-        if let Some(input_account) = light_account.input_compressed_account()? {
+        if let Some(input_account) = light_account.input_compressed_account(owner)? {
             input_compressed_accounts_with_merkle_context.push(input_account);
         }
-        if let Some(output_account) = light_account.output_compressed_account()? {
+        if let Some(output_account) = light_account.output_compressed_account(owner)? {
             output_compressed_accounts.push(output_account);
         }
     }
 
-    // TODO: make zero copy
     let instruction = InstructionDataInvokeCpi {
-        proof: proof.map(|proof| proof.proof),
+        proof,
         new_address_params: new_address_params.unwrap_or_default(),
         relay_fee: None,
         input_compressed_accounts_with_merkle_context,
@@ -91,54 +59,6 @@ pub fn verify_light_account_infos(
         is_compress,
         cpi_context,
     };
-
-    verify_borsh(light_cpi_accounts, &instruction)
-}
-
-// TODO: remove only verify light account infos should exist
-// try to use LightAccount -> to_account_info()
-pub fn verify_light_accounts<T>(
-    light_cpi_accounts: &LightCpiAccounts,
-    proof: Option<ProofRpcResult>,
-    light_accounts: &[LightAccount<T>],
-    new_address_params: Option<Vec<NewAddressParamsPacked>>,
-    compress_or_decompress_lamports: Option<u64>,
-    is_compress: bool,
-    cpi_context: Option<CompressedCpiContext>,
-) -> Result<()>
-where
-    T: BorshSerialize
-        + BorshDeserialize
-        + Clone
-        + DataHasher
-        + Default
-        + Discriminator
-        + std::fmt::Debug,
-{
-    let mut input_compressed_accounts_with_merkle_context =
-        Vec::with_capacity(light_accounts.len());
-    let mut output_compressed_accounts = Vec::with_capacity(light_accounts.len());
-
-    for light_account in light_accounts.iter() {
-        if let Some(input_account) = light_account.input_compressed_account()? {
-            input_compressed_accounts_with_merkle_context.push(input_account);
-        }
-        if let Some(output_account) = light_account.output_compressed_account()? {
-            output_compressed_accounts.push(output_account);
-        }
-    }
-
-    let instruction = InstructionDataInvokeCpi {
-        proof: proof.map(|proof| proof.proof),
-        new_address_params: new_address_params.unwrap_or_default(),
-        relay_fee: None,
-        input_compressed_accounts_with_merkle_context,
-        output_compressed_accounts,
-        compress_or_decompress_lamports,
-        is_compress,
-        cpi_context,
-    };
-
     verify_borsh(light_cpi_accounts, &instruction)
 }
 
@@ -152,11 +72,10 @@ where
     let inputs = inputs.try_to_vec().map_err(|_| LightSdkError::Borsh)?;
 
     let mut data = Vec::with_capacity(8 + 4 + inputs.len());
-    // `InvokeCpi`'s discriminator
     data.extend_from_slice(&light_compressed_account::discriminators::DISCRIMINATOR_INVOKE_CPI);
     data.extend_from_slice(&(inputs.len() as u32).to_le_bytes());
     data.extend(inputs);
-    verify_system_info(&light_system_accounts, data)
+    verify_system_info(light_system_accounts, data)
 }
 
 pub fn verify_system_info(light_system_accounts: &LightCpiAccounts, data: Vec<u8>) -> Result<()> {
@@ -174,20 +93,12 @@ pub fn verify_system_info(light_system_accounts: &LightCpiAccounts, data: Vec<u8
 pub fn invoke_light_system_program(
     invoking_program_id: &Pubkey,
     account_infos: &[AccountInfo],
-    accounts_metas: Vec<AccountMeta>,
+    account_metas: Vec<AccountMeta>,
     data: Vec<u8>,
 ) -> Result<()> {
-    #[cfg(feature = "anchor")]
-    {
-        anchor_lang::prelude::msg!("ACCOUNT METAS (len: {}):", accounts_metas.len(),);
-        for (i, acc_meta) in accounts_metas.iter().enumerate() {
-            anchor_lang::prelude::msg!("{}: {:?}", i, acc_meta);
-        }
-    }
-
     let instruction = Instruction {
         program_id: PROGRAM_ID_LIGHT_SYSTEM,
-        accounts: accounts_metas,
+        accounts: account_metas,
         data,
     };
 
@@ -210,63 +121,6 @@ pub fn invoke_light_system_program(
     }
 
     invoke_signed(&instruction, account_infos, &[signer_seeds.as_slice()])?;
+
     Ok(())
 }
-
-// /// Invokes the light system program to verify and apply a zk-compressed state
-// /// transition. Serializes CPI instruction data, configures necessary accounts,
-// /// and executes the CPI.
-// pub fn verify<T>(
-//     light_system_accounts: &LightCpiAccounts,
-//     inputs: &T,
-//     signer_seeds: &[&[&[u8]]],
-// ) -> Result<()>
-// where
-//     T: BorshSerialize,
-// {
-//     // Probably unnecessary check, since we hardcode program id in instruction.
-//     if light_system_accounts.light_system_program().key != &PROGRAM_ID_LIGHT_SYSTEM {
-//         return Err(LightSdkError::InvalidLightSystemProgram);
-//     }
-//     let inputs = inputs.try_to_vec().map_err(|_| LightSdkError::Borsh)?;
-
-//     let account_infos = light_system_accounts.to_account_infos();
-//     let account_metas = light_system_accounts.to_account_metas();
-//     invoke_cpi(&account_infos, account_metas, inputs, signer_seeds)?;
-//     Ok(())
-// }
-
-// #[inline(always)]
-// pub fn invoke_cpi(
-//     account_infos: &[AccountInfo],
-//     accounts_metas: Vec<AccountMeta>,
-//     inputs: Vec<u8>,
-//     signer_seeds: &[&[&[u8]]],
-// ) -> Result<()> {
-//     let mut data = Vec::with_capacity(8 + 4 + inputs.len());
-//     // `InvokeCpi`'s discriminator
-//     data.extend_from_slice(&light_compressed_account::discriminators::DISCRIMINATOR_INVOKE_CPI);
-//     data.extend_from_slice(&(inputs.len() as u32).to_le_bytes());
-//     data.extend(inputs);
-//     solana_program::msg!(
-//         "account_infos {:?}",
-//         account_infos.iter().map(|x| x.key).collect::<Vec<_>>()
-//     );
-
-//     #[cfg(feature = "anchor")]
-//     {
-//         anchor_lang::prelude::msg!("ACCOUNT METAS (len: {}):", accounts_metas.len(),);
-//         for (i, acc_meta) in accounts_metas.iter().enumerate() {
-//             anchor_lang::prelude::msg!("{}: {:?}", i, acc_meta);
-//         }
-//     }
-
-//     let instruction = Instruction {
-//         program_id: PROGRAM_ID_LIGHT_SYSTEM,
-//         accounts: accounts_metas,
-//         data,
-//     };
-//     invoke_signed(&instruction, account_infos, signer_seeds)?;
-
-//     Ok(())
-// }

--- a/sdk-libs/sdk/src/verify.rs
+++ b/sdk-libs/sdk/src/verify.rs
@@ -29,7 +29,7 @@ pub fn find_cpi_signer(program_id: &Pubkey) -> Pubkey {
 #[macro_export]
 macro_rules! find_cpi_signer_macro {
     ($program_id:expr) => {
-        Pubkey::find_program_address([CPI_AUTHORITY_PDA_SEED].as_slice(), $program_id).0
+        Pubkey::find_program_address([CPI_AUTHORITY_PDA_SEED].as_slice(), $program_id)
     };
 }
 
@@ -62,28 +62,16 @@ pub fn verify_light_account_infos(
     light_cpi_accounts: &LightCpiAccounts,
     proof: Option<ProofRpcResult>,
     light_accounts: &[LightAccountInfo],
+    new_address_params: Option<Vec<NewAddressParamsPacked>>,
     compress_or_decompress_lamports: Option<u64>,
     is_compress: bool,
     cpi_context: Option<CompressedCpiContext>,
 ) -> Result<()> {
-    // TODO: send bump with instruction data or hardcode (best generate with macro during compile time -> hardcode it this way)
-    let bump = Pubkey::find_program_address(
-        &[CPI_AUTHORITY_PDA_SEED],
-        light_cpi_accounts.invoking_program().key,
-    )
-    .1;
-    let signer_seeds = [CPI_AUTHORITY_PDA_SEED, &[bump]];
-
-    let new_address_params = Vec::with_capacity(0);
     let mut input_compressed_accounts_with_merkle_context =
         Vec::with_capacity(light_accounts.len());
     let mut output_compressed_accounts = Vec::with_capacity(light_accounts.len());
 
     for light_account in light_accounts.iter() {
-        // TODO: enable addresses
-        // if let Some(new_address_param) = light_account.new_address_params() {
-        //     new_address_params.push(new_address_param);
-        // }
         if let Some(input_account) = light_account.input_compressed_account()? {
             input_compressed_accounts_with_merkle_context.push(input_account);
         }
@@ -95,7 +83,7 @@ pub fn verify_light_account_infos(
     // TODO: make zero copy
     let instruction = InstructionDataInvokeCpi {
         proof: proof.map(|proof| proof.proof),
-        new_address_params,
+        new_address_params: new_address_params.unwrap_or_default(),
         relay_fee: None,
         input_compressed_accounts_with_merkle_context,
         output_compressed_accounts,
@@ -104,16 +92,16 @@ pub fn verify_light_account_infos(
         cpi_context,
     };
 
-    verify(light_cpi_accounts, &instruction, &[&signer_seeds[..]])?;
-
-    Ok(())
+    verify_borsh(light_cpi_accounts, &instruction)
 }
 
 // TODO: remove only verify light account infos should exist
+// try to use LightAccount -> to_account_info()
 pub fn verify_light_accounts<T>(
     light_cpi_accounts: &LightCpiAccounts,
     proof: Option<ProofRpcResult>,
     light_accounts: &[LightAccount<T>],
+    new_address_params: Option<Vec<NewAddressParamsPacked>>,
     compress_or_decompress_lamports: Option<u64>,
     is_compress: bool,
     cpi_context: Option<CompressedCpiContext>,
@@ -127,23 +115,11 @@ where
         + Discriminator
         + std::fmt::Debug,
 {
-    // TODO: send bump with instruction data or hardcode (best generate with macro during compile time -> hardcode it this way)
-    let bump = Pubkey::find_program_address(
-        &[CPI_AUTHORITY_PDA_SEED],
-        light_cpi_accounts.invoking_program().key,
-    )
-    .1;
-    let signer_seeds = [CPI_AUTHORITY_PDA_SEED, &[bump]];
-
-    let mut new_address_params = Vec::with_capacity(light_accounts.len());
     let mut input_compressed_accounts_with_merkle_context =
         Vec::with_capacity(light_accounts.len());
     let mut output_compressed_accounts = Vec::with_capacity(light_accounts.len());
 
     for light_account in light_accounts.iter() {
-        if let Some(new_address_param) = light_account.new_address_params() {
-            new_address_params.push(new_address_param);
-        }
         if let Some(input_account) = light_account.input_compressed_account()? {
             input_compressed_accounts_with_merkle_context.push(input_account);
         }
@@ -154,7 +130,7 @@ where
 
     let instruction = InstructionDataInvokeCpi {
         proof: proof.map(|proof| proof.proof),
-        new_address_params,
+        new_address_params: new_address_params.unwrap_or_default(),
         relay_fee: None,
         input_compressed_accounts_with_merkle_context,
         output_compressed_accounts,
@@ -163,51 +139,44 @@ where
         cpi_context,
     };
 
-    verify(light_cpi_accounts, &instruction, &[&signer_seeds[..]])?;
-
-    Ok(())
+    verify_borsh(light_cpi_accounts, &instruction)
 }
 
 /// Invokes the light system program to verify and apply a zk-compressed state
 /// transition. Serializes CPI instruction data, configures necessary accounts,
 /// and executes the CPI.
-pub fn verify<T>(
-    light_system_accounts: &LightCpiAccounts,
-    inputs: &T,
-    signer_seeds: &[&[&[u8]]],
-) -> Result<()>
+pub fn verify_borsh<T>(light_system_accounts: &LightCpiAccounts, inputs: &T) -> Result<()>
 where
     T: BorshSerialize,
 {
-    // Probably unnecessary check, since we hardcode program id in instruction.
-    if light_system_accounts.light_system_program().key != &PROGRAM_ID_LIGHT_SYSTEM {
-        return Err(LightSdkError::InvalidLightSystemProgram);
-    }
     let inputs = inputs.try_to_vec().map_err(|_| LightSdkError::Borsh)?;
 
-    let account_infos = light_system_accounts.to_account_infos();
-    let account_metas = light_system_accounts.to_account_metas();
-    invoke_cpi(&account_infos, account_metas, inputs, signer_seeds)?;
-    Ok(())
-}
-
-#[inline(always)]
-pub fn invoke_cpi(
-    account_infos: &[AccountInfo],
-    accounts_metas: Vec<AccountMeta>,
-    inputs: Vec<u8>,
-    signer_seeds: &[&[&[u8]]],
-) -> Result<()> {
     let mut data = Vec::with_capacity(8 + 4 + inputs.len());
     // `InvokeCpi`'s discriminator
     data.extend_from_slice(&light_compressed_account::discriminators::DISCRIMINATOR_INVOKE_CPI);
     data.extend_from_slice(&(inputs.len() as u32).to_le_bytes());
     data.extend(inputs);
-    solana_program::msg!(
-        "account_infos {:?}",
-        account_infos.iter().map(|x| x.key).collect::<Vec<_>>()
-    );
+    verify_system_info(&light_system_accounts, data)
+}
 
+pub fn verify_system_info(light_system_accounts: &LightCpiAccounts, data: Vec<u8>) -> Result<()> {
+    let account_infos = light_system_accounts.to_account_infos();
+    let account_metas = light_system_accounts.to_account_metas();
+    invoke_light_system_program(
+        light_system_accounts.invoking_program().key,
+        &account_infos,
+        account_metas,
+        data,
+    )
+}
+
+#[inline(always)]
+pub fn invoke_light_system_program(
+    invoking_program_id: &Pubkey,
+    account_infos: &[AccountInfo],
+    accounts_metas: Vec<AccountMeta>,
+    data: Vec<u8>,
+) -> Result<()> {
     #[cfg(feature = "anchor")]
     {
         anchor_lang::prelude::msg!("ACCOUNT METAS (len: {}):", accounts_metas.len(),);
@@ -221,7 +190,83 @@ pub fn invoke_cpi(
         accounts: accounts_metas,
         data,
     };
-    invoke_signed(&instruction, account_infos, signer_seeds)?;
 
+    let (authority, bump) = find_cpi_signer_macro!(invoking_program_id);
+    let signer_seeds = [CPI_AUTHORITY_PDA_SEED, &[bump]];
+
+    if *account_infos[1].key != authority {
+        #[cfg(feature = "anchor")]
+        anchor_lang::prelude::msg!(
+            "System program signer authority is invalid. Expected {:?}, found {:?}",
+            authority,
+            account_infos[1].key
+        );
+        #[cfg(feature = "anchor")]
+        anchor_lang::prelude::msg!(
+            "Seeds to derive expected pubkey: [CPI_AUTHORITY_PDA_SEED] {:?}",
+            [CPI_AUTHORITY_PDA_SEED]
+        );
+        return Err(LightSdkError::InvalidCpiSignerAccount);
+    }
+
+    invoke_signed(&instruction, account_infos, &[signer_seeds.as_slice()])?;
     Ok(())
 }
+
+// /// Invokes the light system program to verify and apply a zk-compressed state
+// /// transition. Serializes CPI instruction data, configures necessary accounts,
+// /// and executes the CPI.
+// pub fn verify<T>(
+//     light_system_accounts: &LightCpiAccounts,
+//     inputs: &T,
+//     signer_seeds: &[&[&[u8]]],
+// ) -> Result<()>
+// where
+//     T: BorshSerialize,
+// {
+//     // Probably unnecessary check, since we hardcode program id in instruction.
+//     if light_system_accounts.light_system_program().key != &PROGRAM_ID_LIGHT_SYSTEM {
+//         return Err(LightSdkError::InvalidLightSystemProgram);
+//     }
+//     let inputs = inputs.try_to_vec().map_err(|_| LightSdkError::Borsh)?;
+
+//     let account_infos = light_system_accounts.to_account_infos();
+//     let account_metas = light_system_accounts.to_account_metas();
+//     invoke_cpi(&account_infos, account_metas, inputs, signer_seeds)?;
+//     Ok(())
+// }
+
+// #[inline(always)]
+// pub fn invoke_cpi(
+//     account_infos: &[AccountInfo],
+//     accounts_metas: Vec<AccountMeta>,
+//     inputs: Vec<u8>,
+//     signer_seeds: &[&[&[u8]]],
+// ) -> Result<()> {
+//     let mut data = Vec::with_capacity(8 + 4 + inputs.len());
+//     // `InvokeCpi`'s discriminator
+//     data.extend_from_slice(&light_compressed_account::discriminators::DISCRIMINATOR_INVOKE_CPI);
+//     data.extend_from_slice(&(inputs.len() as u32).to_le_bytes());
+//     data.extend(inputs);
+//     solana_program::msg!(
+//         "account_infos {:?}",
+//         account_infos.iter().map(|x| x.key).collect::<Vec<_>>()
+//     );
+
+//     #[cfg(feature = "anchor")]
+//     {
+//         anchor_lang::prelude::msg!("ACCOUNT METAS (len: {}):", accounts_metas.len(),);
+//         for (i, acc_meta) in accounts_metas.iter().enumerate() {
+//             anchor_lang::prelude::msg!("{}: {:?}", i, acc_meta);
+//         }
+//     }
+
+//     let instruction = Instruction {
+//         program_id: PROGRAM_ID_LIGHT_SYSTEM,
+//         accounts: accounts_metas,
+//         data,
+//     };
+//     invoke_signed(&instruction, account_infos, signer_seeds)?;
+
+//     Ok(())
+// }


### PR DESCRIPTION
### Changes:
- rename `RemainingAccounts` -> `CpiAccounts`
- rename `verify` ->  `verify_borsh` , pull in signer seeds and generate bump seed at compile time in `invoke_light_system_program`
- remove `verify_light_accounts` instead we can do `CAccount.to_account_info()` and use `verify_light_account_infos`
- rename LightAccountInfo -> `CAccountInfo`, split it into `CInAccountInfo` and `COutAccountInfo` for cheaper zero copy
    - removed options for lamports for cheaper zero copy
    - note that `CAccountInfo` will need to move into `light-compressed-account` once we add the pda optimized system program instruction
    - `SystemInfoInstructionData` is unused
-  split up `LightAccountMeta` into 4 specialized structs:
    1. InputAccountMeta (context, address, root_index, output_merkle_tree_index)
        (A pda with address, output, and no lamports is assumed to be the standard case.)
    2. InputAccountMetaNoLamportsNoAddress (context, root_index, output_merkle_tree_index)
    3. InputAccountMetaWithLamportsNoAddress (context, root_index, output_merkle_tree_index)
    4. InputAccountMetaWithLamports (context, lamports, address, root_index, output_merkle_tree_index)
    - `InputAccountMetaTrait` can be used onchain to instantiate a `CAccount` or `CAccountInfo`
- removed `LightAccountMeta` from `LightInstructionData` including it's deserialization function imo it should be part of the devs custom instruction data see tests for usage

### Notes:
- experimented with new naming because the `Light` prefix is makes names even longer, happy to chat about naming
