### PR TITLE
refactor: counter example

### DIFF
--- a/.github/workflows/light-examples-tests.yml
+++ b/.github/workflows/light-examples-tests.yml
@@ -36,6 +36,8 @@ jobs:
             sub-tests: '[
               "cargo test-sbf -p token-escrow -- --test-threads=1"
             ]'
+          - program: counter-test
+            sub-tests: '["cargo test-sbf -p counter"]'
           - program: sdk-test-program
             sub-tests: '["cargo-test-sbf -p sdk-test"]'
           - program: sdk-anchor-test-program

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,6 +1432,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "counter"
+version = "0.0.11"
+dependencies = [
+ "anchor-lang",
+ "borsh 0.10.4",
+ "light-client",
+ "light-compressed-account",
+ "light-hasher",
+ "light-program-test",
+ "light-prover-client",
+ "light-sdk",
+ "light-test-utils",
+ "solana-sdk",
+ "tokio",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
     "xtask",
     "examples/anchor/token-escrow",
     # "examples/anchor/name-service-without-macros",
-    # "examples/anchor/counter",
+    "examples/anchor/counter",
     # "examples/anchor/memo",
     "program-tests/account-compression-test",
     "program-tests/compressed-token-test",

--- a/examples/anchor/counter/src/lib.rs
+++ b/examples/anchor/counter/src/lib.rs
@@ -1,8 +1,11 @@
 use anchor_lang::prelude::*;
 use borsh::BorshDeserialize;
 use light_sdk::{
-    account::LightAccount, instruction_data::LightInstructionData, light_system_accounts,
-    verify::verify_light_accounts, LightDiscriminator, LightHasher, LightTraits,
+    account::CBorshAccount,
+    cpi::verify::verify_compressed_account_infos,
+    error::LightSdkError,
+    instruction::{account_meta::CompressedAccountMeta, instruction_data::LightInstructionData},
+    Discriminator, LightDiscriminator, LightHasher,
 };
 
 declare_id!("GRLu2hKaAiMbxpkAM1HeXzks9YeGuz18SEgXEizVvPqX");
@@ -10,53 +13,59 @@ declare_id!("GRLu2hKaAiMbxpkAM1HeXzks9YeGuz18SEgXEizVvPqX");
 #[program]
 pub mod counter {
     use light_sdk::{
-        address::derive_address, error::LightSdkError,
-        program_merkle_context::unpack_address_merkle_context,
-        system_accounts::CompressionCpiAccounts, Discriminator,
+        address::v1::derive_address, cpi::accounts::CompressionCpiAccounts, NewAddressParamsPacked,
     };
 
     use super::*;
 
     pub fn create_counter<'info>(
-        ctx: Context<'_, '_, '_, 'info, CreateCounter<'info>>,
-        inputs: Vec<u8>,
+        ctx: Context<'_, '_, '_, 'info, GenericAnchorAccounts<'info>>,
+        light_ix_data: LightInstructionData,
+        output_merkle_tree_index: u8,
     ) -> Result<()> {
-        let inputs = LightInstructionData::deserialize(&inputs)?;
-        let accounts = inputs
-            .accounts
-            .as_ref()
-            .ok_or(LightSdkError::ExpectedAccounts)?;
+        let program_id = crate::ID.into();
+        let light_cpi_accounts = CompressionCpiAccounts::new(
+            ctx.accounts.signer.as_ref(),
+            ctx.remaining_accounts,
+            crate::ID,
+        )
+        .map_err(ProgramError::from)?;
 
-        let address_merkle_context = accounts[0]
-            .address_merkle_context
-            .ok_or(LightSdkError::ExpectedAddressMerkleContext)?;
-        let address_merkle_context =
-            unpack_address_merkle_context(address_merkle_context, ctx.remaining_accounts);
+        let address_merkle_context = light_ix_data
+            .new_addresses
+            .ok_or(LightSdkError::ExpectedAddressMerkleContext)
+            .map_err(ProgramError::from)?[0];
+
         let (address, address_seed) = derive_address(
             &[b"counter", ctx.accounts.signer.key().as_ref()],
-            &address_merkle_context,
+            &light_cpi_accounts.tree_accounts()
+                [address_merkle_context.address_merkle_tree_pubkey_index as usize]
+                .key(),
             &crate::ID,
         );
 
-        let mut counter: LightAccount<'_, CounterAccount> = LightAccount::from_meta_init(
-            &accounts[0],
-            CounterAccount::discriminator(),
-            address,
-            address_seed,
-            &crate::ID,
-        )?;
+        let new_address_params = NewAddressParamsPacked {
+            seed: address_seed,
+            address_queue_account_index: address_merkle_context.address_queue_pubkey_index,
+            address_merkle_tree_root_index: address_merkle_context.root_index,
+            address_merkle_tree_account_index: address_merkle_context
+                .address_merkle_tree_pubkey_index,
+        };
+
+        let mut counter = CBorshAccount::<'_, CounterAccount>::new_init(
+            &program_id,
+            Some(address),
+            output_merkle_tree_index,
+        );
 
         counter.owner = ctx.accounts.signer.key();
         counter.value = 0;
-        let light_cpi_accounts = CompressionCpiAccounts::new(
-            ctx.accounts.signer.as_ref(),
-            ctx.accounts.cpi_signer.as_ref(),
-            ctx.remaining_accounts,
-        );
-        verify_light_accounts(
+
+        verify_compressed_account_infos(
             &light_cpi_accounts,
-            inputs.proof,
-            &[counter],
+            light_ix_data.proof,
+            &[counter.to_account_info().unwrap()],
+            Some(vec![new_address_params]),
             None,
             false,
             None,
@@ -67,49 +76,61 @@ pub mod counter {
     }
 
     pub fn increment_counter<'info>(
-        ctx: Context<'_, '_, '_, 'info, UpdateCounter<'info>>,
-        inputs: Vec<u8>,
+        ctx: Context<'_, '_, '_, 'info, GenericAnchorAccounts<'info>>,
+        light_ix_data: LightInstructionData,
+        counter_value: u64,
+        account_meta: CompressedAccountMeta,
     ) -> Result<()> {
-        let inputs = LightInstructionData::deserialize(&inputs)?;
-        let accounts = inputs
-            .accounts
-            .as_ref()
-            .ok_or(LightSdkError::ExpectedAccounts)?;
-        let mut counter: LightAccount<'_, CounterAccount> =
-            LightAccount::meta_mut(&accounts[0], CounterAccount::discriminator(), &crate::ID)?;
+        let program_id = crate::ID.into();
+        let mut counter = CBorshAccount::<'_, CounterAccount>::new_mut(
+            &program_id,
+            &account_meta,
+            CounterAccount {
+                owner: ctx.accounts.signer.key(),
+                value: counter_value,
+            },
+        )
+        .map_err(ProgramError::from)?;
 
-        if counter.owner != ctx.accounts.signer.key() {
-            return err!(CustomError::Unauthorized);
-        }
         counter.value = counter.value.checked_add(1).ok_or(CustomError::Overflow)?;
+
         let light_cpi_accounts = CompressionCpiAccounts::new(
             ctx.accounts.signer.as_ref(),
-            ctx.accounts.cpi_signer.as_ref(),
             ctx.remaining_accounts,
-        );
-        verify_light_accounts(
+            crate::ID,
+        )
+        .map_err(ProgramError::from)?;
+
+        verify_compressed_account_infos(
             &light_cpi_accounts,
-            inputs.proof,
-            &[counter],
+            light_ix_data.proof,
+            &[counter.to_account_info().unwrap()],
+            None,
             None,
             false,
             None,
         )
         .map_err(ProgramError::from)?;
+
         Ok(())
     }
-    pub fn decrement_counter<'info>(
-        ctx: Context<'_, '_, '_, 'info, UpdateCounter<'info>>,
-        inputs: Vec<u8>,
-    ) -> Result<()> {
-        let inputs = LightInstructionData::deserialize(&inputs)?;
-        let accounts = inputs
-            .accounts
-            .as_ref()
-            .ok_or(LightSdkError::ExpectedAccounts)?;
 
-        let mut counter: LightAccount<'_, CounterAccount> =
-            LightAccount::meta_mut(&accounts[0], CounterAccount::discriminator(), &crate::ID)?;
+    pub fn decrement_counter<'info>(
+        ctx: Context<'_, '_, '_, 'info, GenericAnchorAccounts<'info>>,
+        light_ix_data: LightInstructionData,
+        counter_value: u64,
+        account_meta: CompressedAccountMeta,
+    ) -> Result<()> {
+        let program_id = crate::ID.into();
+        let mut counter = CBorshAccount::<'_, CounterAccount>::new_mut(
+            &program_id,
+            &account_meta,
+            CounterAccount {
+                owner: ctx.accounts.signer.key(),
+                value: counter_value,
+            },
+        )
+        .map_err(ProgramError::from)?;
 
         if counter.owner != ctx.accounts.signer.key() {
             return err!(CustomError::Unauthorized);
@@ -119,53 +140,62 @@ pub mod counter {
 
         let light_cpi_accounts = CompressionCpiAccounts::new(
             ctx.accounts.signer.as_ref(),
-            ctx.accounts.cpi_signer.as_ref(),
             ctx.remaining_accounts,
-        );
-        verify_light_accounts(
+            crate::ID,
+        )
+        .map_err(ProgramError::from)?;
+
+        verify_compressed_account_infos(
             &light_cpi_accounts,
-            inputs.proof,
-            &[counter],
+            light_ix_data.proof,
+            &[counter.to_account_info().unwrap()],
+            None,
             None,
             false,
             None,
         )
         .map_err(ProgramError::from)?;
+
         Ok(())
     }
 
     pub fn reset_counter<'info>(
-        ctx: Context<'_, '_, '_, 'info, UpdateCounter<'info>>,
-        inputs: Vec<u8>,
+        ctx: Context<'_, '_, '_, 'info, GenericAnchorAccounts<'info>>,
+        light_ix_data: LightInstructionData,
+        counter_value: u64,
+        account_meta: CompressedAccountMeta,
     ) -> Result<()> {
-        let inputs = LightInstructionData::deserialize(&inputs)?;
-        let accounts = inputs
-            .accounts
-            .as_ref()
-            .ok_or(LightSdkError::ExpectedAccounts)?;
-
-        let mut counter: LightAccount<'_, CounterAccount> =
-            LightAccount::meta_mut(&accounts[0], CounterAccount::discriminator(), &crate::ID)?;
-
-        if counter.owner != ctx.accounts.signer.key() {
-            return err!(CustomError::Unauthorized);
-        }
+        let program_id = crate::ID.into();
+        let mut counter = CBorshAccount::<'_, CounterAccount>::new_mut(
+            &program_id,
+            &account_meta,
+            CounterAccount {
+                owner: ctx.accounts.signer.key(),
+                value: counter_value,
+            },
+        )
+        .map_err(ProgramError::from)?;
 
         counter.value = 0;
+
         let light_cpi_accounts = CompressionCpiAccounts::new(
             ctx.accounts.signer.as_ref(),
-            ctx.accounts.cpi_signer.as_ref(),
             ctx.remaining_accounts,
-        );
-        verify_light_accounts(
+            crate::ID,
+        )
+        .map_err(ProgramError::from)?;
+
+        verify_compressed_account_infos(
             &light_cpi_accounts,
-            inputs.proof,
-            &[counter],
+            light_ix_data.proof,
+            &[counter.to_account_info().unwrap()],
+            None,
             None,
             false,
             None,
         )
         .map_err(ProgramError::from)?;
+
         Ok(())
     }
 }
@@ -189,28 +219,8 @@ pub enum CustomError {
     Underflow,
 }
 
-#[light_system_accounts]
-#[derive(Accounts, LightTraits)]
-pub struct CreateCounter<'info> {
+#[derive(Accounts)]
+pub struct GenericAnchorAccounts<'info> {
     #[account(mut)]
-    #[fee_payer]
     pub signer: Signer<'info>,
-    #[self_program]
-    pub self_program: Program<'info, crate::program::Counter>,
-    /// CHECK: Checked in light-system-program.
-    #[authority]
-    pub cpi_signer: AccountInfo<'info>,
-}
-
-#[light_system_accounts]
-#[derive(Accounts, LightTraits)]
-pub struct UpdateCounter<'info> {
-    #[account(mut)]
-    #[fee_payer]
-    pub signer: Signer<'info>,
-    #[self_program]
-    pub self_program: Program<'info, crate::program::Counter>,
-    /// CHECK: Checked in light-system-program.
-    #[authority]
-    pub cpi_signer: AccountInfo<'info>,
 }

--- a/examples/anchor/counter/src/lib.rs
+++ b/examples/anchor/counter/src/lib.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 use borsh::BorshDeserialize;
 use light_sdk::{
-    account::CBorshAccount,
+    account::LightAccount,
     address::v1::derive_address,
     cpi::{accounts::CompressionCpiAccounts, verify::verify_compressed_account_infos},
     error::LightSdkError,
@@ -21,7 +21,7 @@ pub mod counter {
         output_merkle_tree_index: u8,
     ) -> Result<()> {
         let program_id = crate::ID.into();
-        // CBorshAccount::new_init will create an account with empty output state (no input state).
+        // LightAccount::new_init will create an account with empty output state (no input state).
         // Modifying the account will modify the output state that when converted to_account_info()
         // is hashed with poseidon hashes, serialized with borsh
         // and created with verify_compressed_account_infos by invoking the light-system-program.
@@ -54,7 +54,7 @@ pub mod counter {
                 .address_merkle_tree_pubkey_index,
         };
 
-        let mut counter = CBorshAccount::<'_, CounterAccount>::new_init(
+        let mut counter = LightAccount::<'_, CounterAccount>::new_init(
             &program_id,
             Some(address),
             output_merkle_tree_index,
@@ -84,13 +84,13 @@ pub mod counter {
         account_meta: CompressedAccountMeta,
     ) -> Result<()> {
         let program_id = crate::ID.into();
-        // CBorshAccount::new_mut will create an account with input state and output state.
+        // LightAccount::new_mut will create an account with input state and output state.
         // The input state is hashed immediately when calling new_mut().
         // Modifying the account will modify the output state that when converted to_account_info()
         // is hashed with poseidon hashes, serialized with borsh
         // and created with verify_compressed_account_infos by invoking the light-system-program.
         // The hashing scheme is the account structure derived with LightHasher.
-        let mut counter = CBorshAccount::<'_, CounterAccount>::new_mut(
+        let mut counter = LightAccount::<'_, CounterAccount>::new_mut(
             &program_id,
             &account_meta,
             CounterAccount {
@@ -130,7 +130,7 @@ pub mod counter {
         account_meta: CompressedAccountMeta,
     ) -> Result<()> {
         let program_id = crate::ID.into();
-        let mut counter = CBorshAccount::<'_, CounterAccount>::new_mut(
+        let mut counter = LightAccount::<'_, CounterAccount>::new_mut(
             &program_id,
             &account_meta,
             CounterAccount {
@@ -174,7 +174,7 @@ pub mod counter {
         account_meta: CompressedAccountMeta,
     ) -> Result<()> {
         let program_id = crate::ID.into();
-        let mut counter = CBorshAccount::<'_, CounterAccount>::new_mut(
+        let mut counter = LightAccount::<'_, CounterAccount>::new_mut(
             &program_id,
             &account_meta,
             CounterAccount {
@@ -214,10 +214,10 @@ pub mod counter {
         account_meta: CompressedAccountMeta,
     ) -> Result<()> {
         let program_id = crate::ID.into();
-        // CBorshAccount::new_close() will create an account with only input state and no output state.
+        // LightAccount::new_close() will create an account with only input state and no output state.
         // By providing no output state the account is closed after the instruction.
         // The address of a closed account cannot be reused.
-        let counter = CBorshAccount::<'_, CounterAccount>::new_close(
+        let counter = LightAccount::<'_, CounterAccount>::new_close(
             &program_id,
             &account_meta,
             CounterAccount {

--- a/examples/anchor/counter/tests/test.rs
+++ b/examples/anchor/counter/tests/test.rs
@@ -26,7 +26,6 @@ use light_sdk::{
 use light_test_utils::{RpcConnection, RpcError};
 use solana_sdk::{
     instruction::Instruction,
-    pubkey::Pubkey,
     signature::{Keypair, Signer},
 };
 
@@ -156,12 +155,12 @@ async fn test_counter() {
         .data;
     let counter = CounterAccount::deserialize(&mut &counter[..]).unwrap();
     assert_eq!(counter.value, 0);
-    
+
     // Close the counter.
     close_counter(&mut rpc, &mut test_indexer, &payer, compressed_account)
         .await
         .unwrap();
-        
+
     // Check that it was closed correctly (no compressed accounts after closing).
     let compressed_accounts = test_indexer
         .get_compressed_accounts_by_owner_v2(&counter::ID)

--- a/examples/anchor/counter/tests/test.rs
+++ b/examples/anchor/counter/tests/test.rs
@@ -14,13 +14,14 @@ use light_program_test::{
 };
 use light_prover_client::gnark::helpers::{spawn_prover, ProverConfig, ProverMode};
 use light_sdk::{
-    account_meta::LightAccountMeta,
-    address::derive_address,
-    instruction_data::LightInstructionData,
-    merkle_context::{AddressMerkleContext, PackedAccounts},
-    utils::get_cpi_authority_pda,
-    verify::find_cpi_signer,
-    PROGRAM_ID_ACCOUNT_COMPRESSION, PROGRAM_ID_LIGHT_SYSTEM, PROGRAM_ID_NOOP,
+    address::v1::derive_address,
+    cpi::accounts::SystemAccountMetaConfig,
+    instruction::{
+        account_meta::CompressedAccountMeta,
+        instruction_data::LightInstructionData,
+        merkle_context::{pack_address_merkle_context, pack_merkle_context, AddressMerkleContext},
+        pack_accounts::PackedAccounts,
+    },
 };
 use light_test_utils::{RpcConnection, RpcError};
 use solana_sdk::{
@@ -61,8 +62,6 @@ async fn test_counter() {
     )
     .await;
 
-    let mut remaining_accounts = PackedAccounts::default();
-
     let address_merkle_context = AddressMerkleContext {
         address_merkle_tree_pubkey: env.address_merkle_tree_pubkey,
         address_queue_pubkey: env.address_merkle_tree_queue_pubkey,
@@ -74,27 +73,10 @@ async fn test_counter() {
         &counter::ID,
     );
 
-    let account_compression_authority = get_cpi_authority_pda(&PROGRAM_ID_LIGHT_SYSTEM);
-    let registered_program_pda = Pubkey::find_program_address(
-        &[PROGRAM_ID_LIGHT_SYSTEM.to_bytes().as_slice()],
-        &PROGRAM_ID_ACCOUNT_COMPRESSION,
-    )
-    .0;
-
     // Create the counter.
-    create_counter(
-        &mut rpc,
-        &mut test_indexer,
-        &env,
-        &mut remaining_accounts,
-        &payer,
-        &address,
-        &account_compression_authority,
-        &registered_program_pda,
-        &PROGRAM_ID_LIGHT_SYSTEM,
-    )
-    .await
-    .unwrap();
+    create_counter(&mut rpc, &mut test_indexer, &env, &payer, &address)
+        .await
+        .unwrap();
 
     // Check that it was created correctly.
     let compressed_accounts = test_indexer
@@ -113,18 +95,9 @@ async fn test_counter() {
     assert_eq!(counter.value, 0);
 
     // Increment the counter.
-    increment_counter(
-        &mut rpc,
-        &mut test_indexer,
-        &mut remaining_accounts,
-        &payer,
-        compressed_account,
-        &account_compression_authority,
-        &registered_program_pda,
-        &PROGRAM_ID_LIGHT_SYSTEM,
-    )
-    .await
-    .unwrap();
+    increment_counter(&mut rpc, &mut test_indexer, &payer, compressed_account)
+        .await
+        .unwrap();
 
     // Check that it was incremented correctly.
     let compressed_accounts = test_indexer
@@ -143,18 +116,9 @@ async fn test_counter() {
     assert_eq!(counter.value, 1);
 
     // Decrement the counter.
-    decrement_counter(
-        &mut rpc,
-        &mut test_indexer,
-        &mut remaining_accounts,
-        &payer,
-        compressed_account,
-        &account_compression_authority,
-        &registered_program_pda,
-        &PROGRAM_ID_LIGHT_SYSTEM,
-    )
-    .await
-    .unwrap();
+    decrement_counter(&mut rpc, &mut test_indexer, &payer, compressed_account)
+        .await
+        .unwrap();
 
     // Check that it was decremented correctly.
     let compressed_accounts = test_indexer
@@ -173,18 +137,9 @@ async fn test_counter() {
     assert_eq!(counter.value, 0);
 
     // Reset the counter.
-    reset_counter(
-        &mut rpc,
-        &mut test_indexer,
-        &mut remaining_accounts,
-        &payer,
-        compressed_account,
-        &account_compression_authority,
-        &registered_program_pda,
-        &PROGRAM_ID_LIGHT_SYSTEM,
-    )
-    .await
-    .unwrap();
+    reset_counter(&mut rpc, &mut test_indexer, &payer, compressed_account)
+        .await
+        .unwrap();
 
     // Check that it was reset correctly.
     let compressed_accounts = test_indexer
@@ -208,16 +163,16 @@ async fn create_counter<R>(
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
     env: &EnvAccounts,
-    remaining_accounts: &mut PackedAccounts,
     payer: &Keypair,
     address: &[u8; 32],
-    account_compression_authority: &Pubkey,
-    registered_program_pda: &Pubkey,
-    light_system_program: &Pubkey,
 ) -> Result<(), RpcError>
 where
     R: RpcConnection + MerkleTreeExt,
 {
+    let mut remaining_accounts = PackedAccounts::default();
+    let config = SystemAccountMetaConfig::new(counter::ID);
+    remaining_accounts.add_system_accounts(config);
+
     let rpc_result = test_indexer
         .create_proof_for_compressed_accounts(
             None,
@@ -233,40 +188,37 @@ where
         address_merkle_tree_pubkey: env.address_merkle_tree_pubkey,
         address_queue_pubkey: env.address_merkle_tree_queue_pubkey,
     };
-    let account = LightAccountMeta::new_init(
-        &env.merkle_tree_pubkey,
-        Some(&address_merkle_context),
-        Some(rpc_result.address_root_indices[0]),
-        remaining_accounts,
-    )
-    .unwrap();
 
-    let inputs = LightInstructionData {
-        proof: Some(rpc_result),
-        accounts: Some(vec![account]),
+    let output_merkle_tree_index = remaining_accounts.insert_or_get(env.merkle_tree_pubkey);
+    let packed_address_merkle_context = pack_address_merkle_context(
+        &address_merkle_context,
+        &mut remaining_accounts,
+        rpc_result.address_root_indices[0],
+    );
+
+    let light_ix_data = LightInstructionData {
+        proof: Some(rpc_result.proof),
+        new_addresses: Some(vec![packed_address_merkle_context]),
     };
-    let inputs = inputs.serialize().unwrap();
-    let instruction_data = counter::instruction::CreateCounter { inputs };
 
-    let cpi_signer = find_cpi_signer(&counter::ID);
+    let instruction_data = counter::instruction::CreateCounter {
+        light_ix_data,
+        output_merkle_tree_index,
+    };
 
-    let accounts = counter::accounts::CreateCounter {
+    let accounts = counter::accounts::GenericAnchorAccounts {
         signer: payer.pubkey(),
-        light_system_program: *light_system_program,
-        account_compression_program: PROGRAM_ID_ACCOUNT_COMPRESSION,
-        account_compression_authority: *account_compression_authority,
-        registered_program_pda: *registered_program_pda,
-        noop_program: PROGRAM_ID_NOOP,
-        self_program: counter::ID,
-        cpi_signer,
-        system_program: solana_sdk::system_program::id(),
     };
 
-    let remaining_accounts = remaining_accounts.to_account_metas();
+    let (remaining_accounts_metas, _, _) = remaining_accounts.to_account_metas();
 
     let instruction = Instruction {
         program_id: counter::ID,
-        accounts: [accounts.to_account_metas(Some(true)), remaining_accounts].concat(),
+        accounts: [
+            accounts.to_account_metas(Some(true)),
+            remaining_accounts_metas,
+        ]
+        .concat(),
         data: instruction_data.data(),
     };
 
@@ -287,16 +239,16 @@ where
 async fn increment_counter<R>(
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
-    remaining_accounts: &mut PackedAccounts,
     payer: &Keypair,
     compressed_account: &CompressedAccountWithMerkleContext,
-    account_compression_authority: &Pubkey,
-    registered_program_pda: &Pubkey,
-    light_system_program: &Pubkey,
 ) -> Result<(), RpcError>
 where
     R: RpcConnection + MerkleTreeExt,
 {
+    let mut remaining_accounts = PackedAccounts::default();
+    let config = SystemAccountMetaConfig::new(counter::ID);
+    remaining_accounts.add_system_accounts(config);
+
     let hash = compressed_account.hash().unwrap();
     let merkle_tree_pubkey = compressed_account.merkle_context.merkle_tree_pubkey;
 
@@ -311,39 +263,51 @@ where
         .await
         .unwrap();
 
-    let compressed_account = LightAccountMeta::new_mut(
-        compressed_account,
-        rpc_result.root_indices[0].unwrap(),
-        &merkle_tree_pubkey,
-        remaining_accounts,
-    );
+    let packed_merkle_context =
+        pack_merkle_context(&compressed_account.merkle_context, &mut remaining_accounts);
 
-    let inputs = LightInstructionData {
-        proof: Some(rpc_result),
-        accounts: Some(vec![compressed_account]),
+    let counter_account = CounterAccount::deserialize(
+        &mut compressed_account
+            .compressed_account
+            .data
+            .as_ref()
+            .unwrap()
+            .data
+            .as_slice(),
+    )
+    .unwrap();
+
+    let light_ix_data = LightInstructionData {
+        proof: Some(rpc_result.proof),
+        new_addresses: None,
     };
-    let inputs = inputs.serialize().unwrap();
-    let instruction_data = counter::instruction::IncrementCounter { inputs };
 
-    let cpi_signer = find_cpi_signer(&counter::ID);
+    let account_meta = CompressedAccountMeta {
+        merkle_context: packed_merkle_context,
+        address: compressed_account.compressed_account.address.unwrap(),
+        root_index: Some(rpc_result.root_indices[0].unwrap()),
+        output_merkle_tree_index: packed_merkle_context.merkle_tree_pubkey_index,
+    };
 
-    let accounts = counter::accounts::UpdateCounter {
+    let instruction_data = counter::instruction::IncrementCounter {
+        light_ix_data,
+        counter_value: counter_account.value,
+        account_meta,
+    };
+
+    let accounts = counter::accounts::GenericAnchorAccounts {
         signer: payer.pubkey(),
-        light_system_program: *light_system_program,
-        account_compression_program: PROGRAM_ID_ACCOUNT_COMPRESSION,
-        account_compression_authority: *account_compression_authority,
-        registered_program_pda: *registered_program_pda,
-        noop_program: PROGRAM_ID_NOOP,
-        self_program: counter::ID,
-        cpi_signer,
-        system_program: solana_sdk::system_program::id(),
     };
 
-    let remaining_accounts = remaining_accounts.to_account_metas();
+    let (remaining_accounts_metas, _, _) = remaining_accounts.to_account_metas();
 
     let instruction = Instruction {
         program_id: counter::ID,
-        accounts: [accounts.to_account_metas(Some(true)), remaining_accounts].concat(),
+        accounts: [
+            accounts.to_account_metas(Some(true)),
+            remaining_accounts_metas,
+        ]
+        .concat(),
         data: instruction_data.data(),
     };
 
@@ -364,16 +328,16 @@ where
 async fn decrement_counter<R>(
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
-    remaining_accounts: &mut PackedAccounts,
     payer: &Keypair,
     compressed_account: &CompressedAccountWithMerkleContext,
-    account_compression_authority: &Pubkey,
-    registered_program_pda: &Pubkey,
-    light_system_program: &Pubkey,
 ) -> Result<(), RpcError>
 where
     R: RpcConnection + MerkleTreeExt,
 {
+    let mut remaining_accounts = PackedAccounts::default();
+    let config = SystemAccountMetaConfig::new(counter::ID);
+    remaining_accounts.add_system_accounts(config);
+
     let hash = compressed_account.hash().unwrap();
     let merkle_tree_pubkey = compressed_account.merkle_context.merkle_tree_pubkey;
 
@@ -388,39 +352,51 @@ where
         .await
         .unwrap();
 
-    let compressed_account = LightAccountMeta::new_mut(
-        compressed_account,
-        rpc_result.root_indices[0].unwrap(),
-        &merkle_tree_pubkey,
-        remaining_accounts,
-    );
+    let packed_merkle_context =
+        pack_merkle_context(&compressed_account.merkle_context, &mut remaining_accounts);
 
-    let inputs = LightInstructionData {
-        proof: Some(rpc_result),
-        accounts: Some(vec![compressed_account]),
+    let counter_account = CounterAccount::deserialize(
+        &mut compressed_account
+            .compressed_account
+            .data
+            .as_ref()
+            .unwrap()
+            .data
+            .as_slice(),
+    )
+    .unwrap();
+
+    let light_ix_data = LightInstructionData {
+        proof: Some(rpc_result.proof),
+        new_addresses: None,
     };
-    let inputs = inputs.serialize().unwrap();
-    let instruction_data = counter::instruction::DecrementCounter { inputs };
 
-    let cpi_signer = find_cpi_signer(&counter::ID);
+    let account_meta = CompressedAccountMeta {
+        merkle_context: packed_merkle_context,
+        address: compressed_account.compressed_account.address.unwrap(),
+        root_index: Some(rpc_result.root_indices[0].unwrap()),
+        output_merkle_tree_index: packed_merkle_context.merkle_tree_pubkey_index,
+    };
 
-    let accounts = counter::accounts::UpdateCounter {
+    let instruction_data = counter::instruction::DecrementCounter {
+        light_ix_data,
+        counter_value: counter_account.value,
+        account_meta,
+    };
+
+    let accounts = counter::accounts::GenericAnchorAccounts {
         signer: payer.pubkey(),
-        light_system_program: *light_system_program,
-        account_compression_program: PROGRAM_ID_ACCOUNT_COMPRESSION,
-        account_compression_authority: *account_compression_authority,
-        registered_program_pda: *registered_program_pda,
-        noop_program: PROGRAM_ID_NOOP,
-        self_program: counter::ID,
-        cpi_signer,
-        system_program: solana_sdk::system_program::id(),
     };
 
-    let remaining_accounts = remaining_accounts.to_account_metas();
+    let (remaining_accounts_metas, _, _) = remaining_accounts.to_account_metas();
 
     let instruction = Instruction {
         program_id: counter::ID,
-        accounts: [accounts.to_account_metas(Some(true)), remaining_accounts].concat(),
+        accounts: [
+            accounts.to_account_metas(Some(true)),
+            remaining_accounts_metas,
+        ]
+        .concat(),
         data: instruction_data.data(),
     };
 
@@ -440,16 +416,16 @@ where
 async fn reset_counter<R>(
     rpc: &mut R,
     test_indexer: &mut TestIndexer<R>,
-    remaining_accounts: &mut PackedAccounts,
     payer: &Keypair,
     compressed_account: &CompressedAccountWithMerkleContext,
-    account_compression_authority: &Pubkey,
-    registered_program_pda: &Pubkey,
-    light_system_program: &Pubkey,
 ) -> Result<(), RpcError>
 where
     R: RpcConnection + MerkleTreeExt,
 {
+    let mut remaining_accounts = PackedAccounts::default();
+    let config = SystemAccountMetaConfig::new(counter::ID);
+    remaining_accounts.add_system_accounts(config);
+
     let hash = compressed_account.hash().unwrap();
     let merkle_tree_pubkey = compressed_account.merkle_context.merkle_tree_pubkey;
 
@@ -464,39 +440,51 @@ where
         .await
         .unwrap();
 
-    let compressed_account = LightAccountMeta::new_mut(
-        compressed_account,
-        rpc_result.root_indices[0].unwrap(),
-        &merkle_tree_pubkey,
-        remaining_accounts,
-    );
+    let packed_merkle_context =
+        pack_merkle_context(&compressed_account.merkle_context, &mut remaining_accounts);
 
-    let inputs = LightInstructionData {
-        proof: Some(rpc_result),
-        accounts: Some(vec![compressed_account]),
+    let counter_account = CounterAccount::deserialize(
+        &mut compressed_account
+            .compressed_account
+            .data
+            .as_ref()
+            .unwrap()
+            .data
+            .as_slice(),
+    )
+    .unwrap();
+
+    let light_ix_data = LightInstructionData {
+        proof: Some(rpc_result.proof),
+        new_addresses: None,
     };
-    let inputs = inputs.serialize().unwrap();
-    let instruction_data = counter::instruction::ResetCounter { inputs };
 
-    let cpi_signer = find_cpi_signer(&counter::ID);
+    let account_meta = CompressedAccountMeta {
+        merkle_context: packed_merkle_context,
+        address: compressed_account.compressed_account.address.unwrap(),
+        root_index: Some(rpc_result.root_indices[0].unwrap()),
+        output_merkle_tree_index: packed_merkle_context.merkle_tree_pubkey_index,
+    };
 
-    let accounts = counter::accounts::UpdateCounter {
+    let instruction_data = counter::instruction::ResetCounter {
+        light_ix_data,
+        counter_value: counter_account.value,
+        account_meta,
+    };
+
+    let accounts = counter::accounts::GenericAnchorAccounts {
         signer: payer.pubkey(),
-        light_system_program: *light_system_program,
-        account_compression_program: PROGRAM_ID_ACCOUNT_COMPRESSION,
-        account_compression_authority: *account_compression_authority,
-        registered_program_pda: *registered_program_pda,
-        noop_program: PROGRAM_ID_NOOP,
-        self_program: counter::ID,
-        cpi_signer,
-        system_program: solana_sdk::system_program::id(),
     };
 
-    let remaining_accounts = remaining_accounts.to_account_metas();
+    let (remaining_accounts_metas, _, _) = remaining_accounts.to_account_metas();
 
     let instruction = Instruction {
         program_id: counter::ID,
-        accounts: [accounts.to_account_metas(Some(true)), remaining_accounts].concat(),
+        accounts: [
+            accounts.to_account_metas(Some(true)),
+            remaining_accounts_metas,
+        ]
+        .concat(),
         data: instruction_data.data(),
     };
 

--- a/examples/anchor/counter/tests/test.rs
+++ b/examples/anchor/counter/tests/test.rs
@@ -156,6 +156,18 @@ async fn test_counter() {
         .data;
     let counter = CounterAccount::deserialize(&mut &counter[..]).unwrap();
     assert_eq!(counter.value, 0);
+    
+    // Close the counter.
+    close_counter(&mut rpc, &mut test_indexer, &payer, compressed_account)
+        .await
+        .unwrap();
+        
+    // Check that it was closed correctly (no compressed accounts after closing).
+    let compressed_accounts = test_indexer
+        .get_compressed_accounts_by_owner_v2(&counter::ID)
+        .await
+        .unwrap();
+    assert_eq!(compressed_accounts.len(), 0);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -467,6 +479,94 @@ where
     };
 
     let instruction_data = counter::instruction::ResetCounter {
+        light_ix_data,
+        counter_value: counter_account.value,
+        account_meta,
+    };
+
+    let accounts = counter::accounts::GenericAnchorAccounts {
+        signer: payer.pubkey(),
+    };
+
+    let (remaining_accounts_metas, _, _) = remaining_accounts.to_account_metas();
+
+    let instruction = Instruction {
+        program_id: counter::ID,
+        accounts: [
+            accounts.to_account_metas(Some(true)),
+            remaining_accounts_metas,
+        ]
+        .concat(),
+        data: instruction_data.data(),
+    };
+
+    let event = rpc
+        .create_and_send_transaction_with_public_event(
+            &[instruction],
+            &payer.pubkey(),
+            &[payer],
+            None,
+        )
+        .await?;
+    let slot = rpc.get_slot().await.unwrap();
+    test_indexer.add_compressed_accounts_with_token_data(slot, &event.unwrap().0);
+    Ok(())
+}
+
+async fn close_counter<R>(
+    rpc: &mut R,
+    test_indexer: &mut TestIndexer<R>,
+    payer: &Keypair,
+    compressed_account: &CompressedAccountWithMerkleContext,
+) -> Result<(), RpcError>
+where
+    R: RpcConnection + MerkleTreeExt,
+{
+    let mut remaining_accounts = PackedAccounts::default();
+    let config = SystemAccountMetaConfig::new(counter::ID);
+    remaining_accounts.add_system_accounts(config);
+
+    let hash = compressed_account.hash().unwrap();
+    let merkle_tree_pubkey = compressed_account.merkle_context.merkle_tree_pubkey;
+
+    let rpc_result = test_indexer
+        .create_proof_for_compressed_accounts(
+            Some(Vec::from(&[hash])),
+            Some(Vec::from(&[merkle_tree_pubkey])),
+            None,
+            None,
+            rpc,
+        )
+        .await
+        .unwrap();
+
+    let packed_merkle_context =
+        pack_merkle_context(&compressed_account.merkle_context, &mut remaining_accounts);
+
+    let counter_account = CounterAccount::deserialize(
+        &mut compressed_account
+            .compressed_account
+            .data
+            .as_ref()
+            .unwrap()
+            .data
+            .as_slice(),
+    )
+    .unwrap();
+
+    let light_ix_data = LightInstructionData {
+        proof: Some(rpc_result.proof),
+        new_addresses: None,
+    };
+
+    let account_meta = CompressedAccountMeta {
+        merkle_context: packed_merkle_context,
+        address: compressed_account.compressed_account.address.unwrap(),
+        root_index: Some(rpc_result.root_indices[0].unwrap()),
+        output_merkle_tree_index: packed_merkle_context.merkle_tree_pubkey_index,
+    };
+
+    let instruction_data = counter::instruction::CloseCounter {
         light_ix_data,
         counter_value: counter_account.value,
         account_meta,

--- a/program-tests/sdk-anchor-test/programs/sdk-anchor-test/src/lib.rs
+++ b/program-tests/sdk-anchor-test/programs/sdk-anchor-test/src/lib.rs
@@ -12,7 +12,7 @@ declare_id!("2tzfijPBGbrR5PboyFUFKzfEoLTwdDSHUjANCw929wyt");
 #[program]
 pub mod sdk_anchor_test {
     use light_sdk::{
-        account::CBorshAccount, cpi::accounts::CompressionCpiAccounts, NewAddressParamsPacked,
+        account::LightAccount, cpi::accounts::CompressionCpiAccounts, NewAddressParamsPacked,
     };
 
     use super::*;
@@ -50,7 +50,7 @@ pub mod sdk_anchor_test {
                 .address_merkle_tree_pubkey_index,
         };
 
-        let mut my_compressed_account = CBorshAccount::<'_, MyCompressedAccount>::new_init(
+        let mut my_compressed_account = LightAccount::<'_, MyCompressedAccount>::new_init(
             &program_id,
             Some(address),
             output_merkle_tree_index,
@@ -81,7 +81,7 @@ pub mod sdk_anchor_test {
         nested_data: NestedData,
     ) -> Result<()> {
         let program_id = crate::ID.into();
-        let mut my_compressed_account = CBorshAccount::<'_, MyCompressedAccount>::new_mut(
+        let mut my_compressed_account = LightAccount::<'_, MyCompressedAccount>::new_mut(
             &program_id,
             &account_meta,
             my_compressed_account,

--- a/program-tests/sdk-anchor-test/programs/sdk-anchor-test/src/lib.rs
+++ b/program-tests/sdk-anchor-test/programs/sdk-anchor-test/src/lib.rs
@@ -4,7 +4,7 @@ use light_sdk::{
     cpi::verify::verify_compressed_account_infos,
     error::LightSdkError,
     instruction::{account_meta::CompressedAccountMeta, instruction_data::LightInstructionData},
-    light_account, Discriminator, LightHasher,
+    Discriminator, LightDiscriminator, LightHasher,
 };
 
 declare_id!("2tzfijPBGbrR5PboyFUFKzfEoLTwdDSHUjANCw929wyt");
@@ -120,8 +120,9 @@ pub mod sdk_anchor_test {
     }
 }
 
-#[light_account]
-#[derive(Clone, Debug, Default)]
+#[derive(
+    Clone, Debug, Default, LightHasher, LightDiscriminator, AnchorSerialize, AnchorDeserialize,
+)]
 pub struct MyCompressedAccount {
     pub name: String,
     pub nested: NestedData,

--- a/program-tests/sdk-test/src/create_pda.rs
+++ b/program-tests/sdk-test/src/create_pda.rs
@@ -1,6 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use light_sdk::{
-    account::CBorshAccount,
+    account::LightAccount,
     cpi::{
         accounts::{CompressionCpiAccounts, CompressionCpiAccountsConfig},
         verify::verify_compressed_account_infos,
@@ -73,7 +73,7 @@ pub fn create_pda<const BATCHED: bool>(
     };
 
     let program_id = crate::ID.into();
-    let mut my_compressed_account = CBorshAccount::<'_, MyCompressedAccount>::new_init(
+    let mut my_compressed_account = LightAccount::<'_, MyCompressedAccount>::new_init(
         &program_id,
         Some(address),
         instruction_data.output_merkle_tree_index,

--- a/program-tests/sdk-test/src/update_pda.rs
+++ b/program-tests/sdk-test/src/update_pda.rs
@@ -1,6 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use light_sdk::{
-    account::CBorshAccount,
+    account::LightAccount,
     cpi::{
         accounts::{CompressionCpiAccounts, CompressionCpiAccountsConfig},
         verify::verify_compressed_account_infos,
@@ -24,7 +24,7 @@ pub fn update_pda<const BATCHED: bool>(
         .map_err(|_| LightSdkError::Borsh)?;
 
     let program_id = crate::ID.into();
-    let mut my_compressed_account = CBorshAccount::<'_, MyCompressedAccount>::new_mut(
+    let mut my_compressed_account = LightAccount::<'_, MyCompressedAccount>::new_mut(
         &program_id,
         &instruction_data.my_compressed_account.meta,
         MyCompressedAccount {

--- a/sdk-libs/sdk/src/account.rs
+++ b/sdk-libs/sdk/src/account.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq)]
-pub struct CBorshAccount<
+pub struct LightAccount<
     'a,
     A: AnchorSerialize + AnchorDeserialize + Discriminator + DataHasher + Default,
 > {
@@ -22,7 +22,7 @@ pub struct CBorshAccount<
 }
 
 impl<'a, A: AnchorSerialize + AnchorDeserialize + Discriminator + DataHasher + Default>
-    CBorshAccount<'a, A>
+    LightAccount<'a, A>
 {
     pub fn new_init(
         owner: &'a Pubkey,
@@ -164,7 +164,7 @@ impl<'a, A: AnchorSerialize + AnchorDeserialize + Discriminator + DataHasher + D
 }
 
 impl<A: AnchorSerialize + AnchorDeserialize + Discriminator + DataHasher + Default> Deref
-    for CBorshAccount<'_, A>
+    for LightAccount<'_, A>
 {
     type Target = A;
 
@@ -174,7 +174,7 @@ impl<A: AnchorSerialize + AnchorDeserialize + Discriminator + DataHasher + Defau
 }
 
 impl<A: AnchorSerialize + AnchorDeserialize + Discriminator + DataHasher + Default> DerefMut
-    for CBorshAccount<'_, A>
+    for LightAccount<'_, A>
 {
     fn deref_mut(&mut self) -> &mut <Self as Deref>::Target {
         &mut self.account


### PR DESCRIPTION
Changes:
1. adapt counter example to new sdk
2. add close instruction to counter example
3. renamed `CBorshAccount` -> `LightAccount`