### PR TITLE
feat: add log rotation for forester

### DIFF
--- a/forester/src/telemetry.rs
+++ b/forester/src/telemetry.rs
@@ -8,34 +8,54 @@ static INIT: Once = Once::new();
 
 pub fn setup_telemetry() {
     INIT.call_once(|| {
-        let file_appender = RollingFileAppender::new(Rotation::HOURLY, "logs", "forester.log");
-        let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+        let file_appender = match RollingFileAppender::builder()
+            .rotation(Rotation::HOURLY)
+            .filename_prefix("forester")
+            .filename_suffix("log")
+            .max_log_files(48) // 2 days
+            .build("logs")
+        {
+            Ok(appender) => Some(appender),
+            Err(e) => {
+                eprintln!(
+                    "Warning: Failed to create log file appender: {}. Logging to stdout only.",
+                    e
+                );
+                None
+            }
+        };
 
-        let env_filter = EnvFilter::try_from_default_env()
-            .unwrap_or_else(|_| EnvFilter::new("info,forester=debug"));
-
-        let file_env_filter = EnvFilter::new("info,forester=debug");
+        let env_filter =
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
         let stdout_env_filter =
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug"));
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
         let stdout_layer = fmt::Layer::new()
             .with_writer(std::io::stdout)
             .with_ansi(true)
             .with_filter(stdout_env_filter);
 
-        let file_layer = fmt::Layer::new()
-            .with_writer(non_blocking)
-            .with_filter(file_env_filter);
+        if let Some(file_appender) = file_appender {
+            let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+            let file_env_filter = EnvFilter::new("info");
+            let file_layer = fmt::Layer::new()
+                .with_writer(non_blocking)
+                .with_filter(file_env_filter);
 
-        tracing_subscriber::registry()
-            .with(stdout_layer)
-            .with(file_layer)
-            .with(env_filter)
-            .init();
+            tracing_subscriber::registry()
+                .with(stdout_layer)
+                .with(file_layer)
+                .with(env_filter)
+                .init();
 
-        // Keep _guard in scope to keep the non-blocking writer alive
-        std::mem::forget(_guard);
+            std::mem::forget(_guard);
+        } else {
+            tracing_subscriber::registry()
+                .with(stdout_layer)
+                .with(env_filter)
+                .init();
+        }
     });
 }
 


### PR DESCRIPTION
Added log rotation with 48-hour retention (2 days) and fallback to stdout logging when file appender creation fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of log file creation and error handling; if log files cannot be created, logging will continue to standard output without interruption.

* **Refactor**
  * Simplified log level settings to default to "info" for both general and stdout logging.
  * Enhanced internal handling of log file rotation and retention for better stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->