### PR TITLE
fix: use `DEFAULT_ADDRESS_ZKP_BATCH_SIZE` in `InitAddressTreeAccountsInstructionData::testnet_default`

### DIFF
--- a/program-libs/batched-merkle-tree/src/initialize_address_tree.rs
+++ b/program-libs/batched-merkle-tree/src/initialize_address_tree.rs
@@ -176,7 +176,7 @@ pub fn get_address_merkle_tree_account_size_from_params(
 pub mod test_utils {
     pub use super::InitAddressTreeAccountsInstructionData;
     use crate::constants::{
-        DEFAULT_ZKP_BATCH_SIZE, TEST_DEFAULT_BATCH_SIZE, TEST_DEFAULT_ZKP_BATCH_SIZE,
+        DEFAULT_ADDRESS_ZKP_BATCH_SIZE, TEST_DEFAULT_BATCH_SIZE, TEST_DEFAULT_ZKP_BATCH_SIZE,
     };
 
     impl InitAddressTreeAccountsInstructionData {
@@ -220,7 +220,7 @@ pub mod test_utils {
                 forester: None,
                 bloom_filter_num_iters: 3,
                 input_queue_batch_size: 2000,
-                input_queue_zkp_batch_size: DEFAULT_ZKP_BATCH_SIZE,
+                input_queue_zkp_batch_size: DEFAULT_ADDRESS_ZKP_BATCH_SIZE,
                 height: 40,
                 root_history_capacity: 20,
                 bloom_filter_capacity: 20_000 * 8,

--- a/program-tests/registry-test/tests/tests.rs
+++ b/program-tests/registry-test/tests/tests.rs
@@ -626,7 +626,7 @@ async fn test_custom_forester() {
 #[serial]
 #[tokio::test]
 async fn test_custom_forester_batched() {
-    let mut rpc = LightProgramTest::new(ProgramTestConfig::default_test_forster(true))
+    let mut rpc = LightProgramTest::new(ProgramTestConfig::default_test_forester(true))
         .await
         .unwrap();
     rpc.indexer = None;
@@ -1849,7 +1849,7 @@ async fn test_rollover_batch_state_tree() {
 #[serial]
 #[tokio::test]
 async fn test_batch_address_tree() {
-    let mut config = ProgramTestConfig::default_test_forster(true);
+    let mut config = ProgramTestConfig::default_test_forester(true);
     let tree_params = config.v2_address_tree_config.unwrap();
     config.v2_state_tree_config = Some(InitStateTreeAccountsInstructionData::default());
     config.additional_programs = Some(vec![(

--- a/program-tests/system-test/tests/test.rs
+++ b/program-tests/system-test/tests/test.rs
@@ -1836,7 +1836,7 @@ pub fn rustfmt(code: String) -> Result<Vec<u8>, io::Error> {
 #[serial]
 #[tokio::test]
 async fn batch_invoke_test() {
-    let config = ProgramTestConfig::default_test_forster(false);
+    let config = ProgramTestConfig::default_test_forester(false);
 
     let mut rpc = LightProgramTest::new(config).await.unwrap();
 

--- a/sdk-libs/program-test/src/program_test/config.rs
+++ b/sdk-libs/program-test/src/program_test/config.rs
@@ -65,7 +65,7 @@ impl ProgramTestConfig {
     }
 
     #[cfg(feature = "devenv")]
-    pub fn default_test_forster(with_prover: bool) -> Self {
+    pub fn default_test_forester(with_prover: bool) -> Self {
         Self {
             additional_programs: None,
             with_prover,


### PR DESCRIPTION
- use `DEFAULT_ADDRESS_ZKP_BATCH_SIZE` in `InitAddressTreeAccountsInstructionData::testnet_default`
- fix typo in forester test config method name