### PR TITLE
chore: bloom filter opt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,12 +2031,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastmurmur3"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d7e9bc68be4cdabbb8938140b01a8b5bc1191937f2c7e7ecc2fcebbe2d749df"
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3270,11 +3264,11 @@ name = "light-bloom-filter"
 version = "0.2.0"
 dependencies = [
  "bitvec",
- "fastmurmur3",
  "light-hasher",
  "num-bigint 0.4.6",
  "pinocchio",
  "rand 0.8.5",
+ "solana-nostd-keccak",
  "solana-program-error",
  "thiserror 2.0.12",
 ]
@@ -3428,6 +3422,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.10.9",
  "sha3",
+ "solana-nostd-keccak",
  "solana-program-error",
  "solana-pubkey",
  "thiserror 2.0.12",
@@ -6891,6 +6886,15 @@ dependencies = [
  "solana-hash",
  "solana-nonce",
  "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-nostd-keccak"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8ced70920435b1baa58f76e6f84bbc1110ddd1d6161ec76b6d731ae8431e9c4"
+dependencies = [
+ "sha3",
 ]
 
 [[package]]

--- a/program-libs/bloom-filter/Cargo.toml
+++ b/program-libs/bloom-filter/Cargo.toml
@@ -12,7 +12,7 @@ pinocchio = ["dep:pinocchio"]
 
 [dependencies]
 bitvec = "1.0.1"
-fastmurmur3 = "0.2.0"
+solana-nostd-keccak = "0.1.3"
 num-bigint = { workspace = true }
 solana-program-error = { workspace = true, optional = true }
 pinocchio = { workspace = true, optional = true }

--- a/program-libs/hasher/Cargo.toml
+++ b/program-libs/hasher/Cargo.toml
@@ -23,6 +23,7 @@ solana-program-error = { workspace = true, optional = true }
 solana-pubkey = { workspace = true, optional = true }
 pinocchio = { workspace = true, optional = true }
 borsh = { workspace = true }
+solana-nostd-keccak = "0.1.3"
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 ark-bn254 = { workspace = true }

--- a/program-libs/hasher/src/keccak.rs
+++ b/program-libs/hasher/src/keccak.rs
@@ -14,31 +14,7 @@ impl Hasher for Keccak {
     }
 
     fn hashv(vals: &[&[u8]]) -> Result<Hash, HasherError> {
-        #[cfg(not(target_os = "solana"))]
-        {
-            use sha3::{Digest, Keccak256};
-
-            let mut hasher = Keccak256::default();
-            for val in vals {
-                hasher.update(val);
-            }
-            Ok(hasher.finalize().into())
-        }
-        // Call via a system call to perform the calculation
-        #[cfg(target_os = "solana")]
-        {
-            use crate::HASH_BYTES;
-
-            let mut hash_result = [0; HASH_BYTES];
-            unsafe {
-                crate::syscalls::sol_keccak256(
-                    vals as *const _ as *const u8,
-                    vals.len() as u64,
-                    &mut hash_result as *mut _ as *mut u8,
-                );
-            }
-            Ok(hash_result)
-        }
+        Ok(solana_nostd_keccak::hashv(vals))
     }
 
     fn zero_bytes() -> ZeroBytes {


### PR DESCRIPTION
### Issue:
- we use 2 hashes in bloom filter hashing, this is not strictly necessary

### Solution:
- Remove one of the hashes
- switch to `no-std-keccak` hashes which are a couple CU cheaper than fastmurmur3
- use the complete value as keccak hash input and use the complete keccak output
    -> this makes it harder to construct an account to produce a bloom filter collision

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated hashing implementation to use a Keccak-based approach, replacing previous hashing methods.
  - Simplified and unified hashing logic for improved maintainability and consistency across platforms.

- **Chores**
  - Updated dependencies to remove unused libraries and add the new Keccak hashing library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->