### PR TITLE
fix: indexer get_compressed_account return type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3352,6 +3352,7 @@ dependencies = [
  "base64 0.13.1",
  "borsh 0.10.4",
  "bs58",
+ "lazy_static",
  "light-compressed-account",
  "light-compressed-token",
  "light-concurrent-merkle-tree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ futures = "0.3.17"
 tokio = { version = "1.43.0", features = ["rt", "macros", "rt-multi-thread"] }
 async-trait = "0.1.82"
 bb8 = "0.8.6"
+lazy_static = "1.5.0"
 
 # Logging
 log = "0.4"

--- a/sdk-libs/client/Cargo.toml
+++ b/sdk-libs/client/Cargo.toml
@@ -52,6 +52,7 @@ bs58 = { workspace = true }
 tokio = { workspace = true, features = ["rt", "time"] }
 
 tracing = { workspace = true }
+lazy_static = { workspace = true }
 
 [dev-dependencies]
 light-program-test = { workspace = true }

--- a/sdk-libs/client/src/indexer/mod.rs
+++ b/sdk-libs/client/src/indexer/mod.rs
@@ -2,19 +2,22 @@ use std::{fmt::Debug, str::FromStr};
 
 use async_trait::async_trait;
 use light_compressed_account::compressed_account::{
-    CompressedAccount, CompressedAccountData, CompressedAccountWithMerkleContext, MerkleContext,
+    CompressedAccount, CompressedAccountData, CompressedAccountWithMerkleContext,
 };
 use light_indexed_merkle_tree::array::IndexedElement;
 use light_merkle_tree_metadata::QueueType;
 use light_sdk::token::{AccountState, TokenData, TokenDataWithMerkleContext};
 use num_bigint::BigUint;
-use photon_api::models::{Account, TokenAccount, TokenAccountList, TokenBalanceList};
+use photon_api::models::{
+    Account as PhotonAccount, TokenAccount, TokenAccountList, TokenBalanceList,
+};
 use solana_pubkey::Pubkey;
 
 pub mod photon_indexer;
 
 mod base58;
 mod error;
+pub(crate) mod tree_info;
 mod types;
 
 pub use base58::Base58Conversions;
@@ -22,8 +25,8 @@ pub use error::IndexerError;
 //
 pub use types::ProofRpcResultV2;
 pub use types::{
-    Address, AddressWithTree, Hash, MerkleProof, MerkleProofWithContext, ProofOfLeaf,
-    ProofRpcResult,
+    Account, Address, AddressWithTree, Hash, MerkleContext, MerkleProof, MerkleProofWithContext,
+    ProofOfLeaf, ProofRpcResult, TreeContextInfo,
 };
 
 #[derive(Debug, Clone)]
@@ -48,6 +51,11 @@ pub trait Indexer: std::marker::Send + std::marker::Sync {
         &self,
         hashes: Vec<String>,
     ) -> Result<Vec<MerkleProof>, IndexerError>;
+
+    async fn get_compressed_accounts_by_owner(
+        &self,
+        owner: &Pubkey,
+    ) -> Result<Vec<CompressedAccountWithMerkleContext>, IndexerError>;
 
     async fn get_compressed_accounts_by_owner_v2(
         &self,
@@ -179,7 +187,7 @@ pub struct AddressMerkleTreeAccounts {
 }
 
 pub trait IntoPhotonAccount {
-    fn into_photon_account(self) -> Account;
+    fn into_photon_account(self) -> PhotonAccount;
 }
 
 pub trait IntoPhotonTokenAccount {
@@ -187,7 +195,7 @@ pub trait IntoPhotonTokenAccount {
 }
 
 impl IntoPhotonAccount for CompressedAccountWithMerkleContext {
-    fn into_photon_account(self) -> Account {
+    fn into_photon_account(self) -> PhotonAccount {
         let address = self.compressed_account.address.map(|a| a.to_base58());
         let hash = self.hash().unwrap().to_base58();
 
@@ -202,7 +210,7 @@ impl IntoPhotonAccount for CompressedAccountWithMerkleContext {
             }));
         }
 
-        Account {
+        PhotonAccount {
             address,
             hash: hash.to_string(),
             lamports: self.compressed_account.lamports,
@@ -246,14 +254,14 @@ impl IntoPhotonTokenAccount for TokenDataWithMerkleContext {
     }
 }
 
-pub struct LocalPhotonAccount(Account);
+pub struct LocalPhotonAccount(PhotonAccount);
 
 impl TryFrom<LocalPhotonAccount> for CompressedAccountWithMerkleContext {
     type Error = Box<dyn std::error::Error>;
 
     fn try_from(local_account: LocalPhotonAccount) -> Result<Self, Self::Error> {
         let account = local_account.0;
-        let merkle_context = MerkleContext {
+        let merkle_context = light_compressed_account::compressed_account::MerkleContext {
             merkle_tree_pubkey: Pubkey::from_str(&account.tree)?,
             queue_pubkey: Default::default(),
             leaf_index: account.leaf_index,
@@ -273,7 +281,7 @@ impl TryFrom<LocalPhotonAccount> for CompressedAccountWithMerkleContext {
         if let Some(data) = account.data {
             let data_decoded = base64::decode(&data.data)?;
             compressed_account.data = Some(CompressedAccountData {
-                discriminator: data.discriminator.to_le_bytes(),
+                discriminator: data.discriminator.to_be_bytes(),
                 data: data_decoded,
                 data_hash: <[u8; 32]>::from_base58(&data.data_hash)?,
             });

--- a/sdk-libs/client/src/indexer/mod.rs
+++ b/sdk-libs/client/src/indexer/mod.rs
@@ -281,7 +281,7 @@ impl TryFrom<LocalPhotonAccount> for CompressedAccountWithMerkleContext {
         if let Some(data) = account.data {
             let data_decoded = base64::decode(&data.data)?;
             compressed_account.data = Some(CompressedAccountData {
-                discriminator: data.discriminator.to_be_bytes(),
+                discriminator: data.discriminator.to_le_bytes(),
                 data: data_decoded,
                 data_hash: <[u8; 32]>::from_base58(&data.data_hash)?,
             });

--- a/sdk-libs/client/src/indexer/photon_indexer.rs
+++ b/sdk-libs/client/src/indexer/photon_indexer.rs
@@ -268,7 +268,7 @@ impl Indexer for PhotonIndexer {
                         .address
                         .map(|address| Hash::from_base58(&address).unwrap()),
                     data: acc.data.map(|data| CompressedAccountData {
-                        discriminator: data.discriminator.to_be_bytes(),
+                        discriminator: data.discriminator.to_le_bytes(),
                         data: base64::decode(data.data).unwrap(),
                         data_hash: Hash::from_base58(&data.data_hash).unwrap(),
                     }),
@@ -333,7 +333,7 @@ impl Indexer for PhotonIndexer {
                             .address
                             .map(|address| Hash::from_base58(&address).unwrap()),
                         data: acc.data.map(|data| CompressedAccountData {
-                            discriminator: data.discriminator.to_be_bytes(),
+                            discriminator: data.discriminator.to_le_bytes(),
                             data: base64::decode(data.data).unwrap(),
                             data_hash: Hash::from_base58(&data.data_hash).unwrap(),
                         }),
@@ -432,7 +432,7 @@ impl Indexer for PhotonIndexer {
                                     .map(|x| Hash::from_base58(x).unwrap()),
                                 data: account.account.data.as_ref().map(|data| {
                                     CompressedAccountData {
-                                        discriminator: data.discriminator.to_be_bytes(),
+                                        discriminator: data.discriminator.to_le_bytes(),
                                         data: base64::decode(&data.data).unwrap(),
                                         data_hash: Hash::from_base58(&data.data_hash).unwrap(),
                                     }

--- a/sdk-libs/client/src/indexer/photon_indexer.rs
+++ b/sdk-libs/client/src/indexer/photon_indexer.rs
@@ -238,9 +238,8 @@ impl Indexer for PhotonIndexer {
 
     async fn get_compressed_accounts_by_owner(
         &self,
-        _owner: &Pubkey,
+        owner: &Pubkey,
     ) -> Result<Vec<CompressedAccountWithMerkleContext>, IndexerError> {
-        let owner = _owner;
         self.retry(|| async {
             let request = photon_api::models::GetCompressedAccountsByOwnerPostRequest {
                 params: Box::from(GetCompressedAccountsByOwnerPostRequestParams {

--- a/sdk-libs/client/src/indexer/tree_info.rs
+++ b/sdk-libs/client/src/indexer/tree_info.rs
@@ -1,0 +1,255 @@
+#![allow(dead_code)]
+use std::collections::HashMap;
+
+use lazy_static::lazy_static;
+use light_compressed_account::TreeType;
+use solana_pubkey::{pubkey, Pubkey};
+
+#[derive(Debug, Clone)]
+pub struct TreeInfo {
+    pub tree: Pubkey,
+    pub queue: Pubkey,
+    pub height: u32,
+    pub tree_type: TreeType,
+}
+
+impl TreeInfo {
+    pub fn get(pubkey: &str) -> Option<&TreeInfo> {
+        QUEUE_TREE_MAPPING.get(pubkey)
+    }
+
+    pub fn height(pubkey: &str) -> Option<u32> {
+        QUEUE_TREE_MAPPING.get(pubkey).map(|x| x.height)
+    }
+}
+
+// TODO: keep updated with new trees. We could put it into a separate crate.
+lazy_static! {
+    pub static ref QUEUE_TREE_MAPPING: HashMap<String, TreeInfo> = {
+        let legacy_state_trees = [
+            (
+                pubkey!("smt1NamzXdq4AMqS2fS2F1i5KTYPZRhoHgWx38d8WsT"),
+                pubkey!("nfq1NvQDJ2GEgnS8zt9prAe8rjjpAW1zFkrvZoBR148"),
+            ),
+            (
+                pubkey!("smt2rJAFdyJJupwMKAqTNAJwvjhmiZ4JYGZmbVRw1Ho"),
+                pubkey!("nfq2hgS7NYemXsFaFUCe3EMXSDSfnZnAe27jC6aPP1X"),
+            ),
+            (
+                pubkey!("smt3AFtReRGVcrP11D6bSLEaKdUmrGfaTNowMVccJeu"),
+                pubkey!("nfq3de4qt9d3wHxXWy1wcge3EXhid25mCr12bNWFdtV"),
+            ),
+            (
+                pubkey!("smt4vjXvdjDFzvRMUxwTWnSy4c7cKkMaHuPrGsdDH7V"),
+                pubkey!("nfq4Ncp1vk3mFnCQ9cvwidp9k2L6fxEyCo2nerYD25A"),
+            ),
+            (
+                pubkey!("smt5uPaQT9n6b1qAkgyonmzRxtuazA53Rddwntqistc"),
+                pubkey!("nfq5b5xEguPtdD6uPetZduyrB5EUqad7gcUE46rALau"),
+            ),
+            (
+                pubkey!("smt6ukQDSPPYHSshQovmiRUjG9jGFq2hW9vgrDFk5Yz"),
+                pubkey!("nfq6uzaNZ5n3EWF4t64M93AWzLGt5dXTikEA9fFRktv"),
+            ),
+            (
+                pubkey!("smt7onMFkvi3RbyhQCMajudYQkB1afAFt9CDXBQTLz6"),
+                pubkey!("nfq7yytdKkkLabu1KpvLsa5VPkvCT4jPWus5Yi74HTH"),
+            ),
+            (
+                pubkey!("smt8TYxNy8SuhAdKJ8CeLtDkr2w6dgDmdz5ruiDw9Y9"),
+                pubkey!("nfq8vExDykci3VUSpj9R1totVst87hJfFWevNK4hiFb"),
+            ),
+            (
+                pubkey!("smt9ReAYRF5eFjTd5gBJMn5aKwNRcmp3ub2CQr2vW7j"),
+                pubkey!("nfq9KFpNQL45ppP6ZG7zBpUeN18LZrNGkKyvV1kjTX2"),
+            ),
+            (
+                pubkey!("smtAvYA5UbTRyKAkAj5kHs1CmrA42t6WkVLi4c6mA1f"),
+                pubkey!("nfqAroCRkcZBgsAJDNkptKpsSWyM6cgB9XpWNNiCEC4"),
+            ),
+            (
+                pubkey!("smtBvnJx2B2u85wc3sMkF6G8rVMfN8Ek3nVKZ8gQUFn"),
+                pubkey!("nfqB3FAiiB1p3ksiWHB48LzSycpaJZ5RTp5C8RtNyUH"),
+            ),
+            (
+                pubkey!("smtCEeVJsWyeeawgn5cQR5iK7dsJwnxJq7QwdQUepx8"),
+                pubkey!("nfqC5pX1HzaTgUApL2DTp7Xh8j3A5Augk42jngRCoKF"),
+            ),
+            (
+                pubkey!("smtF9XTNZeyMgGQxxWfxyS1Ff6CA4W4RgYi8X1wWxa9"),
+                pubkey!("nfqFa5ZzBYELWDnMQZe7SA3gd1x98aqtPf4sfaJZQJm"),
+            ),
+            (
+                pubkey!("smtGeMYXeGoyQVcnrDg985h74ak9aRPW4gsfdW25DVy"),
+                pubkey!("nfqGKBHxkUbDvTtkiDXNWskBhM6R9YfCeNu52baqvaf"),
+            ),
+            (
+                pubkey!("smtHxHypFJoK6z6CCgx7eP9jqDykUBE7PbrXrTVoejR"),
+                pubkey!("nfqHEE21vgXLnD7wxauCvX6pfeAs1zJbE4YyZ4YQ1rG"),
+            ),
+            (
+                pubkey!("smtJsXesAF3vEc7Kz86rvaaHnNndvRWRfTj3XhgbCyb"),
+                pubkey!("nfqJnTp7kgAa2AF2QTRi5qNVinkpAdA15gBYYqeZUgA"),
+            ),
+            (
+                pubkey!("smtKAoGiqSb6YwGhCSwsJer5tMMgk7sH1a2K5BNeNQQ"),
+                pubkey!("nfqKejGFuD6xkNLt8zzp2HaypMeRDsptBaeVGB4Utoq"),
+            ),
+            (
+                pubkey!("smtLdHZPfJfqK3cKCQ9sqQTCQaoDgZKA11MQZ9P4UFR"),
+                pubkey!("nfqLk1L9ezj8AbDyeQueeQoKUvU6Jzz9eQs28QgTEfx"),
+            ),
+            (
+                pubkey!("smtNKu3Dwsyw4YVVA7S9cWYGvLrwUVD3T593ZJnyggv"),
+                pubkey!("nfqNG4bDC6e8SzamFhvDytxwzKdzbwoTsLHZFi11AD1"),
+            ),
+            (
+                pubkey!("smta2xk2kZTeFBRzpSrtCpwmxkrQpv7LGgut1aMNsme"),
+                pubkey!("nfqa2szxnkgX4xBTVG81HYK7mzZe8pSF8wv2yMXaTTG"),
+            ),
+            (
+                pubkey!("smtb2BcLRWygF3svygXMprcRjXKUDnxvNFnseNgH6VT"),
+                pubkey!("nfqbgaRZGC1BGtFjRMvJmx79fzg8bBuSJBCEbJzoGTG"),
+            ),
+            (
+                pubkey!("smtd3wjo4AzEKd9tRE2zTanxEEWRAXAAs9AtF9NcfAs"),
+                pubkey!("nfqd5yiNJJ5mvZxitwXY9bR5dfBs2WNcTKctFBYwSuv"),
+            ),
+            (
+                pubkey!("smte57v68vyf21wT5xzxYvZpr6iiFG1WQ5dX7J1Y85E"),
+                pubkey!("nfqecsLrkXwRpdBJZEpR2bJYbXc2jrh78mqg1kRDZKm"),
+            ),
+            (
+                pubkey!("smtobNxYYVi8YfJDjzdoW1jR7xyZaVeXwmSHNgL3tA1"),
+                pubkey!("nfqoqboretu8sLtCB4mTe3HKRmzc18HAPUAkEn18axG"),
+            ),
+            (
+                pubkey!("smtpQZk7YARxMaz7VeW7zPMLNJAhbP9v1AZzLopaB2M"),
+                pubkey!("nfqp7yDaPgGenuaFFAogXLvy5A5c3Znn5pYe6TmQ9RQ"),
+            ),
+            (
+                pubkey!("smtqHbhmXHjVxeDNq5NPTMBw92L2ZsEF4q2WgNqjN7Y"),
+                pubkey!("nfqqqib2xCHLXSVABHoczoY4u495T5eFCcypZ6C22gB"),
+            ),
+            (
+                pubkey!("smtrG9ekG1obtqBRoB4mMUEwicfjTRRzZUm3z4LX8UJ"),
+                pubkey!("nfqroTsZ4EX37MuYb26Km8nPmS2WhfG3HTFgCuuwe7U"),
+            ),
+            (
+                pubkey!("smtsAZefsicmjKXz9Wtzidwt67pU3kqbhB6f2yD3rQJ"),
+                pubkey!("nfqs5Hdbd7oKtDdRmVQFy4wytRn5gDb1DPwPyQCmHS2"),
+            ),
+            (
+                pubkey!("smtt9Ra1v3mu8eSx7nrq5Q8bRqqPRf5mfpUvkpkP29L"),
+                pubkey!("nfqt3kLwwcAm8wLfNCVGPThN7fpHimPoiBegoGeRxUy"),
+            ),
+            (
+                pubkey!("smtu3VAWgucXQmMhy4S8nNojpuVJHgVrGQFkai1jXRw"),
+                pubkey!("nfqu1jDCGChJQxQpU5XWjeHUtzYWBEoKZ24VXXdKdkk"),
+            ),
+            (
+                pubkey!("smtvbupk8wjpXa48Zg29SVtTL8BpSJVrc6tfMGAA5A3"),
+                pubkey!("nfqvcYyr6TzAugHSaX398fXPBSRygmb7TfmXoXvL8Qu"),
+            ),
+            (
+                pubkey!("smtwntNZBnj3w5dw1mYjzgHBBhxAYvHjZhh5whVEaBS"),
+                pubkey!("nfqw14GHxV2LJsNwwXLGCXDyQXqnUn6GDL9DKqBbeep"),
+            ),
+            (
+                pubkey!("smtx7SjhPmjChWsUNiyZ4VF2U82zSBDf2yArGKr5BDb"),
+                pubkey!("nfqxAGA7bDoHDxqA4K25fV1wZZ5NHzGrxReiCC5Ztet"),
+            ),
+            (
+                pubkey!("smty1QArd6Z73H67TvoqpxitEc2E5A9zBtw42ZKZJkn"),
+                pubkey!("nfqy55aAqL8qG5qBRixUtLnDqNd61ft2jtXyoYGHNGb"),
+            ),
+            (
+                pubkey!("smtz1CZdRkGuMpYPZHihP2WruMj9ZHYjK6Ag9gLBzWM"),
+                pubkey!("nfqzF2r8viCVTMpzVAL5jHVKsGF45RsASxun8ZpRKnm"),
+            ),
+        ];
+
+        let address_trees_v1 = [(
+            pubkey!("amt1Ayt45jfbdw5YSo7iz6WZxUmnZsQTYXy82hVwyC2"),
+            pubkey!("aq1S9z4reTSQAdgWHGD2zDaS39sjGrAxbR31vxJ2F4F"),
+        )];
+
+        let mut m = HashMap::new();
+
+        for (legacy_tree, legacy_queue) in legacy_state_trees.iter() {
+            m.insert(
+                legacy_queue.to_string(),
+                TreeInfo {
+                    tree: *legacy_tree,
+                    queue: *legacy_queue,
+                    height: 26,
+                    tree_type: TreeType::StateV1,
+                },
+            );
+
+            m.insert(
+                legacy_tree.to_string(),
+                TreeInfo {
+                    tree: *legacy_tree,
+                    queue: *legacy_queue,
+                    height: 26,
+                    tree_type: TreeType::StateV1,
+                },
+            );
+        }
+
+        for (legacy_tree, legacy_queue) in address_trees_v1.iter() {
+            m.insert(
+                legacy_queue.to_string(),
+                TreeInfo {
+                    tree: *legacy_tree,
+                    queue: *legacy_queue,
+                    height: 26,
+                    tree_type: TreeType::AddressV1,
+                },
+            );
+
+            m.insert(
+                legacy_tree.to_string(),
+                TreeInfo {
+                    tree: *legacy_tree,
+                    queue: *legacy_queue,
+                    height: 26,
+                    tree_type: TreeType::AddressV1,
+                },
+            );
+        }
+
+        m.insert(
+            "6L7SzhYB3anwEQ9cphpJ1U7Scwj57bx2xueReg7R9cKU".to_string(),
+            TreeInfo {
+                tree: pubkey!("HLKs5NJ8FXkJg8BrzJt56adFYYuwg5etzDtBbQYTsixu"),
+                queue: pubkey!("6L7SzhYB3anwEQ9cphpJ1U7Scwj57bx2xueReg7R9cKU"),
+                height: 32,
+                tree_type: TreeType::StateV2,
+            },
+        );
+
+        m.insert(
+            "HLKs5NJ8FXkJg8BrzJt56adFYYuwg5etzDtBbQYTsixu".to_string(),
+            TreeInfo {
+                tree: pubkey!("HLKs5NJ8FXkJg8BrzJt56adFYYuwg5etzDtBbQYTsixu"),
+                queue: pubkey!("6L7SzhYB3anwEQ9cphpJ1U7Scwj57bx2xueReg7R9cKU"),
+                height: 32,
+                tree_type: TreeType::StateV2,
+            },
+        );
+
+        m.insert(
+            "EzKE84aVTkCUhDHLELqyJaq1Y7UVVmqxXqZjVHwHY3rK".to_string(),
+            TreeInfo {
+                tree: pubkey!("EzKE84aVTkCUhDHLELqyJaq1Y7UVVmqxXqZjVHwHY3rK"),
+                queue: pubkey!("EzKE84aVTkCUhDHLELqyJaq1Y7UVVmqxXqZjVHwHY3rK"),
+                height: 40,
+                tree_type: TreeType::AddressV2,
+            },
+        );
+
+        m
+    };
+}

--- a/sdk-libs/client/src/indexer/types.rs
+++ b/sdk-libs/client/src/indexer/types.rs
@@ -232,7 +232,7 @@ impl TryFrom<&photon_api::models::Account> for Account {
     fn try_from(account: &photon_api::models::Account) -> Result<Self, Self::Error> {
         let data = if let Some(data) = &account.data {
             Ok::<Option<CompressedAccountData>, IndexerError>(Some(CompressedAccountData {
-                discriminator: data.discriminator.to_be_bytes(),
+                discriminator: data.discriminator.to_le_bytes(),
                 data: base64::decode_config(&data.data, base64::STANDARD_NO_PAD)
                     .map_err(|_| IndexerError::InvalidResponseData)?,
                 data_hash: decode_base58_to_fixed_array(&data.data_hash)?,

--- a/sdk-libs/client/src/indexer/types.rs
+++ b/sdk-libs/client/src/indexer/types.rs
@@ -1,9 +1,13 @@
-use light_compressed_account::instruction_data::compressed_proof::CompressedProof;
+use light_compressed_account::{
+    compressed_account::{CompressedAccountData, CompressedAccountWithMerkleContext},
+    TreeType,
+};
 use light_indexed_merkle_tree::array::IndexedElement;
+use light_sdk::verifier::CompressedProof;
 use num_bigint::BigUint;
 use solana_pubkey::Pubkey;
 
-use super::IndexerError;
+use super::{base58::decode_base58_to_fixed_array, tree_info::QUEUE_TREE_MAPPING, IndexerError};
 
 pub struct ProofOfLeaf {
     pub leaf: [u8; 32],
@@ -34,6 +38,7 @@ pub struct MerkleProof {
     pub root_seq: u64,
     pub root: [u8; 32],
 }
+
 #[derive(Debug, Clone, Copy)]
 pub struct AddressWithTree {
     pub address: Address,
@@ -105,7 +110,7 @@ impl ProofRpcResult {
     }
 }
 
-#[cfg(feature = "v2")]
+// #[cfg(feature = "v2")]
 #[derive(Debug, Default, Clone)]
 pub struct ProofRpcResultV2 {
     pub proof: Option<CompressedProof>,
@@ -114,7 +119,7 @@ pub struct ProofRpcResultV2 {
     pub address_root_indices: Vec<u16>,
 }
 
-#[cfg(feature = "v2")]
+// #[cfg(feature = "v2")]
 impl ProofRpcResultV2 {
     pub fn from_api_model(
         value: photon_api::models::CompressedProofWithContextV2,
@@ -157,6 +162,119 @@ impl ProofRpcResultV2 {
                 .iter()
                 .map(|x| x.root_index)
                 .collect::<Vec<u16>>(),
+        })
+    }
+}
+
+#[derive(Clone, Default, Debug, PartialEq)]
+pub struct TreeContextInfo {
+    pub cpi_context: Option<Pubkey>,
+    pub queue: Pubkey,
+    pub tree: Pubkey,
+    pub tree_type: u16,
+}
+
+#[derive(Clone, Default, Debug, PartialEq)]
+pub struct MerkleContext {
+    pub cpi_context: Option<Pubkey>,
+    pub next_tree_context: Option<TreeContextInfo>,
+    pub queue: Pubkey,
+    pub tree: Pubkey,
+    pub tree_type: TreeType,
+}
+
+#[derive(Clone, Default, Debug, PartialEq)]
+pub struct Account {
+    pub address: Option<[u8; 32]>,
+    pub data: Option<CompressedAccountData>,
+    pub hash: [u8; 32],
+    pub lamports: u64,
+    pub leaf_index: u32,
+    pub merkle_context: MerkleContext,
+    pub owner: Pubkey,
+    pub prove_by_index: bool,
+    pub seq: Option<u64>,
+    pub slot_created: u64,
+}
+
+impl TryFrom<CompressedAccountWithMerkleContext> for Account {
+    type Error = IndexerError;
+
+    fn try_from(account: CompressedAccountWithMerkleContext) -> Result<Self, Self::Error> {
+        let hash = account
+            .hash()
+            .map_err(|_| IndexerError::InvalidResponseData)?;
+
+        Ok(Account {
+            address: account.compressed_account.address,
+            data: account.compressed_account.data,
+            hash,
+            lamports: account.compressed_account.lamports,
+            leaf_index: account.merkle_context.leaf_index,
+            merkle_context: MerkleContext {
+                tree: account.merkle_context.merkle_tree_pubkey,
+                queue: account.merkle_context.queue_pubkey,
+                tree_type: account.merkle_context.tree_type,
+                cpi_context: None,
+                next_tree_context: None,
+            },
+            owner: account.compressed_account.owner,
+            prove_by_index: account.merkle_context.prove_by_index,
+            seq: None,
+            slot_created: u64::MAX,
+        })
+    }
+}
+
+impl TryFrom<&photon_api::models::Account> for Account {
+    type Error = IndexerError;
+
+    fn try_from(account: &photon_api::models::Account) -> Result<Self, Self::Error> {
+        let data = if let Some(data) = &account.data {
+            Ok::<Option<CompressedAccountData>, IndexerError>(Some(CompressedAccountData {
+                discriminator: data.discriminator.to_be_bytes(),
+                data: base64::decode_config(&data.data, base64::STANDARD_NO_PAD)
+                    .map_err(|_| IndexerError::InvalidResponseData)?,
+                data_hash: decode_base58_to_fixed_array(&data.data_hash)?,
+            }))
+        } else {
+            Ok::<Option<CompressedAccountData>, IndexerError>(None)
+        }?;
+        let owner = Pubkey::new_from_array(decode_base58_to_fixed_array(&account.owner)?);
+        let address = account
+            .address
+            .as_ref()
+            .map(|address| decode_base58_to_fixed_array(address))
+            .transpose()?;
+        let hash = decode_base58_to_fixed_array(&account.hash)?;
+        let seq = account.seq;
+        let slot_created = account.slot_created;
+        let lamports = account.lamports;
+        let leaf_index = account.leaf_index;
+
+        let tree_info = QUEUE_TREE_MAPPING
+            .get(&account.tree)
+            .ok_or(IndexerError::InvalidResponseData)?;
+
+        let merkle_context = MerkleContext {
+            cpi_context: None,
+            queue: tree_info.tree,
+            tree_type: tree_info.tree_type,
+            next_tree_context: None,
+            tree: tree_info.tree,
+        };
+
+        Ok(Account {
+            owner,
+            address,
+            data,
+            hash,
+            lamports,
+            leaf_index,
+            seq,
+            slot_created,
+            merkle_context,
+            prove_by_index: false,
         })
     }
 }

--- a/sdk-libs/client/src/indexer/types.rs
+++ b/sdk-libs/client/src/indexer/types.rs
@@ -110,7 +110,6 @@ impl ProofRpcResult {
     }
 }
 
-// #[cfg(feature = "v2")]
 #[derive(Debug, Default, Clone)]
 pub struct ProofRpcResultV2 {
     pub proof: Option<CompressedProof>,
@@ -119,7 +118,6 @@ pub struct ProofRpcResultV2 {
     pub address_root_indices: Vec<u16>,
 }
 
-// #[cfg(feature = "v2")]
 impl ProofRpcResultV2 {
     pub fn from_api_model(
         value: photon_api::models::CompressedProofWithContextV2,

--- a/sdk-libs/client/src/rpc/errors.rs
+++ b/sdk-libs/client/src/rpc/errors.rs
@@ -54,6 +54,7 @@ impl From<light_compressed_account::indexer_event::error::ParseIndexerEventError
 impl Clone for RpcError {
     fn clone(&self) -> Self {
         match self {
+            #[cfg(feature = "program-test")]
             RpcError::BanksError(_) => RpcError::CustomError("BanksError".to_string()),
             RpcError::TransactionError(e) => RpcError::TransactionError(e.clone()),
             RpcError::ClientError(_) => RpcError::CustomError("ClientError".to_string()),

--- a/sdk-libs/client/src/rpc/indexer.rs
+++ b/sdk-libs/client/src/rpc/indexer.rs
@@ -1,13 +1,13 @@
 use async_trait::async_trait;
 use light_compressed_account::{compressed_account::CompressedAccountWithMerkleContext, QueueType};
 use light_sdk::token::TokenDataWithMerkleContext;
-use photon_api::models::{Account, TokenBalanceList};
+use photon_api::models::TokenBalanceList;
 use solana_pubkey::Pubkey;
 
 use super::SolanaRpcConnection;
 use crate::indexer::{
-    Address, AddressWithTree, BatchAddressUpdateIndexerResponse, Hash, Indexer, IndexerError,
-    MerkleProof, MerkleProofWithContext, NewAddressProofWithContext, ProofRpcResult,
+    Account, Address, AddressWithTree, BatchAddressUpdateIndexerResponse, Hash, Indexer,
+    IndexerError, MerkleProof, MerkleProofWithContext, NewAddressProofWithContext, ProofRpcResult,
     ProofRpcResultV2,
 };
 
@@ -57,6 +57,18 @@ impl Indexer for SolanaRpcConnection {
             .as_ref()
             .ok_or(IndexerError::NotInitialized)?
             .get_multiple_compressed_account_proofs(hashes)
+            .await?)
+    }
+
+    async fn get_compressed_accounts_by_owner(
+        &self,
+        owner: &Pubkey,
+    ) -> Result<Vec<CompressedAccountWithMerkleContext>, IndexerError> {
+        Ok(self
+            .indexer
+            .as_ref()
+            .ok_or(IndexerError::NotInitialized)?
+            .get_compressed_accounts_by_owner(owner)
             .await?)
     }
 

--- a/sdk-libs/client/tests/rpc_client.rs
+++ b/sdk-libs/client/tests/rpc_client.rs
@@ -170,10 +170,7 @@ async fn test_all_endpoints() {
         .unwrap();
 
     assert!(!accounts.is_empty());
-    assert_eq!(
-        Hash::from_base58(&accounts[0].hash).unwrap(),
-        first_account.hash().unwrap()
-    );
+    assert_eq!(accounts[0].hash, first_account.hash().unwrap());
 
     let result = rpc
         .indexer()
@@ -191,7 +188,7 @@ async fn test_all_endpoints() {
         .await
         .unwrap();
     assert_eq!(account.lamports, lamports);
-    assert_eq!(account.owner, rpc.get_payer().pubkey().to_string());
+    assert_eq!(account.owner, rpc.get_payer().pubkey());
 
     let balance = rpc
         .indexer()

--- a/sdk-libs/program-test/src/program_test/indexer.rs
+++ b/sdk-libs/program-test/src/program_test/indexer.rs
@@ -1,12 +1,12 @@
 use async_trait::async_trait;
 use light_client::indexer::{
-    Address, AddressWithTree, BatchAddressUpdateIndexerResponse, Hash, Indexer, IndexerError,
-    MerkleProof, MerkleProofWithContext, NewAddressProofWithContext, ProofRpcResult,
+    Account, Address, AddressWithTree, BatchAddressUpdateIndexerResponse, Hash, Indexer,
+    IndexerError, MerkleProof, MerkleProofWithContext, NewAddressProofWithContext, ProofRpcResult,
     ProofRpcResultV2,
 };
 use light_compressed_account::{compressed_account::CompressedAccountWithMerkleContext, QueueType};
 use light_sdk::token::TokenDataWithMerkleContext;
-use photon_api::models::{Account, TokenBalanceList};
+use photon_api::models::TokenBalanceList;
 use solana_sdk::pubkey::Pubkey;
 
 use crate::program_test::LightProgramTest;
@@ -59,7 +59,19 @@ impl Indexer for LightProgramTest {
             .get_multiple_compressed_account_proofs(hashes)
             .await?)
     }
-    // TODO: implement get_compressed_accounts_by_owner
+
+    async fn get_compressed_accounts_by_owner(
+        &self,
+        owner: &Pubkey,
+    ) -> Result<Vec<CompressedAccountWithMerkleContext>, IndexerError> {
+        Ok(self
+            .indexer
+            .as_ref()
+            .ok_or(IndexerError::NotInitialized)?
+            .get_compressed_accounts_by_owner(owner)
+            .await?)
+    }
+
     async fn get_compressed_accounts_by_owner_v2(
         &self,
         owner: &Pubkey,

--- a/sdk-libs/sdk/src/instruction/merkle_context.rs
+++ b/sdk-libs/sdk/src/instruction/merkle_context.rs
@@ -63,6 +63,8 @@ pub fn pack_address_merkle_contexts<'a>(
 
 /// Returns a [`PackedAddressMerkleContext`] and fills up `remaining_accounts`
 /// based on the given `merkle_context`.
+/// Packs Merkle tree account first.
+/// Packs queue account second.
 pub fn pack_address_merkle_context(
     address_merkle_context: &AddressMerkleContext,
     remaining_accounts: &mut PackedAccounts,


### PR DESCRIPTION
### Changes:
1. add `get_compressed_accounts_by_owner`
2. remove vector in base58 to fixed sized array conversion
3. implement `Account` type equivalent to photon indexer `AccountV2`
4. use new `Account` type as return type for `get_compressed_account`
