### PR TITLE
chore: rename instruction data traits

### DIFF
--- a/program-libs/compressed-account/src/instruction_data/traits.rs
+++ b/program-libs/compressed-account/src/instruction_data/traits.rs
@@ -9,11 +9,11 @@ use super::{
 };
 use crate::{compressed_account::CompressedAccountData, pubkey::Pubkey, CompressedAccountError};
 
-pub trait InstructionDataTrait<'a> {
+pub trait InstructionData<'a> {
     fn owner(&self) -> Pubkey;
-    fn new_addresses(&self) -> &[impl NewAddressParamsTrait<'a>];
-    fn input_accounts(&self) -> &[impl InputAccountTrait<'a>];
-    fn output_accounts(&self) -> &[impl OutputAccountTrait<'a>];
+    fn new_addresses(&self) -> &[impl NewAddress<'a>];
+    fn input_accounts(&self) -> &[impl InputAccount<'a>];
+    fn output_accounts(&self) -> &[impl OutputAccount<'a>];
     fn read_only_accounts(&self) -> Option<&[ZPackedReadOnlyCompressedAccount]>;
     fn read_only_addresses(&self) -> Option<&[ZPackedReadOnlyAddress]>;
     fn is_compress(&self) -> bool;
@@ -25,7 +25,7 @@ pub trait InstructionDataTrait<'a> {
     fn with_transaction_hash(&self) -> bool;
 }
 
-pub trait NewAddressParamsTrait<'a>
+pub trait NewAddress<'a>
 where
     Self: Debug,
 {
@@ -36,7 +36,7 @@ where
     fn assigned_compressed_account_index(&self) -> Option<usize>;
 }
 
-pub trait InputAccountTrait<'a>
+pub trait InputAccount<'a>
 where
     Self: Debug,
 {
@@ -57,7 +57,7 @@ where
     fn root_index(&self) -> u16;
 }
 
-pub trait OutputAccountTrait<'a>
+pub trait OutputAccount<'a>
 where
     Self: Debug,
 {

--- a/program-libs/compressed-account/src/instruction_data/with_account_info.rs
+++ b/program-libs/compressed-account/src/instruction_data/with_account_info.rs
@@ -10,10 +10,7 @@ use super::{
     compressed_proof::CompressedProof,
     cpi_context::CompressedCpiContext,
     data::{NewAddressParamsAssignedPacked, PackedReadOnlyAddress},
-    traits::{
-        AccountOptions, InputAccountTrait, InstructionDataTrait, NewAddressParamsTrait,
-        OutputAccountTrait,
-    },
+    traits::{AccountOptions, InputAccount, InstructionData, NewAddress, OutputAccount},
     with_readonly::ZInstructionDataInvokeCpiWithReadOnlyMeta,
     zero_copy::{
         ZNewAddressParamsAssignedPacked, ZPackedMerkleContext, ZPackedReadOnlyAddress,
@@ -70,7 +67,7 @@ pub struct OutAccountInfo {
     pub data: Vec<u8>,
 }
 
-impl<'a> InputAccountTrait<'a> for ZCAccountInfo<'a> {
+impl<'a> InputAccount<'a> for ZCAccountInfo<'a> {
     fn owner(&self) -> &Pubkey {
         &self.owner
     }
@@ -123,7 +120,7 @@ impl<'a> InputAccountTrait<'a> for ZCAccountInfo<'a> {
     }
 }
 
-impl<'a> OutputAccountTrait<'a> for ZCAccountInfo<'a> {
+impl<'a> OutputAccount<'a> for ZCAccountInfo<'a> {
     fn lamports(&self) -> u64 {
         self.output.as_ref().unwrap().lamports.into()
     }
@@ -298,7 +295,7 @@ pub struct InstructionDataInvokeCpiWithAccountInfo {
     pub read_only_accounts: Vec<PackedReadOnlyCompressedAccount>,
 }
 
-impl<'a> InstructionDataTrait<'a> for ZInstructionDataInvokeCpiWithAccountInfo<'a> {
+impl<'a> InstructionData<'a> for ZInstructionDataInvokeCpiWithAccountInfo<'a> {
     fn bump(&self) -> Option<u8> {
         Some(self.bump)
     }
@@ -328,7 +325,7 @@ impl<'a> InstructionDataTrait<'a> for ZInstructionDataInvokeCpiWithAccountInfo<'
         self.meta.invoking_program_id
     }
 
-    fn new_addresses(&self) -> &[impl NewAddressParamsTrait<'a>] {
+    fn new_addresses(&self) -> &[impl NewAddress<'a>] {
         self.new_address_params.as_slice()
     }
 
@@ -352,11 +349,11 @@ impl<'a> InstructionDataTrait<'a> for ZInstructionDataInvokeCpiWithAccountInfo<'
         !self.meta.is_decompress()
     }
 
-    fn input_accounts(&self) -> &[impl InputAccountTrait<'a>] {
+    fn input_accounts(&self) -> &[impl InputAccount<'a>] {
         self.account_infos.as_slice()
     }
 
-    fn output_accounts(&self) -> &[impl super::traits::OutputAccountTrait<'a>] {
+    fn output_accounts(&self) -> &[impl super::traits::OutputAccount<'a>] {
         self.account_infos.as_slice()
     }
 

--- a/program-libs/compressed-account/src/instruction_data/with_readonly.rs
+++ b/program-libs/compressed-account/src/instruction_data/with_readonly.rs
@@ -13,7 +13,7 @@ use super::{
         NewAddressParamsAssignedPacked, OutputCompressedAccountWithPackedContext,
         PackedReadOnlyAddress,
     },
-    traits::{AccountOptions, InputAccountTrait, InstructionDataTrait, NewAddressParamsTrait},
+    traits::{AccountOptions, InputAccount, InstructionData, NewAddress},
     zero_copy::{
         ZCompressedCpiContext, ZNewAddressParamsAssignedPacked,
         ZOutputCompressedAccountWithPackedContext, ZPackedMerkleContext, ZPackedReadOnlyAddress,
@@ -67,7 +67,7 @@ impl From<PackedCompressedAccountWithMerkleContext> for InAccount {
     }
 }
 
-impl<'a> InputAccountTrait<'a> for ZInAccount<'a> {
+impl<'a> InputAccount<'a> for ZInAccount<'a> {
     fn owner(&self) -> &Pubkey {
         &self.owner
     }
@@ -253,7 +253,7 @@ pub struct ZInstructionDataInvokeCpiWithReadOnly<'a> {
     pub read_only_accounts: ZeroCopySliceBorsh<'a, ZPackedReadOnlyCompressedAccount>,
 }
 
-impl<'a> InstructionDataTrait<'a> for ZInstructionDataInvokeCpiWithReadOnly<'a> {
+impl<'a> InstructionData<'a> for ZInstructionDataInvokeCpiWithReadOnly<'a> {
     fn account_option_config(&self) -> AccountOptions {
         AccountOptions {
             sol_pool_pda: self.is_compress(),
@@ -282,7 +282,7 @@ impl<'a> InstructionDataTrait<'a> for ZInstructionDataInvokeCpiWithReadOnly<'a> 
         self.meta.invoking_program_id
     }
 
-    fn new_addresses(&self) -> &[impl NewAddressParamsTrait<'a>] {
+    fn new_addresses(&self) -> &[impl NewAddress<'a>] {
         self.new_address_params.as_slice()
     }
 
@@ -306,11 +306,11 @@ impl<'a> InstructionDataTrait<'a> for ZInstructionDataInvokeCpiWithReadOnly<'a> 
         !self.meta.is_decompress() && self.compress_or_decompress_lamports().is_some()
     }
 
-    fn input_accounts(&self) -> &[impl InputAccountTrait<'a>] {
+    fn input_accounts(&self) -> &[impl InputAccount<'a>] {
         self.input_compressed_accounts.as_slice()
     }
 
-    fn output_accounts(&self) -> &[impl super::traits::OutputAccountTrait<'a>] {
+    fn output_accounts(&self) -> &[impl super::traits::OutputAccount<'a>] {
         self.output_compressed_accounts.as_slice()
     }
 

--- a/program-libs/compressed-account/src/instruction_data/zero_copy.rs
+++ b/program-libs/compressed-account/src/instruction_data/zero_copy.rs
@@ -8,10 +8,7 @@ use zerocopy::{
 
 use super::{
     invoke_cpi::InstructionDataInvokeCpi,
-    traits::{
-        AccountOptions, InputAccountTrait, InstructionDataTrait, NewAddressParamsTrait,
-        OutputAccountTrait,
-    },
+    traits::{AccountOptions, InputAccount, InstructionData, NewAddress, OutputAccount},
 };
 use crate::{
     compressed_account::{
@@ -64,7 +61,7 @@ pub struct ZNewAddressParamsPacked {
     pub address_merkle_tree_root_index: U16,
 }
 
-impl NewAddressParamsTrait<'_> for ZNewAddressParamsPacked {
+impl NewAddress<'_> for ZNewAddressParamsPacked {
     fn seed(&self) -> [u8; 32] {
         self.seed
     }
@@ -117,7 +114,7 @@ pub struct ZOutputCompressedAccountWithPackedContext<'a> {
     pub merkle_tree_index: u8,
 }
 
-impl<'a> OutputAccountTrait<'a> for ZOutputCompressedAccountWithPackedContext<'a> {
+impl<'a> OutputAccount<'a> for ZOutputCompressedAccountWithPackedContext<'a> {
     fn lamports(&self) -> u64 {
         self.compressed_account.lamports.into()
     }
@@ -332,7 +329,7 @@ pub struct ZPackedCompressedAccountWithMerkleContext<'a> {
     meta: Ref<&'a [u8], ZPackedCompressedAccountWithMerkleContextMeta>,
 }
 
-impl<'a> InputAccountTrait<'a> for ZPackedCompressedAccountWithMerkleContext<'a> {
+impl<'a> InputAccount<'a> for ZPackedCompressedAccountWithMerkleContext<'a> {
     fn owner(&self) -> &crate::pubkey::Pubkey {
         &self.compressed_account.owner
     }
@@ -428,7 +425,7 @@ pub struct ZInstructionDataInvoke<'a> {
     pub is_compress: bool,
 }
 
-impl<'a> InstructionDataTrait<'a> for ZInstructionDataInvoke<'a> {
+impl<'a> InstructionData<'a> for ZInstructionDataInvoke<'a> {
     fn bump(&self) -> Option<u8> {
         None
     }
@@ -467,16 +464,16 @@ impl<'a> InstructionDataTrait<'a> for ZInstructionDataInvoke<'a> {
         }
     }
 
-    fn new_addresses(&self) -> &[impl NewAddressParamsTrait<'a>] {
+    fn new_addresses(&self) -> &[impl NewAddress<'a>] {
         self.new_address_params.as_slice()
     }
 
-    fn input_accounts(&self) -> &[impl InputAccountTrait<'a>] {
+    fn input_accounts(&self) -> &[impl InputAccount<'a>] {
         self.input_compressed_accounts_with_merkle_context
             .as_slice()
     }
 
-    fn output_accounts(&self) -> &[impl OutputAccountTrait<'a>] {
+    fn output_accounts(&self) -> &[impl OutputAccount<'a>] {
         self.output_compressed_accounts.as_slice()
     }
 
@@ -544,7 +541,7 @@ impl ZInstructionDataInvokeCpi<'_> {
     }
 }
 
-impl<'a> InstructionDataTrait<'a> for ZInstructionDataInvokeCpi<'a> {
+impl<'a> InstructionData<'a> for ZInstructionDataInvokeCpi<'a> {
     fn bump(&self) -> Option<u8> {
         None
     }
@@ -591,15 +588,15 @@ impl<'a> InstructionDataTrait<'a> for ZInstructionDataInvokeCpi<'a> {
         self.proof
     }
 
-    fn new_addresses(&self) -> &[impl NewAddressParamsTrait<'a>] {
+    fn new_addresses(&self) -> &[impl NewAddress<'a>] {
         self.new_address_params.as_slice()
     }
 
-    fn output_accounts(&self) -> &[impl OutputAccountTrait<'a>] {
+    fn output_accounts(&self) -> &[impl OutputAccount<'a>] {
         self.output_compressed_accounts.as_slice()
     }
 
-    fn input_accounts(&self) -> &[impl InputAccountTrait<'a>] {
+    fn input_accounts(&self) -> &[impl InputAccount<'a>] {
         self.input_compressed_accounts_with_merkle_context
             .as_slice()
     }
@@ -776,7 +773,7 @@ pub struct ZNewAddressParamsAssignedPacked {
     pub assigned_account_index: u8,
 }
 
-impl NewAddressParamsTrait<'_> for ZNewAddressParamsAssignedPacked {
+impl NewAddress<'_> for ZNewAddressParamsAssignedPacked {
     fn seed(&self) -> [u8; 32] {
         self.seed
     }

--- a/programs/system/src/invoke_cpi/process_cpi_context.rs
+++ b/programs/system/src/invoke_cpi/process_cpi_context.rs
@@ -1,5 +1,5 @@
 use light_compressed_account::instruction_data::{
-    invoke_cpi::InstructionDataInvokeCpi, traits::InstructionDataTrait,
+    invoke_cpi::InstructionDataInvokeCpi, traits::InstructionData,
 };
 use pinocchio::{account_info::AccountInfo, msg, pubkey::Pubkey};
 
@@ -31,7 +31,7 @@ use crate::{context::WrappedInstructionData, errors::SystemProgramError, Result}
 ///    compressed account, reads cpi context and combines the instruction inputs
 ///    with verified inputs from the cpi context. The proof is verified and
 ///    other state transition is executed with the combined inputs.
-pub fn process_cpi_context<'a, 'info, T: InstructionDataTrait<'a>>(
+pub fn process_cpi_context<'a, 'info, T: InstructionData<'a>>(
     mut inputs: WrappedInstructionData<'a, T>,
     cpi_context_account_info: Option<&'info AccountInfo>,
     fee_payer: Pubkey,
@@ -91,7 +91,7 @@ pub fn process_cpi_context<'a, 'info, T: InstructionDataTrait<'a>>(
     Ok(Some((0, inputs)))
 }
 
-pub fn set_cpi_context<'a, 'info, T: InstructionDataTrait<'a>>(
+pub fn set_cpi_context<'a, 'info, T: InstructionData<'a>>(
     fee_payer: Pubkey,
     cpi_context_account_info: &'info AccountInfo,
     inputs: WrappedInstructionData<'a, T>,

--- a/programs/system/src/invoke_cpi/processor.rs
+++ b/programs/system/src/invoke_cpi/processor.rs
@@ -1,4 +1,4 @@
-use light_compressed_account::instruction_data::traits::InstructionDataTrait;
+use light_compressed_account::instruction_data::traits::InstructionData;
 #[cfg(feature = "bench-sbf")]
 use light_heap::{bench_sbf_end, bench_sbf_start};
 use pinocchio::{account_info::AccountInfo, msg, pubkey::Pubkey};
@@ -22,7 +22,7 @@ pub fn process_invoke_cpi<
     'info,
     const ADDRESS_ASSIGNMENT: bool,
     A: SignerAccounts<'info> + InvokeAccounts<'info> + CpiContextAccountTrait<'info>,
-    T: InstructionDataTrait<'a>,
+    T: InstructionData<'a>,
 >(
     invoking_program: Pubkey,
     ctx: A,

--- a/programs/system/src/invoke_cpi/verify_signer.rs
+++ b/programs/system/src/invoke_cpi/verify_signer.rs
@@ -1,5 +1,5 @@
 #![allow(unused_imports)]
-use light_compressed_account::instruction_data::traits::InstructionDataTrait;
+use light_compressed_account::instruction_data::traits::InstructionData;
 #[cfg(feature = "bench-sbf")]
 use light_heap::{bench_sbf_end, bench_sbf_start};
 use pinocchio::{
@@ -18,7 +18,7 @@ use crate::{
 ///    (input_compressed_accounts_signer_check)
 /// 3. Output compressed accounts with data are owned by the invoking program
 ///    (output_compressed_accounts_write_access_check)
-pub fn cpi_signer_checks<'a, T: InstructionDataTrait<'a>>(
+pub fn cpi_signer_checks<'a, T: InstructionData<'a>>(
     invoking_program_id: &Pubkey,
     authority: &Pubkey,
     inputs: &WrappedInstructionData<'a, T>,
@@ -109,7 +109,7 @@ pub fn cpi_signer_check(
 }
 
 /// Checks that the invoking program owns all input compressed accounts.
-pub fn input_compressed_accounts_signer_check<'a, 'info, T: InstructionDataTrait<'a>>(
+pub fn input_compressed_accounts_signer_check<'a, 'info, T: InstructionData<'a>>(
     inputs: &WrappedInstructionData<'a, T>,
     invoking_program_id: &Pubkey,
 ) -> Result<()> {
@@ -136,7 +136,7 @@ pub fn input_compressed_accounts_signer_check<'a, 'info, T: InstructionDataTrait
 ///     invoking_program.
 /// - outputs without data can be owned by any pubkey.
 #[inline(never)]
-pub fn output_compressed_accounts_write_access_check<'a, 'info, T: InstructionDataTrait<'a>>(
+pub fn output_compressed_accounts_write_access_check<'a, 'info, T: InstructionData<'a>>(
     inputs: &WrappedInstructionData<'a, T>,
     invoking_program_id: &Pubkey,
 ) -> Result<()> {

--- a/programs/system/src/lib.rs
+++ b/programs/system/src/lib.rs
@@ -17,7 +17,7 @@ use invoke_cpi::{
     small_accounts::InvokeCpiInstructionSmall,
 };
 use light_compressed_account::instruction_data::{
-    traits::InstructionDataTrait,
+    traits::InstructionData,
     with_account_info::InstructionDataInvokeCpiWithAccountInfo,
     with_readonly::InstructionDataInvokeCpiWithReadOnly,
     zero_copy::{ZInstructionDataInvoke, ZInstructionDataInvokeCpi},
@@ -181,7 +181,7 @@ pub fn invoke_cpi_with_account_info<'a, 'b, 'c: 'info, 'info>(
     )
 }
 
-fn shared_invoke_cpi<'a, 'info, T: InstructionDataTrait<'a>>(
+fn shared_invoke_cpi<'a, 'info, T: InstructionData<'a>>(
     accounts: &[AccountInfo],
     invoking_program: Pubkey,
     mode: AccountMode,

--- a/programs/system/src/processor/create_address_cpi_data.rs
+++ b/programs/system/src/processor/create_address_cpi_data.rs
@@ -1,7 +1,7 @@
 use light_compressed_account::{
     address::{derive_address, derive_address_legacy},
     instruction_data::{
-        insert_into_queues::InsertIntoQueuesInstructionDataMut, traits::NewAddressParamsTrait,
+        insert_into_queues::InsertIntoQueuesInstructionDataMut, traits::NewAddress,
     },
 };
 use pinocchio::{account_info::AccountInfo, program_error::ProgramError};
@@ -12,7 +12,7 @@ use crate::{
 };
 
 pub fn derive_new_addresses<'info, 'a, 'b: 'a, const ADDRESS_ASSIGNMENT: bool>(
-    new_address_params: impl Iterator<Item = &'a (dyn NewAddressParamsTrait<'b> + 'a)>,
+    new_address_params: impl Iterator<Item = &'a (dyn NewAddress<'b> + 'a)>,
     remaining_accounts: &'info [AccountInfo],
     context: &mut SystemContext<'info>,
     cpi_ix_data: &mut InsertIntoQueuesInstructionDataMut<'_>,

--- a/programs/system/src/processor/create_inputs_cpi_data.rs
+++ b/programs/system/src/processor/create_inputs_cpi_data.rs
@@ -2,7 +2,7 @@ use light_compressed_account::{
     hash_to_bn254_field_size_be,
     instruction_data::{
         insert_into_queues::{InsertIntoQueuesInstructionDataMut, InsertNullifierInput},
-        traits::InstructionDataTrait,
+        traits::InstructionData,
     },
 };
 use light_hasher::{Hasher, Poseidon};
@@ -19,7 +19,7 @@ use crate::{
 /// Merkle tree pubkeys are hashed and stored in the hashed_pubkeys array.
 /// Merkle tree pubkeys should be ordered for efficiency.
 #[inline(always)]
-pub fn create_inputs_cpi_data<'a, 'info, T: InstructionDataTrait<'a>>(
+pub fn create_inputs_cpi_data<'a, 'info, T: InstructionData<'a>>(
     remaining_accounts: &'info [AccountInfo],
     instruction_data: &WrappedInstructionData<'a, T>,
     context: &mut SystemContext<'info>,

--- a/programs/system/src/processor/create_outputs_cpi_data.rs
+++ b/programs/system/src/processor/create_outputs_cpi_data.rs
@@ -2,7 +2,7 @@ use light_compressed_account::{
     hash_to_bn254_field_size_be,
     instruction_data::{
         insert_into_queues::{InsertIntoQueuesInstructionDataMut, MerkleTreeSequenceNumber},
-        traits::{InstructionDataTrait, OutputAccountTrait},
+        traits::{InstructionData, OutputAccount},
     },
     TreeType,
 };
@@ -30,7 +30,7 @@ use crate::{
 ///    output compressed accounts. This will close the account.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
-pub fn create_outputs_cpi_data<'a, 'info, T: InstructionDataTrait<'a>>(
+pub fn create_outputs_cpi_data<'a, 'info, T: InstructionData<'a>>(
     inputs: &WrappedInstructionData<'a, T>,
     remaining_accounts: &'info [AccountInfo],
     context: &mut SystemContext<'info>,
@@ -196,7 +196,7 @@ pub fn create_outputs_cpi_data<'a, 'info, T: InstructionDataTrait<'a>>(
 }
 
 // Check that new addresses are assigned correctly to the compressed output accounts specified by index
-pub fn check_new_address_assignment<'a, 'info, T: InstructionDataTrait<'a>>(
+pub fn check_new_address_assignment<'a, 'info, T: InstructionData<'a>>(
     inputs: &WrappedInstructionData<'a, T>,
     cpi_ix_data: &InsertIntoQueuesInstructionDataMut<'_>,
 ) -> std::result::Result<(), SystemProgramError> {

--- a/programs/system/src/processor/process.rs
+++ b/programs/system/src/processor/process.rs
@@ -4,7 +4,7 @@ use light_compressed_account::{
     instruction_data::{
         compressed_proof::CompressedProof,
         insert_into_queues::{InsertIntoQueuesInstructionDataMut, InsertNullifierInput},
-        traits::InstructionDataTrait,
+        traits::InstructionData,
         zero_copy::ZPackedReadOnlyCompressedAccount,
     },
     tx_hash::create_tx_hash_from_hash_chains,
@@ -84,7 +84,7 @@ pub fn process<
     'info,
     const ADDRESS_ASSIGNMENT: bool,
     A: InvokeAccounts<'info> + SignerAccounts<'info>,
-    T: InstructionDataTrait<'a>,
+    T: InstructionData<'a>,
 >(
     inputs: WrappedInstructionData<'a, T>,
     invoking_program: Option<Pubkey>,

--- a/programs/system/src/processor/sum_check.rs
+++ b/programs/system/src/processor/sum_check.rs
@@ -1,10 +1,10 @@
-use light_compressed_account::instruction_data::traits::InstructionDataTrait;
+use light_compressed_account::instruction_data::traits::InstructionData;
 use pinocchio::program_error::ProgramError;
 
 use crate::{context::WrappedInstructionData, errors::SystemProgramError, Result};
 
 #[inline(always)]
-pub fn sum_check<'a, T: InstructionDataTrait<'a>>(
+pub fn sum_check<'a, T: InstructionData<'a>>(
     inputs: &WrappedInstructionData<'a, T>,
     relay_fee: &Option<u64>,
     is_compress: &bool,

--- a/programs/system/src/processor/verify_proof.rs
+++ b/programs/system/src/processor/verify_proof.rs
@@ -5,7 +5,7 @@ use light_compressed_account::{
     hash_chain::{create_hash_chain_from_slice, create_two_inputs_hash_chain},
     instruction_data::{
         compressed_proof::CompressedProof,
-        traits::{InputAccountTrait, NewAddressParamsTrait},
+        traits::{InputAccount, NewAddress},
         zero_copy::{ZPackedReadOnlyAddress, ZPackedReadOnlyCompressedAccount},
     },
 };
@@ -25,9 +25,7 @@ const IS_NOT_STATE: bool = false;
 #[inline(always)]
 pub fn read_input_state_roots<'a: 'b, 'b>(
     remaining_accounts: &[AcpAccount<'_>],
-    input_compressed_accounts_with_merkle_context: impl Iterator<
-        Item = &'b (dyn InputAccountTrait<'a> + 'b),
-    >,
+    input_compressed_accounts_with_merkle_context: impl Iterator<Item = &'b (dyn InputAccount<'a> + 'b)>,
     read_only_accounts: &[ZPackedReadOnlyCompressedAccount],
     input_roots: &mut Vec<[u8; 32]>,
 ) -> Result<u8, SystemProgramError> {
@@ -85,7 +83,7 @@ pub fn read_input_state_roots<'a: 'b, 'b>(
 #[inline(always)]
 pub fn read_address_roots<'a, 'b: 'a>(
     remaining_accounts: &[AcpAccount<'_>],
-    new_address_params: impl Iterator<Item = &'a (dyn NewAddressParamsTrait<'b> + 'a)>,
+    new_address_params: impl Iterator<Item = &'a (dyn NewAddress<'b> + 'a)>,
     read_only_addresses: &'a [ZPackedReadOnlyAddress],
     address_roots: &'a mut Vec<[u8; 32]>,
 ) -> Result<u8, SystemProgramError> {


### PR DESCRIPTION
Changes:
1. `InstructionDataTrait` -> `InstructionData`
2. `InputAccountTrait` -> `InputAccount`
3. `OutputAccountTrait` -> `OutputAccount`
4. `NewAddressParamsTrait` -> `NewAddress`