### PR TITLE
chore: disable cpi context ctoken

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3591,46 +3591,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "name-service"
-version = "0.7.0"
-dependencies = [
- "anchor-lang",
- "borsh 0.10.3",
- "light-client",
- "light-hasher",
- "light-macros",
- "light-program-test",
- "light-sdk",
- "light-sdk-macros",
- "light-test-utils",
- "light-utils",
- "light-verifier",
- "solana-program-test",
- "solana-sdk",
- "tokio",
-]
-
-[[package]]
-name = "name-service-without-macros"
-version = "0.7.0"
-dependencies = [
- "anchor-lang",
- "borsh 0.10.3",
- "light-client",
- "light-hasher",
- "light-macros",
- "light-program-test",
- "light-sdk",
- "light-sdk-macros",
- "light-test-utils",
- "light-utils",
- "light-verifier",
- "solana-program-test",
- "solana-sdk",
- "tokio",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ members = [
     "sdk-libs/photon-api",
     "sdk-libs/program-test",
     "xtask",
-    "examples/name-service/programs/*",
     "examples/token-escrow/programs/*",
     "program-tests/account-compression-test/",
     "program-tests/compressed-token-test/",

--- a/programs/compressed-token/src/burn.rs
+++ b/programs/compressed-token/src/burn.rs
@@ -35,7 +35,9 @@ pub fn process_burn<'a, 'b, 'c, 'info: 'b + 'c>(
 ) -> Result<()> {
     let inputs: CompressedTokenInstructionDataBurn =
         CompressedTokenInstructionDataBurn::deserialize(&mut inputs.as_slice())?;
-
+    if inputs.cpi_context.is_some() {
+        unimplemented!("Cpi context feature is not enabled.");
+    }
     burn_spl_from_pool_pda(&ctx, &inputs)?;
     let mint = ctx.accounts.mint.key();
     let (compressed_input_accounts, output_compressed_accounts) =

--- a/programs/compressed-token/src/constants.rs
+++ b/programs/compressed-token/src/constants.rs
@@ -5,4 +5,4 @@ pub const NOT_FROZEN: bool = false;
 pub const POOL_SEED: &[u8] = b"pool";
 
 /// Maximum number of pool accounts that can be created for each mint.
-pub const NUM_MAX_POOL_ACCOUNTS: u8 = 5;
+pub const NUM_MAX_POOL_ACCOUNTS: u8 = 4;

--- a/programs/compressed-token/src/delegation.rs
+++ b/programs/compressed-token/src/delegation.rs
@@ -48,6 +48,9 @@ pub fn process_approve<'a, 'b, 'c, 'info: 'b + 'c>(
 ) -> Result<()> {
     let inputs: CompressedTokenInstructionDataApprove =
         CompressedTokenInstructionDataApprove::deserialize(&mut inputs.as_slice())?;
+    if inputs.cpi_context.is_some() {
+        unimplemented!("Cpi context feature is not enabled.");
+    }
     let (compressed_input_accounts, output_compressed_accounts) =
         create_input_and_output_accounts_approve(
             &inputs,
@@ -182,6 +185,9 @@ pub fn process_revoke<'a, 'b, 'c, 'info: 'b + 'c>(
 ) -> Result<()> {
     let inputs: CompressedTokenInstructionDataRevoke =
         CompressedTokenInstructionDataRevoke::deserialize(&mut inputs.as_slice())?;
+    if inputs.cpi_context.is_some() {
+        unimplemented!("Cpi context feature is not enabled.");
+    }
     let (compressed_input_accounts, output_compressed_accounts) =
         create_input_and_output_accounts_revoke(
             &inputs,

--- a/programs/compressed-token/src/freeze.rs
+++ b/programs/compressed-token/src/freeze.rs
@@ -45,6 +45,9 @@ pub fn process_freeze_or_thaw<
 ) -> Result<()> {
     let inputs: CompressedTokenInstructionDataFreeze =
         CompressedTokenInstructionDataFreeze::deserialize(&mut inputs.as_slice())?;
+    if inputs.cpi_context.is_some() {
+        unimplemented!("Cpi context feature is not enabled.");
+    }
     let (compressed_input_accounts, output_compressed_accounts) =
         create_input_and_output_accounts_freeze_or_thaw::<FROZEN_INPUTS, FROZEN_OUTPUTS>(
             &inputs,

--- a/programs/compressed-token/src/lib.rs
+++ b/programs/compressed-token/src/lib.rs
@@ -108,6 +108,9 @@ pub mod light_compressed_token {
     ) -> Result<()> {
         let inputs: CompressedTokenInstructionDataTransfer =
             CompressedTokenInstructionDataTransfer::deserialize(&mut inputs.as_slice())?;
+        if inputs.cpi_context.is_some() {
+            unimplemented!("Cpi context feature is not enabled.");
+        }
         process_transfer::process_transfer(ctx, inputs)
     }
 

--- a/programs/compressed-token/src/process_compress_spl_token_account.rs
+++ b/programs/compressed-token/src/process_compress_spl_token_account.rs
@@ -15,6 +15,9 @@ pub fn process_compress_spl_token_account<'info>(
     remaining_amount: Option<u64>,
     cpi_context: Option<CompressedCpiContext>,
 ) -> Result<()> {
+    if cpi_context.is_some() {
+        unimplemented!("Cpi context feature is not enabled.");
+    }
     let compression_token_account =
         if let Some(token_account) = ctx.accounts.compress_or_decompress_token_account.as_ref() {
             token_account


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added checks to prevent operations when a CPI context is provided, displaying an error message indicating the feature is not enabled for burn, approve, revoke, freeze/thaw, transfer, and compress SPL token account operations.
  * Updated the maximum number of pool accounts per mint from 5 to 4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->