### PR TITLE
chore: unify account and merkle_context

### DIFF
--- a/examples/anchor/counter/tests/test.rs
+++ b/examples/anchor/counter/tests/test.rs
@@ -200,8 +200,8 @@ where
             .unwrap();
 
     let account_meta = CompressedAccountMeta {
-        tree_info: packed_tree_accounts.packed_tree_infos[0],
         address: compressed_account.address.unwrap(),
+        tree_info: packed_tree_accounts.packed_tree_infos[0],
         output_state_tree_index: packed_tree_accounts.output_tree_index,
     };
 

--- a/js/compressed-token/src/types.ts
+++ b/js/compressed-token/src/types.ts
@@ -3,7 +3,7 @@ import BN from 'bn.js';
 import { Buffer } from 'buffer';
 import {
     ValidityProof,
-    PackedMerkleContext,
+    PackedMerkleContextLegacy,
     CompressedCpiContext,
 } from '@lightprotocol/stateless.js';
 import { TokenPoolInfo } from './utils/get-token-pool-infos';
@@ -53,7 +53,7 @@ export type PackedTokenTransferOutputData = {
 export type InputTokenDataWithContext = {
     amount: BN;
     delegateIndex: number | null;
-    merkleContext: PackedMerkleContext;
+    merkleContext: PackedMerkleContextLegacy;
     rootIndex: number;
     lamports: BN | null;
     tlv: Buffer | null;

--- a/js/compressed-token/tests/e2e/delegate.test.ts
+++ b/js/compressed-token/tests/e2e/delegate.test.ts
@@ -176,15 +176,8 @@ describe('delegate', () => {
                 mint,
             })
         ).items;
-        const txId = await approve(
-            rpc,
-            payer,
-            mint,
-            totalAmount,
-            payer,
-            bob.publicKey,
-        );
-        console.log('txid approve ', txId);
+        await approve(rpc, payer, mint, totalAmount, payer, bob.publicKey);
+
         await assertDelegate(
             rpc,
             mint,

--- a/js/compressed-token/tests/e2e/layout.test.ts
+++ b/js/compressed-token/tests/e2e/layout.test.ts
@@ -10,7 +10,7 @@ import BN from 'bn.js';
 import {
     bn,
     InputTokenDataWithContext,
-    PackedMerkleContext,
+    PackedMerkleContextLegacy,
     ValidityProof,
     COMPRESSED_TOKEN_PROGRAM_ID,
     defaultStaticAccountsStruct,
@@ -165,7 +165,7 @@ describe('layout', () => {
                                 queuePubkeyIndex: 1,
                                 leafIndex: 10,
                                 proveByIndex: false,
-                            } as PackedMerkleContext,
+                            } as PackedMerkleContextLegacy,
                             rootIndex: 11,
                             lamports: null,
                             tlv: null,

--- a/js/compressed-token/tests/e2e/mint-to.test.ts
+++ b/js/compressed-token/tests/e2e/mint-to.test.ts
@@ -102,10 +102,6 @@ describe('mintTo', () => {
     }, 80_000);
 
     it('should mint to bob', async () => {
-        console.log('statetreeinfo', stateTreeInfo);
-        console.log('tokenpoolinfo', tokenPoolInfo);
-        console.log('all state tree infos', await rpc.getStateTreeInfos());
-
         const amount = bn(1000);
         const txId = await mintTo(
             rpc,
@@ -117,7 +113,6 @@ describe('mintTo', () => {
             stateTreeInfo,
             tokenPoolInfo,
         );
-        console.log('txId', txId);
 
         await assertMintTo(rpc, mint, amount, bob.publicKey);
 
@@ -172,7 +167,7 @@ describe('mintTo', () => {
             stateTreeInfo,
             tokenPoolInfo,
         );
-        console.log('txId 10 recipients', tx);
+
         // Uneven amounts
         await expect(
             mintTo(
@@ -215,6 +210,5 @@ describe('mintTo', () => {
             [lookupTableAccount],
         );
         const txId = await sendAndConfirmTx(rpc, tx);
-        console.log('txId 22 recipients', txId);
     });
 });

--- a/js/stateless.js/src/programs/system/program.ts
+++ b/js/stateless.js/src/programs/system/program.ts
@@ -6,13 +6,13 @@ import {
 } from '@solana/web3.js';
 import { Buffer } from 'buffer';
 import {
-    CompressedAccount,
     CompressedAccountWithMerkleContext,
     ValidityProof,
     InstructionDataInvoke,
     TreeInfo,
     bn,
-    createCompressedAccount,
+    createCompressedAccountLegacy,
+    CompressedAccountLegacy,
 } from '../../state';
 import {
     packCompressedAccounts,
@@ -199,7 +199,7 @@ export class LightSystemProgram {
         inputCompressedAccounts: CompressedAccountWithMerkleContext[],
         toAddress: PublicKey,
         lamports: number | BN,
-    ): CompressedAccount[] {
+    ): CompressedAccountLegacy[] {
         lamports = bn(lamports);
         const inputLamports = sumUpLamports(inputCompressedAccounts);
         const changeLamports = inputLamports.sub(lamports);
@@ -207,17 +207,17 @@ export class LightSystemProgram {
         validateSufficientBalance(changeLamports);
 
         if (changeLamports.eq(bn(0))) {
-            return [createCompressedAccount(toAddress, lamports)];
+            return [createCompressedAccountLegacy(toAddress, lamports)];
         }
 
         validateSameOwner(inputCompressedAccounts);
 
-        const outputCompressedAccounts: CompressedAccount[] = [
-            createCompressedAccount(
+        const outputCompressedAccounts: CompressedAccountLegacy[] = [
+            createCompressedAccountLegacy(
                 inputCompressedAccounts[0].owner,
                 changeLamports,
             ),
-            createCompressedAccount(toAddress, lamports),
+            createCompressedAccountLegacy(toAddress, lamports),
         ];
         return outputCompressedAccounts;
     }
@@ -225,7 +225,7 @@ export class LightSystemProgram {
     static createDecompressOutputState(
         inputCompressedAccounts: CompressedAccountWithMerkleContext[],
         lamports: number | BN,
-    ): CompressedAccount[] {
+    ): CompressedAccountLegacy[] {
         lamports = bn(lamports);
         const inputLamports = sumUpLamports(inputCompressedAccounts);
         const changeLamports = inputLamports.sub(lamports);
@@ -239,8 +239,8 @@ export class LightSystemProgram {
 
         validateSameOwner(inputCompressedAccounts);
 
-        const outputCompressedAccounts: CompressedAccount[] = [
-            createCompressedAccount(
+        const outputCompressedAccounts: CompressedAccountLegacy[] = [
+            createCompressedAccountLegacy(
                 inputCompressedAccounts[0].owner,
                 changeLamports,
             ),
@@ -256,7 +256,7 @@ export class LightSystemProgram {
         owner: PublicKey,
         lamports?: BN | number,
         inputCompressedAccounts?: CompressedAccountWithMerkleContext[],
-    ): CompressedAccount[] {
+    ): CompressedAccountLegacy[] {
         lamports = bn(lamports ?? 0);
         const inputLamports = sumUpLamports(inputCompressedAccounts ?? []);
         const changeLamports = inputLamports.sub(lamports);
@@ -265,17 +265,22 @@ export class LightSystemProgram {
 
         if (changeLamports.eq(bn(0)) || !inputCompressedAccounts) {
             return [
-                createCompressedAccount(owner, lamports, undefined, address),
+                createCompressedAccountLegacy(
+                    owner,
+                    lamports,
+                    undefined,
+                    address,
+                ),
             ];
         }
 
         validateSameOwner(inputCompressedAccounts);
-        const outputCompressedAccounts: CompressedAccount[] = [
-            createCompressedAccount(
+        const outputCompressedAccounts: CompressedAccountLegacy[] = [
+            createCompressedAccountLegacy(
                 inputCompressedAccounts[0].owner,
                 changeLamports,
             ),
-            createCompressedAccount(owner, lamports, undefined, address),
+            createCompressedAccountLegacy(owner, lamports, undefined, address),
         ];
         return outputCompressedAccounts;
     }
@@ -422,7 +427,7 @@ export class LightSystemProgram {
         /// Create output state
         lamports = bn(lamports);
 
-        const outputCompressedAccount = createCompressedAccount(
+        const outputCompressedAccount = createCompressedAccountLegacy(
             toAddress,
             lamports,
         );

--- a/js/stateless.js/src/rpc.ts
+++ b/js/stateless.js/src/rpc.ts
@@ -58,8 +58,8 @@ import {
     bn,
     CompressedAccountWithMerkleContext,
     encodeBN254toBase58,
-    createCompressedAccountWithMerkleContext,
-    createMerkleContext,
+    createCompressedAccountWithMerkleContextLegacy,
+    createMerkleContextLegacy,
     TokenData,
     ValidityProof,
     TreeType,
@@ -171,8 +171,8 @@ async function getCompressedTokenAccountsByOwnerOrDelegate(
         );
 
         const compressedAccount: CompressedAccountWithMerkleContext =
-            createCompressedAccountWithMerkleContext(
-                createMerkleContext(
+            createCompressedAccountWithMerkleContextLegacy(
+                createMerkleContextLegacy(
                     stateTreeInfo,
                     _account.hash,
                     _account.leafIndex,
@@ -575,8 +575,8 @@ function buildCompressedAccountWithMaybeTokenData(
         accountStructWithOptionalTokenData.optionalTokenData;
 
     const compressedAccount: CompressedAccountWithMerkleContext =
-        createCompressedAccountWithMerkleContext(
-            createMerkleContext(
+        createCompressedAccountWithMerkleContextLegacy(
+            createMerkleContextLegacy(
                 compressedAccountResult.treeInfo,
                 compressedAccountResult.hash.toArray('be', 32),
                 compressedAccountResult.leafIndex,
@@ -754,8 +754,8 @@ export class Rpc extends Connection implements CompressionApiInterface {
         );
         const item = res.result.value;
 
-        return createCompressedAccountWithMerkleContext(
-            createMerkleContext(stateTreeInfo, item.hash, item.leafIndex),
+        return createCompressedAccountWithMerkleContextLegacy(
+            createMerkleContextLegacy(stateTreeInfo, item.hash, item.leafIndex),
             item.owner,
             bn(item.lamports),
             item.data ? parseAccountData(item.data) : undefined,
@@ -925,8 +925,8 @@ export class Rpc extends Connection implements CompressionApiInterface {
                 activeStateTreeInfo,
                 tree,
             );
-            const account = createCompressedAccountWithMerkleContext(
-                createMerkleContext(
+            const account = createCompressedAccountWithMerkleContextLegacy(
+                createMerkleContextLegacy(
                     stateTreeInfo,
                     bn(item.hash.toArray('be', 32)),
                     item.leafIndex,
@@ -1059,8 +1059,8 @@ export class Rpc extends Connection implements CompressionApiInterface {
                 activeStateTreeInfo,
                 featureFlags.isV2() ? item.merkleContext.tree : item.tree,
             );
-            const account = createCompressedAccountWithMerkleContext(
-                createMerkleContext(
+            const account = createCompressedAccountWithMerkleContextLegacy(
+                createMerkleContextLegacy(
                     stateTreeInfo,
                     bn(item.hash.toArray('be', 32)),
                     item.leafIndex,
@@ -1337,8 +1337,8 @@ export class Rpc extends Connection implements CompressionApiInterface {
                     activeStateTreeInfo,
                     item.account.tree,
                 );
-                const account = createCompressedAccountWithMerkleContext(
-                    createMerkleContext(
+                const account = createCompressedAccountWithMerkleContextLegacy(
+                    createMerkleContextLegacy(
                         stateTreeInfo,
                         bn(item.account.hash.toArray('be', 32)),
                         item.account.leafIndex,
@@ -1361,8 +1361,8 @@ export class Rpc extends Connection implements CompressionApiInterface {
                     activeStateTreeInfo,
                     item.account.tree,
                 );
-                const account = createCompressedAccountWithMerkleContext(
-                    createMerkleContext(
+                const account = createCompressedAccountWithMerkleContextLegacy(
+                    createMerkleContextLegacy(
                         stateTreeInfo,
                         bn(item.account.hash.toArray('be', 32)),
                         item.account.leafIndex,

--- a/js/stateless.js/src/state/compressed-account.ts
+++ b/js/stateless.js/src/state/compressed-account.ts
@@ -1,21 +1,32 @@
 import { PublicKey } from '@solana/web3.js';
 import {
-    CompressedAccount,
     CompressedAccountData,
     CompressedAccountLegacy,
+    PackedMerkleContextLegacy,
     TreeInfo,
 } from './types';
 import BN from 'bn.js';
 import { BN254 } from './BN254';
-import { bn } from './bn';
 
-// @deprecated use {@link CompressedAccount} instead
-// export type CompressedAccountWithMerkleContext = CompressedAccount &
-//     MerkleContext & {
-//         readOnly: boolean;
-//     };
+/**
+ * @deprecated use {@link CompressedAccount} instead
+ */
+export type CompressedAccountWithMerkleContext = CompressedAccount &
+    MerkleContext & {
+        readOnly: boolean;
+    };
 
-export type CompressedAccountWithMerkleContext = MerkleContext & {
+/**
+ * @deprecated use {@link CompressedAccount} instead
+ */
+export type CompressedAccountWithMerkleContextLegacy = CompressedAccount &
+    MerkleContext;
+
+/**
+ * Compressed account + metadata about the state tree in which the account is
+ * stored.
+ */
+export type CompressedAccount = {
     /**
      * Public key of program or user owning the account.
      */
@@ -32,18 +43,17 @@ export type CompressedAccountWithMerkleContext = MerkleContext & {
      * Optional data attached to the account.
      */
     data: CompressedAccountData | null;
-} & {
-    readOnly: boolean;
-};
-
-// @deprecated use {@link CompressedAccount} instead
-// export type CompressedAccountWithMerkleContextLegacy = CompressedAccount &
-//     MerkleContextLegacy;
+} & MerkleContext & {
+        /**
+         * Read only.
+         */
+        readOnly: boolean;
+    };
 
 /**
  * @deprecated use {@link MerkleContext} instead.
  *
- * Legacy MerkleContext
+ * Legacy MerkleContext.
  */
 export type MerkleContextLegacy = {
     /**
@@ -104,31 +114,148 @@ export type MerkleContextWithMerkleProof = MerkleContext & {
     root: BN254;
 };
 
-export const createCompressedAccount = (
+/**
+ * Packed compressed account and state tree info.
+ */
+export type PackedStateTreeInfo = {
+    /**
+     * Recent valid root index.
+     */
+    rootIndex: number;
+    /**
+     * Whether the account can be proven by index or by merkle proof
+     */
+    proveByIndex: boolean;
+    /**
+     * Index of the merkle tree in which the account is stored.
+     */
+    merkleTreePubkeyIndex: number;
+    /**
+     * Index of the queue in which the account is stored.
+     */
+    queuePubkeyIndex: number;
+    /**
+     * Index of the leaf in the state tree.
+     */
+    leafIndex: number;
+};
+
+/**
+ * Packed tree info for a new program-derived address (PDA).
+ */
+export type PackedAddressTreeInfo = {
+    /**
+     * Index of the merkle tree in which the account is stored.
+     */
+    addressMerkleTreePubkeyIndex: number;
+    /**
+     * Index of the queue in which the account is stored.
+     */
+    addressQueuePubkeyIndex: number;
+    /**
+     * Recent valid root index.
+     */
+    rootIndex: number;
+};
+
+/**
+ * Compressed account meta in instruction.
+ *
+ */
+export type CompressedAccountMeta = {
+    /**
+     * Packed Tree info.
+     */
+    treeInfo: PackedStateTreeInfo;
+    /**
+     * Address.
+     */
+    address: number[] | null;
+    /**
+     * Lamports.
+     */
+    lamports: BN | null;
+    /**
+     * index of state tree in which the new account state is stored.
+     */
+    outputStateTreeIndex: number;
+};
+
+/**
+ * Create an output compressed account meta for a new account.
+ * Client-side only.
+ */
+export const createCompressedAccountMeta = (
+    treeInfo: PackedStateTreeInfo,
+    outputStateTreeIndex: number,
+    address?: number[],
+    lamports?: BN,
+): CompressedAccountMeta => ({
+    treeInfo,
+    outputStateTreeIndex,
+    address: address ?? null,
+    lamports: lamports ?? null,
+});
+
+/**
+ * @deprecated Use {@link PackedStateTreeInfo} instead.
+ * Packed compressed account with merkle context.
+ */
+export interface PackedCompressedAccountWithMerkleContext {
+    /**
+     * Compressed account.
+     */
+    compressedAccount: CompressedAccountLegacy;
+    /**
+     * Merkle context.
+     */
+    merkleContext: PackedMerkleContextLegacy;
+    /**
+     * Root index.
+     */
+    rootIndex: number;
+    /**
+     * Read only.
+     */
+    readOnly: boolean;
+}
+
+/**
+ * @deprecated use {@link createCompressedAccountMeta} instead.
+ */
+export const createCompressedAccountLegacy = (
     owner: PublicKey,
     lamports?: BN,
     data?: CompressedAccountData,
     address?: number[],
-): CompressedAccount => ({
+): CompressedAccountLegacy => ({
     owner,
-    lamports: lamports ?? bn(0),
+    lamports: lamports ?? new BN(0),
     address: address ?? null,
     data: data ?? null,
 });
-
-export const createCompressedAccountWithMerkleContext = (
+/**
+ * @deprecated.
+ */
+export const createCompressedAccountWithMerkleContextLegacy = (
     merkleContext: MerkleContext,
     owner: PublicKey,
     lamports?: BN,
     data?: CompressedAccountData,
     address?: number[],
 ): CompressedAccountWithMerkleContext => ({
-    ...createCompressedAccount(owner, lamports, data, address),
     ...merkleContext,
+    owner,
+    lamports: lamports ?? new BN(0),
+    address: address ?? null,
+    data: data ?? null,
     readOnly: false,
 });
 
-export const createMerkleContext = (
+/**
+ * @deprecated use {@link createCompressedAccountMeta} instead.
+ */
+export const createMerkleContextLegacy = (
     treeInfo: TreeInfo,
     hash: BN254,
     leafIndex: number,

--- a/js/stateless.js/src/state/types.ts
+++ b/js/stateless.js/src/state/types.ts
@@ -2,6 +2,7 @@ import BN from 'bn.js';
 import { PublicKey } from '@solana/web3.js';
 import { Buffer } from 'buffer';
 import { NewAddressParamsPacked } from '../utils';
+import { PackedCompressedAccountWithMerkleContext } from './compressed-account';
 
 export enum TreeType {
     /**
@@ -114,31 +115,9 @@ export type AddressTreeInfo = Omit<
 };
 
 /**
- * Packed compressed account with merkle context.
- */
-export interface PackedCompressedAccountWithMerkleContext {
-    /**
-     * Compressed account.
-     */
-    compressedAccount: CompressedAccount;
-    /**
-     * Merkle context.
-     */
-    merkleContext: PackedMerkleContext;
-    /**
-     * Root index.
-     */
-    rootIndex: number;
-    /**
-     * Read only.
-     */
-    readOnly: boolean;
-}
-
-/**
  * Packed merkle context.
  */
-export interface PackedMerkleContext {
+export interface PackedMerkleContextLegacy {
     /**
      * Merkle tree pubkey index.
      */
@@ -155,29 +134,6 @@ export interface PackedMerkleContext {
      * Whether to prove by index or validity proof.
      */
     proveByIndex: boolean;
-}
-
-/**
- * Describe the generic compressed account details applicable to every
- * compressed account.
- * */
-export interface CompressedAccount {
-    /**
-     * Public key of program or user owning the account.
-     */
-    owner: PublicKey;
-    /**
-     * Lamports attached to the account.
-     */
-    lamports: BN;
-    /**
-     * Optional unique account ID that is persistent across transactions.
-     */
-    address: number[] | null;
-    /**
-     * Optional data attached to the account.
-     */
-    data: CompressedAccountData | null;
 }
 
 /**
@@ -206,13 +162,36 @@ export interface CompressedAccountLegacy {
     data: CompressedAccountData | null;
 }
 /**
+ * @deprecated Use {@link CompressedAccountMeta} instead.
+ *
  * Describe the generic compressed account details applicable to every
  * compressed account.
  */
 export interface OutputCompressedAccountWithPackedContext {
-    compressedAccount: CompressedAccount;
+    compressedAccount: CompressedAccountLegacy;
     merkleTreeIndex: number;
 }
+
+/**
+ * Compressed account-related proof metadata.
+ */
+export type AccountProofInput = {
+    hash: BN;
+    treeInfo: TreeInfo;
+    leafIndex: number;
+    rootIndex: number;
+    proveByIndex: boolean;
+};
+
+/**
+ * New address proof metadata.
+ */
+export type NewAddressProofInput = {
+    treeInfo: TreeInfo;
+    address: number[];
+    rootIndex: number;
+    root: BN;
+};
 
 /**
  * Describes compressed account data.
@@ -445,7 +424,7 @@ export interface InputTokenDataWithContext {
     /**
      * Merkle context.
      */
-    merkleContext: PackedMerkleContext;
+    merkleContext: PackedMerkleContextLegacy;
     /**
      * Root index.
      */

--- a/js/stateless.js/src/test-helpers/test-rpc/get-compressed-accounts.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/get-compressed-accounts.ts
@@ -6,7 +6,7 @@ import {
     CompressedAccountWithMerkleContext,
     bn,
     MerkleContext,
-    createCompressedAccountWithMerkleContext,
+    createCompressedAccountWithMerkleContextLegacy,
     TreeType,
 } from '../../state';
 import { getStateTreeInfoByPubkey } from '../../utils/get-state-tree-infos';
@@ -67,7 +67,7 @@ async function getCompressedAccountsForTest(rpc: Rpc) {
                 proveByIndex: treeInfo.treeType === TreeType.StateV2,
             };
             const withCtx: CompressedAccountWithMerkleContext =
-                createCompressedAccountWithMerkleContext(
+                createCompressedAccountWithMerkleContextLegacy(
                     merkleContext,
                     account.compressedAccount.owner,
                     account.compressedAccount.lamports,

--- a/js/stateless.js/src/test-helpers/test-rpc/get-compressed-token-accounts.ts
+++ b/js/stateless.js/src/test-helpers/test-rpc/get-compressed-token-accounts.ts
@@ -6,12 +6,12 @@ import { Rpc } from '../../rpc';
 import { getStateTreeInfoByPubkey } from '../../utils/get-state-tree-infos';
 import { ParsedTokenAccount, WithCursor } from '../../rpc-interface';
 import {
-    CompressedAccount,
     PublicTransactionEvent,
     MerkleContext,
-    createCompressedAccountWithMerkleContext,
+    createCompressedAccountWithMerkleContextLegacy,
     bn,
     TreeType,
+    CompressedAccountLegacy,
 } from '../../state';
 import {
     struct,
@@ -53,7 +53,7 @@ export type EventWithParsedTokenTlvData = {
  * @returns The parsed token data
  */
 export function parseTokenLayoutWithIdl(
-    compressedAccount: CompressedAccount,
+    compressedAccount: CompressedAccountLegacy,
     programId: PublicKey = COMPRESSED_TOKEN_PROGRAM_ID,
 ): TokenData | null {
     if (compressedAccount.data === null) return null;
@@ -123,13 +123,14 @@ async function parseEventWithTokenTlvData(
                 compressedAccount.compressedAccount,
             );
             if (!parsedData) throw new Error('Invalid token data');
-            const withMerkleContext = createCompressedAccountWithMerkleContext(
-                merkleContext,
-                compressedAccount.compressedAccount.owner,
-                compressedAccount.compressedAccount.lamports,
-                compressedAccount.compressedAccount.data,
-                compressedAccount.compressedAccount.address ?? undefined,
-            );
+            const withMerkleContext =
+                createCompressedAccountWithMerkleContextLegacy(
+                    merkleContext,
+                    compressedAccount.compressedAccount.owner,
+                    compressedAccount.compressedAccount.lamports,
+                    compressedAccount.compressedAccount.data,
+                    compressedAccount.compressedAccount.address ?? undefined,
+                );
             return {
                 compressedAccount: withMerkleContext,
                 parsed: parsedData,

--- a/js/stateless.js/src/utils/conversion.ts
+++ b/js/stateless.js/src/utils/conversion.ts
@@ -8,10 +8,10 @@ import camelcaseKeys from 'camelcase-keys';
 import {
     InstructionDataInvoke,
     PackedCompressedAccountWithMerkleContext,
-    CompressedAccount,
+    CompressedAccountLegacy,
     OutputCompressedAccountWithPackedContext,
-    PackedMerkleContext,
-} from '../state/types';
+    PackedMerkleContextLegacy,
+} from '../state';
 import { NewAddressParamsPacked } from './address';
 
 export function byteArrayToKeypair(byteArray: number[]): Keypair {
@@ -129,14 +129,14 @@ export function convertInvokeCpiWithReadOnlyToInvoke(
     // Convert input_compressed_accounts to PackedCompressedAccountWithMerkleContext format
     const inputCompressedAccountsWithMerkleContext: PackedCompressedAccountWithMerkleContext[] =
         data.input_compressed_accounts.map((account: any) => {
-            const compressedAccount: CompressedAccount = {
+            const compressedAccount: CompressedAccountLegacy = {
                 owner: new PublicKey(Buffer.alloc(32)),
                 lamports: account.lamports,
                 address: account.address,
                 data: null,
             };
 
-            const merkleContext: PackedMerkleContext = {
+            const merkleContext: PackedMerkleContextLegacy = {
                 merkleTreePubkeyIndex:
                     account.packedMerkleContext.merkle_tree_pubkey_index,
                 queuePubkeyIndex:
@@ -149,6 +149,7 @@ export function convertInvokeCpiWithReadOnlyToInvoke(
                 compressedAccount,
                 merkleContext,
                 rootIndex: account.root_index,
+                // TODO: confirm this is valid.
                 readOnly: false,
             };
         });

--- a/js/stateless.js/src/utils/send-and-confirm.ts
+++ b/js/stateless.js/src/utils/send-and-confirm.ts
@@ -1,6 +1,5 @@
 import {
     VersionedTransaction,
-    TransactionConfirmationStrategy,
     SignatureResult,
     RpcResponseAndContext,
     Signer,
@@ -10,11 +9,8 @@ import {
     TransactionSignature,
     PublicKey,
     AddressLookupTableAccount,
-    SignatureStatus,
-    SignatureStatusConfig,
 } from '@solana/web3.js';
 import { Rpc } from '../rpc';
-import { sleep } from './sleep';
 import { isLocalTest } from '../constants';
 
 /**

--- a/js/stateless.js/src/utils/validation.ts
+++ b/js/stateless.js/src/utils/validation.ts
@@ -1,6 +1,6 @@
 import BN from 'bn.js';
 import {
-    CompressedAccount,
+    CompressedAccountLegacy,
     CompressedAccountWithMerkleContext,
     bn,
 } from '../state';
@@ -13,7 +13,7 @@ export const validateSufficientBalance = (balance: BN) => {
 
 export const validateSameOwner = (
     compressedAccounts:
-        | CompressedAccount[]
+        | CompressedAccountLegacy[]
         | CompressedAccountWithMerkleContext[],
 ) => {
     if (compressedAccounts.length === 0) {

--- a/js/stateless.js/tests/unit/state/compressed-account.test.ts
+++ b/js/stateless.js/tests/unit/state/compressed-account.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
-    createCompressedAccount,
-    createCompressedAccountWithMerkleContext,
-    createMerkleContext,
+    createCompressedAccountLegacy,
+    createCompressedAccountWithMerkleContextLegacy,
+    createMerkleContextLegacy,
 } from '../../../src/state/compressed-account';
 import { PublicKey } from '@solana/web3.js';
 import { bn } from '../../../src/state';
@@ -11,7 +11,7 @@ import { TreeType } from '../../../src/state';
 describe('createCompressedAccount function', () => {
     it('should create a compressed account with default values', () => {
         const owner = PublicKey.unique();
-        const account = createCompressedAccount(owner);
+        const account = createCompressedAccountLegacy(owner);
         expect(account).toEqual({
             owner,
             lamports: bn(0),
@@ -29,7 +29,12 @@ describe('createCompressedAccount function', () => {
             dataHash: [0],
         };
         const address = Array.from(PublicKey.unique().toBytes());
-        const account = createCompressedAccount(owner, lamports, data, address);
+        const account = createCompressedAccountLegacy(
+            owner,
+            lamports,
+            data,
+            address,
+        );
         expect(account).toEqual({
             owner,
             lamports,
@@ -39,14 +44,14 @@ describe('createCompressedAccount function', () => {
     });
 });
 
-describe('createCompressedAccountWithMerkleContext function', () => {
+describe('createCompressedAccountWithMerkleContextLegacy function', () => {
     it('should create a compressed account with merkle context', () => {
         const owner = PublicKey.unique();
         const merkleTree = PublicKey.unique();
         const nullifierQueue = PublicKey.unique();
         const hash = new Array(32).fill(1);
         const leafIndex = 0;
-        const merkleContext = createMerkleContext(
+        const merkleContext = createMerkleContextLegacy(
             {
                 tree: merkleTree,
                 queue: nullifierQueue,
@@ -57,7 +62,10 @@ describe('createCompressedAccountWithMerkleContext function', () => {
             leafIndex,
         );
         const accountWithMerkleContext =
-            createCompressedAccountWithMerkleContext(merkleContext, owner);
+            createCompressedAccountWithMerkleContextLegacy(
+                merkleContext,
+                owner,
+            );
         expect(accountWithMerkleContext).toEqual({
             owner,
             lamports: bn(0),
@@ -84,7 +92,7 @@ describe('createMerkleContext function', () => {
         const hash = new Array(32).fill(1);
 
         const leafIndex = 0;
-        const merkleContext = createMerkleContext(
+        const merkleContext = createMerkleContextLegacy(
             {
                 tree: merkleTree,
                 queue: nullifierQueue,

--- a/js/stateless.js/tests/unit/utils/conversion.test.ts
+++ b/js/stateless.js/tests/unit/utils/conversion.test.ts
@@ -662,6 +662,9 @@ describe('convertInvokeCpiWithReadOnlyToInvoke', () => {
         // First account (from input_compressed_accounts)
         const firstAccount = result.inputCompressedAccountsWithMerkleContext[0];
         expect(firstAccount.rootIndex).toBe(789);
+        console.log('result', result);
+        console.log('firstAccount', firstAccount);
+
         expect(firstAccount.readOnly).toBe(false);
         expect(firstAccount.compressedAccount.lamports).toEqual(new BN(2000));
         expect(firstAccount.merkleContext.merkleTreePubkeyIndex).toBe(8);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,7 +110,7 @@ importers:
         version: link:../programs
       '@oclif/test':
         specifier: 2.3.9
-        version: 2.3.9(@types/node@20.19.0)(typescript@5.8.3)
+        version: 2.3.9(@types/node@20.17.57)(typescript@5.5.3)
       '@solana/spl-token':
         specifier: ^0.3.11
         version: 0.3.11(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
@@ -128,7 +128,7 @@ importers:
         version: 10.0.7
       '@types/node':
         specifier: ^20.12.8
-        version: 20.19.0
+        version: 20.17.57
       '@types/tar':
         specifier: ^6.1.12
         version: 6.1.12
@@ -137,10 +137,10 @@ importers:
         version: 3.0.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.6.0
-        version: 7.18.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3)
+        version: 7.18.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)
       '@typescript-eslint/parser':
         specifier: ^7.6.0
-        version: 7.13.1(eslint@8.57.0)(typescript@5.8.3)
+        version: 7.13.1(eslint@8.57.0)(typescript@5.5.3)
       chai:
         specifier: ^4.4.1
         version: 4.5.0
@@ -152,7 +152,7 @@ importers:
         version: 5.1.1(eslint@8.57.0)
       eslint-config-oclif-typescript:
         specifier: 3.1.4
-        version: 3.1.4(eslint@8.57.0)(typescript@5.8.3)
+        version: 3.1.4(eslint@8.57.0)(typescript@5.5.3)
       eslint-config-prettier:
         specifier: 9.1.0
         version: 9.1.0(eslint@8.57.0)
@@ -173,13 +173,13 @@ importers:
         version: 10.1.0(mocha@10.8.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.19.0)(typescript@5.8.3)
+        version: 10.9.2(@types/node@20.17.57)(typescript@5.5.3)
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
       typescript:
         specifier: ^5.5.3
-        version: 5.8.3
+        version: 5.5.3
 
   examples/anchor: {}
 
@@ -223,14 +223,14 @@ importers:
         version: 19.1.0(react@19.1.0)
     devDependencies:
       '@types/node':
-        specifier: ^22.15.30
-        version: 22.15.30
+        specifier: ^22.15.29
+        version: 22.15.29
       '@types/react':
-        specifier: ^19.1.6
-        version: 19.1.6
+        specifier: ^19.1.4
+        version: 19.1.4
       '@types/react-dom':
         specifier: ^19.1.4
-        version: 19.1.4(@types/react@19.1.6)
+        version: 19.1.4(@types/react@19.1.4)
       eslint:
         specifier: 9.28.0
         version: 9.28.0
@@ -254,11 +254,11 @@ importers:
         version: 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     devDependencies:
       '@types/node':
-        specifier: ^22.15.30
-        version: 22.15.30
+        specifier: ^22.15.29
+        version: 22.15.29
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.7.2
+        version: 5.7.2
 
   forester:
     devDependencies:
@@ -316,10 +316,10 @@ importers:
         version: 0.4.4(rollup@4.21.3)
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
-        version: 11.1.6(rollup@4.21.3)(tslib@2.7.0)(typescript@5.8.3)
+        version: 11.1.6(rollup@4.21.3)(tslib@2.7.0)(typescript@5.6.2)
       '@solana/spl-token':
         specifier: 0.4.8
-        version: 0.4.8(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+        version: 0.4.8(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)(utf-8-validate@5.0.10)
       '@solana/web3.js':
         specifier: 1.98.0
         version: 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -328,13 +328,13 @@ importers:
         version: 5.1.5
       '@types/node':
         specifier: ^22.5.5
-        version: 22.15.30
+        version: 22.15.29
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.13.1
-        version: 7.18.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3)
+        version: 7.18.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)
       '@typescript-eslint/parser':
         specifier: ^7.13.1
-        version: 7.13.1(eslint@8.57.0)(typescript@5.8.3)
+        version: 7.13.1(eslint@8.57.0)(typescript@5.6.2)
       add:
         specifier: ^2.0.6
         version: 2.0.6
@@ -346,7 +346,7 @@ importers:
         version: 8.57.0
       eslint-plugin-import:
         specifier: ^2.30.0
-        version: 2.30.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)
+        version: 2.30.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)
       eslint-plugin-n:
         specifier: ^17.10.2
         version: 17.10.2(eslint@8.57.0)
@@ -355,7 +355,7 @@ importers:
         version: 7.1.0(eslint@8.57.0)
       eslint-plugin-vitest:
         specifier: ^0.5.4
-        version: 0.5.4(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3)(vitest@2.1.1(@types/node@22.15.30)(terser@5.42.0))
+        version: 0.5.4(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)(vitest@2.1.1(@types/node@22.15.29)(terser@5.41.0))
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
@@ -370,7 +370,7 @@ importers:
         version: 3.5.0
       rollup-plugin-dts:
         specifier: ^6.1.1
-        version: 6.1.1(rollup@4.21.3)(typescript@5.8.3)
+        version: 6.1.1(rollup@4.21.3)(typescript@5.6.2)
       rollup-plugin-polyfill-node:
         specifier: ^0.13.0
         version: 0.13.0(rollup@4.21.3)
@@ -379,16 +379,16 @@ importers:
         version: 5.12.0(rollup@4.21.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.15.30)(typescript@5.8.3)
+        version: 10.9.2(@types/node@22.15.29)(typescript@5.6.2)
       tslib:
         specifier: ^2.7.0
         version: 2.7.0
       typescript:
         specifier: ^5.6.2
-        version: 5.8.3
+        version: 5.6.2
       vitest:
         specifier: ^2.1.1
-        version: 2.1.1(@types/node@22.15.30)(terser@5.42.0)
+        version: 2.1.1(@types/node@22.15.29)(terser@5.41.0)
 
   js/stateless.js:
     dependencies:
@@ -455,7 +455,7 @@ importers:
         version: 0.4.4(rollup@4.21.3)
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
-        version: 11.1.6(rollup@4.21.3)(tslib@2.7.0)(typescript@5.8.3)
+        version: 11.1.6(rollup@4.21.3)(tslib@2.7.0)(typescript@5.6.2)
       '@solana/web3.js':
         specifier: 1.98.0
         version: 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -464,13 +464,13 @@ importers:
         version: 5.1.5
       '@types/node':
         specifier: ^22.5.5
-        version: 22.15.30
+        version: 22.15.29
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.13.1
-        version: 7.18.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3)
+        version: 7.18.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)
       '@typescript-eslint/parser':
         specifier: ^7.13.1
-        version: 7.13.1(eslint@8.57.0)(typescript@5.8.3)
+        version: 7.13.1(eslint@8.57.0)(typescript@5.6.2)
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -482,7 +482,7 @@ importers:
         version: 7.1.0(eslint@8.57.0)
       eslint-plugin-vitest:
         specifier: ^0.5.4
-        version: 0.5.4(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3)(vitest@2.1.1(@types/node@22.15.30)(terser@5.42.0))
+        version: 0.5.4(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)(vitest@2.1.1(@types/node@22.15.29)(terser@5.41.0))
       http-server:
         specifier: ^14.1.1
         version: 14.1.1
@@ -500,13 +500,13 @@ importers:
         version: 4.21.3
       rollup-plugin-dts:
         specifier: ^6.1.1
-        version: 6.1.1(rollup@4.21.3)(typescript@5.8.3)
+        version: 6.1.1(rollup@4.21.3)(typescript@5.6.2)
       rollup-plugin-polyfill-node:
         specifier: ^0.13.0
         version: 0.13.0(rollup@4.21.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.15.30)(typescript@5.8.3)
+        version: 10.9.2(@types/node@22.15.29)(typescript@5.6.2)
       tslib:
         specifier: ^2.7.0
         version: 2.7.0
@@ -515,10 +515,10 @@ importers:
         version: 1.0.3
       typescript:
         specifier: ^5.6.2
-        version: 5.8.3
+        version: 5.6.2
       vitest:
         specifier: ^2.1.1
-        version: 2.1.1(@types/node@22.15.30)(terser@5.42.0)
+        version: 2.1.1(@types/node@22.15.29)(terser@5.41.0)
 
   program-tests: {}
 
@@ -551,10 +551,10 @@ importers:
         version: 3.4.2
       ts-mocha:
         specifier: ^11.1.0
-        version: 11.1.0(mocha@11.5.0)(ts-node@10.9.2(@types/node@22.15.30)(typescript@5.8.3))(tsconfig-paths@4.2.0)
+        version: 11.1.0(mocha@11.5.0)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.7.2))(tsconfig-paths@4.2.0)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.7.2
+        version: 5.7.2
 
   programs: {}
 
@@ -3068,11 +3068,11 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@20.19.0':
-    resolution: {integrity: sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==}
+  '@types/node@20.17.57':
+    resolution: {integrity: sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==}
 
-  '@types/node@22.15.30':
-    resolution: {integrity: sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==}
+  '@types/node@22.15.29':
+    resolution: {integrity: sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==}
 
   '@types/node@22.5.5':
     resolution: {integrity: sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==}
@@ -3085,8 +3085,8 @@ packages:
     peerDependencies:
       '@types/react': ^19.0.0
 
-  '@types/react@19.1.6':
-    resolution: {integrity: sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==}
+  '@types/react@19.1.4':
+    resolution: {integrity: sha512-EB1yiiYdvySuIITtD5lhW4yPyJ31RkJkkDw794LaQYrxCSaQV/47y5o1FMC4zF9ZyjUjzJMZwbovEnT5yHTW6g==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -3505,11 +3505,6 @@ packages:
 
   acorn@8.14.1:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -4206,8 +4201,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  core-js-compat@3.43.0:
-    resolution: {integrity: sha512-2GML2ZsCc5LR7hZYz4AXmjQw8zuy2T//2QntwdnpuYI7jteT6GVYJL7F6C2C57R7gSYrcqVW3lAALefdbhBLDA==}
+  core-js-compat@3.42.0:
+    resolution: {integrity: sha512-bQasjMfyDGyaeWKBIu33lHh9qlSR0MFE/Nmc6nMjf/iU9b3rSMdAYz1Baxrv4lPdGUsTqZudHA4jIGSJy0SWZQ==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -4510,8 +4505,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.5.166:
-    resolution: {integrity: sha512-QPWqHL0BglzPYyJJ1zSSmwFFL6MFXhbACOCcsCdUMCkzPdS9/OIBVxg516X/Ado2qwAq8k0nJJ7phQPCqiaFAw==}
+  electron-to-chromium@1.5.165:
+    resolution: {integrity: sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw==}
 
   elliptic@6.5.4:
     resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
@@ -7873,8 +7868,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  terser@5.42.0:
-    resolution: {integrity: sha512-UYCvU9YQW2f/Vwl+P0GfhxJxbUGLwd+5QrrGgLajzWAtC/23AX0vcise32kkP7Eu0Wu9VlzzHAXkLObgjQfFlQ==}
+  terser@5.41.0:
+    resolution: {integrity: sha512-H406eLPXpZbAX14+B8psIuvIr8+3c+2hkuYzpMkoE0ij+NdsVATbA78vb8neA/eqrj7rywa2pIkdmWRsXW6wmw==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -8118,6 +8113,21 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
+  typescript@5.5.3:
+    resolution: {integrity: sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.6.2:
+    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.7.2:
+    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
@@ -8138,6 +8148,9 @@ packages:
 
   underscore@1.12.1:
     resolution: {integrity: sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -9907,7 +9920,7 @@ snapshots:
       babel-plugin-polyfill-corejs2: 0.4.13(@babel/core@7.27.4)
       babel-plugin-polyfill-corejs3: 0.10.6(@babel/core@7.27.4)
       babel-plugin-polyfill-regenerator: 0.6.4(@babel/core@7.27.4)
-      core-js-compat: 3.43.0
+      core-js-compat: 3.42.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -10407,7 +10420,7 @@ snapshots:
     dependencies:
       '@inquirer/type': 1.2.1
       '@types/mute-stream': 0.0.4
-      '@types/node': 20.19.0
+      '@types/node': 20.17.57
       '@types/wrap-ansi': 3.0.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -10451,14 +10464,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
       jest-mock: 29.7.0
 
   '@jest/fake-timers@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -10471,7 +10484,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
       '@types/yargs': 15.0.19
       chalk: 4.1.2
 
@@ -10479,7 +10492,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
       '@types/yargs': 16.0.9
       chalk: 4.1.2
 
@@ -10488,7 +10501,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -10644,7 +10657,7 @@ snapshots:
   '@nx/nx-win32-x64-msvc@20.8.1':
     optional: true
 
-  '@oclif/core@2.15.0(@types/node@20.19.0)(typescript@5.8.3)':
+  '@oclif/core@2.15.0(@types/node@20.17.57)(typescript@5.5.3)':
     dependencies:
       '@types/cli-progress': 3.11.5
       ansi-escapes: 4.3.2
@@ -10669,7 +10682,7 @@ snapshots:
       strip-ansi: 6.0.1
       supports-color: 8.1.1
       supports-hyperlinks: 2.3.0
-      ts-node: 10.9.2(@types/node@20.19.0)(typescript@5.8.3)
+      ts-node: 10.9.2(@types/node@20.17.57)(typescript@5.5.3)
       tslib: 2.7.0
       widest-line: 3.1.0
       wordwrap: 1.0.0
@@ -10754,9 +10767,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@oclif/test@2.3.9(@types/node@20.19.0)(typescript@5.8.3)':
+  '@oclif/test@2.3.9(@types/node@20.17.57)(typescript@5.5.3)':
     dependencies:
-      '@oclif/core': 2.15.0(@types/node@20.19.0)(typescript@5.8.3)
+      '@oclif/core': 2.15.0(@types/node@20.17.57)(typescript@5.5.3)
       fancy-test: 2.0.42
     transitivePeerDependencies:
       - '@swc/core'
@@ -11029,11 +11042,11 @@ snapshots:
     optionalDependencies:
       rollup: 4.21.3
 
-  '@rollup/plugin-typescript@11.1.6(rollup@4.21.3)(tslib@2.7.0)(typescript@5.8.3)':
+  '@rollup/plugin-typescript@11.1.6(rollup@4.21.3)(tslib@2.7.0)(typescript@5.6.2)':
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.21.3)
       resolve: 1.22.8
-      typescript: 5.8.3
+      typescript: 5.6.2
     optionalDependencies:
       rollup: 4.21.3
       tslib: 2.7.0
@@ -11444,7 +11457,7 @@ snapshots:
       bs58: 5.0.0
       dotenv: 16.4.5
       prettier: 3.3.3
-      typescript: 5.8.3
+      typescript: 5.5.3
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -11521,50 +11534,50 @@ snapshots:
 
   '@solana/codecs-core@2.0.0-experimental.8618508': {}
 
-  '@solana/codecs-core@2.0.0-preview.4(typescript@5.8.3)':
+  '@solana/codecs-core@2.0.0-preview.4(typescript@5.6.2)':
     dependencies:
-      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/errors': 2.0.0-preview.4(typescript@5.6.2)
+      typescript: 5.6.2
 
-  '@solana/codecs-core@2.0.0-rc.1(typescript@5.8.3)':
+  '@solana/codecs-core@2.0.0-rc.1(typescript@5.6.2)':
     dependencies:
-      '@solana/errors': 2.0.0-rc.1(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/errors': 2.0.0-rc.1(typescript@5.6.2)
+      typescript: 5.6.2
 
   '@solana/codecs-data-structures@2.0.0-experimental.8618508':
     dependencies:
       '@solana/codecs-core': 2.0.0-experimental.8618508
       '@solana/codecs-numbers': 2.0.0-experimental.8618508
 
-  '@solana/codecs-data-structures@2.0.0-preview.4(typescript@5.8.3)':
+  '@solana/codecs-data-structures@2.0.0-preview.4(typescript@5.6.2)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.6.2)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.6.2)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.6.2)
+      typescript: 5.6.2
 
-  '@solana/codecs-data-structures@2.0.0-rc.1(typescript@5.8.3)':
+  '@solana/codecs-data-structures@2.0.0-rc.1(typescript@5.6.2)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/errors': 2.0.0-rc.1(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.6.2)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.6.2)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.6.2)
+      typescript: 5.6.2
 
   '@solana/codecs-numbers@2.0.0-experimental.8618508':
     dependencies:
       '@solana/codecs-core': 2.0.0-experimental.8618508
 
-  '@solana/codecs-numbers@2.0.0-preview.4(typescript@5.8.3)':
+  '@solana/codecs-numbers@2.0.0-preview.4(typescript@5.6.2)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.6.2)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.6.2)
+      typescript: 5.6.2
 
-  '@solana/codecs-numbers@2.0.0-rc.1(typescript@5.8.3)':
+  '@solana/codecs-numbers@2.0.0-rc.1(typescript@5.6.2)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/errors': 2.0.0-rc.1(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.6.2)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.6.2)
+      typescript: 5.6.2
 
   '@solana/codecs-strings@2.0.0-experimental.8618508(fastestsmallesttextencoderdecoder@1.0.22)':
     dependencies:
@@ -11572,86 +11585,86 @@ snapshots:
       '@solana/codecs-numbers': 2.0.0-experimental.8618508
       fastestsmallesttextencoderdecoder: 1.0.22
 
-  '@solana/codecs-strings@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+  '@solana/codecs-strings@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.6.2)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.6.2)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.6.2)
       fastestsmallesttextencoderdecoder: 1.0.22
-      typescript: 5.8.3
+      typescript: 5.6.2
 
-  '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+  '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/errors': 2.0.0-rc.1(typescript@5.8.3)
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.6.2)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.6.2)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.6.2)
       fastestsmallesttextencoderdecoder: 1.0.22
-      typescript: 5.8.3
+      typescript: 5.6.2
 
-  '@solana/codecs@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+  '@solana/codecs@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/options': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.6.2)
+      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.6.2)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.6.2)
+      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)
+      '@solana/options': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)
+      typescript: 5.6.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/codecs@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+  '@solana/codecs@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/options': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.6.2)
+      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.6.2)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.6.2)
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)
+      '@solana/options': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)
+      typescript: 5.6.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/errors@2.0.0-preview.4(typescript@5.8.3)':
+  '@solana/errors@2.0.0-preview.4(typescript@5.6.2)':
     dependencies:
       chalk: 5.4.1
       commander: 12.1.0
-      typescript: 5.8.3
+      typescript: 5.6.2
 
-  '@solana/errors@2.0.0-rc.1(typescript@5.8.3)':
+  '@solana/errors@2.0.0-rc.1(typescript@5.6.2)':
     dependencies:
       chalk: 5.4.1
       commander: 12.1.0
-      typescript: 5.8.3
+      typescript: 5.6.2
 
   '@solana/options@2.0.0-experimental.8618508':
     dependencies:
       '@solana/codecs-core': 2.0.0-experimental.8618508
       '@solana/codecs-numbers': 2.0.0-experimental.8618508
 
-  '@solana/options@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+  '@solana/options@2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.8.3)
-      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/errors': 2.0.0-preview.4(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 2.0.0-preview.4(typescript@5.6.2)
+      '@solana/codecs-data-structures': 2.0.0-preview.4(typescript@5.6.2)
+      '@solana/codecs-numbers': 2.0.0-preview.4(typescript@5.6.2)
+      '@solana/codecs-strings': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)
+      '@solana/errors': 2.0.0-preview.4(typescript@5.6.2)
+      typescript: 5.6.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/options@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+  '@solana/options@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)':
     dependencies:
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/errors': 2.0.0-rc.1(typescript@5.8.3)
-      typescript: 5.8.3
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.6.2)
+      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.6.2)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.6.2)
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.6.2)
+      typescript: 5.6.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/spl-token-group@0.0.5(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+  '@solana/spl-token-group@0.0.5(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)':
     dependencies:
-      '@solana/codecs': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs': 2.0.0-preview.4(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)
       '@solana/spl-type-length-value': 0.1.0
       '@solana/web3.js': 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -11670,9 +11683,9 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/spl-token-metadata@0.1.5(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
+  '@solana/spl-token-metadata@0.1.5(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)':
     dependencies:
-      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)
       '@solana/spl-type-length-value': 0.1.0
       '@solana/web3.js': 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -11692,12 +11705,12 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@solana/spl-token@0.4.8(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+  '@solana/spl-token@0.4.8(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/buffer-layout': 4.0.1
       '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@solana/spl-token-group': 0.0.5(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/spl-token-metadata': 0.1.5(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/spl-token-group': 0.0.5(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)
+      '@solana/spl-token-metadata': 0.1.5(@solana/web3.js@1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.6.2)
       '@solana/web3.js': 1.98.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       buffer: 6.0.3
     transitivePeerDependencies:
@@ -11900,11 +11913,11 @@ snapshots:
 
   '@types/bn.js@5.1.5':
     dependencies:
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
 
   '@types/bn.js@5.1.6':
     dependencies:
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
 
   '@types/chai@4.3.16': {}
 
@@ -11914,11 +11927,11 @@ snapshots:
 
   '@types/cli-progress@3.11.5':
     dependencies:
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
 
   '@types/connect@3.4.36':
     dependencies:
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
 
   '@types/deep-eql@4.0.2': {}
 
@@ -11928,12 +11941,12 @@ snapshots:
 
   '@types/fs-extra@8.1.5':
     dependencies:
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
 
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
 
   '@types/http-cache-semantics@4.0.2': {}
 
@@ -11959,15 +11972,15 @@ snapshots:
 
   '@types/mute-stream@0.0.4':
     dependencies:
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
 
   '@types/node@12.20.55': {}
 
-  '@types/node@20.19.0':
+  '@types/node@20.17.57':
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 6.19.8
 
-  '@types/node@22.15.30':
+  '@types/node@22.15.29':
     dependencies:
       undici-types: 6.21.0
 
@@ -11977,11 +11990,11 @@ snapshots:
 
   '@types/normalize-package-data@2.4.2': {}
 
-  '@types/react-dom@19.1.4(@types/react@19.1.6)':
+  '@types/react-dom@19.1.4(@types/react@19.1.4)':
     dependencies:
-      '@types/react': 19.1.6
+      '@types/react': 19.1.4
 
-  '@types/react@19.1.6':
+  '@types/react@19.1.4':
     dependencies:
       csstype: 3.1.3
 
@@ -11999,7 +12012,7 @@ snapshots:
 
   '@types/tar@6.1.12':
     dependencies:
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
       minipass: 4.2.8
 
   '@types/uuid@8.3.4': {}
@@ -12010,11 +12023,11 @@ snapshots:
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
 
   '@types/ws@8.5.10':
     dependencies:
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -12030,13 +12043,13 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
       '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.4.1(supports-color@8.1.1)
       eslint: 8.57.0
@@ -12044,27 +12057,45 @@ snapshots:
       ignore: 5.3.2
       natural-compare: 1.4.0
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.8.3)
+      ts-api-utils: 1.3.0(typescript@5.5.3)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 7.13.1(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 7.13.1(eslint@8.57.0)(typescript@5.5.3)
       '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/type-utils': 7.18.0(eslint@8.57.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 7.18.0(eslint@8.57.0)(typescript@5.5.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.5.3)
       '@typescript-eslint/visitor-keys': 7.18.0
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.8.3)
+      ts-api-utils: 1.3.0(typescript@5.5.3)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.5.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.11.0
+      '@typescript-eslint/parser': 7.13.1(eslint@8.57.0)(typescript@5.6.2)
+      '@typescript-eslint/scope-manager': 7.18.0
+      '@typescript-eslint/type-utils': 7.18.0(eslint@8.57.0)(typescript@5.6.2)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.6.2)
+      '@typescript-eslint/visitor-keys': 7.18.0
+      eslint: 8.57.0
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      natural-compare: 1.4.0
+      ts-api-utils: 1.3.0(typescript@5.6.2)
+    optionalDependencies:
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12085,29 +12116,42 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3)':
+  '@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.5.3)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.4.1(supports-color@8.1.1)
       eslint: 8.57.0
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3)':
+  '@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.5.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.13.1
       '@typescript-eslint/types': 7.13.1
-      '@typescript-eslint/typescript-estree': 7.13.1(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 7.13.1(typescript@5.5.3)
       '@typescript-eslint/visitor-keys': 7.13.1
       debug: 4.3.7
       eslint: 8.57.0
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.5.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.6.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 7.13.1
+      '@typescript-eslint/types': 7.13.1
+      '@typescript-eslint/typescript-estree': 7.13.1(typescript@5.6.2)
+      '@typescript-eslint/visitor-keys': 7.13.1
+      debug: 4.3.7
+      eslint: 8.57.0
+    optionalDependencies:
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12143,27 +12187,39 @@ snapshots:
       '@typescript-eslint/types': 8.32.1
       '@typescript-eslint/visitor-keys': 8.32.1
 
-  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.0)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.0)(typescript@5.5.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.5.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
       debug: 4.4.1(supports-color@8.1.1)
       eslint: 8.57.0
-      ts-api-utils: 1.0.3(typescript@5.8.3)
+      ts-api-utils: 1.0.3(typescript@5.5.3)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@7.18.0(eslint@8.57.0)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@7.18.0(eslint@8.57.0)(typescript@5.5.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.5.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.5.3)
       debug: 4.4.1(supports-color@8.1.1)
       eslint: 8.57.0
-      ts-api-utils: 1.3.0(typescript@5.8.3)
+      ts-api-utils: 1.3.0(typescript@5.5.3)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.5.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@7.18.0(eslint@8.57.0)(typescript@5.6.2)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.2)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.6.2)
+      debug: 4.4.1(supports-color@8.1.1)
+      eslint: 8.57.0
+      ts-api-utils: 1.3.0(typescript@5.6.2)
+    optionalDependencies:
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12186,7 +12242,7 @@ snapshots:
 
   '@typescript-eslint/types@8.32.1': {}
 
-  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.5.3)':
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
@@ -12195,13 +12251,13 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.7.1
-      ts-api-utils: 1.3.0(typescript@5.8.3)
+      ts-api-utils: 1.3.0(typescript@5.5.3)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@7.13.1(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@7.13.1(typescript@5.5.3)':
     dependencies:
       '@typescript-eslint/types': 7.13.1
       '@typescript-eslint/visitor-keys': 7.13.1
@@ -12210,13 +12266,28 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.8.3)
+      ts-api-utils: 1.3.0(typescript@5.5.3)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@7.13.1(typescript@5.6.2)':
+    dependencies:
+      '@typescript-eslint/types': 7.13.1
+      '@typescript-eslint/visitor-keys': 7.13.1
+      debug: 4.3.7
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.6.3
+      ts-api-utils: 1.3.0(typescript@5.6.2)
+    optionalDependencies:
+      typescript: 5.6.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.5.3)':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
@@ -12225,9 +12296,24 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.1
-      ts-api-utils: 1.3.0(typescript@5.8.3)
+      ts-api-utils: 1.3.0(typescript@5.5.3)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.5.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.6.2)':
+    dependencies:
+      '@typescript-eslint/types': 7.18.0
+      '@typescript-eslint/visitor-keys': 7.18.0
+      debug: 4.4.1(supports-color@8.1.1)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      ts-api-utils: 1.3.0(typescript@5.6.2)
+    optionalDependencies:
+      typescript: 5.6.2
     transitivePeerDependencies:
       - supports-color
 
@@ -12245,37 +12331,48 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@6.21.0(eslint@8.57.0)(typescript@5.8.3)':
+  '@typescript-eslint/utils@6.21.0(eslint@8.57.0)(typescript@5.5.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.2
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.5.3)
       eslint: 8.57.0
       semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.13.1(eslint@8.57.0)(typescript@5.8.3)':
+  '@typescript-eslint/utils@7.13.1(eslint@8.57.0)(typescript@5.6.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.0)
       '@typescript-eslint/scope-manager': 7.13.1
       '@typescript-eslint/types': 7.13.1
-      '@typescript-eslint/typescript-estree': 7.13.1(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 7.13.1(typescript@5.6.2)
       eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.18.0(eslint@8.57.0)(typescript@5.8.3)':
+  '@typescript-eslint/utils@7.18.0(eslint@8.57.0)(typescript@5.5.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.0)
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.5.3)
+      eslint: 8.57.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/utils@7.18.0(eslint@8.57.0)(typescript@5.6.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.0)
+      '@typescript-eslint/scope-manager': 7.18.0
+      '@typescript-eslint/types': 7.18.0
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.2)
       eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
@@ -12374,13 +12471,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.1(@vitest/spy@2.1.1)(vite@5.0.4(@types/node@22.15.30)(terser@5.42.0))':
+  '@vitest/mocker@2.1.1(@vitest/spy@2.1.1)(vite@5.0.4(@types/node@22.15.29)(terser@5.41.0))':
     dependencies:
       '@vitest/spy': 2.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.11
     optionalDependencies:
-      vite: 5.0.4(@types/node@22.15.30)(terser@5.42.0)
+      vite: 5.0.4(@types/node@22.15.29)(terser@5.41.0)
 
   '@vitest/mocker@2.1.1(@vitest/spy@2.1.1)(vite@5.0.4(@types/node@22.5.5)(terser@5.39.0))':
     dependencies:
@@ -12476,8 +12573,6 @@ snapshots:
   acorn@8.11.3: {}
 
   acorn@8.14.1: {}
-
-  acorn@8.15.0: {}
 
   add@2.0.6: {}
 
@@ -12765,7 +12860,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.4
       '@babel/helper-define-polyfill-provider': 0.6.4(@babel/core@7.27.4)
-      core-js-compat: 3.43.0
+      core-js-compat: 3.42.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12773,7 +12868,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.4
       '@babel/helper-define-polyfill-provider': 0.6.4(@babel/core@7.27.4)
-      core-js-compat: 3.43.0
+      core-js-compat: 3.42.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12948,7 +13043,7 @@ snapshots:
   browserslist@4.25.0:
     dependencies:
       caniuse-lite: 1.0.30001721
-      electron-to-chromium: 1.5.166
+      electron-to-chromium: 1.5.165
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.0)
 
@@ -13323,7 +13418,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  core-js-compat@3.43.0:
+  core-js-compat@3.42.0:
     dependencies:
       browserslist: 4.25.0
 
@@ -13617,7 +13712,7 @@ snapshots:
     dependencies:
       jake: 10.8.7
 
-  electron-to-chromium@1.5.166: {}
+  electron-to-chromium@1.5.165: {}
 
   elliptic@6.5.4:
     dependencies:
@@ -14008,16 +14103,16 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-oclif-typescript@3.1.4(eslint@8.57.0)(typescript@5.8.3):
+  eslint-config-oclif-typescript@3.1.4(eslint@8.57.0)(typescript@5.5.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3)
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
       eslint-config-xo-space: 0.35.0(eslint@8.57.0)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)
       eslint-plugin-mocha: 10.4.2(eslint@8.57.0)
       eslint-plugin-n: 15.7.0(eslint@8.57.0)
-      eslint-plugin-perfectionist: 2.8.0(eslint@8.57.0)(typescript@5.8.3)
+      eslint-plugin-perfectionist: 2.8.0(eslint@8.57.0)(typescript@5.5.3)
     transitivePeerDependencies:
       - astro-eslint-parser
       - eslint
@@ -14075,13 +14170,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
       debug: 4.4.1(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.57.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
       is-core-module: 2.15.1
@@ -14092,23 +14187,23 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.11.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.13.1(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 7.13.1(eslint@8.57.0)(typescript@5.6.2)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
       eslint: 8.57.0
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.8.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14123,11 +14218,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.13.1(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 7.13.1(eslint@8.57.0)(typescript@5.5.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -14146,7 +14241,7 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -14156,7 +14251,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -14167,13 +14262,13 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.13.1(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 7.13.1(eslint@8.57.0)(typescript@5.5.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0):
+  eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -14184,7 +14279,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -14195,7 +14290,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.13.1(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 7.13.1(eslint@8.57.0)(typescript@5.6.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -14280,9 +14375,9 @@ snapshots:
       minimatch: 9.0.5
       semver: 7.6.3
 
-  eslint-plugin-perfectionist@2.8.0(eslint@8.57.0)(typescript@5.8.3):
+  eslint-plugin-perfectionist@2.8.0(eslint@8.57.0)(typescript@5.5.3):
     dependencies:
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
       eslint: 8.57.0
       minimatch: 9.0.5
       natural-compare-lite: 1.4.0
@@ -14339,13 +14434,13 @@ snapshots:
       semver: 7.6.3
       strip-indent: 3.0.0
 
-  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3)(vitest@2.1.1(@types/node@22.15.30)(terser@5.42.0)):
+  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)(vitest@2.1.1(@types/node@22.15.29)(terser@5.41.0)):
     dependencies:
-      '@typescript-eslint/utils': 7.13.1(eslint@8.57.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 7.13.1(eslint@8.57.0)(typescript@5.6.2)
       eslint: 8.57.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3)
-      vitest: 2.1.1(@types/node@22.15.30)(terser@5.42.0)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.13.1(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)
+      vitest: 2.1.1(@types/node@22.15.29)(terser@5.41.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -14538,7 +14633,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.0.1
       '@types/lodash': 4.14.199
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
       '@types/sinon': 10.0.16
       lodash: 4.17.21
       mock-stdin: 1.0.0
@@ -15562,7 +15657,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -15583,7 +15678,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
       jest-util: 29.7.0
 
   jest-regex-util@27.5.1: {}
@@ -15591,7 +15686,7 @@ snapshots:
   jest-util@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -15600,7 +15695,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -15617,7 +15712,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -15951,7 +16046,7 @@ snapshots:
 
   metro-minify-terser@0.76.9:
     dependencies:
-      terser: 5.42.0
+      terser: 5.41.0
 
   metro-minify-uglify@0.76.9:
     dependencies:
@@ -17236,11 +17331,11 @@ snapshots:
       globby: 10.0.1
       is-plain-object: 3.0.1
 
-  rollup-plugin-dts@6.1.1(rollup@4.21.3)(typescript@5.8.3):
+  rollup-plugin-dts@6.1.1(rollup@4.21.3)(typescript@5.6.2):
     dependencies:
       magic-string: 0.30.11
       rollup: 4.21.3
-      typescript: 5.8.3
+      typescript: 5.6.2
     optionalDependencies:
       '@babel/code-frame': 7.24.2
 
@@ -17851,10 +17946,10 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  terser@5.42.0:
+  terser@5.41.0:
     dependencies:
       '@jridgewell/source-map': 0.3.6
-      acorn: 8.15.0
+      acorn: 8.14.1
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -17906,13 +18001,17 @@ snapshots:
 
   tryer@1.0.1: {}
 
-  ts-api-utils@1.0.3(typescript@5.8.3):
+  ts-api-utils@1.0.3(typescript@5.5.3):
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.5.3
 
-  ts-api-utils@1.3.0(typescript@5.8.3):
+  ts-api-utils@1.3.0(typescript@5.5.3):
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.5.3
+
+  ts-api-utils@1.3.0(typescript@5.6.2):
+    dependencies:
+      typescript: 5.6.2
 
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
@@ -17925,46 +18024,64 @@ snapshots:
     optionalDependencies:
       tsconfig-paths: 3.15.0
 
-  ts-mocha@11.1.0(mocha@11.5.0)(ts-node@10.9.2(@types/node@22.15.30)(typescript@5.8.3))(tsconfig-paths@4.2.0):
+  ts-mocha@11.1.0(mocha@11.5.0)(ts-node@10.9.2(@types/node@22.15.29)(typescript@5.7.2))(tsconfig-paths@4.2.0):
     dependencies:
       mocha: 11.5.0
-      ts-node: 10.9.2(@types/node@22.15.30)(typescript@5.8.3)
+      ts-node: 10.9.2(@types/node@22.15.29)(typescript@5.7.2)
     optionalDependencies:
       tsconfig-paths: 4.2.0
 
-  ts-node@10.9.2(@types/node@20.19.0)(typescript@5.8.3):
+  ts-node@10.9.2(@types/node@20.17.57)(typescript@5.5.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.0
+      '@types/node': 20.17.57
       acorn: 8.11.3
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.8.3
+      typescript: 5.5.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@22.15.30)(typescript@5.8.3):
+  ts-node@10.9.2(@types/node@22.15.29)(typescript@5.6.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
       acorn: 8.11.3
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.8.3
+      typescript: 5.6.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@22.15.29)(typescript@5.7.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.15.29
+      acorn: 8.11.3
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.7.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -18142,6 +18259,12 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
+  typescript@5.5.3: {}
+
+  typescript@5.6.2: {}
+
+  typescript@5.7.2: {}
+
   typescript@5.8.3: {}
 
   uglify-es@3.3.9:
@@ -18164,6 +18287,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   underscore@1.12.1: {}
+
+  undici-types@6.19.8: {}
 
   undici-types@6.21.0: {}
 
@@ -18262,12 +18387,12 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@2.1.1(@types/node@22.15.30)(terser@5.42.0):
+  vite-node@2.1.1(@types/node@22.15.29)(terser@5.41.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1(supports-color@8.1.1)
       pathe: 1.1.2
-      vite: 5.0.4(@types/node@22.15.30)(terser@5.42.0)
+      vite: 5.0.4(@types/node@22.15.29)(terser@5.41.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -18278,20 +18403,20 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.0.4(@types/node@22.15.30)(terser@5.42.0):
+  vite@5.0.4(@types/node@22.15.29)(terser@5.41.0):
     dependencies:
       esbuild: 0.19.5
       postcss: 8.5.1
       rollup: 4.21.3
     optionalDependencies:
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
       fsevents: 2.3.3
-      terser: 5.42.0
+      terser: 5.41.0
 
-  vitest@2.1.1(@types/node@22.15.30)(terser@5.42.0):
+  vitest@2.1.1(@types/node@22.15.29)(terser@5.41.0):
     dependencies:
       '@vitest/expect': 2.1.1
-      '@vitest/mocker': 2.1.1(@vitest/spy@2.1.1)(vite@5.0.4(@types/node@22.15.30)(terser@5.42.0))
+      '@vitest/mocker': 2.1.1(@vitest/spy@2.1.1)(vite@5.0.4(@types/node@22.15.29)(terser@5.41.0))
       '@vitest/pretty-format': 2.1.1
       '@vitest/runner': 2.1.1
       '@vitest/snapshot': 2.1.1
@@ -18306,11 +18431,11 @@ snapshots:
       tinyexec: 0.3.0
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.0.4(@types/node@22.15.30)(terser@5.42.0)
-      vite-node: 2.1.1(@types/node@22.15.30)(terser@5.42.0)
+      vite: 5.0.4(@types/node@22.15.29)(terser@5.41.0)
+      vite-node: 2.1.1(@types/node@22.15.29)(terser@5.41.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.15.30
+      '@types/node': 22.15.29
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
* adds `CompressedAccount` which replaces `CompressedAccountWithMerkleContext` going forward

* adds `pack_tree_infos` as a standalone function so we don't have to migrate ValidityProof to a Class and break existing clients

* TS system program client implementation now uses legacy types and methods so as to not break method params

