### PR TITLE
refactor: improve epoch_manager error handling and logging

### DIFF
--- a/forester/package.json
+++ b/forester/package.json
@@ -10,7 +10,7 @@
     "test-state-batched-indexer-async": "RUST_LOG=forester=debug,forester_utils=debug cargo test --package forester test_state_indexer_async_batched -- --nocapture",
     "test-fetch-root": "RUST_LOG=forester=debug,forester_utils=debug cargo test --package forester test_state_indexer_fetch_root -- --nocapture",
     "test-address-batched-local": "RUST_LOG=forester=debug,forester_utils=debug cargo test --package forester test_address_batched -- --nocapture",
-    "test-e2e-legacy-local": "cargo test --package forester test_epoch_monitor_with_2_foresters -- --nocapture",
+    "test-e2e-legacy-local": "RUST_LOG=forester=debug,forester_utils=debug cargo test --package forester test_epoch_monitor_with_2_foresters -- --nocapture",
     "test-address-v2": "RUST_LOG=forester=debug,forester_utils=debug cargo test --package forester test_create_v2_address -- --nocapture",
     "docker:build": "docker build --tag forester -f Dockerfile .."
   },


### PR DESCRIPTION
1. Increases log verbosity for key operations in `process_queue` (finding slots, waiting, sending txs) by changing several `trace!` calls to `info!`.
2. Modifies error handling within the main loop:
- Errors encountered during the rollover check (`check_for_epoch_rollover`) are now logged as errors but no longer cause the `process_queue` function to return immediately.
- Failures during `send_batched_transactions` are also logged as errors, but the function now continues processing the epoch instead of returning the error. This makes the forester more resilient to transient transaction send issues.
3. Removes a redundant `TODO` comment.