### PR TITLE
refactor: unify Discriminator traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3540,6 +3540,7 @@ dependencies = [
  "account-compression",
  "anchor-lang",
  "borsh 0.10.4",
+ "light-account-checks",
  "light-compressed-account",
  "light-hasher",
  "light-macros",
@@ -5292,7 +5293,6 @@ name = "sdk-test"
 version = "1.0.0"
 dependencies = [
  "borsh 0.10.4",
- "light-account-checks",
  "light-client",
  "light-compressed-account",
  "light-hasher",

--- a/examples/anchor/counter/src/lib.rs
+++ b/examples/anchor/counter/src/lib.rs
@@ -9,11 +9,10 @@ declare_id!("GRLu2hKaAiMbxpkAM1HeXzks9YeGuz18SEgXEizVvPqX");
 
 #[program]
 pub mod counter {
-    use light_hasher::Discriminator;
     use light_sdk::{
         address::derive_address, error::LightSdkError,
         program_merkle_context::unpack_address_merkle_context,
-        system_accounts::CompressionCpiAccounts,
+        system_accounts::CompressionCpiAccounts, Discriminator,
     };
 
     use super::*;

--- a/examples/anchor/memo/src/lib.rs
+++ b/examples/anchor/memo/src/lib.rs
@@ -12,10 +12,9 @@ declare_id!("GRLu2hKaAiMbxpkAM1HeXzks9YeGuz18SEgXEizVvPqX");
 
 #[program]
 pub mod memo {
-    use light_hasher::Discriminator;
     use light_sdk::{
         address::derive_address, error::LightSdkError,
-        program_merkle_context::unpack_address_merkle_context,
+        program_merkle_context::unpack_address_merkle_context, Discriminator,
     };
 
     use super::*;

--- a/examples/anchor/name-service-without-macros/src/lib.rs
+++ b/examples/anchor/name-service-without-macros/src/lib.rs
@@ -12,10 +12,9 @@ declare_id!("7yucc7fL3JGbyMwg4neUaenNSdySS39hbAk89Ao3t1Hz");
 
 #[program]
 pub mod name_service {
-    use light_hasher::Discriminator;
     use light_sdk::{
         address::derive_address, error::LightSdkError,
-        program_merkle_context::unpack_address_merkle_context,
+        program_merkle_context::unpack_address_merkle_context, Discriminator,
     };
 
     use super::*;

--- a/program-libs/account-checks/src/discriminator.rs
+++ b/program-libs/account-checks/src/discriminator.rs
@@ -1,8 +1,8 @@
-pub const ANCHOR_DISCRIMINATOR_LEN: usize = 8;
+pub const DISCRIMINATOR_LEN: usize = 8;
 
-pub trait Discriminator<const T: usize> {
-    const DISCRIMINATOR: [u8; T];
-    fn discriminator() -> [u8; T] {
+pub trait Discriminator {
+    const DISCRIMINATOR: [u8; 8];
+    fn discriminator() -> [u8; 8] {
         Self::DISCRIMINATOR
     }
 }

--- a/program-libs/batched-merkle-tree/src/queue.rs
+++ b/program-libs/batched-merkle-tree/src/queue.rs
@@ -3,7 +3,7 @@ use std::ops::{Deref, DerefMut};
 use aligned_sized::aligned_sized;
 use light_account_checks::{
     checks::{check_account_info, set_discriminator},
-    discriminator::{Discriminator, ANCHOR_DISCRIMINATOR_LEN},
+    discriminator::{Discriminator, DISCRIMINATOR_LEN},
 };
 use light_compressed_account::{
     hash_to_bn254_field_size_be, pubkey::Pubkey, QueueType, BATCHED_OUTPUT_QUEUE_TYPE,
@@ -133,7 +133,7 @@ pub struct BatchedQueueAccount<'a> {
     pub hash_chain_stores: [ZeroCopyVecU64<'a, [u8; 32]>; 2],
 }
 
-impl Discriminator<ANCHOR_DISCRIMINATOR_LEN> for BatchedQueueAccount<'_> {
+impl Discriminator for BatchedQueueAccount<'_> {
     const DISCRIMINATOR: [u8; 8] = *b"queueacc";
 }
 
@@ -160,7 +160,7 @@ impl<'a> BatchedQueueAccount<'a> {
         program_id: &crate::Pubkey,
         account_info: &AccountInfo,
     ) -> Result<BatchedQueueAccount<'a>, BatchedMerkleTreeError> {
-        check_account_info::<Self, ANCHOR_DISCRIMINATOR_LEN>(program_id, account_info)?;
+        check_account_info::<Self>(program_id, account_info)?;
         let account_data = &mut account_info.try_borrow_mut_data()?;
         // Necessary to convince the borrow checker.
         let account_data: &'a mut [u8] = unsafe {
@@ -176,10 +176,7 @@ impl<'a> BatchedQueueAccount<'a> {
     pub fn output_from_bytes(
         account_data: &'a mut [u8],
     ) -> Result<BatchedQueueAccount<'a>, BatchedMerkleTreeError> {
-        light_account_checks::checks::check_discriminator::<
-            BatchedQueueAccount,
-            ANCHOR_DISCRIMINATOR_LEN,
-        >(account_data)?;
+        light_account_checks::checks::check_discriminator::<BatchedQueueAccount>(account_data)?;
         Self::from_bytes::<BATCHED_OUTPUT_QUEUE_TYPE>(account_data, Pubkey::default())
     }
 
@@ -187,7 +184,7 @@ impl<'a> BatchedQueueAccount<'a> {
         account_data: &'a mut [u8],
         pubkey: Pubkey,
     ) -> Result<BatchedQueueAccount<'a>, BatchedMerkleTreeError> {
-        let (_discriminator, account_data) = account_data.split_at_mut(ANCHOR_DISCRIMINATOR_LEN);
+        let (_discriminator, account_data) = account_data.split_at_mut(DISCRIMINATOR_LEN);
         let (metadata, account_data) =
             Ref::<&'a mut [u8], BatchedQueueMetadata>::from_prefix(account_data)
                 .map_err(ZeroCopyError::from)?;
@@ -220,8 +217,8 @@ impl<'a> BatchedQueueAccount<'a> {
         pubkey: Pubkey,
     ) -> Result<BatchedQueueAccount<'a>, BatchedMerkleTreeError> {
         let account_data_len = account_data.len();
-        let (discriminator, account_data) = account_data.split_at_mut(ANCHOR_DISCRIMINATOR_LEN);
-        set_discriminator::<Self, ANCHOR_DISCRIMINATOR_LEN>(discriminator)?;
+        let (discriminator, account_data) = account_data.split_at_mut(DISCRIMINATOR_LEN);
+        set_discriminator::<Self>(discriminator)?;
 
         let (mut account_metadata, account_data) =
             Ref::<&mut [u8], BatchedQueueMetadata>::from_prefix(account_data)

--- a/program-libs/hasher/src/lib.rs
+++ b/program-libs/hasher/src/lib.rs
@@ -29,14 +29,6 @@ pub trait Hasher {
     fn zero_indexed_leaf() -> [u8; 32];
 }
 
-// TODO: remove once light-sdk is switched to account-checks
-pub trait Discriminator {
-    const DISCRIMINATOR: [u8; 8];
-    fn discriminator() -> [u8; 8] {
-        Self::DISCRIMINATOR
-    }
-}
-
 #[cfg(feature = "pinocchio")]
 use pinocchio::program_error::ProgramError;
 #[cfg(not(feature = "pinocchio"))]

--- a/program-tests/sdk-anchor-test/programs/sdk-anchor-test/Cargo.toml
+++ b/program-tests/sdk-anchor-test/programs/sdk-anchor-test/Cargo.toml
@@ -21,11 +21,10 @@ bench-sbf = []
 idl-build = ["anchor-lang/idl-build", "light-sdk/idl-build"]
 
 [dependencies]
+# Needs to be imported for LightHasher
 light-hasher = { workspace = true, features = ["solana"] }
 anchor-lang = { workspace = true }
-light-sdk = { workspace = true, features = [
-    "anchor",
-] }
+light-sdk = { workspace = true, features = ["anchor"] }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 solana-sdk = { workspace = true }

--- a/program-tests/sdk-anchor-test/programs/sdk-anchor-test/src/lib.rs
+++ b/program-tests/sdk-anchor-test/programs/sdk-anchor-test/src/lib.rs
@@ -4,7 +4,7 @@ use light_sdk::{
     cpi::verify::verify_compressed_account_infos,
     error::LightSdkError,
     instruction::{account_meta::CompressedAccountMeta, instruction_data::LightInstructionData},
-    light_account, LightHasher,
+    light_account, Discriminator, LightHasher,
 };
 
 declare_id!("2tzfijPBGbrR5PboyFUFKzfEoLTwdDSHUjANCw929wyt");

--- a/program-tests/sdk-test/Cargo.toml
+++ b/program-tests/sdk-test/Cargo.toml
@@ -21,11 +21,10 @@ default = []
 [dependencies]
 light-sdk = { workspace = true, features = ["solana"] }
 light-hasher = { workspace = true, features = ["solana"] }
-light-compressed-account = { workspace = true, features = ["solana"] }
 solana-program = { workspace = true }
 light-macros = { workspace = true, features = ["solana"] }
-light-account-checks = { workspace = true, features = ["solana"] }
 borsh = { workspace = true }
+light-compressed-account = { workspace = true, features = ["solana"] }
 
 [dev-dependencies]
 light-program-test = { workspace = true, features = ["devenv"] }

--- a/programs/system/src/invoke_cpi/account.rs
+++ b/programs/system/src/invoke_cpi/account.rs
@@ -25,7 +25,7 @@ pub struct CpiContextAccount {
     pub context: Vec<InstructionDataInvokeCpi>,
 }
 
-impl Discriminator<8> for CpiContextAccount {
+impl Discriminator for CpiContextAccount {
     const DISCRIMINATOR: [u8; 8] = [22, 20, 149, 218, 74, 204, 128, 166];
 }
 

--- a/programs/system/src/invoke_cpi/instruction.rs
+++ b/programs/system/src/invoke_cpi/instruction.rs
@@ -74,7 +74,7 @@ impl<'info> InvokeCpiInstruction<'info> {
             None
         } else {
             check_owner(&crate::ID, option_cpi_context_account).map_err(ProgramError::from)?;
-            check_discriminator::<CpiContextAccount, 8>(
+            check_discriminator::<CpiContextAccount>(
                 option_cpi_context_account.try_borrow_data()?.as_ref(),
             )
             .map_err(ProgramError::from)?;

--- a/programs/system/src/invoke_cpi/small_accounts.rs
+++ b/programs/system/src/invoke_cpi/small_accounts.rs
@@ -61,7 +61,7 @@ impl<'info> InvokeCpiInstructionSmall<'info> {
         let cpi_context_account = if options_config.cpi_context_account {
             let option_cpi_context_account = &accounts[account_counter];
             check_owner(&crate::ID, option_cpi_context_account).map_err(ProgramError::from)?;
-            check_discriminator::<CpiContextAccount, 8>(
+            check_discriminator::<CpiContextAccount>(
                 option_cpi_context_account.try_borrow_data()?.as_ref(),
             )
             .map_err(ProgramError::from)?;

--- a/sdk-libs/macros/src/discriminator.rs
+++ b/sdk-libs/macros/src/discriminator.rs
@@ -13,8 +13,12 @@ pub(crate) fn discriminator(input: ItemStruct) -> Result<TokenStream> {
     let discriminator: proc_macro2::TokenStream = format!("{discriminator:?}").parse().unwrap();
 
     Ok(quote! {
-        impl #impl_gen light_hasher::Discriminator for #account_name #type_gen #where_clause {
+        impl #impl_gen Discriminator for #account_name #type_gen #where_clause {
             const DISCRIMINATOR: [u8; 8] = #discriminator;
+
+            fn discriminator() -> [u8; 8] {
+                Self::DISCRIMINATOR
+            }
         }
     })
 }
@@ -39,7 +43,7 @@ mod tests {
         let output = discriminator(input).unwrap();
         let output = output.to_string();
 
-        assert!(output.contains("impl light_hasher :: Discriminator for MyAccount"));
+        assert!(output.contains("impl Discriminator for MyAccount"));
         assert!(output.contains("[181 , 255 , 112 , 42 , 17 , 188 , 66 , 199]"));
     }
 }

--- a/sdk-libs/sdk/Cargo.toml
+++ b/sdk-libs/sdk/Cargo.toml
@@ -53,6 +53,7 @@ light-macros = { workspace = true }
 light-compressed-account = { workspace = true }
 light-verifier = { workspace = true }
 light-hasher = { workspace = true }
+light-account-checks = { workspace = true }
 
 [dev-dependencies]
 num-bigint = { workspace = true }

--- a/sdk-libs/sdk/src/account.rs
+++ b/sdk-libs/sdk/src/account.rs
@@ -1,13 +1,13 @@
 use std::ops::{Deref, DerefMut};
 
 use light_compressed_account::pubkey::Pubkey;
-use light_hasher::{DataHasher, Discriminator, Poseidon};
+use light_hasher::{DataHasher, Poseidon};
 
 use crate::{
     account_info::{CompressedAccountInfo, InAccountInfo, OutAccountInfo},
     error::LightSdkError,
     instruction::account_meta::CompressedAccountMetaTrait,
-    AnchorDeserialize, AnchorSerialize,
+    AnchorDeserialize, AnchorSerialize, Discriminator,
 };
 
 #[derive(Debug, PartialEq)]

--- a/sdk-libs/sdk/src/lib.rs
+++ b/sdk-libs/sdk/src/lib.rs
@@ -1,6 +1,3 @@
-pub use light_macros::*;
-pub use light_sdk_macros::*;
-
 pub mod account;
 pub mod account_info;
 pub mod address;
@@ -18,8 +15,11 @@ pub mod utils;
 use anchor_lang::{AnchorDeserialize, AnchorSerialize};
 #[cfg(not(feature = "anchor"))]
 use borsh::{BorshDeserialize as AnchorDeserialize, BorshSerialize as AnchorSerialize};
+pub use light_account_checks::{discriminator::Discriminator, *};
 pub use light_compressed_account::instruction_data::data::*;
-pub use light_hasher as hasher;
+pub use light_hasher::*;
+pub use light_macros::*;
+pub use light_sdk_macros::*;
 pub use light_verifier as verifier;
 use solana_program::{
     account_info::AccountInfo,


### PR DESCRIPTION
**changes:**
1. refactor discriminator sdk macro to implement `Discriminator` instead of `light_hasher::Discriminator`
2. light-hasher remove Discriminator
3. light-account-checks remove constant from Discriminator
    3.1. adapt batched Merkle tree impl of Discriminator trait  