### PR TITLE
CI: migrate workflows to cache v4

### DIFF
--- a/.github/actions/setup-and-build-nocheck/action.yml
+++ b/.github/actions/setup-and-build-nocheck/action.yml
@@ -15,7 +15,7 @@ runs:
 
     - name: Restore .local directory cache
       id: restore-local-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           .local
@@ -68,7 +68,7 @@ runs:
         npx nx build @lightprotocol/zk-compression-cli
 
     - name: Cache .local directory
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           .local


### PR DESCRIPTION
GitHub runners now default to Node 20; actions/cache@v4 is the recommended version. Only workflow files changed—no functional impact.