### PR TITLE
refactor: sdk use compressed account info from light-compressed-account

### DIFF
--- a/examples/anchor/counter/src/lib.rs
+++ b/examples/anchor/counter/src/lib.rs
@@ -76,7 +76,7 @@ pub mod counter {
             .as_ref()
             .ok_or(LightSdkError::ExpectedAccounts)?;
         let mut counter: LightAccount<'_, CounterAccount> =
-            LightAccount::from_meta_mut(&accounts[0], CounterAccount::discriminator(), &crate::ID)?;
+            LightAccount::meta_mut(&accounts[0], CounterAccount::discriminator(), &crate::ID)?;
 
         if counter.owner != ctx.accounts.signer.key() {
             return err!(CustomError::Unauthorized);
@@ -109,7 +109,7 @@ pub mod counter {
             .ok_or(LightSdkError::ExpectedAccounts)?;
 
         let mut counter: LightAccount<'_, CounterAccount> =
-            LightAccount::from_meta_mut(&accounts[0], CounterAccount::discriminator(), &crate::ID)?;
+            LightAccount::meta_mut(&accounts[0], CounterAccount::discriminator(), &crate::ID)?;
 
         if counter.owner != ctx.accounts.signer.key() {
             return err!(CustomError::Unauthorized);
@@ -145,7 +145,7 @@ pub mod counter {
             .ok_or(LightSdkError::ExpectedAccounts)?;
 
         let mut counter: LightAccount<'_, CounterAccount> =
-            LightAccount::from_meta_mut(&accounts[0], CounterAccount::discriminator(), &crate::ID)?;
+            LightAccount::meta_mut(&accounts[0], CounterAccount::discriminator(), &crate::ID)?;
 
         if counter.owner != ctx.accounts.signer.key() {
             return err!(CustomError::Unauthorized);

--- a/examples/anchor/memo/src/lib.rs
+++ b/examples/anchor/memo/src/lib.rs
@@ -86,7 +86,7 @@ pub mod memo {
             .map_err(ProgramError::from)?;
 
         let mut memo: LightAccount<'_, MemoAccount> =
-            LightAccount::from_meta_mut(&accounts[0], MemoAccount::discriminator(), &crate::ID)
+            LightAccount::meta_mut(&accounts[0], MemoAccount::discriminator(), &crate::ID)
                 .map_err(ProgramError::from)?;
 
         if memo.authority != ctx.accounts.signer.key() {
@@ -126,7 +126,7 @@ pub mod memo {
             .map_err(ProgramError::from)?;
 
         let memo: LightAccount<'_, MemoAccount> =
-            LightAccount::from_meta_close(&accounts[0], MemoAccount::discriminator(), &crate::ID)
+            LightAccount::meta_close(&accounts[0], MemoAccount::discriminator(), &crate::ID)
                 .map_err(ProgramError::from)?;
 
         if memo.authority != ctx.accounts.signer.key() {

--- a/examples/anchor/name-service-without-macros/src/lib.rs
+++ b/examples/anchor/name-service-without-macros/src/lib.rs
@@ -74,7 +74,7 @@ pub mod name_service {
 
         // Convert `LightAccountMeta` to `LightAccount`.
         let mut record: LightAccount<'_, NameRecord> =
-            LightAccount::from_meta_mut(&accounts[0], NameRecord::discriminator(), &crate::ID)?;
+            LightAccount::meta_mut(&accounts[0], NameRecord::discriminator(), &crate::ID)?;
 
         // Check the ownership of the `record`.
         if record.owner != ctx.accounts.signer.key() {
@@ -99,7 +99,7 @@ pub mod name_service {
             .ok_or(LightSdkError::ExpectedAccounts)?;
 
         let record: LightAccount<'_, NameRecord> =
-            LightAccount::from_meta_close(&accounts[0], NameRecord::discriminator(), &crate::ID)?;
+            LightAccount::meta_close(&accounts[0], NameRecord::discriminator(), &crate::ID)?;
 
         if record.owner != ctx.accounts.signer.key() {
             return err!(CustomError::Unauthorized);

--- a/program-libs/compressed-account/src/instruction_data/with_account_info.rs
+++ b/program-libs/compressed-account/src/instruction_data/with_account_info.rs
@@ -230,8 +230,7 @@ impl DerefMut for ZOutAccountInfoMut<'_> {
 }
 
 #[derive(Debug, PartialEq, Clone, Default, AnchorSerialize, AnchorDeserialize)]
-pub struct CAccountInfo {
-    pub discriminator: [u8; 8], // 1
+pub struct CompressedAccountInfo {
     /// Address.
     pub address: Option<[u8; 32]>, // 2
     /// Input account.
@@ -252,7 +251,7 @@ pub struct ZCAccountInfo<'a> {
     pub output: Option<ZOutAccountInfo<'a>>, // 5
 }
 
-impl<'a> CAccountInfo {
+impl<'a> CompressedAccountInfo {
     pub fn zero_copy_at_with_owner(
         bytes: &'a [u8],
         owner: Pubkey,
@@ -289,7 +288,7 @@ pub struct InstructionDataInvokeCpiWithAccountInfo {
     pub cpi_context: CompressedCpiContext,
     pub proof: Option<CompressedProof>,
     pub new_address_params: Vec<NewAddressParamsPacked>,
-    pub account_infos: Vec<CAccountInfo>,
+    pub account_infos: Vec<CompressedAccountInfo>,
     pub read_only_addresses: Vec<PackedReadOnlyAddress>,
     pub read_only_accounts: Vec<PackedReadOnlyCompressedAccount>,
 }
@@ -420,8 +419,10 @@ impl<'a> Deserialize<'a> for InstructionDataInvokeCpiWithAccountInfo {
             // This prevents agains invalid data allocating a lot of heap memory
             let mut slices = Vec::with_capacity(num_slices);
             for _ in 0..num_slices {
-                let (slice, _bytes) =
-                    CAccountInfo::zero_copy_at_with_owner(bytes, meta.invoking_program_id)?;
+                let (slice, _bytes) = CompressedAccountInfo::zero_copy_at_with_owner(
+                    bytes,
+                    meta.invoking_program_id,
+                )?;
                 bytes = _bytes;
                 slices.push(slice);
             }

--- a/sdk-libs/sdk/src/account.rs
+++ b/sdk-libs/sdk/src/account.rs
@@ -1,13 +1,14 @@
 use std::ops::{Deref, DerefMut};
 
-use light_compressed_account::pubkey::Pubkey;
+use light_compressed_account::{
+    instruction_data::with_account_info::{CompressedAccountInfo, InAccountInfo, OutAccountInfo},
+    pubkey::Pubkey,
+};
 use light_hasher::{DataHasher, Poseidon};
 
 use crate::{
-    account_info::{CompressedAccountInfo, InAccountInfo, OutAccountInfo},
-    error::LightSdkError,
-    instruction::account_meta::CompressedAccountMetaTrait,
-    AnchorDeserialize, AnchorSerialize, Discriminator,
+    error::LightSdkError, instruction::account_meta::CompressedAccountMetaTrait, AnchorDeserialize,
+    AnchorSerialize, Discriminator,
 };
 
 #[derive(Debug, PartialEq)]

--- a/sdk-libs/sdk/src/account.rs
+++ b/sdk-libs/sdk/src/account.rs
@@ -30,13 +30,13 @@ impl<'a, A: AnchorSerialize + AnchorDeserialize + Discriminator + DataHasher + D
     ) -> Self {
         let output_account_info = OutAccountInfo {
             output_merkle_tree_index,
+            discriminator: A::DISCRIMINATOR,
             ..Default::default()
         };
         Self {
             owner,
             account: A::default(),
             account_info: CompressedAccountInfo {
-                discriminator: A::discriminator(),
                 address,
                 input: None,
                 output: Some(output_account_info),
@@ -56,12 +56,14 @@ impl<'a, A: AnchorSerialize + AnchorDeserialize + Discriminator + DataHasher + D
                 lamports: input_account_meta.get_lamports().unwrap_or_default(),
                 merkle_context: *input_account_meta.get_merkle_context(),
                 root_index: input_account_meta.get_root_index().unwrap_or_default(),
+                discriminator: A::DISCRIMINATOR,
             }
         };
         let output_account_info = {
             OutAccountInfo {
                 lamports: input_account_meta.get_lamports().unwrap_or_default(),
                 output_merkle_tree_index: input_account_meta.get_output_merkle_tree_index(),
+                discriminator: A::DISCRIMINATOR,
                 ..Default::default()
             }
         };
@@ -70,7 +72,6 @@ impl<'a, A: AnchorSerialize + AnchorDeserialize + Discriminator + DataHasher + D
             owner,
             account: input_account,
             account_info: CompressedAccountInfo {
-                discriminator: A::discriminator(),
                 address: input_account_meta.get_address(),
                 input: Some(input_account_info),
                 output: Some(output_account_info),
@@ -90,13 +91,13 @@ impl<'a, A: AnchorSerialize + AnchorDeserialize + Discriminator + DataHasher + D
                 lamports: input_account_meta.get_lamports().unwrap_or_default(),
                 merkle_context: *input_account_meta.get_merkle_context(),
                 root_index: input_account_meta.get_root_index().unwrap_or_default(),
+                discriminator: A::DISCRIMINATOR,
             }
         };
         Ok(Self {
             owner,
             account: input_account,
             account_info: CompressedAccountInfo {
-                discriminator: A::discriminator(),
                 address: input_account_meta.get_address(),
                 input: Some(input_account_info),
                 output: None,
@@ -105,7 +106,7 @@ impl<'a, A: AnchorSerialize + AnchorDeserialize + Discriminator + DataHasher + D
     }
 
     pub fn discriminator(&self) -> &[u8; 8] {
-        &self.account_info.discriminator
+        &A::DISCRIMINATOR
     }
 
     pub fn lamports(&self) -> u64 {

--- a/sdk-libs/sdk/src/account_info.rs
+++ b/sdk-libs/sdk/src/account_info.rs
@@ -1,84 +1,37 @@
 use light_compressed_account::{
     compressed_account::{
         CompressedAccount, CompressedAccountData, PackedCompressedAccountWithMerkleContext,
-        PackedMerkleContext, PackedReadOnlyCompressedAccount,
     },
     instruction_data::{
-        compressed_proof::CompressedProof,
-        cpi_context::CompressedCpiContext,
-        data::{
-            NewAddressParamsPacked, OutputCompressedAccountWithPackedContext, PackedReadOnlyAddress,
-        },
+        data::OutputCompressedAccountWithPackedContext,
+        with_account_info::{CompressedAccountInfo, InAccountInfo},
     },
-    pubkey::Pubkey,
     CompressedAccountError,
 };
 
-use crate::{
-    error::LightSdkError, instruction::account_meta::CompressedAccountMetaTrait, msg,
-    AnchorDeserialize, AnchorSerialize,
-};
+use crate::{error::LightSdkError, instruction::account_meta::CompressedAccountMetaTrait, msg};
 
-#[derive(Debug, AnchorSerialize, AnchorDeserialize)]
-pub struct SystemInfoInstructionData {
-    pub bump: u8,
-    pub invoking_program_id: Pubkey,
-    pub is_compress: bool,
-    pub compress_or_decompress_lamports: u64,
-    pub cpi_context: CompressedCpiContext,
-    pub proof: Option<CompressedProof>,
-    pub new_addresses: Vec<NewAddressParamsPacked>,
-    pub read_only_accounts: Vec<PackedReadOnlyCompressedAccount>,
-    pub read_only_addresses: Vec<PackedReadOnlyAddress>,
-    pub light_account_infos: Vec<CompressedAccountInfo>,
-}
-
-#[derive(Debug, Default, PartialEq, AnchorSerialize, AnchorDeserialize)]
-pub struct InAccountInfo {
-    /// Data hash
-    pub data_hash: [u8; 32],
-    /// Merkle tree context.
-    pub merkle_context: PackedMerkleContext,
-    /// Root index.
-    pub root_index: u16,
-    /// Lamports.
-    pub lamports: u64,
-}
-
-#[derive(Debug, Default, PartialEq, AnchorSerialize, AnchorDeserialize)]
-pub struct OutAccountInfo {
-    /// Data hash
-    pub data_hash: [u8; 32],
-    pub output_merkle_tree_index: u8,
-    /// Lamports.
-    pub lamports: u64,
-    /// Account data.
-    pub data: Vec<u8>,
-}
-
-#[derive(Debug, Default, PartialEq, AnchorSerialize, AnchorDeserialize)]
-pub struct CompressedAccountInfo {
-    // TODO: optimize parsing by manually implementing ZeroCopy and using the bitmask.
-    // bitmask: u8,
-    pub discriminator: [u8; 8], // 1
-    /// Address.
-    pub address: Option<[u8; 32]>, // 2
-    /// Input account.
-    pub input: Option<InAccountInfo>, // 3
-    /// Output account.
-    pub output: Option<OutAccountInfo>, // 5
-}
-
-impl InAccountInfo {
-    pub fn from_input_meta<T: CompressedAccountMetaTrait>(
+pub trait InAccountInfoTrait {
+    fn input_meta<T: CompressedAccountMetaTrait>(
         &mut self,
         meta: &T,
         data_hash: [u8; 32],
+        discriminator: [u8; 8],
+    );
+}
+
+impl InAccountInfoTrait for InAccountInfo {
+    fn input_meta<T: CompressedAccountMetaTrait>(
+        &mut self,
+        meta: &T,
+        data_hash: [u8; 32],
+        discriminator: [u8; 8],
     ) {
         if let Some(input_lamports) = meta.get_lamports() {
             self.lamports = input_lamports;
         }
         self.data_hash = data_hash;
+        self.discriminator = discriminator;
         if let Some(root_index) = meta.get_root_index().as_ref() {
             self.root_index = *root_index;
         }
@@ -86,17 +39,49 @@ impl InAccountInfo {
     }
 }
 
-impl CompressedAccountInfo {
+pub trait AccountInfoTrait {
+    fn init(
+        &mut self,
+        discriminator: [u8; 8],
+        address: Option<[u8; 32]>,
+        output_merkle_tree_index: u8,
+    ) -> Result<(), CompressedAccountError>;
+
+    fn meta_mut<M: CompressedAccountMetaTrait>(
+        &mut self,
+        // Input
+        input_account_meta: &M,
+        input_data_hash: [u8; 32],
+        discriminator: [u8; 8],
+        output_merkle_tree_index: u8,
+    ) -> Result<(), CompressedAccountError>;
+
+    fn meta_close<M: CompressedAccountMetaTrait>(
+        &mut self,
+        input_account_meta: &M,
+        input_data_hash: [u8; 32],
+        discriminator: [u8; 8],
+    ) -> Result<(), CompressedAccountError>;
+    fn input_compressed_account(
+        &self,
+        owner: crate::Pubkey,
+    ) -> Result<Option<PackedCompressedAccountWithMerkleContext>, LightSdkError>;
+    fn output_compressed_account(
+        &self,
+        owner: crate::Pubkey,
+    ) -> Result<Option<OutputCompressedAccountWithPackedContext>, LightSdkError>;
+}
+
+impl AccountInfoTrait for CompressedAccountInfo {
     /// Initializes a compressed account info with address.
     /// 1. The account is zeroed, data has to be added in a separate step.
     /// 2. Once data is added the data hash has to be added.
-    pub fn init(
+    fn init(
         &mut self,
         discriminator: [u8; 8],
         address: Option<[u8; 32]>,
         output_merkle_tree_index: u8,
     ) -> Result<(), CompressedAccountError> {
-        self.discriminator = discriminator;
         if let Some(self_address) = self.address.as_mut() {
             if let Some(address) = address {
                 self_address.copy_from_slice(&address);
@@ -110,6 +95,7 @@ impl CompressedAccountInfo {
         }
         if let Some(output) = self.output.as_mut() {
             output.output_merkle_tree_index = output_merkle_tree_index;
+            output.discriminator = discriminator;
         } else {
             msg!("init_with_address: output is none");
             return Err(CompressedAccountError::InvalidAccountSize);
@@ -120,7 +106,7 @@ impl CompressedAccountInfo {
     /// Initializes a compressed account info with address.
     /// 1. The account is zeroed, data has to be added in a separate step.
     /// 2. Once data is added the data hash has to be added.
-    pub fn from_meta_mut<M: CompressedAccountMetaTrait>(
+    fn meta_mut<M: CompressedAccountMetaTrait>(
         &mut self,
         // Input
         input_account_meta: &M,
@@ -128,12 +114,6 @@ impl CompressedAccountInfo {
         discriminator: [u8; 8],
         output_merkle_tree_index: u8,
     ) -> Result<(), CompressedAccountError> {
-        if self.discriminator != [0; 8] {
-            msg!("from_z_meta_mut: discriminator is not zeroed. Account already loaded.");
-            return Err(CompressedAccountError::InvalidAccountSize);
-        }
-        self.discriminator = discriminator;
-
         if let Some(self_address) = self.address.as_mut() {
             if let Some(address) = input_account_meta.get_address().as_ref() {
                 *self_address = *address;
@@ -147,7 +127,7 @@ impl CompressedAccountInfo {
         }
 
         if let Some(input) = self.input.as_mut() {
-            input.from_input_meta(input_account_meta, input_data_hash);
+            input.input_meta(input_account_meta, input_data_hash, discriminator);
         } else {
             msg!("from_z_meta_mut: input is none");
             return Err(CompressedAccountError::InvalidAccountSize);
@@ -155,6 +135,7 @@ impl CompressedAccountInfo {
 
         if let Some(output) = self.output.as_mut() {
             output.output_merkle_tree_index = output_merkle_tree_index;
+            output.discriminator = discriminator;
 
             if let Some(input_lamports) = input_account_meta.get_lamports() {
                 output.lamports = input_lamports;
@@ -172,14 +153,12 @@ impl CompressedAccountInfo {
     /// Initializes a compressed account info with address.
     /// 1. The account is zeroed, data has to be added in a separate step.
     /// 2. Once data is added the data hash has to be added.
-    pub fn from_meta_close<M: CompressedAccountMetaTrait>(
+    fn meta_close<M: CompressedAccountMetaTrait>(
         &mut self,
         input_account_meta: &M,
         input_data_hash: [u8; 32],
         discriminator: [u8; 8],
     ) -> Result<(), CompressedAccountError> {
-        self.discriminator = discriminator;
-
         if let Some(self_address) = self.address.as_mut() {
             if let Some(address) = input_account_meta.get_address() {
                 self_address.copy_from_slice(&address);
@@ -193,7 +172,7 @@ impl CompressedAccountInfo {
         }
 
         if let Some(input) = self.input.as_mut() {
-            input.from_input_meta(input_account_meta, input_data_hash);
+            input.input_meta(input_account_meta, input_data_hash, discriminator);
         } else {
             msg!("from_z_meta_mut: input is none");
             return Err(CompressedAccountError::InvalidAccountSize);
@@ -202,14 +181,14 @@ impl CompressedAccountInfo {
         Ok(())
     }
 
-    pub(crate) fn input_compressed_account(
+    fn input_compressed_account(
         &self,
         owner: crate::Pubkey,
     ) -> Result<Option<PackedCompressedAccountWithMerkleContext>, LightSdkError> {
         match self.input.as_ref() {
             Some(input) => {
                 let data = Some(CompressedAccountData {
-                    discriminator: self.discriminator,
+                    discriminator: input.discriminator,
                     data: Vec::new(),
                     data_hash: input.data_hash,
                 });
@@ -229,14 +208,14 @@ impl CompressedAccountInfo {
         }
     }
 
-    pub fn output_compressed_account(
+    fn output_compressed_account(
         &self,
         owner: crate::Pubkey,
     ) -> Result<Option<OutputCompressedAccountWithPackedContext>, LightSdkError> {
         match self.output.as_ref() {
             Some(output) => {
                 let data = Some(CompressedAccountData {
-                    discriminator: self.discriminator,
+                    discriminator: output.discriminator,
                     data: output.data.clone(),
                     data_hash: output.data_hash,
                 });

--- a/sdk-libs/sdk/src/cpi/verify.rs
+++ b/sdk-libs/sdk/src/cpi/verify.rs
@@ -1,10 +1,11 @@
 use light_compressed_account::instruction_data::{
     compressed_proof::CompressedProof, cpi_context::CompressedCpiContext,
     data::NewAddressParamsPacked, invoke_cpi::InstructionDataInvokeCpi,
+    with_account_info::CompressedAccountInfo,
 };
 
 use crate::{
-    account_info::CompressedAccountInfo,
+    account_info::AccountInfoTrait,
     cpi::accounts::CompressionCpiAccounts,
     error::{LightSdkError, Result},
     find_cpi_signer_macro, invoke_signed, AccountInfo, AccountMeta, AnchorSerialize, Instruction,

--- a/sdk-libs/sdk/src/transfer.rs
+++ b/sdk-libs/sdk/src/transfer.rs
@@ -1,7 +1,6 @@
-use crate::{
-    account_info::CompressedAccountInfo,
-    error::{LightSdkError, Result},
-};
+use light_compressed_account::instruction_data::with_account_info::CompressedAccountInfo;
+
+use crate::error::{LightSdkError, Result};
 
 /// Transfers a specified amount of lamports from one account to another.
 ///
@@ -50,13 +49,15 @@ pub fn transfer_compressed_sol(
 
 #[cfg(test)]
 mod tests {
-    use light_compressed_account::compressed_account::PackedMerkleContext;
+    use light_compressed_account::{
+        compressed_account::PackedMerkleContext,
+        instruction_data::with_account_info::{
+            CompressedAccountInfo, InAccountInfo, OutAccountInfo,
+        },
+    };
 
     use super::*;
-    use crate::{
-        account_info::{CompressedAccountInfo, InAccountInfo, OutAccountInfo},
-        Pubkey,
-    };
+    use crate::Pubkey;
 
     /// Creates a mock account with the given input lamports.
     fn mock_account(_owner: &Pubkey, lamports: Option<u64>) -> CompressedAccountInfo {
@@ -72,6 +73,8 @@ mod tests {
                     leaf_index: 0,
                     prove_by_index: false,
                 },
+                // None of the following values matter.
+                discriminator: [0; 8],
                 root_index: 0,
             }),
             output: Some(OutAccountInfo {
@@ -80,9 +83,9 @@ mod tests {
                 data_hash: [0; 32],
                 data: Vec::new(),
                 output_merkle_tree_index: 0,
+                // None of the following values matter.
+                discriminator: [0; 8],
             }),
-            // None of the following values matter.
-            discriminator: [0; 8],
             address: Some([1; 32]),
         }
     }
@@ -97,9 +100,9 @@ mod tests {
                 data_hash: [0; 32],
                 data: Vec::new(),
                 output_merkle_tree_index: 0,
+                // None of the following values matter.
+                discriminator: [0; 8],
             }),
-            // None of the following values matter.
-            discriminator: [0; 8],
             address: Some([1; 32]),
         }
     }


### PR DESCRIPTION
Changes:
1. rename `from_meta_mut` -> `meta_mut`
2. rename `CAccountInfo` -> `CompressedAccountInfo`
3. remove `light-sdk` implementations and import from `light-compressed-account` instead 
    3.1. `SystemInfoInstructionData`
    3.2. `InAccountInfo`
    3.3. `OutAccountInfo`
4. create `AccountInfoTrait` in `light-sdk` so that I don't need to implement sdk methods in `light-compressed-account`
5. create `InAccountInfoTrait` in `light-sdk` so that I don't need to implement sdk methods in `light-compressed-account`