### PR TITLE
fix: correct Clone implementation for complex IndexerError variants

### DIFF
--- a/sdk-libs/client/src/indexer/error.rs
+++ b/sdk-libs/client/src/indexer/error.rs
@@ -132,14 +132,14 @@ impl Clone for IndexerError {
             },
             IndexerError::NotImplemented(message) => IndexerError::NotImplemented(message.clone()),
             IndexerError::Unknown(message) => IndexerError::Unknown(message.clone()),
-            IndexerError::ReferenceIndexedMerkleTreeError(_) => {
-                IndexerError::CustomError("ReferenceIndexedMerkleTreeError".to_string())
+            IndexerError::ReferenceIndexedMerkleTreeError(err) => {
+                IndexerError::ReferenceIndexedMerkleTreeError(err.clone())
             }
-            IndexerError::IndexedMerkleTreeError(_) => {
-                IndexerError::CustomError("IndexedMerkleTreeError".to_string())
+            IndexerError::IndexedMerkleTreeError(err) => {
+                IndexerError::IndexedMerkleTreeError(err.clone())
             }
             IndexerError::InvalidResponseData => IndexerError::InvalidResponseData,
-            IndexerError::CustomError(_) => IndexerError::CustomError("IndexerError".to_string()),
+            IndexerError::CustomError(message) => IndexerError::CustomError(message.clone()),
             IndexerError::NotInitialized => IndexerError::NotInitialized,
             IndexerError::IndexerNotSyncedToSlot => IndexerError::IndexerNotSyncedToSlot,
             IndexerError::InvalidPackTreeType => IndexerError::InvalidPackTreeType,


### PR DESCRIPTION
Fix IndexerError Clone implementation to preserve error information

- Properly clone ReferenceIndexedMerkleTreeError and IndexedMerkleTreeError
- Fix CustomError to clone actual message instead of fixed string
- Maintain error semantics and improve debugging capabilities