### PR TITLE
chore: remove global solana from PATH filtering, use isolated .local tooling when entering devenv.sh

### DIFF
--- a/scripts/devenv.sh
+++ b/scripts/devenv.sh
@@ -66,8 +66,8 @@ PATH="${LIGHT_PROTOCOL_TOPLEVEL}/.local/cargo/bin:${PATH}"
 PATH="${LIGHT_PROTOCOL_TOPLEVEL}/.local/go/bin:${PATH}"
 PATH="${LIGHT_PROTOCOL_TOPLEVEL}/.local/npm-global/bin:${PATH}"
 
-# Remove the original Rust-related PATH entries
-PATH=$(echo "$PATH" | tr ':' '\n' | grep -vE "/.rustup/|/.cargo/" | tr '\n' ':' | sed 's/:$//')
+# Remove the original Rust-related PATH entries and global Solana installations
+PATH=$(echo "$PATH" | tr ':' '\n' | grep -vE "/.rustup/|/.cargo/|/.local/share/solana/" | tr '\n' ':' | sed 's/:$//')
 
 # Define alias of `light` to use the CLI built from source (only if not in CI)
 if [ -z "${CI:-}" ]; then


### PR DESCRIPTION
1. devenv.sh update fixes the error when global tooling does not have solana target installed:

```
  error[E0463]: can't find crate for `std`
          |
          = note: the `sbpf-solana-solana` target may not be installed
          = help: consider adding the standard library to the sysroot with `x build library --target sbpf-solana-solana`
          = help: consider building the standard library from source with `cargo build -Zbuild-std`
        
        For more information about this error, try `rustc --explain E0463`.
        error: could not compile `solana-big-mod-exp` (lib) due to 1 previous error
        warning: build failed, waiting for other jobs to finish...
        error[E0463]: can't find crate for `core`
          |
          = note: the `sbpf-solana-solana` target may not be installed
          = help: consider adding the standard library to the sysroot with `x build library --target sbpf-solana-solana`
          = help: consider building the standard library from source with `cargo build -Zbuild-std`
        
        error: could not compile `itoa` (lib) due to 1 previous error
         ELIFECYCLE  Command failed with exit code 1.
         WARN   Local package.json exists, but node_modules missing, did you mean to install?
```

2. test.sh update fixes the error which prevents to run test.sh when you're in the devenv:
```
./scripts/test.sh 
  Failed to source devenv.sh. Aborting.

```