### PR TITLE
feat: add processor mode selection to forester CLI

### DIFF
--- a/.github/workflows/forester-tests.yml
+++ b/.github/workflows/forester-tests.yml
@@ -43,7 +43,7 @@ jobs:
   test:
     name: Forester e2e test
     runs-on: warp-ubuntu-latest-x64-4x
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     services:
       redis:

--- a/forester/package.json
+++ b/forester/package.json
@@ -4,7 +4,7 @@
   "license": "GPL-3.0",
   "scripts": {
     "build": "cargo build",
-    "test": "source .env && RUST_LOG=forester=debug,forester_utils=debug cargo test --package forester test_e2e_v2 -- --nocapture",
+    "test": "source .env && RUST_LOG=forester=debug,forester_utils=debug cargo test --package forester e2e_test -- --nocapture",
     "docker:build": "docker build --tag forester -f Dockerfile .."
   },
   "devDependencies": {

--- a/forester/src/config.rs
+++ b/forester/src/config.rs
@@ -8,7 +8,7 @@ use light_registry::{EpochPda, ForesterEpochPda};
 use solana_sdk::{pubkey::Pubkey, signature::Keypair};
 
 use crate::{
-    cli::{StartArgs, StatusArgs},
+    cli::{ProcessorMode, StartArgs, StatusArgs},
     errors::ConfigError,
     Result,
 };
@@ -245,10 +245,10 @@ impl ForesterConfig {
                 slot_update_interval_seconds: args.slot_update_interval_seconds,
                 tree_discovery_interval_seconds: args.tree_discovery_interval_seconds,
                 enable_metrics: args.enable_metrics(),
-                skip_v1_state_trees: false,
-                skip_v2_state_trees: false,
-                skip_v1_address_trees: false,
-                skip_v2_address_trees: false,
+                skip_v1_state_trees: args.processor_mode == ProcessorMode::V2,
+                skip_v2_state_trees: args.processor_mode == ProcessorMode::V1,
+                skip_v1_address_trees: args.processor_mode == ProcessorMode::V2,
+                skip_v2_address_trees: args.processor_mode == ProcessorMode::V1,
             },
             rpc_pool_config: RpcPoolConfig {
                 max_size: args.rpc_pool_size,

--- a/forester/src/epoch_manager.rs
+++ b/forester/src/epoch_manager.rs
@@ -1453,6 +1453,19 @@ pub async fn run_service<R: Rpc>(
 ) -> Result<()> {
     info_span!("run_service", forester = %config.payer_keypair.pubkey())
         .in_scope(|| async {
+            let processor_mode_str = match (
+                config.general_config.skip_v1_state_trees
+                    && config.general_config.skip_v1_address_trees,
+                config.general_config.skip_v2_state_trees
+                    && config.general_config.skip_v2_address_trees,
+            ) {
+                (true, false) => "v2",
+                (false, true) => "v1",
+                (false, false) => "all",
+                _ => "unknown",
+            };
+            info!("Starting forester in {} mode", processor_mode_str);
+
             const INITIAL_RETRY_DELAY: Duration = Duration::from_secs(1);
             const MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
 

--- a/forester/tests/priority_fee_test.rs
+++ b/forester/tests/priority_fee_test.rs
@@ -1,5 +1,5 @@
 use forester::{
-    cli::StartArgs,
+    cli::{ProcessorMode, StartArgs},
     processor::v1::{
         config::CapConfig,
         helpers::{get_capped_priority_fee, request_priority_fee_estimate},
@@ -75,6 +75,7 @@ async fn test_priority_fee_request() {
         rpc_rate_limit: None,
         photon_rate_limit: None,
         send_tx_rate_limit: None,
+        processor_mode: ProcessorMode::All,
     };
 
     let config = ForesterConfig::new_for_start(&args).expect("Failed to create config");

--- a/sdk-libs/client/src/rpc/client.rs
+++ b/sdk-libs/client/src/rpc/client.rs
@@ -175,7 +175,6 @@ impl LightClient {
                             self.retry_config.max_retries,
                             e
                         );
-                        tokio::task::yield_now().await;
                         sleep(self.retry_config.retry_delay).await;
                     } else {
                         return Err(e);


### PR DESCRIPTION
Add the ability to select processing mode (v1/v2/all trees) via a new CLI flag.