### PR TITLE
fix: get_validity_proof order

### DIFF
--- a/sdk-libs/program-test/src/indexer/test_indexer.rs
+++ b/sdk-libs/program-test/src/indexer/test_indexer.rs
@@ -554,14 +554,12 @@ impl Indexer for TestIndexer {
                     }
                 }
 
-                // reverse so that we can pop elements.
-                proof_inputs.reverse();
-                // Reinsert.
-                for index in indices_to_remove.iter().rev() {
-                    if root_indices.len() <= *index {
-                        root_indices.push(proof_inputs.pop().unwrap());
+                // Reinsert proof_inputs at their original positions in forward order
+                for (proof_input, &index) in proof_inputs.iter().zip(indices_to_remove.iter()) {
+                    if root_indices.len() <= index {
+                        root_indices.push(proof_input.clone());
                     } else {
-                        root_indices.insert(*index, proof_inputs.pop().unwrap());
+                        root_indices.insert(index, proof_input.clone());
                     }
                 }
                 root_indices


### PR DESCRIPTION
Issue:
- get validity proof results are not in the original order for multiple inputs 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the logic for reinserting items in validity proof handling, resulting in more straightforward and maintainable processing. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->