### PR TITLE
feat: assign addresses

### DIFF
--- a/program-libs/compressed-account/src/address.rs
+++ b/program-libs/compressed-account/src/address.rs
@@ -77,7 +77,7 @@ pub fn pack_new_address_params_assigned(
             address_merkle_tree_root_index: new_address_param.address_merkle_tree_root_index,
             address_merkle_tree_account_index,
             assigned_to_account: new_address_param.assigned_account_index.is_some(),
-            assigned_account_index: new_address_param.assigned_account_index.unwrap(),
+            assigned_account_index: new_address_param.assigned_account_index.unwrap_or_default(),
         });
     }
 

--- a/program-libs/compressed-account/src/address.rs
+++ b/program-libs/compressed-account/src/address.rs
@@ -8,7 +8,9 @@ use super::compressed_account::{
 use crate::{
     hash_to_bn254_field_size_be,
     instruction_data::data::{
-        NewAddressParams, NewAddressParamsPacked, PackedReadOnlyAddress, ReadOnlyAddress,
+        pack_pubkey_usize, NewAddressParams, NewAddressParamsAssigned,
+        NewAddressParamsAssignedPacked, NewAddressParamsPacked, PackedReadOnlyAddress,
+        ReadOnlyAddress,
     },
     CompressedAccountError, Pubkey,
 };
@@ -54,6 +56,31 @@ pub fn add_and_get_remaining_account_indices(
         };
         vec.push(*remaining_accounts.get(pubkey).unwrap() as u8);
     }
+    vec
+}
+
+pub fn pack_new_address_params_assigned(
+    new_address_params: &[NewAddressParamsAssigned],
+    remaining_accounts: &mut HashMap<Pubkey, usize>,
+) -> Vec<NewAddressParamsAssignedPacked> {
+    let mut vec = Vec::new();
+    for new_address_param in new_address_params.iter() {
+        let address_merkle_tree_account_index = pack_pubkey_usize(
+            &new_address_param.address_merkle_tree_pubkey,
+            remaining_accounts,
+        );
+        let address_queue_account_index =
+            pack_pubkey_usize(&new_address_param.address_queue_pubkey, remaining_accounts);
+        vec.push(NewAddressParamsAssignedPacked {
+            seed: new_address_param.seed,
+            address_queue_account_index,
+            address_merkle_tree_root_index: new_address_param.address_merkle_tree_root_index,
+            address_merkle_tree_account_index,
+            assigned_to_account: new_address_param.assigned_account_index.is_some(),
+            assigned_account_index: new_address_param.assigned_account_index.unwrap(),
+        });
+    }
+
     vec
 }
 

--- a/program-libs/compressed-account/src/instruction_data/data.rs
+++ b/program-libs/compressed-account/src/instruction_data/data.rs
@@ -38,12 +38,52 @@ pub struct NewAddressParamsPacked {
     pub address_merkle_tree_root_index: u16,
 }
 
+#[derive(Debug, PartialEq, Default, Clone, Copy, AnchorDeserialize, AnchorSerialize)]
+pub struct NewAddressParamsAssignedPacked {
+    pub seed: [u8; 32],
+    pub address_queue_account_index: u8,
+    pub address_merkle_tree_account_index: u8,
+    pub address_merkle_tree_root_index: u16,
+    pub assigned_to_account: bool,
+    pub assigned_account_index: u8,
+}
+
+impl NewAddressParamsAssignedPacked {
+    pub fn new(address_params: NewAddressParamsPacked, index: Option<u8>) -> Self {
+        Self {
+            seed: address_params.seed,
+            address_queue_account_index: address_params.address_queue_account_index,
+            address_merkle_tree_account_index: address_params.address_merkle_tree_account_index,
+            address_merkle_tree_root_index: address_params.address_merkle_tree_root_index,
+            assigned_to_account: index.is_some(),
+            assigned_account_index: index.unwrap_or_default(),
+        }
+    }
+
+    pub fn assigned_account_index(&self) -> Option<u8> {
+        if self.assigned_to_account {
+            Some(self.assigned_account_index)
+        } else {
+            None
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Default, Clone, AnchorDeserialize, AnchorSerialize)]
 pub struct NewAddressParams {
     pub seed: [u8; 32],
     pub address_queue_pubkey: Pubkey,
     pub address_merkle_tree_pubkey: Pubkey,
     pub address_merkle_tree_root_index: u16,
+}
+
+#[derive(Debug, PartialEq, Default, Clone, AnchorDeserialize, AnchorSerialize)]
+pub struct NewAddressParamsAssigned {
+    pub seed: [u8; 32],
+    pub address_queue_pubkey: Pubkey,
+    pub address_merkle_tree_pubkey: Pubkey,
+    pub address_merkle_tree_root_index: u16,
+    pub assigned_account_index: Option<u8>,
 }
 
 #[derive(Debug, PartialEq, Default, Clone, Copy, AnchorDeserialize, AnchorSerialize)]
@@ -59,7 +99,7 @@ pub struct ReadOnlyAddress {
     pub address_merkle_tree_pubkey: Pubkey,
     pub address_merkle_tree_root_index: u16,
 }
-
+// TODO: move
 pub fn pack_pubkey(pubkey: &Pubkey, hash_set: &mut HashMap<Pubkey, u8>) -> u8 {
     match hash_set.get(pubkey) {
         Some(index) => *index,
@@ -67,6 +107,17 @@ pub fn pack_pubkey(pubkey: &Pubkey, hash_set: &mut HashMap<Pubkey, u8>) -> u8 {
             let index = hash_set.len() as u8;
             hash_set.insert(*pubkey, index);
             index
+        }
+    }
+}
+
+pub fn pack_pubkey_usize(pubkey: &Pubkey, hash_set: &mut HashMap<Pubkey, usize>) -> u8 {
+    match hash_set.get(pubkey) {
+        Some(index) => (*index) as u8,
+        None => {
+            let index = hash_set.len();
+            hash_set.insert(*pubkey, index);
+            index as u8
         }
     }
 }

--- a/program-libs/compressed-account/src/instruction_data/traits.rs
+++ b/program-libs/compressed-account/src/instruction_data/traits.rs
@@ -22,6 +22,7 @@ pub trait InstructionDataTrait<'a> {
     fn cpi_context(&self) -> Option<CompressedCpiContext>;
     fn bump(&self) -> Option<u8>;
     fn account_option_config(&self) -> AccountOptions;
+    fn with_transaction_hash(&self) -> bool;
 }
 
 pub trait NewAddressParamsTrait<'a>

--- a/program-libs/compressed-account/src/instruction_data/traits.rs
+++ b/program-libs/compressed-account/src/instruction_data/traits.rs
@@ -5,16 +5,13 @@ use zerocopy::Ref;
 use super::{
     compressed_proof::CompressedProof,
     cpi_context::CompressedCpiContext,
-    zero_copy::{
-        ZNewAddressParamsPacked, ZPackedMerkleContext, ZPackedReadOnlyAddress,
-        ZPackedReadOnlyCompressedAccount,
-    },
+    zero_copy::{ZPackedMerkleContext, ZPackedReadOnlyAddress, ZPackedReadOnlyCompressedAccount},
 };
 use crate::{compressed_account::CompressedAccountData, pubkey::Pubkey, CompressedAccountError};
 
 pub trait InstructionDataTrait<'a> {
     fn owner(&self) -> Pubkey;
-    fn new_addresses(&self) -> &[ZNewAddressParamsPacked];
+    fn new_addresses(&self) -> &[impl NewAddressParamsTrait<'a>];
     fn input_accounts(&self) -> &[impl InputAccountTrait<'a>];
     fn output_accounts(&self) -> &[impl OutputAccountTrait<'a>];
     fn read_only_accounts(&self) -> Option<&[ZPackedReadOnlyCompressedAccount]>;
@@ -25,6 +22,17 @@ pub trait InstructionDataTrait<'a> {
     fn cpi_context(&self) -> Option<CompressedCpiContext>;
     fn bump(&self) -> Option<u8>;
     fn account_option_config(&self) -> AccountOptions;
+}
+
+pub trait NewAddressParamsTrait<'a>
+where
+    Self: Debug,
+{
+    fn seed(&self) -> [u8; 32];
+    fn address_queue_index(&self) -> u8;
+    fn address_merkle_tree_account_index(&self) -> u8;
+    fn address_merkle_tree_root_index(&self) -> u16;
+    fn assigned_compressed_account_index(&self) -> Option<usize>;
 }
 
 pub trait InputAccountTrait<'a>

--- a/program-libs/compressed-account/src/instruction_data/with_account_info.rs
+++ b/program-libs/compressed-account/src/instruction_data/with_account_info.rs
@@ -9,10 +9,13 @@ use zerocopy::{
 use super::{
     compressed_proof::CompressedProof,
     cpi_context::CompressedCpiContext,
-    data::{NewAddressParamsPacked, PackedReadOnlyAddress},
-    traits::{AccountOptions, InputAccountTrait, InstructionDataTrait, OutputAccountTrait},
+    data::{NewAddressParamsAssignedPacked, PackedReadOnlyAddress},
+    traits::{
+        AccountOptions, InputAccountTrait, InstructionDataTrait, NewAddressParamsTrait,
+        OutputAccountTrait,
+    },
     zero_copy::{
-        ZCompressedCpiContext, ZNewAddressParamsPacked, ZPackedMerkleContext,
+        ZCompressedCpiContext, ZNewAddressParamsAssignedPacked, ZPackedMerkleContext,
         ZPackedReadOnlyAddress, ZPackedReadOnlyCompressedAccount,
     },
 };
@@ -287,7 +290,7 @@ pub struct InstructionDataInvokeCpiWithAccountInfo {
     pub with_cpi_context: bool,
     pub cpi_context: CompressedCpiContext,
     pub proof: Option<CompressedProof>,
-    pub new_address_params: Vec<NewAddressParamsPacked>,
+    pub new_address_params: Vec<NewAddressParamsAssignedPacked>,
     pub account_infos: Vec<CompressedAccountInfo>,
     pub read_only_addresses: Vec<PackedReadOnlyAddress>,
     pub read_only_accounts: Vec<PackedReadOnlyCompressedAccount>,
@@ -319,7 +322,7 @@ impl<'a> InstructionDataTrait<'a> for ZInstructionDataInvokeCpiWithAccountInfo<'
         self.meta.invoking_program_id
     }
 
-    fn new_addresses(&self) -> &[ZNewAddressParamsPacked] {
+    fn new_addresses(&self) -> &[impl NewAddressParamsTrait<'a>] {
         self.new_address_params.as_slice()
     }
 
@@ -390,7 +393,7 @@ impl ZInstructionDataInvokeCpiWithAccountInfoMeta {
 pub struct ZInstructionDataInvokeCpiWithAccountInfo<'a> {
     meta: Ref<&'a [u8], ZInstructionDataInvokeCpiWithAccountInfoMeta>,
     pub proof: Option<Ref<&'a [u8], CompressedProof>>,
-    pub new_address_params: ZeroCopySliceBorsh<'a, ZNewAddressParamsPacked>,
+    pub new_address_params: ZeroCopySliceBorsh<'a, ZNewAddressParamsAssignedPacked>,
     pub account_infos: Vec<ZCAccountInfo<'a>>,
     pub read_only_addresses: ZeroCopySliceBorsh<'a, ZPackedReadOnlyAddress>,
     pub read_only_accounts: ZeroCopySliceBorsh<'a, ZPackedReadOnlyCompressedAccount>,
@@ -411,7 +414,7 @@ impl<'a> Deserialize<'a> for InstructionDataInvokeCpiWithAccountInfo {
             Ref::<&[u8], ZInstructionDataInvokeCpiWithAccountInfoMeta>::from_prefix(bytes)?;
         let (proof, bytes) = Option::<Ref<&[u8], CompressedProof>>::zero_copy_at(bytes)?;
         let (new_address_params, bytes) =
-            ZeroCopySliceBorsh::<'a, ZNewAddressParamsPacked>::from_bytes_at(bytes)?;
+            ZeroCopySliceBorsh::<'a, ZNewAddressParamsAssignedPacked>::from_bytes_at(bytes)?;
         let (account_infos, bytes) = {
             let (num_slices, mut bytes) = Ref::<&[u8], U32>::from_prefix(bytes)?;
             let num_slices = u32::from(*num_slices) as usize;

--- a/program-libs/compressed-account/src/instruction_data/with_readonly.rs
+++ b/program-libs/compressed-account/src/instruction_data/with_readonly.rs
@@ -201,6 +201,7 @@ pub struct InstructionDataInvokeCpiWithReadOnly {
     /// -> expect account decompression_recipient
     pub is_decompress: bool,
     pub with_cpi_context: bool,
+    pub with_transaction_hash: bool,
     pub cpi_context: CompressedCpiContext,
     pub proof: Option<CompressedProof>,
     pub new_address_params: Vec<NewAddressParamsAssignedPacked>,
@@ -225,6 +226,7 @@ pub struct ZInstructionDataInvokeCpiWithReadOnlyMeta {
     /// -> expect account decompression_recipient
     is_decompress: u8,
     with_cpi_context: u8,
+    with_transaction_hash: u8,
     pub cpi_context: ZCompressedCpiContext,
 }
 
@@ -234,6 +236,9 @@ impl ZInstructionDataInvokeCpiWithReadOnlyMeta {
     }
     pub fn with_cpi_context(&self) -> bool {
         self.with_cpi_context > 0
+    }
+    pub fn with_transaction_hash(&self) -> bool {
+        self.with_transaction_hash > 0
     }
 }
 
@@ -256,6 +261,10 @@ impl<'a> InstructionDataTrait<'a> for ZInstructionDataInvokeCpiWithReadOnly<'a> 
                 && !self.is_compress(),
             cpi_context_account: self.cpi_context().is_some(),
         }
+    }
+
+    fn with_transaction_hash(&self) -> bool {
+        self.meta.with_transaction_hash()
     }
 
     fn bump(&self) -> Option<u8> {
@@ -429,6 +438,7 @@ fn test_read_only_zero_copy() {
         compress_or_decompress_lamports: 0,
         is_decompress: false,
         with_cpi_context: false,
+        with_transaction_hash: true,
         cpi_context: CompressedCpiContext {
             set_context: false,
             first_set_context: false,

--- a/program-libs/compressed-account/src/instruction_data/zero_copy.rs
+++ b/program-libs/compressed-account/src/instruction_data/zero_copy.rs
@@ -433,7 +433,7 @@ impl<'a> InstructionDataTrait<'a> for ZInstructionDataInvoke<'a> {
         None
     }
     fn with_transaction_hash(&self) -> bool {
-        false
+        true
     }
     fn account_option_config(&self) -> AccountOptions {
         unimplemented!()
@@ -550,7 +550,7 @@ impl<'a> InstructionDataTrait<'a> for ZInstructionDataInvokeCpi<'a> {
     }
 
     fn with_transaction_hash(&self) -> bool {
-        false
+        true
     }
 
     fn account_option_config(&self) -> AccountOptions {

--- a/program-libs/compressed-account/src/instruction_data/zero_copy.rs
+++ b/program-libs/compressed-account/src/instruction_data/zero_copy.rs
@@ -432,6 +432,9 @@ impl<'a> InstructionDataTrait<'a> for ZInstructionDataInvoke<'a> {
     fn bump(&self) -> Option<u8> {
         None
     }
+    fn with_transaction_hash(&self) -> bool {
+        false
+    }
     fn account_option_config(&self) -> AccountOptions {
         unimplemented!()
     }
@@ -544,6 +547,10 @@ impl ZInstructionDataInvokeCpi<'_> {
 impl<'a> InstructionDataTrait<'a> for ZInstructionDataInvokeCpi<'a> {
     fn bump(&self) -> Option<u8> {
         None
+    }
+
+    fn with_transaction_hash(&self) -> bool {
+        false
     }
 
     fn account_option_config(&self) -> AccountOptions {

--- a/program-tests/system-cpi-test/src/create_pda.rs
+++ b/program-tests/system-cpi-test/src/create_pda.rs
@@ -378,6 +378,7 @@ fn cpi_compressed_pda_transfer_as_program<'info>(
         let inputs_struct = InstructionDataInvokeCpiWithReadOnly {
             mode: 0,
             bump,
+            with_transaction_hash: true,
             with_cpi_context: inputs_struct.cpi_context.is_some(),
             invoking_program_id: crate::ID.into(),
             proof: inputs_struct.proof,

--- a/program-tests/system-cpi-test/src/create_pda.rs
+++ b/program-tests/system-cpi-test/src/create_pda.rs
@@ -15,7 +15,8 @@ use light_compressed_account::{
         compressed_proof::CompressedProof,
         cpi_context::CompressedCpiContext,
         data::{
-            NewAddressParamsPacked, OutputCompressedAccountWithPackedContext, PackedReadOnlyAddress,
+            NewAddressParamsAssignedPacked, NewAddressParamsPacked,
+            OutputCompressedAccountWithPackedContext, PackedReadOnlyAddress,
         },
         invoke_cpi::InstructionDataInvokeCpi,
         with_readonly::{InAccount, InstructionDataInvokeCpiWithReadOnly},
@@ -380,7 +381,12 @@ fn cpi_compressed_pda_transfer_as_program<'info>(
             with_cpi_context: inputs_struct.cpi_context.is_some(),
             invoking_program_id: crate::ID.into(),
             proof: inputs_struct.proof,
-            new_address_params: inputs_struct.new_address_params,
+            // Should fail because of this.
+            new_address_params: inputs_struct
+                .new_address_params
+                .iter()
+                .map(|x| NewAddressParamsAssignedPacked::new(*x, None))
+                .collect::<Vec<_>>(),
             cpi_context: inputs_struct.cpi_context.unwrap_or_default(),
             is_decompress: !inputs_struct.is_compress,
             compress_or_decompress_lamports: inputs_struct

--- a/program-tests/system-cpi-test/src/create_pda.rs
+++ b/program-tests/system-cpi-test/src/create_pda.rs
@@ -386,7 +386,8 @@ fn cpi_compressed_pda_transfer_as_program<'info>(
             new_address_params: inputs_struct
                 .new_address_params
                 .iter()
-                .map(|x| NewAddressParamsAssignedPacked::new(*x, None))
+                .enumerate()
+                .map(|(i, x)| NewAddressParamsAssignedPacked::new(*x, Some(i as u8)))
                 .collect::<Vec<_>>(),
             cpi_context: inputs_struct.cpi_context.unwrap_or_default(),
             is_decompress: !inputs_struct.is_compress,

--- a/program-tests/system-cpi-test/tests/event.rs
+++ b/program-tests/system-cpi-test/tests/event.rs
@@ -701,6 +701,7 @@ async fn perform_test_transaction<R: RpcConnection>(
                 root_index: x.root_index,
             })
             .collect::<Vec<_>>(),
+        with_transaction_hash: true,
         ..Default::default()
     };
     let remaining_accounts = to_account_metas(remaining_accounts);

--- a/program-tests/system-cpi-test/tests/event.rs
+++ b/program-tests/system-cpi-test/tests/event.rs
@@ -1,11 +1,11 @@
-// #![cfg(feature = "test-sbf")]
+#![cfg(feature = "test-sbf")]
 
 use std::collections::HashMap;
 
 use anchor_lang::prelude::borsh::BorshSerialize;
 use create_address_test_program::create_invoke_cpi_instruction;
 use light_compressed_account::{
-    address::{derive_address, derive_address_legacy, pack_new_address_params},
+    address::{derive_address, derive_address_legacy, pack_new_address_params_assigned},
     compressed_account::{
         pack_compressed_accounts, pack_output_compressed_accounts, CompressedAccount,
         CompressedAccountData, CompressedAccountWithMerkleContext, MerkleContext,
@@ -17,11 +17,7 @@ use light_compressed_account::{
     },
     instruction_data::{
         compressed_proof::CompressedProof,
-        data::{
-            NewAddressParams, OutputCompressedAccountWithContext,
-            OutputCompressedAccountWithPackedContext,
-        },
-        invoke_cpi::InstructionDataInvokeCpi,
+        data::{OutputCompressedAccountWithContext, OutputCompressedAccountWithPackedContext},
         with_readonly::{InAccount, InstructionDataInvokeCpiWithReadOnly},
     },
     nullifier::create_nullifier,
@@ -37,6 +33,7 @@ use light_program_test::{
 use light_prover_client::gnark::helpers::{
     spawn_prover, spawn_validator, LightValidatorConfig, ProverConfig, ProverMode,
 };
+use light_sdk::NewAddressParamsAssigned;
 use light_test_utils::{RpcConnection, RpcError, SolanaRpcConnection, SolanaRpcUrl};
 use serial_test::serial;
 use solana_sdk::{
@@ -149,17 +146,19 @@ async fn parse_batched_event_functional() {
             .await;
 
         let new_address_params = vec![
-            NewAddressParams {
+            NewAddressParamsAssigned {
                 seed: [1u8; 32],
                 address_queue_pubkey: env.address_merkle_tree_queue_pubkey,
                 address_merkle_tree_pubkey: env.address_merkle_tree_pubkey,
                 address_merkle_tree_root_index: proof_res.address_root_indices[0],
+                assigned_account_index: None,
             },
-            NewAddressParams {
+            NewAddressParamsAssigned {
                 seed: [2u8; 32],
                 address_queue_pubkey: env.address_merkle_tree_queue_pubkey,
                 address_merkle_tree_pubkey: env.address_merkle_tree_pubkey,
                 address_merkle_tree_root_index: proof_res.address_root_indices[1],
+                assigned_account_index: None,
             },
         ];
         let (events, output_accounts, _) = perform_test_transaction(
@@ -308,17 +307,19 @@ async fn parse_batched_event_functional() {
             .await;
 
         let new_address_params = vec![
-            NewAddressParams {
+            NewAddressParamsAssigned {
                 seed: [1u8; 32],
                 address_queue_pubkey: env.batch_address_merkle_tree,
                 address_merkle_tree_pubkey: env.batch_address_merkle_tree,
                 address_merkle_tree_root_index: proof_res.address_root_indices[0],
+                assigned_account_index: None,
             },
-            NewAddressParams {
+            NewAddressParamsAssigned {
                 seed: [2u8; 32],
                 address_queue_pubkey: env.batch_address_merkle_tree,
                 address_merkle_tree_pubkey: env.batch_address_merkle_tree,
                 address_merkle_tree_root_index: proof_res.address_root_indices[1],
+                assigned_account_index: None,
             },
         ];
         let (events, output_accounts, _) = perform_test_transaction(
@@ -644,7 +645,7 @@ async fn perform_test_transaction<R: RpcConnection>(
     payer: &Keypair,
     input_accounts: Vec<CompressedAccountWithMerkleContext>,
     output_accounts: Vec<OutputCompressedAccountWithContext>,
-    new_addresses: Vec<NewAddressParams>,
+    new_addresses: Vec<NewAddressParamsAssigned>,
     num_cpis: Option<u8>,
     proof: Option<CompressedProof>,
 ) -> Result<
@@ -658,7 +659,7 @@ async fn perform_test_transaction<R: RpcConnection>(
     let mut remaining_accounts = HashMap::<Pubkey, usize>::new();
 
     let packed_new_address_params =
-        pack_new_address_params(new_addresses.as_slice(), &mut remaining_accounts);
+        pack_new_address_params_assigned(new_addresses.as_slice(), &mut remaining_accounts);
 
     let packed_inputs = pack_compressed_accounts(
         input_accounts.as_slice(),
@@ -678,31 +679,18 @@ async fn perform_test_transaction<R: RpcConnection>(
             .as_slice(),
         &mut remaining_accounts,
     );
-    let inputs_struct = InstructionDataInvokeCpi {
-        proof,
-        new_address_params: packed_new_address_params,
-        input_compressed_accounts_with_merkle_context: packed_inputs.clone(),
-        output_compressed_accounts: output_compressed_accounts.clone(),
-        relay_fee: None,
-        compress_or_decompress_lamports: None,
-        is_compress: false,
-        cpi_context: None,
-    };
 
     let ix_data = InstructionDataInvokeCpiWithReadOnly {
         mode: 0,
-        bump: 255, // TODO: correct
-        with_cpi_context: inputs_struct.cpi_context.is_some(),
+        bump: 255,
+        with_cpi_context: false,
         invoking_program_id: create_address_test_program::ID.into(),
-        proof: inputs_struct.proof,
-        new_address_params: inputs_struct.new_address_params,
+        proof,
+        new_address_params: packed_new_address_params,
         is_decompress: false,
-        compress_or_decompress_lamports: inputs_struct
-            .compress_or_decompress_lamports
-            .unwrap_or_default(),
-        output_compressed_accounts: inputs_struct.output_compressed_accounts,
-        input_compressed_accounts: inputs_struct
-            .input_compressed_accounts_with_merkle_context
+        compress_or_decompress_lamports: 0,
+        output_compressed_accounts: output_compressed_accounts.clone(),
+        input_compressed_accounts: packed_inputs
             .iter()
             .map(|x| InAccount {
                 address: x.compressed_account.address,

--- a/program-tests/utils/src/e2e_test_env.rs
+++ b/program-tests/utils/src/e2e_test_env.rs
@@ -2763,6 +2763,7 @@ where
         let ix_data: InstructionDataInvokeCpiWithReadOnly = InstructionDataInvokeCpiWithReadOnly {
             mode: 0,
             bump,
+            with_transaction_hash: self.rng.gen(),
             invoking_program_id: create_address_test_program::ID.into(),
             proof: invoke_cpi.proof,
             new_address_params,

--- a/programs/system/src/context.rs
+++ b/programs/system/src/context.rs
@@ -201,6 +201,10 @@ impl<'a, 'b, T: InstructionDataTrait<'a>> WrappedInstructionData<'a, T> {
         self.instruction_data.bump()
     }
 
+    pub fn with_transaction_hash(&self) -> bool {
+        self.instruction_data.with_transaction_hash()
+    }
+
     pub fn get_output_account(
         &'b self,
         index: usize,

--- a/programs/system/src/context.rs
+++ b/programs/system/src/context.rs
@@ -1,16 +1,14 @@
-use std::{iter::Chain, slice::Iter};
-
 use light_compressed_account::{
     compressed_account::{CompressedAccount, PackedCompressedAccountWithMerkleContext},
     hash_to_bn254_field_size_be,
     instruction_data::{
         cpi_context::CompressedCpiContext,
-        data::OutputCompressedAccountWithPackedContext,
+        data::{NewAddressParamsPacked, OutputCompressedAccountWithPackedContext},
         invoke_cpi::InstructionDataInvokeCpi,
-        traits::{InputAccountTrait, InstructionDataTrait, OutputAccountTrait},
-        zero_copy::{
-            ZNewAddressParamsPacked, ZPackedReadOnlyAddress, ZPackedReadOnlyCompressedAccount,
+        traits::{
+            InputAccountTrait, InstructionDataTrait, NewAddressParamsTrait, OutputAccountTrait,
         },
+        zero_copy::{ZPackedReadOnlyAddress, ZPackedReadOnlyCompressedAccount},
     },
 };
 use pinocchio::{account_info::AccountInfo, instruction::AccountMeta, msg, pubkey::Pubkey};
@@ -145,7 +143,7 @@ pub struct WrappedInstructionData<'a, T: InstructionDataTrait<'a>> {
     outputs_len: usize,
 }
 
-impl<'a, T: InstructionDataTrait<'a>> WrappedInstructionData<'a, T> {
+impl<'a, 'b, T: InstructionDataTrait<'a>> WrappedInstructionData<'a, T> {
     pub fn new(instruction_data: T) -> Self {
         Self {
             input_len: instruction_data.input_accounts().len(),
@@ -202,6 +200,17 @@ impl<'a, T: InstructionDataTrait<'a>> WrappedInstructionData<'a, T> {
     pub fn bump(&self) -> Option<u8> {
         self.instruction_data.bump()
     }
+
+    pub fn get_output_account(
+        &'b self,
+        index: usize,
+    ) -> Option<&'b (impl OutputAccountTrait<'a> + 'b)> {
+        if index > self.instruction_data.output_accounts().len() {
+            None
+        } else {
+            Some(&self.instruction_data.output_accounts()[index])
+        }
+    }
 }
 
 impl<'a, T: InstructionDataTrait<'a>> WrappedInstructionData<'a, T> {
@@ -227,18 +236,18 @@ impl<'a, T: InstructionDataTrait<'a>> WrappedInstructionData<'a, T> {
 
     pub fn new_addresses<'b>(
         &'b self,
-    ) -> Chain<Iter<'b, ZNewAddressParamsPacked>, Iter<'b, ZNewAddressParamsPacked>> {
+    ) -> impl Iterator<Item = &'b (dyn NewAddressParamsTrait<'a> + 'b)> {
         if let Some(cpi_context) = &self.cpi_context {
-            self.instruction_data
-                .new_addresses()
-                .iter()
-                .chain(cpi_context.context[0].new_addresses().iter())
+            if cpi_context.context.len() > 1 {
+                panic!("Cpi context len > 1");
+            }
+            chain_new_addresses(
+                self.instruction_data.new_addresses(),
+                cpi_context.context[0].new_addresses(),
+            )
         } else {
-            let empty_slice: &'b [ZNewAddressParamsPacked] = &[];
-            self.instruction_data
-                .new_addresses()
-                .iter()
-                .chain(empty_slice.iter())
+            let empty_slice = &[];
+            chain_new_addresses(self.instruction_data.new_addresses(), empty_slice)
         }
     }
 
@@ -311,9 +320,23 @@ impl<'a, T: InstructionDataTrait<'a>> WrappedInstructionData<'a, T> {
         }
 
         for new_address_params in self.instruction_data.new_addresses() {
+            if new_address_params
+                .assigned_compressed_account_index()
+                .is_some()
+            {
+                unimplemented!("Address assignment cannot be guaranteed with cpi context.");
+            }
             cpi_account_data
                 .new_address_params
-                .push(new_address_params.into());
+                .push(NewAddressParamsPacked {
+                    seed: new_address_params.seed(),
+                    address_queue_account_index: new_address_params
+                        .address_merkle_tree_account_index(),
+                    address_merkle_tree_root_index: new_address_params
+                        .address_merkle_tree_root_index(),
+                    address_merkle_tree_account_index: new_address_params
+                        .address_merkle_tree_account_index(),
+                });
         }
     }
 
@@ -352,4 +375,18 @@ pub fn chain_inputs<'a, 'b: 'a>(
         .iter()
         .map(|item| item as &dyn InputAccountTrait<'b>)
         .chain(slice2.iter().map(|item| item as &dyn InputAccountTrait<'b>))
+}
+
+pub fn chain_new_addresses<'a, 'b: 'a>(
+    slice1: &'a [impl NewAddressParamsTrait<'b>],
+    slice2: &'a [impl NewAddressParamsTrait<'b>],
+) -> impl Iterator<Item = &'a (dyn NewAddressParamsTrait<'b> + 'a)> {
+    slice1
+        .iter()
+        .map(|item| item as &dyn NewAddressParamsTrait<'b>)
+        .chain(
+            slice2
+                .iter()
+                .map(|item| item as &dyn NewAddressParamsTrait<'b>),
+        )
 }

--- a/programs/system/src/errors.rs
+++ b/programs/system/src/errors.rs
@@ -96,6 +96,10 @@ pub enum SystemProgramError {
     InvalidAccountMode,
     #[error("InvalidInstructionDataDiscriminator")]
     InvalidInstructionDataDiscriminator,
+    #[error("NewAddressAssignedIndexOutOfBounds")]
+    NewAddressAssignedIndexOutOfBounds,
+    #[error("AddressIsNone")]
+    AddressIsNone,
 }
 
 impl From<SystemProgramError> for ProgramError {

--- a/programs/system/src/invoke_cpi/processor.rs
+++ b/programs/system/src/invoke_cpi/processor.rs
@@ -20,8 +20,9 @@ use crate::{
 pub fn process_invoke_cpi<
     'a,
     'info,
-    T: InstructionDataTrait<'a>,
+    const ADDRESS_ASSIGNMENT: bool,
     A: SignerAccounts<'info> + InvokeAccounts<'info> + CpiContextAccountTrait<'info>,
+    T: InstructionDataTrait<'a>,
 >(
     invoking_program: Pubkey,
     ctx: A,
@@ -52,7 +53,7 @@ pub fn process_invoke_cpi<
     #[cfg(feature = "bench-sbf")]
     bench_sbf_end!("cpda_process_cpi_context");
 
-    process(
+    process::<ADDRESS_ASSIGNMENT, A, T>(
         inputs,
         Some(invoking_program),
         &ctx,

--- a/programs/system/src/lib.rs
+++ b/programs/system/src/lib.rs
@@ -105,7 +105,13 @@ pub fn invoke<'a, 'b, 'c: 'info, 'info>(
         ctx.authority.key(),
     )?;
     let wrapped_inputs = context::WrappedInstructionData::new(inputs);
-    process(wrapped_inputs, None, &ctx, 0, remaining_accounts)?;
+    process::<false, InvokeInstruction, ZInstructionDataInvoke>(
+        wrapped_inputs,
+        None,
+        &ctx,
+        0,
+        remaining_accounts,
+    )?;
     sol_log_compute_units();
     Ok(())
 }
@@ -125,7 +131,7 @@ pub fn invoke_cpi<'a, 'b, 'c: 'info, 'info>(
     let (ctx, remaining_accounts) = InvokeCpiInstruction::from_account_infos(accounts)?;
 
     let wrapped_inputs = WrappedInstructionData::new(inputs);
-    process_invoke_cpi(
+    process_invoke_cpi::<false, InvokeCpiInstruction, ZInstructionDataInvokeCpi>(
         *ctx.invoking_program.key(),
         ctx,
         wrapped_inputs,
@@ -185,7 +191,7 @@ fn shared_invoke_cpi<'a, 'info, T: InstructionDataTrait<'a>>(
     match mode {
         AccountMode::Anchor => {
             let (ctx, remaining_accounts) = InvokeCpiInstruction::from_account_infos(accounts)?;
-            process_invoke_cpi(
+            process_invoke_cpi::<true, InvokeCpiInstruction, T>(
                 invoking_program,
                 ctx,
                 WrappedInstructionData::new(inputs),
@@ -197,7 +203,7 @@ fn shared_invoke_cpi<'a, 'info, T: InstructionDataTrait<'a>>(
                 accounts,
                 inputs.account_option_config(),
             )?;
-            process_invoke_cpi(
+            process_invoke_cpi::<true, InvokeCpiInstructionSmall, T>(
                 invoking_program,
                 ctx,
                 WrappedInstructionData::new(inputs),

--- a/programs/system/src/processor/process.rs
+++ b/programs/system/src/processor/process.rs
@@ -225,12 +225,14 @@ pub fn process<
         // 8.1. Create a tx hash
         use pinocchio::sysvars::Sysvar;
         let current_slot = Clock::get()?.slot;
-        cpi_ix_data.tx_hash = create_tx_hash_from_hash_chains(
-            &input_compressed_account_hashes,
-            &output_compressed_account_hashes,
-            current_slot,
-        )
-        .map_err(ProgramError::from)?;
+        if inputs.with_transaction_hash() {
+            cpi_ix_data.tx_hash = create_tx_hash_from_hash_chains(
+                &input_compressed_account_hashes,
+                &output_compressed_account_hashes,
+                current_slot,
+            )
+            .map_err(ProgramError::from)?;
+        }
     }
     #[cfg(feature = "bench-sbf")]
     bench_sbf_end!("cpda_nullifiers");

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -102,7 +102,7 @@ install_rust() {
         export PATH="${PREFIX}/cargo/bin:${PATH}"
         rustup component add clippy rustfmt
         cargo install cargo-expand --locked
-        cargo install --git https://github.com/Lightprotocol/photon.git --rev ed8b8f0a0972f9084426cbfeced6dd3ffdecaef3 --locked
+        cargo install --git https://github.com/Lightprotocol/photon.git --rev 0e513a62daa4fe0eb40c21ac1e208a753ee687d5 --locked
         log "rust"
     fi
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -102,7 +102,7 @@ install_rust() {
         export PATH="${PREFIX}/cargo/bin:${PATH}"
         rustup component add clippy rustfmt
         cargo install cargo-expand --locked
-        cargo install --git https://github.com/Lightprotocol/photon.git --rev 0e513a62daa4fe0eb40c21ac1e208a753ee687d5 --locked
+        cargo install --git https://github.com/Lightprotocol/photon.git --rev edff82c5cb7fd891b5ab62faed9126594c97d90b --locked
         log "rust"
     fi
 }

--- a/sdk-libs/program-test/src/test_batch_forester.rs
+++ b/sdk-libs/program-test/src/test_batch_forester.rs
@@ -304,6 +304,7 @@ pub async fn get_batched_nullify_ix_data<Rpc: RpcConnection>(
         let index_bytes = index.to_be_bytes();
         use light_hasher::Hasher;
         let nullifier = Poseidon::hashv(&[&leaf, &index_bytes, &leaf_info.tx_hash]).unwrap();
+
         tx_hashes.push(leaf_info.tx_hash);
         nullifiers.push(nullifier);
         bundle.merkle_tree.update(&nullifier, index).unwrap();


### PR DESCRIPTION
### 1. Issue:
- To ensure that a new address is assigned to a specific compressed output account a program currently needs to derive the address and set it onchain. This results in the address being derived twice once in the program, once in the system program. 

### 1. Solution:
1. extend instruction data for new address params with `assigned_account_index`
    - add `NewAddressParamsAssigned` and `NewAddressParamsAssignedPacked`
     - diff to `NewAddressParams` is the additional field:   `pub assigned_account_index: Option<u8>`
        `None` -> address is not assigned to any account.
        `Some(index)` system checks that output account with index X holds the address.
2. compare address derived from new address params with the address of the output account in `assigned_account_index`
    - `check_new_address_assignment` 

### 1. Tests:
- functional test coverage as part of e2e-test
- will add failing test coverage in a separate pr

### 2. Issue
- tx hash computation is expensive

### 2. Solution
- make tx hash optional in new instructions
- disable tx hash in existing instructions

### Note:
- we need to bump the photon commit hash because the event parsing has changed because of the instruction data change