### PR TITLE
fix: non nullable data

### DIFF
--- a/js/stateless.js/src/rpc-interface.ts
+++ b/js/stateless.js/src/rpc-interface.ts
@@ -300,11 +300,7 @@ const BNFromStringOrNumber = coerce(
  *
  * @internal
  */
-const Base64EncodedCompressedAccountDataResult = coerce(
-    string(),
-    string(),
-    value => value,
-);
+const Base64EncodedCompressedAccountDataResult = string();
 /**
  * @internal
  */


### PR DESCRIPTION
The compressed account data returned by the indexer is never null (empty string if there is no data), so the type coercion should not return null. Otherwise, the validation fails