### PR TITLE
refactor: merkle context nullifier to queue pubkey

### DIFF
--- a/examples/anchor/token-escrow/tests/test.rs
+++ b/examples/anchor/token-escrow/tests/test.rs
@@ -264,7 +264,7 @@ pub async fn perform_escrow<R: RpcConnection, I: Indexer<R> + TestIndexerExtensi
                 .merkle_context
                 .leaf_index,
             merkle_tree_pubkey: env.merkle_tree_pubkey,
-            nullifier_queue_pubkey: env.nullifier_queue_pubkey,
+            queue_pubkey: env.nullifier_queue_pubkey,
             prove_by_index: false,
             tree_type: TreeType::StateV1,
         }],
@@ -426,7 +426,7 @@ pub async fn perform_withdrawal<R: RpcConnection, I: Indexer<R> + TestIndexerExt
                 .merkle_context
                 .leaf_index,
             merkle_tree_pubkey: env.merkle_tree_pubkey,
-            nullifier_queue_pubkey: env.nullifier_queue_pubkey,
+            queue_pubkey: env.nullifier_queue_pubkey,
             prove_by_index: false,
             tree_type: TreeType::StateV1,
         }],

--- a/examples/anchor/token-escrow/tests/test_compressed_pda.rs
+++ b/examples/anchor/token-escrow/tests/test_compressed_pda.rs
@@ -270,7 +270,7 @@ async fn create_escrow_ix<R: RpcConnection + MerkleTreeExt>(
                 .merkle_context
                 .leaf_index,
             merkle_tree_pubkey: env.merkle_tree_pubkey,
-            nullifier_queue_pubkey: env.nullifier_queue_pubkey,
+            queue_pubkey: env.nullifier_queue_pubkey,
             prove_by_index: false,
             tree_type: TreeType::StateV1,
         }],
@@ -475,7 +475,7 @@ pub async fn perform_withdrawal<R: RpcConnection + MerkleTreeExt>(
         input_token_escrow_merkle_context: MerkleContext {
             leaf_index: token_escrow_account.merkle_context.leaf_index,
             merkle_tree_pubkey: env.merkle_tree_pubkey,
-            nullifier_queue_pubkey: env.nullifier_queue_pubkey,
+            queue_pubkey: env.nullifier_queue_pubkey,
             prove_by_index: false,
             tree_type: TreeType::StateV1,
         },
@@ -483,7 +483,7 @@ pub async fn perform_withdrawal<R: RpcConnection + MerkleTreeExt>(
         input_cpda_merkle_context: MerkleContext {
             leaf_index: compressed_escrow_pda.merkle_context.leaf_index,
             merkle_tree_pubkey: env.merkle_tree_pubkey,
-            nullifier_queue_pubkey: env.nullifier_queue_pubkey,
+            queue_pubkey: env.nullifier_queue_pubkey,
             prove_by_index: false,
             tree_type: TreeType::StateV1,
         },

--- a/program-libs/compressed-account/src/compressed_account.rs
+++ b/program-libs/compressed-account/src/compressed_account.rs
@@ -114,8 +114,8 @@ impl CompressedAccountWithMerkleContext {
                     &self.merkle_context.merkle_tree_pubkey,
                     remaining_accounts,
                 ),
-                nullifier_queue_pubkey_index: pack_account(
-                    &self.merkle_context.nullifier_queue_pubkey,
+                queue_pubkey_index: pack_account(
+                    &self.merkle_context.queue_pubkey,
                     remaining_accounts,
                 ),
                 leaf_index: self.merkle_context.leaf_index,
@@ -143,7 +143,7 @@ pub struct PackedReadOnlyCompressedAccount {
 #[derive(Debug, Clone, Copy, AnchorSerialize, AnchorDeserialize, PartialEq, Default)]
 pub struct MerkleContext {
     pub merkle_tree_pubkey: Pubkey,
-    pub nullifier_queue_pubkey: Pubkey,
+    pub queue_pubkey: Pubkey,
     pub leaf_index: u32,
     pub prove_by_index: bool,
     pub tree_type: TreeType,
@@ -152,7 +152,7 @@ pub struct MerkleContext {
 #[derive(Debug, Clone, Copy, AnchorSerialize, AnchorDeserialize, PartialEq, Default)]
 pub struct PackedMerkleContext {
     pub merkle_tree_pubkey_index: u8,
-    pub nullifier_queue_pubkey_index: u8,
+    pub queue_pubkey_index: u8,
     pub leaf_index: u32,
     pub prove_by_index: bool,
 }
@@ -211,10 +211,7 @@ pub fn pack_merkle_context(
                 &merkle_context.merkle_tree_pubkey,
                 remaining_accounts,
             ),
-            nullifier_queue_pubkey_index: pack_account(
-                &merkle_context.nullifier_queue_pubkey,
-                remaining_accounts,
-            ),
+            queue_pubkey_index: pack_account(&merkle_context.queue_pubkey, remaining_accounts),
             prove_by_index: merkle_context.prove_by_index,
         })
         .collect::<Vec<_>>()

--- a/program-libs/compressed-account/src/instruction_data/with_readonly.rs
+++ b/program-libs/compressed-account/src/instruction_data/with_readonly.rs
@@ -443,7 +443,7 @@ fn test_read_only_zero_copy() {
             data_hash: [10; 32],
             merkle_context: PackedMerkleContext {
                 merkle_tree_pubkey_index: 1,
-                nullifier_queue_pubkey_index: 2,
+                queue_pubkey_index: 2,
                 leaf_index: 3,
                 prove_by_index: false,
             },
@@ -473,7 +473,7 @@ fn test_read_only_zero_copy() {
             account_hash: [80; 32],
             merkle_context: PackedMerkleContext {
                 merkle_tree_pubkey_index: 5,
-                nullifier_queue_pubkey_index: 6,
+                queue_pubkey_index: 6,
                 leaf_index: 7,
                 prove_by_index: false,
             },

--- a/program-libs/compressed-account/src/instruction_data/zero_copy.rs
+++ b/program-libs/compressed-account/src/instruction_data/zero_copy.rs
@@ -90,7 +90,7 @@ impl From<&ZNewAddressParamsPacked> for NewAddressParamsPacked {
 )]
 pub struct ZPackedMerkleContext {
     pub merkle_tree_pubkey_index: u8,
-    pub nullifier_queue_pubkey_index: u8,
+    pub queue_pubkey_index: u8,
     pub leaf_index: U32,
     prove_by_index: u8,
 }
@@ -318,7 +318,7 @@ impl From<ZPackedMerkleContext> for PackedMerkleContext {
     fn from(merkle_context: ZPackedMerkleContext) -> Self {
         PackedMerkleContext {
             merkle_tree_pubkey_index: merkle_context.merkle_tree_pubkey_index,
-            nullifier_queue_pubkey_index: merkle_context.nullifier_queue_pubkey_index,
+            queue_pubkey_index: merkle_context.queue_pubkey_index,
             leaf_index: merkle_context.leaf_index.into(),
             prove_by_index: merkle_context.prove_by_index == 1,
         }
@@ -1073,7 +1073,7 @@ mod test {
             },
             merkle_context: PackedMerkleContext {
                 merkle_tree_pubkey_index: 1,
-                nullifier_queue_pubkey_index: 2,
+                queue_pubkey_index: 2,
                 leaf_index: 3,
                 prove_by_index: true,
             },
@@ -1092,7 +1092,7 @@ mod test {
             },
             merkle_context: PackedMerkleContext {
                 merkle_tree_pubkey_index: rng.gen(),
-                nullifier_queue_pubkey_index: rng.gen(),
+                queue_pubkey_index: rng.gen(),
                 leaf_index: rng.gen(),
                 prove_by_index: rng.gen(),
             },
@@ -1300,7 +1300,7 @@ mod test {
         if reference.merkle_tree_pubkey_index != z_copy.merkle_tree_pubkey_index {
             return Err(CompressedAccountError::InvalidArgument);
         }
-        if reference.nullifier_queue_pubkey_index != z_copy.nullifier_queue_pubkey_index {
+        if reference.queue_pubkey_index != z_copy.queue_pubkey_index {
             return Err(CompressedAccountError::InvalidArgument);
         }
         if reference.leaf_index != u32::from(z_copy.leaf_index) {

--- a/program-tests/compressed-token-test/tests/test.rs
+++ b/program-tests/compressed-token-test/tests/test.rs
@@ -3096,7 +3096,7 @@ async fn test_burn() {
             let invalid_change_account_merkle_tree = input_compressed_accounts[0]
                 .compressed_account
                 .merkle_context
-                .nullifier_queue_pubkey;
+                .queue_pubkey;
             let mut additional_token_pool_accounts = (0..4)
                 .map(|x| get_token_pool_pda_with_index(&mint, x))
                 .collect::<Vec<_>>();
@@ -3416,7 +3416,7 @@ async fn failing_tests_burn() {
             let invalid_change_account_merkle_tree = input_compressed_accounts[0]
                 .compressed_account
                 .merkle_context
-                .nullifier_queue_pubkey;
+                .queue_pubkey;
             let (_, _, _, _, instruction) = create_burn_test_instruction(
                 &sender,
                 &mut rpc,
@@ -3451,7 +3451,7 @@ async fn failing_tests_burn() {
             let invalid_change_account_merkle_tree = input_compressed_accounts[0]
                 .compressed_account
                 .merkle_context
-                .nullifier_queue_pubkey;
+                .queue_pubkey;
             let (_, _, _, _, instruction) = create_burn_test_instruction(
                 &sender,
                 &mut rpc,
@@ -3481,7 +3481,7 @@ async fn failing_tests_burn() {
             let invalid_change_account_merkle_tree = input_compressed_accounts[0]
                 .compressed_account
                 .merkle_context
-                .nullifier_queue_pubkey;
+                .queue_pubkey;
             let (_, _, _, _, mut instruction) = create_burn_test_instruction(
                 &sender,
                 &mut rpc,
@@ -5368,7 +5368,7 @@ async fn perform_transfer_failing_test<R: RpcConnection>(
             .iter()
             .map(|x| MerkleContext {
                 merkle_tree_pubkey: *merkle_tree_pubkey,
-                nullifier_queue_pubkey: *nullifier_queue_pubkey,
+                queue_pubkey: *nullifier_queue_pubkey,
                 leaf_index: x.merkle_context.leaf_index,
                 prove_by_index: false,
                 tree_type: TreeType::StateV1,

--- a/program-tests/system-cpi-test/src/create_pda.rs
+++ b/program-tests/system-cpi-test/src/create_pda.rs
@@ -327,9 +327,7 @@ fn cpi_compressed_pda_transfer_as_program<'info>(
             match mode {
                 CreatePdaMode::InvalidReadOnlyAccountMerkleTree => {
                     read_only_account[0].merkle_context.merkle_tree_pubkey_index =
-                        read_only_account[0]
-                            .merkle_context
-                            .nullifier_queue_pubkey_index;
+                        read_only_account[0].merkle_context.queue_pubkey_index;
                 }
                 CreatePdaMode::InvalidReadOnlyAccountRootIndex => {
                     let init_value = read_only_account[0].root_index;
@@ -350,9 +348,7 @@ fn cpi_compressed_pda_transfer_as_program<'info>(
                     inputs_struct.proof = Some(CompressedProof::default());
                 }
                 CreatePdaMode::InvalidReadOnlyAccountOutputQueue => {
-                    read_only_account[0]
-                        .merkle_context
-                        .nullifier_queue_pubkey_index =
+                    read_only_account[0].merkle_context.queue_pubkey_index =
                         read_only_account[0].merkle_context.merkle_tree_pubkey_index;
                 }
                 CreatePdaMode::AccountNotInValueVecMarkedProofByIndex => {

--- a/program-tests/system-cpi-test/tests/event.rs
+++ b/program-tests/system-cpi-test/tests/event.rs
@@ -125,7 +125,7 @@ async fn parse_batched_event_functional() {
                     leaf_index: i,
                     merkle_tree_pubkey: env.batched_state_merkle_tree,
                     prove_by_index: true,
-                    nullifier_queue_pubkey: env.batched_output_queue,
+                    queue_pubkey: env.batched_output_queue,
                     tree_type: light_compressed_account::TreeType::StateV2,
                 })
             })
@@ -276,7 +276,7 @@ async fn parse_batched_event_functional() {
                     leaf_index: i,
                     merkle_tree_pubkey: env.batched_state_merkle_tree,
                     prove_by_index: true,
-                    nullifier_queue_pubkey: env.batched_output_queue,
+                    queue_pubkey: env.batched_output_queue,
                     tree_type: light_compressed_account::TreeType::StateV2,
                 })
             })

--- a/program-tests/system-cpi-test/tests/test.rs
+++ b/program-tests/system-cpi-test/tests/test.rs
@@ -1915,7 +1915,7 @@ pub async fn perform_with_input_accounts<
         );
     }
     let merkle_tree_pubkey = compressed_account.merkle_context.merkle_tree_pubkey;
-    let nullifier_pubkey = compressed_account.merkle_context.nullifier_queue_pubkey;
+    let nullifier_pubkey = compressed_account.merkle_context.queue_pubkey;
     let cpi_context = match mode {
         WithInputAccountsMode::Freeze
         | WithInputAccountsMode::Thaw
@@ -1970,7 +1970,7 @@ pub async fn perform_with_input_accounts<
                 merkle_context: PackedMerkleContext {
                     leaf_index: token_account.compressed_account.merkle_context.leaf_index,
                     merkle_tree_pubkey_index: 0,
-                    nullifier_queue_pubkey_index: 1,
+                    queue_pubkey_index: 1,
                     prove_by_index: false,
                 },
                 lamports: if token_account.compressed_account.compressed_account.lamports != 0 {
@@ -2000,7 +2000,7 @@ pub async fn perform_with_input_accounts<
             merkle_context: PackedMerkleContext {
                 leaf_index: compressed_account.merkle_context.leaf_index,
                 merkle_tree_pubkey_index: 0,
-                nullifier_queue_pubkey_index: 1,
+                queue_pubkey_index: 1,
                 prove_by_index: false,
             },
             root_index: rpc_result.root_indices[0].unwrap(),

--- a/program-tests/system-test/tests/test.rs
+++ b/program-tests/system-test/tests/test.rs
@@ -520,7 +520,7 @@ pub async fn failing_transaction_inputs_inner<R: RpcConnection>(
         remaining_accounts[inputs_struct.input_compressed_accounts_with_merkle_context
             [num_inputs - 1]
             .merkle_context
-            .nullifier_queue_pubkey_index as usize] = AccountMeta {
+            .queue_pubkey_index as usize] = AccountMeta {
             pubkey: env.address_merkle_tree_queue_pubkey,
             is_signer: false,
             is_writable: true,
@@ -542,7 +542,7 @@ pub async fn failing_transaction_inputs_inner<R: RpcConnection>(
         remaining_accounts[inputs_struct.input_compressed_accounts_with_merkle_context
             [num_inputs - 1]
             .merkle_context
-            .nullifier_queue_pubkey_index as usize] = AccountMeta {
+            .queue_pubkey_index as usize] = AccountMeta {
             pubkey: env.address_merkle_tree_pubkey,
             is_signer: false,
             is_writable: true,
@@ -993,7 +993,7 @@ async fn invoke_test() {
         &[MerkleContext {
             merkle_tree_pubkey,
             leaf_index: 0,
-            nullifier_queue_pubkey,
+            queue_pubkey: nullifier_queue_pubkey,
             prove_by_index: false,
             tree_type: TreeType::StateV1,
         }],
@@ -1028,7 +1028,7 @@ async fn invoke_test() {
         &[MerkleContext {
             merkle_tree_pubkey,
             leaf_index: 0,
-            nullifier_queue_pubkey,
+            queue_pubkey: nullifier_queue_pubkey,
             prove_by_index: false,
             tree_type: TreeType::StateV1,
         }],
@@ -1076,7 +1076,7 @@ async fn invoke_test() {
         &[MerkleContext {
             merkle_tree_pubkey,
             leaf_index: 0,
-            nullifier_queue_pubkey,
+            queue_pubkey: nullifier_queue_pubkey,
             prove_by_index: false,
             tree_type: TreeType::StateV1,
         }],
@@ -1126,7 +1126,7 @@ async fn invoke_test() {
         &[MerkleContext {
             merkle_tree_pubkey,
             leaf_index: 0,
-            nullifier_queue_pubkey,
+            queue_pubkey: nullifier_queue_pubkey,
             prove_by_index: false,
             tree_type: TreeType::StateV1,
         }],
@@ -1158,7 +1158,7 @@ async fn invoke_test() {
         &[MerkleContext {
             merkle_tree_pubkey,
             leaf_index: 1,
-            nullifier_queue_pubkey,
+            queue_pubkey: nullifier_queue_pubkey,
             prove_by_index: false,
             tree_type: TreeType::StateV1,
         }],
@@ -1607,7 +1607,7 @@ async fn test_with_compression() {
         &[MerkleContext {
             merkle_tree_pubkey,
             leaf_index: 0,
-            nullifier_queue_pubkey,
+            queue_pubkey: nullifier_queue_pubkey,
             prove_by_index: false,
             tree_type: TreeType::StateV1,
         }],
@@ -1863,7 +1863,7 @@ async fn batch_invoke_test() {
         &[MerkleContext {
             merkle_tree_pubkey,
             leaf_index: 0,
-            nullifier_queue_pubkey: output_queue_pubkey,
+            queue_pubkey: output_queue_pubkey,
             prove_by_index: false,
             tree_type: TreeType::StateV1,
         }],
@@ -1904,7 +1904,7 @@ async fn batch_invoke_test() {
         &[MerkleContext {
             merkle_tree_pubkey,
             leaf_index: 0,
-            nullifier_queue_pubkey: output_queue_pubkey,
+            queue_pubkey: output_queue_pubkey,
             prove_by_index: false,
             tree_type: TreeType::StateV1,
         }],
@@ -1959,7 +1959,7 @@ async fn batch_invoke_test() {
             &[MerkleContext {
                 merkle_tree_pubkey,
                 leaf_index: compressed_account_with_context.merkle_context.leaf_index,
-                nullifier_queue_pubkey: output_queue_pubkey,
+                queue_pubkey: output_queue_pubkey,
                 prove_by_index: true,
                 tree_type: TreeType::StateV2,
             }],
@@ -2010,7 +2010,7 @@ async fn batch_invoke_test() {
             &[MerkleContext {
                 merkle_tree_pubkey,
                 leaf_index: 0,
-                nullifier_queue_pubkey: output_queue_pubkey,
+                queue_pubkey: output_queue_pubkey,
                 prove_by_index: true,
                 tree_type: TreeType::StateV2,
             }],
@@ -2038,7 +2038,7 @@ async fn batch_invoke_test() {
         let input_compressed_account = test_indexer
             .get_compressed_accounts_with_merkle_context_by_owner(&payer_pubkey)
             .iter()
-            .filter(|x| x.merkle_context.nullifier_queue_pubkey == output_queue_pubkey)
+            .filter(|x| x.merkle_context.queue_pubkey == output_queue_pubkey)
             .last()
             .unwrap()
             .clone();
@@ -2056,7 +2056,7 @@ async fn batch_invoke_test() {
             &[MerkleContext {
                 merkle_tree_pubkey,
                 leaf_index: input_compressed_account.merkle_context.leaf_index - 1,
-                nullifier_queue_pubkey: output_queue_pubkey,
+                queue_pubkey: output_queue_pubkey,
                 prove_by_index: true,
                 tree_type: TreeType::StateV2,
             }],
@@ -2101,7 +2101,7 @@ async fn batch_invoke_test() {
             .iter()
             .filter(|x| {
                 x.compressed_account.owner == payer_pubkey
-                    && x.merkle_context.nullifier_queue_pubkey == output_queue_pubkey
+                    && x.merkle_context.queue_pubkey == output_queue_pubkey
             })
             .cloned()
             .collect::<Vec<_>>()
@@ -2114,7 +2114,7 @@ async fn batch_invoke_test() {
             .iter()
             .filter(|x| {
                 x.compressed_account.owner == payer_pubkey
-                    && x.merkle_context.nullifier_queue_pubkey == env.nullifier_queue_pubkey
+                    && x.merkle_context.queue_pubkey == env.nullifier_queue_pubkey
             })
             .collect::<Vec<_>>()[0]
             .clone();
@@ -2175,7 +2175,7 @@ async fn batch_invoke_test() {
             &output_compressed_accounts,
             merkle_context.as_slice(),
             &[
-                merkle_context_1.nullifier_queue_pubkey, // output queue
+                merkle_context_1.queue_pubkey, // output queue
                 merkle_context_2.merkle_tree_pubkey,
             ],
             &proof_rpc_result.root_indices,
@@ -2221,7 +2221,7 @@ async fn batch_invoke_test() {
             .iter()
             .filter(|x| {
                 x.compressed_account.owner == payer_pubkey
-                    && x.merkle_context.nullifier_queue_pubkey == output_queue_pubkey
+                    && x.merkle_context.queue_pubkey == output_queue_pubkey
             })
             .last()
             .unwrap()
@@ -2252,7 +2252,7 @@ async fn batch_invoke_test() {
             .iter()
             .filter(|x| {
                 x.compressed_account.owner == payer_pubkey
-                    && x.merkle_context.nullifier_queue_pubkey == output_queue_pubkey
+                    && x.merkle_context.queue_pubkey == output_queue_pubkey
             })
             .last()
             .unwrap()
@@ -2283,7 +2283,7 @@ async fn batch_invoke_test() {
             .iter()
             .filter(|x| {
                 x.compressed_account.owner == payer_pubkey
-                    && x.merkle_context.nullifier_queue_pubkey == output_queue_pubkey
+                    && x.merkle_context.queue_pubkey == output_queue_pubkey
             })
             .last()
             .unwrap()
@@ -2314,7 +2314,7 @@ async fn batch_invoke_test() {
             .iter()
             .filter(|x| {
                 x.compressed_account.owner == payer_pubkey
-                    && x.merkle_context.nullifier_queue_pubkey == output_queue_pubkey
+                    && x.merkle_context.queue_pubkey == output_queue_pubkey
             })
             .last()
             .unwrap()
@@ -2352,7 +2352,7 @@ async fn batch_invoke_test() {
             .iter()
             .filter(|x| {
                 x.compressed_account.owner == payer_pubkey
-                    && x.merkle_context.nullifier_queue_pubkey == output_queue_pubkey
+                    && x.merkle_context.queue_pubkey == output_queue_pubkey
             })
             .collect::<Vec<_>>();
         let compressed_account_with_context_1 = accounts[1].clone();
@@ -2395,7 +2395,7 @@ async fn batch_invoke_test() {
             &[compressed_account_with_context_1.compressed_account],
             &output_compressed_accounts,
             &[merkle_context],
-            &[merkle_context.nullifier_queue_pubkey],
+            &[merkle_context.queue_pubkey],
             &[None],
             &Vec::new(),
             None,
@@ -2425,7 +2425,7 @@ async fn batch_invoke_test() {
             .iter()
             .filter(|x| {
                 x.compressed_account.owner == payer_pubkey
-                    && x.merkle_context.nullifier_queue_pubkey != output_queue_pubkey
+                    && x.merkle_context.queue_pubkey != output_queue_pubkey
             })
             .last()
             .unwrap()
@@ -2509,7 +2509,7 @@ pub async fn double_spend_compressed_account<
         &input_compressed_accounts,
         &output_compressed_accounts,
         &[merkle_context_1],
-        &[merkle_context_1.nullifier_queue_pubkey],
+        &[merkle_context_1.queue_pubkey],
         &proof_rpc_result.root_indices,
         &Vec::new(),
         proof,
@@ -2528,7 +2528,7 @@ pub async fn double_spend_compressed_account<
             &input_compressed_accounts,
             &output_compressed_accounts,
             &[merkle_context],
-            &[merkle_context.nullifier_queue_pubkey],
+            &[merkle_context.queue_pubkey],
             &[None],
             &Vec::new(),
             None,

--- a/program-tests/utils/src/assert_compressed_tx.rs
+++ b/program-tests/utils/src/assert_compressed_tx.rs
@@ -242,7 +242,7 @@ pub fn assert_created_compressed_accounts(
         assert!(output_merkle_tree_pubkeys
             .iter()
             .any(|x| *x == output_account.merkle_context.merkle_tree_pubkey
-                || *x == output_account.merkle_context.nullifier_queue_pubkey),);
+                || *x == output_account.merkle_context.queue_pubkey),);
     }
 }
 

--- a/program-tests/utils/src/system_program.rs
+++ b/program-tests/utils/src/system_program.rs
@@ -580,7 +580,7 @@ pub fn create_invoke_instruction_data_and_remaining_accounts(
                 merkle_tree_pubkey_index: *remaining_accounts
                     .get(&context.merkle_tree_pubkey)
                     .unwrap() as u8,
-                nullifier_queue_pubkey_index: 0,
+                queue_pubkey_index: 0,
                 leaf_index: context.leaf_index,
                 prove_by_index,
             },
@@ -590,18 +590,16 @@ pub fn create_invoke_instruction_data_and_remaining_accounts(
     }
 
     for (i, context) in merkle_context.iter().enumerate() {
-        match remaining_accounts.get(&context.nullifier_queue_pubkey) {
+        match remaining_accounts.get(&context.queue_pubkey) {
             Some(_) => {}
             None => {
-                remaining_accounts.insert(context.nullifier_queue_pubkey, index);
+                remaining_accounts.insert(context.queue_pubkey, index);
                 index += 1;
             }
         };
         _input_compressed_accounts[i]
             .merkle_context
-            .nullifier_queue_pubkey_index = *remaining_accounts
-            .get(&context.nullifier_queue_pubkey)
-            .unwrap() as u8;
+            .queue_pubkey_index = *remaining_accounts.get(&context.queue_pubkey).unwrap() as u8;
     }
 
     let mut output_compressed_accounts_with_context: Vec<OutputCompressedAccountWithPackedContext> =
@@ -721,14 +719,14 @@ mod test {
         let input_merkle_context = vec![
             MerkleContext {
                 merkle_tree_pubkey,
-                nullifier_queue_pubkey: nullifier_array_pubkey,
+                queue_pubkey: nullifier_array_pubkey,
                 leaf_index: 0,
                 prove_by_index: false,
                 tree_type: light_compressed_account::TreeType::StateV1,
             },
             MerkleContext {
                 merkle_tree_pubkey,
-                nullifier_queue_pubkey: nullifier_array_pubkey,
+                queue_pubkey: nullifier_array_pubkey,
                 leaf_index: 1,
                 prove_by_index: false,
                 tree_type: light_compressed_account::TreeType::StateV1,
@@ -812,13 +810,13 @@ mod test {
         assert_eq!(
             deserialized_instruction_data.input_compressed_accounts_with_merkle_context[0]
                 .merkle_context
-                .nullifier_queue_pubkey_index,
+                .queue_pubkey_index,
             1
         );
         assert_eq!(
             deserialized_instruction_data.input_compressed_accounts_with_merkle_context[1]
                 .merkle_context
-                .nullifier_queue_pubkey_index,
+                .queue_pubkey_index,
             1
         );
         assert_eq!(
@@ -839,14 +837,14 @@ mod test {
             instruction.accounts[9 + deserialized_instruction_data
                 .input_compressed_accounts_with_merkle_context[0]
                 .merkle_context
-                .nullifier_queue_pubkey_index as usize],
+                .queue_pubkey_index as usize],
             AccountMeta::new(nullifier_array_pubkey, false)
         );
         assert_eq!(
             instruction.accounts[9 + deserialized_instruction_data
                 .input_compressed_accounts_with_merkle_context[1]
                 .merkle_context
-                .nullifier_queue_pubkey_index as usize],
+                .queue_pubkey_index as usize],
             AccountMeta::new(nullifier_array_pubkey, false)
         );
         assert_eq!(

--- a/programs/compressed-token/src/burn.rs
+++ b/programs/compressed-token/src/burn.rs
@@ -381,7 +381,7 @@ mod test {
                 amount: test_amount,
                 merkle_context: PackedMerkleContext {
                     merkle_tree_pubkey_index: 0,
-                    nullifier_queue_pubkey_index: 1,
+                    queue_pubkey_index: 1,
                     leaf_index: 1,
                     prove_by_index: false,
                 },
@@ -588,7 +588,7 @@ mod test {
             amount: 100,
             merkle_context: PackedMerkleContext {
                 merkle_tree_pubkey_index: 0,
-                nullifier_queue_pubkey_index: 1,
+                queue_pubkey_index: 1,
                 leaf_index: 1,
                 prove_by_index: false,
             },

--- a/programs/compressed-token/src/delegation.rs
+++ b/programs/compressed-token/src/delegation.rs
@@ -506,7 +506,7 @@ mod test {
                 amount: 100,
                 merkle_context: PackedMerkleContext {
                     merkle_tree_pubkey_index: 0,
-                    nullifier_queue_pubkey_index: 1,
+                    queue_pubkey_index: 1,
                     leaf_index: 1,
                     prove_by_index: false,
                 },
@@ -519,7 +519,7 @@ mod test {
                 amount: 101,
                 merkle_context: PackedMerkleContext {
                     merkle_tree_pubkey_index: 0,
-                    nullifier_queue_pubkey_index: 1,
+                    queue_pubkey_index: 1,
                     leaf_index: 2,
                     prove_by_index: false,
                 },
@@ -624,7 +624,7 @@ mod test {
 
                 merkle_context: PackedMerkleContext {
                     merkle_tree_pubkey_index: 0,
-                    nullifier_queue_pubkey_index: 1,
+                    queue_pubkey_index: 1,
                     leaf_index: 1,
                     prove_by_index: false,
                 },
@@ -638,7 +638,7 @@ mod test {
 
                 merkle_context: PackedMerkleContext {
                     merkle_tree_pubkey_index: 0,
-                    nullifier_queue_pubkey_index: 1,
+                    queue_pubkey_index: 1,
                     leaf_index: 2,
                     prove_by_index: false,
                 },
@@ -683,7 +683,7 @@ mod test {
 
                 merkle_context: PackedMerkleContext {
                     merkle_tree_pubkey_index: 0,
-                    nullifier_queue_pubkey_index: 1,
+                    queue_pubkey_index: 1,
                     leaf_index: 1,
                     prove_by_index: false,
                 },
@@ -697,7 +697,7 @@ mod test {
 
                 merkle_context: PackedMerkleContext {
                     merkle_tree_pubkey_index: 0,
-                    nullifier_queue_pubkey_index: 1,
+                    queue_pubkey_index: 1,
                     leaf_index: 2,
                     prove_by_index: false,
                 },

--- a/programs/compressed-token/src/freeze.rs
+++ b/programs/compressed-token/src/freeze.rs
@@ -395,7 +395,7 @@ pub mod test_freeze {
 
                 merkle_context: PackedMerkleContext {
                     merkle_tree_pubkey_index: 0,
-                    nullifier_queue_pubkey_index: 1,
+                    queue_pubkey_index: 1,
                     leaf_index: 1,
                     prove_by_index: false,
                 },
@@ -409,7 +409,7 @@ pub mod test_freeze {
 
                 merkle_context: PackedMerkleContext {
                     merkle_tree_pubkey_index: 0,
-                    nullifier_queue_pubkey_index: 1,
+                    queue_pubkey_index: 1,
                     leaf_index: 2,
                     prove_by_index: false,
                 },
@@ -551,7 +551,7 @@ pub mod test_freeze {
                 amount: rng.gen_range(0..1_000_000_000),
                 merkle_context: PackedMerkleContext {
                     merkle_tree_pubkey_index: 0,
-                    nullifier_queue_pubkey_index: 1,
+                    queue_pubkey_index: 1,
                     leaf_index: rng.gen_range(0..1_000_000_000),
                     prove_by_index: false,
                 },

--- a/programs/compressed-token/src/process_transfer.rs
+++ b/programs/compressed-token/src/process_transfer.rs
@@ -959,7 +959,7 @@ pub mod transfer_sdk {
                     merkle_tree_pubkey_index: *remaining_accounts
                         .get(&input_merkle_context[i].merkle_tree_pubkey)
                         .unwrap() as u8,
-                    nullifier_queue_pubkey_index: 0,
+                    queue_pubkey_index: 0,
                     leaf_index: input_merkle_context[i].leaf_index,
                     prove_by_index,
                 },
@@ -970,18 +970,17 @@ pub mod transfer_sdk {
             input_token_data_with_context.push(token_data_with_context);
         }
         for (i, _) in input_token_data.iter().enumerate() {
-            match remaining_accounts.get(&input_merkle_context[i].nullifier_queue_pubkey) {
+            match remaining_accounts.get(&input_merkle_context[i].queue_pubkey) {
                 Some(_) => {}
                 None => {
-                    remaining_accounts
-                        .insert(input_merkle_context[i].nullifier_queue_pubkey, index);
+                    remaining_accounts.insert(input_merkle_context[i].queue_pubkey, index);
                     index += 1;
                 }
             };
             input_token_data_with_context[i]
                 .merkle_context
-                .nullifier_queue_pubkey_index = *remaining_accounts
-                .get(&input_merkle_context[i].nullifier_queue_pubkey)
+                .queue_pubkey_index = *remaining_accounts
+                .get(&input_merkle_context[i].queue_pubkey)
                 .unwrap() as u8;
         }
         let mut _output_compressed_accounts: Vec<PackedTokenTransferOutputData> =

--- a/programs/system/src/processor/create_inputs_cpi_data.rs
+++ b/programs/system/src/processor/create_inputs_cpi_data.rs
@@ -90,10 +90,8 @@ pub fn create_inputs_cpi_data<'a, 'info, T: InstructionDataTrait<'a>>(
             hashed_owner = context.get_or_hash_pubkey(owner_pubkey.into());
         }
         let merkle_context = input_compressed_account_with_context.merkle_context();
-        let queue_index = context.get_index_or_insert(
-            merkle_context.nullifier_queue_pubkey_index,
-            remaining_accounts,
-        );
+        let queue_index =
+            context.get_index_or_insert(merkle_context.queue_pubkey_index, remaining_accounts);
         let tree_index = context
             .get_index_or_insert(merkle_context.merkle_tree_pubkey_index, remaining_accounts);
         cpi_ix_data.nullifiers[j] = InsertNullifierInput {
@@ -122,11 +120,11 @@ pub fn create_inputs_cpi_data<'a, 'info, T: InstructionDataTrait<'a>>(
         .input_accounts()
         .enumerate()
         .filter(|(i, x)| {
-            let candidate = x.merkle_context().nullifier_queue_pubkey_index;
+            let candidate = x.merkle_context().queue_pubkey_index;
             !instruction_data
                 .input_accounts()
                 .take(*i)
-                .any(|y| y.merkle_context().nullifier_queue_pubkey_index == candidate)
+                .any(|y| y.merkle_context().queue_pubkey_index == candidate)
         })
         .count() as u8;
 

--- a/programs/system/src/processor/read_only_account.rs
+++ b/programs/system/src/processor/read_only_account.rs
@@ -19,9 +19,7 @@ pub fn verify_read_only_account_inclusion_by_index(
 ) -> Result<usize> {
     let mut num_prove_read_only_accounts_prove_by_index = 0;
     for read_only_account in read_only_accounts.iter() {
-        let queue_index = read_only_account
-            .merkle_context
-            .nullifier_queue_pubkey_index;
+        let queue_index = read_only_account.merkle_context.queue_pubkey_index;
         let tree_index = read_only_account.merkle_context.merkle_tree_pubkey_index;
         let (output_queue_account_info, merkle_tree_account_info) =
             get_queue_and_tree_accounts(accounts, queue_index as usize, tree_index as usize)?;

--- a/programs/system/src/processor/sum_check.rs
+++ b/programs/system/src/processor/sum_check.rs
@@ -165,7 +165,7 @@ mod test {
             let prove_by_index = index < num_by_index;
             let merkle_context = PackedMerkleContext {
                 merkle_tree_pubkey_index: 0,
-                nullifier_queue_pubkey_index: 0,
+                queue_pubkey_index: 0,
                 leaf_index: 0,
                 prove_by_index,
             };

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -22,3 +22,12 @@ cargo clippy \
 # We import the same crates with different features in light-system-program-pinocchio than in account-compression
 # clippy cannot handle this. -> check light-system-program-pinocchio separately
 cargo clippy --package light-system-program-pinocchio --all-targets -- -D warnings
+
+# Make sure that tests compile
+cargo test-sbf -p system-test --no-run
+cargo test-sbf -p system-cpi-test --no-run
+cargo test-sbf -p e2e-test --no-run
+cargo test-sbf -p compressed-token-test --no-run
+cargo test-sbf -p token-escrow --no-run
+cargo test-sbf -p sdk-test --no-run
+cargo test-sbf -p sdk-anchor-test --no-run

--- a/sdk-libs/client/src/indexer/mod.rs
+++ b/sdk-libs/client/src/indexer/mod.rs
@@ -613,7 +613,7 @@ impl TryFrom<LocalPhotonAccount> for CompressedAccountWithMerkleContext {
         let account = local_account.0;
         let merkle_context = MerkleContext {
             merkle_tree_pubkey: Pubkey::from_str(&account.tree)?,
-            nullifier_queue_pubkey: Default::default(),
+            queue_pubkey: Default::default(),
             leaf_index: account.leaf_index,
             prove_by_index: false,
             tree_type: light_compressed_account::TreeType::StateV1,

--- a/sdk-libs/program-test/src/indexer/test_indexer.rs
+++ b/sdk-libs/program-test/src/indexer/test_indexer.rs
@@ -1855,7 +1855,7 @@ where
                                     merkle_context: MerkleContext {
                                         leaf_index: event.output_leaf_indices[i],
                                         merkle_tree_pubkey,
-                                        nullifier_queue_pubkey,
+                                        queue_pubkey: nullifier_queue_pubkey,
                                         prove_by_index: false,
                                         tree_type: if merkle_tree.version == 2 {
                                             TreeType::StateV2
@@ -1872,7 +1872,7 @@ where
                             merkle_context: MerkleContext {
                                 leaf_index: event.output_leaf_indices[i],
                                 merkle_tree_pubkey,
-                                nullifier_queue_pubkey,
+                                queue_pubkey: nullifier_queue_pubkey,
                                 prove_by_index: false,
                                 tree_type: if merkle_tree.version == 2 {
                                     TreeType::StateV2
@@ -1889,7 +1889,7 @@ where
                         merkle_context: MerkleContext {
                             leaf_index: event.output_leaf_indices[i],
                             merkle_tree_pubkey,
-                            nullifier_queue_pubkey,
+                            queue_pubkey: nullifier_queue_pubkey,
                             prove_by_index: false,
                             tree_type: if merkle_tree.version == 2 {
                                 TreeType::StateV2

--- a/sdk-libs/sdk/src/instruction/merkle_context.rs
+++ b/sdk-libs/sdk/src/instruction/merkle_context.rs
@@ -32,17 +32,17 @@ pub fn pack_merkle_context(
 ) -> PackedMerkleContext {
     let MerkleContext {
         merkle_tree_pubkey,
-        nullifier_queue_pubkey,
+        queue_pubkey,
         leaf_index,
         prove_by_index,
         ..
     } = merkle_context;
     let merkle_tree_pubkey_index = remaining_accounts.insert_or_get(*merkle_tree_pubkey);
-    let nullifier_queue_pubkey_index = remaining_accounts.insert_or_get(*nullifier_queue_pubkey);
+    let queue_pubkey_index = remaining_accounts.insert_or_get(*queue_pubkey);
 
     PackedMerkleContext {
         merkle_tree_pubkey_index,
-        nullifier_queue_pubkey_index,
+        queue_pubkey_index,
         leaf_index: *leaf_index,
         prove_by_index: *prove_by_index,
     }
@@ -117,10 +117,10 @@ mod test {
         let mut remaining_accounts = PackedAccounts::default();
 
         let merkle_tree_pubkey = Pubkey::new_unique();
-        let nullifier_queue_pubkey = Pubkey::new_unique();
+        let queue_pubkey = Pubkey::new_unique();
         let merkle_context = MerkleContext {
             merkle_tree_pubkey,
-            nullifier_queue_pubkey,
+            queue_pubkey,
             leaf_index: 69,
             prove_by_index: false,
             ..Default::default()
@@ -131,7 +131,7 @@ mod test {
             packed_merkle_context,
             PackedMerkleContext {
                 merkle_tree_pubkey_index: 0,
-                nullifier_queue_pubkey_index: 1,
+                queue_pubkey_index: 1,
                 leaf_index: 69,
                 prove_by_index: false,
             }
@@ -145,21 +145,21 @@ mod test {
         let merkle_contexts = &[
             MerkleContext {
                 merkle_tree_pubkey: Pubkey::new_unique(),
-                nullifier_queue_pubkey: Pubkey::new_unique(),
+                queue_pubkey: Pubkey::new_unique(),
                 leaf_index: 10,
                 prove_by_index: false,
                 ..Default::default()
             },
             MerkleContext {
                 merkle_tree_pubkey: Pubkey::new_unique(),
-                nullifier_queue_pubkey: Pubkey::new_unique(),
+                queue_pubkey: Pubkey::new_unique(),
                 leaf_index: 11,
                 prove_by_index: true,
                 ..Default::default()
             },
             MerkleContext {
                 merkle_tree_pubkey: Pubkey::new_unique(),
-                nullifier_queue_pubkey: Pubkey::new_unique(),
+                queue_pubkey: Pubkey::new_unique(),
                 leaf_index: 12,
                 prove_by_index: false,
                 ..Default::default()
@@ -173,19 +173,19 @@ mod test {
             &[
                 PackedMerkleContext {
                     merkle_tree_pubkey_index: 0,
-                    nullifier_queue_pubkey_index: 1,
+                    queue_pubkey_index: 1,
                     leaf_index: 10,
                     prove_by_index: false
                 },
                 PackedMerkleContext {
                     merkle_tree_pubkey_index: 2,
-                    nullifier_queue_pubkey_index: 3,
+                    queue_pubkey_index: 3,
                     leaf_index: 11,
                     prove_by_index: true
                 },
                 PackedMerkleContext {
                     merkle_tree_pubkey_index: 4,
-                    nullifier_queue_pubkey_index: 5,
+                    queue_pubkey_index: 5,
                     leaf_index: 12,
                     prove_by_index: false,
                 }

--- a/sdk-libs/sdk/src/transfer.rs
+++ b/sdk-libs/sdk/src/transfer.rs
@@ -69,7 +69,7 @@ mod tests {
                 data_hash: [0; 32],
                 merkle_context: PackedMerkleContext {
                     merkle_tree_pubkey_index: 0,
-                    nullifier_queue_pubkey_index: 0,
+                    queue_pubkey_index: 0,
                     leaf_index: 0,
                     prove_by_index: false,
                 },


### PR DESCRIPTION
Changes:
1. `MerkleContext` `nullifier_queue_pubkey` -> `queue_pubkey`
2. `PackedMerkleContext` `nullifier_queue_pubkey_index` -> `queue_pubkey_index`