### PR TITLE
feat: address v2 test with multiple addresses, add async yields

### DIFF
--- a/forester-utils/src/utils.rs
+++ b/forester-utils/src/utils.rs
@@ -68,6 +68,8 @@ pub async fn wait_for_indexer<R: RpcConnection, I: Indexer<R>>(
             "waiting for indexer to catch up, rpc_slot: {}, indexer_slot: {}",
             rpc_slot, indexer_slot
         );
+
+        tokio::task::yield_now().await;
         sleep(std::time::Duration::from_millis(400)).await;
         indexer_slot = indexer.get_indexer_slot(rpc).await.map_err(|e| {
             error!("failed to get indexer slot from indexer: {:?}", e);

--- a/forester/src/epoch_manager.rs
+++ b/forester/src/epoch_manager.rs
@@ -484,6 +484,7 @@ impl<R: RpcConnection, I: Indexer<R> + IndexerType<R>> EpochManager<R, I> {
                         e
                     );
                     if attempt < max_retries - 1 {
+                        tokio::task::yield_now().await;
                         sleep(retry_delay).await;
                     } else {
                         if let Err(alert_err) = send_pagerduty_alert(
@@ -1257,6 +1258,7 @@ pub async fn run_service<R: RpcConnection, I: Indexer<R> + IndexerType<R>>(
                         retry_count += 1;
                         if retry_count < config.retry_config.max_retries {
                             debug!("Retrying in {:?}", retry_delay);
+                            tokio::task::yield_now().await;
                             sleep(retry_delay).await;
                             retry_delay = std::cmp::min(retry_delay * 2, MAX_RETRY_DELAY);
                         } else {

--- a/forester/src/slot_tracker.rs
+++ b/forester/src/slot_tracker.rs
@@ -70,6 +70,7 @@ impl SlotTracker {
                 }
                 Err(e) => error!("Failed to get slot: {:?}", e),
             }
+            tokio::task::yield_now().await;
             tokio::time::sleep(self.update_interval).await;
         }
     }
@@ -105,6 +106,7 @@ pub async fn wait_until_slot_reached<R: RpcConnection>(
             current_estimated_slot,
             sleep_duration.as_secs_f64()
         );
+        tokio::task::yield_now().await;
         sleep(sleep_duration).await;
     }
 

--- a/forester/src/smart_transaction.rs
+++ b/forester/src/smart_transaction.rs
@@ -71,6 +71,7 @@ pub async fn poll_transaction_confirmation<'a, R: RpcConnection>(
                 }
             }
             None => {
+                tokio::task::yield_now().await;
                 sleep(interval).await;
             }
         }

--- a/prover/server/prover/proving_keys_utils.go
+++ b/prover/server/prover/proving_keys_utils.go
@@ -111,6 +111,9 @@ func GetKeys(keysDir string, runMode RunMode, circuits []string) []string {
 		keysDir + "non-inclusion_26_2.key",
 		keysDir + "non-inclusion_40_1.key",
 		keysDir + "non-inclusion_40_2.key",
+		keysDir + "non-inclusion_40_3.key",
+		keysDir + "non-inclusion_40_4.key",
+		keysDir + "non-inclusion_40_8.key",
 	}
 
 	var combinedKeys []string = []string{

--- a/sdk-libs/client/src/rpc/solana_rpc.rs
+++ b/sdk-libs/client/src/rpc/solana_rpc.rs
@@ -191,6 +191,7 @@ impl SolanaRpcConnection {
                         "Transaction operation failed, retrying in {:?} (attempt {}/{}): {:?}",
                         self.retry_config.retry_delay, attempts, self.retry_config.max_retries, e
                     );
+                    tokio::task::yield_now().await;
                     sleep(self.retry_config.retry_delay).await;
                 }
             }

--- a/sdk-libs/client/src/rpc_pool.rs
+++ b/sdk-libs/client/src/rpc_pool.rs
@@ -118,6 +118,7 @@ impl<R: RpcConnection> SolanaRpcPool<R> {
                 Err(e) if retries < max_retries => {
                     retries += 1;
                     eprintln!("Failed to get connection (attempt {}): {:?}", retries, e);
+                    tokio::task::yield_now().await;
                     sleep(delay).await;
                 }
                 Err(e) => return Err(PoolError::Pool(e.to_string())),

--- a/sdk-libs/program-test/src/indexer/test_indexer.rs
+++ b/sdk-libs/program-test/src/indexer/test_indexer.rs
@@ -319,8 +319,10 @@ where
                 compressed_accounts.unwrap().len()
             )
         }
-        if new_addresses.is_some() && ![1usize, 2usize].contains(&new_addresses.unwrap().len()) {
-            panic!("new_addresses must be of length 1, 2")
+        if new_addresses.is_some()
+            && ![1usize, 2usize, 3usize, 4usize, 8usize].contains(&new_addresses.unwrap().len())
+        {
+            panic!("new_addresses must be of length 1, 2, 3, 4 or 8")
         }
         let client = Client::new();
         let (root_indices, address_root_indices, json_payload) =
@@ -352,6 +354,7 @@ where
                     } else {
                         payload_legacy.unwrap().to_string()
                     };
+                    // println!("Payload string: {}", payload_string);
                     (Vec::<u16>::new(), indices, payload_string)
                 }
                 (Some(accounts), Some(addresses)) => {
@@ -424,6 +427,8 @@ where
 
         let mut retries = 1000;
         while retries > 0 {
+            // println!("Retries: {}", retries);
+            // println!("JSON Payload: {}", json_payload);
             let response_result = client
                 .post(format!("{}{}", SERVER_ADDRESS, PROVE_PATH))
                 .header("Content-Type", "text/plain; charset=utf-8")
@@ -431,6 +436,7 @@ where
                 .send()
                 .await;
             if let Ok(response_result) = response_result {
+                // println!("Response: {:#?}", response_result);
                 if response_result.status().is_success() {
                     let body = response_result.text().await.unwrap();
                     let proof_json = deserialize_gnark_proof_json(&body).unwrap();

--- a/sdk-libs/program-test/src/indexer/test_indexer.rs
+++ b/sdk-libs/program-test/src/indexer/test_indexer.rs
@@ -354,7 +354,6 @@ where
                     } else {
                         payload_legacy.unwrap().to_string()
                     };
-                    // println!("Payload string: {}", payload_string);
                     (Vec::<u16>::new(), indices, payload_string)
                 }
                 (Some(accounts), Some(addresses)) => {
@@ -427,8 +426,6 @@ where
 
         let mut retries = 1000;
         while retries > 0 {
-            // println!("Retries: {}", retries);
-            // println!("JSON Payload: {}", json_payload);
             let response_result = client
                 .post(format!("{}{}", SERVER_ADDRESS, PROVE_PATH))
                 .header("Content-Type", "text/plain; charset=utf-8")
@@ -436,7 +433,6 @@ where
                 .send()
                 .await;
             if let Ok(response_result) = response_result {
-                // println!("Response: {:#?}", response_result);
                 if response_result.status().is_success() {
                     let body = response_result.text().await.unwrap();
                     let proof_json = deserialize_gnark_proof_json(&body).unwrap();


### PR DESCRIPTION
* enhance address creation logic to support multiple addresses
* add `tokio::task::yield_now()` in async loops to improve responsiveness