### PR TITLE
fix: check_account_balance_is_rent_exempt return rent_exemption

### DIFF
--- a/program-libs/account-checks/src/checks.rs
+++ b/program-libs/account-checks/src/checks.rs
@@ -116,10 +116,13 @@ pub fn check_account_balance_is_rent_exempt(
         if lamports < rent_exemption {
             return Err(AccountError::InvalidAccountBalance);
         }
+        Ok(rent_exemption)
     }
     #[cfg(not(target_os = "solana"))]
-    println!("Rent exemption check skipped since not target_os solana.");
-    Ok(lamports)
+    {
+        println!("Rent exemption check skipped since not target_os solana.");
+        Ok(lamports)
+    }
 }
 
 #[cfg(not(feature = "pinocchio"))]

--- a/program-tests/account-compression-test/tests/batched_merkle_tree_test.rs
+++ b/program-tests/account-compression-test/tests/batched_merkle_tree_test.rs
@@ -4,10 +4,7 @@ use account_compression::{errors::AccountCompressionErrorCode, ID};
 use anchor_lang::{
     error::ErrorCode, prelude::AccountMeta, AnchorSerialize, InstructionData, ToAccountMetas,
 };
-use anchor_spl::{
-    token::Mint,
-    token_2022::spl_token_2022::extension::default_account_state::instruction::decode_instruction,
-};
+use anchor_spl::token::Mint;
 use light_account_checks::error::AccountError;
 use light_batched_merkle_tree::{
     errors::BatchedMerkleTreeError,

--- a/program-tests/account-compression-test/tests/batched_merkle_tree_test.rs
+++ b/program-tests/account-compression-test/tests/batched_merkle_tree_test.rs
@@ -4,7 +4,10 @@ use account_compression::{errors::AccountCompressionErrorCode, ID};
 use anchor_lang::{
     error::ErrorCode, prelude::AccountMeta, AnchorSerialize, InstructionData, ToAccountMetas,
 };
-use anchor_spl::token::Mint;
+use anchor_spl::{
+    token::Mint,
+    token_2022::spl_token_2022::extension::default_account_state::instruction::decode_instruction,
+};
 use light_account_checks::error::AccountError;
 use light_batched_merkle_tree::{
     errors::BatchedMerkleTreeError,
@@ -56,6 +59,7 @@ use solana_sdk::{
     instruction::Instruction,
     pubkey::Pubkey,
     signature::{Keypair, Signature, Signer},
+    system_instruction,
 };
 
 pub enum TestMode {
@@ -1234,7 +1238,7 @@ async fn test_rollover_batch_state_merkle_trees() {
     airdrop_lamports(
         &mut context,
         &nullifier_queue_keypair.pubkey(),
-        100_000_000_000,
+        1000_000_000_000,
     )
     .await
     .unwrap();
@@ -1249,7 +1253,7 @@ async fn test_rollover_batch_state_merkle_trees() {
             &new_output_queue_keypair,
             params.additional_bytes,
             params.network_fee,
-            BatchStateMerkleTreeRollOverTestMode::Functional,
+            BatchStateMerkleTreeRollOverTestMode::FunctionalWithAdditionalLamports,
         )
         .await
         .unwrap();
@@ -1274,6 +1278,7 @@ async fn test_rollover_batch_state_merkle_trees() {
 #[derive(Debug, PartialEq)]
 pub enum BatchStateMerkleTreeRollOverTestMode {
     Functional,
+    FunctionalWithAdditionalLamports,
     InvalidProgramOwnerMerkleTree,
     InvalidProgramOwnerQueue,
     InvalidDiscriminatorMerkleTree,
@@ -1375,9 +1380,21 @@ pub async fn perform_rollover_batch_state_merkle_tree<R: RpcConnection>(
         accounts: accounts.to_account_metas(Some(true)),
         data: instruction_data.data(),
     };
+    let mut instructions = vec![create_mt_account_ix, create_queue_account_ix, instruction];
 
+    if test_mode == BatchStateMerkleTreeRollOverTestMode::FunctionalWithAdditionalLamports {
+        // Transfer 100 sol to new state merkle tree account to increase its balance.
+        // Assert that rollover fee is still correct.
+        let additional_lamports = 100_000_000_000;
+        let additional_lamports_instruction = system_instruction::transfer(
+            &payer_pubkey,
+            &new_state_merkle_tree_keypair.pubkey(),
+            additional_lamports,
+        );
+        instructions.insert(2, additional_lamports_instruction);
+    }
     rpc.create_and_send_transaction(
-        &[create_mt_account_ix, create_queue_account_ix, instruction],
+        instructions.as_slice(),
         &payer_pubkey,
         &[
             payer,

--- a/sdk-libs/program-test/src/test_batch_forester.rs
+++ b/sdk-libs/program-test/src/test_batch_forester.rs
@@ -680,11 +680,30 @@ pub async fn assert_perform_state_mt_roll_over<R: RpcConnection>(
         .unwrap()
         .data;
     let new_queue_account = rpc.get_account(new_queue_pubkey).await.unwrap().unwrap();
-
+    let old_queue_rent_exempt = rpc
+        .get_minimum_balance_for_rent_exemption(old_queue_account_data.len())
+        .await
+        .unwrap();
+    let old_tree_rent_exempt = rpc
+        .get_minimum_balance_for_rent_exemption(old_state_merkle_tree.data.len())
+        .await
+        .unwrap();
+    let queue_rent_exempt = rpc
+        .get_minimum_balance_for_rent_exemption(new_queue_account.data.len())
+        .await
+        .unwrap();
+    let tree_rent_exempt = rpc
+        .get_minimum_balance_for_rent_exemption(new_state_merkle_tree.data.len())
+        .await
+        .unwrap();
+    println!("queue rent exempt : {}", queue_rent_exempt);
+    println!("tree rent exempt : {}", tree_rent_exempt);
+    println!("old queue rent exempt : {}", old_queue_rent_exempt);
+    println!("old tree rent exempt : {}", old_tree_rent_exempt);
     let queue_params = CreateOutputQueueParams::from(
         params,
         owner.into(),
-        new_queue_account.lamports + new_state_merkle_tree.lamports + additional_bytes_rent,
+        old_tree_rent_exempt + old_queue_rent_exempt + additional_bytes_rent,
         old_state_merkle_tree_pubkey.into(),
         old_queue_pubkey.into(),
     );
@@ -692,7 +711,7 @@ pub async fn assert_perform_state_mt_roll_over<R: RpcConnection>(
     let queue_params = CreateOutputQueueParams::from(
         params,
         owner.into(),
-        new_queue_account.lamports + new_state_merkle_tree.lamports + additional_bytes_rent,
+        tree_rent_exempt + queue_rent_exempt + additional_bytes_rent,
         old_state_merkle_tree_pubkey.into(),
         new_queue_pubkey.into(),
     );


### PR DESCRIPTION
Issue:
- an increase in accounts lamports increased the rollover fee

Solution:
- return rent exempt amount instead of account lamports