### PR TITLE
chore: bump program-libs versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "light-account-checks"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "borsh 0.10.4",
  "pinocchio",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "light-batched-merkle-tree"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "aligned-sized",
  "borsh 0.10.4",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "light-bloom-filter"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitvec",
  "light-hasher",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "light-compressed-account"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anchor-lang",
  "ark-bn254 0.5.0",
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "light-concurrent-merkle-tree"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "light-hash-set"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "light-hasher"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
@@ -3595,7 +3595,7 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-merkle-tree"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "light-bounded-vec",
  "light-concurrent-merkle-tree",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-metadata"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anchor-lang",
  "borsh 0.10.4",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-reference"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "light-hasher",
  "light-indexed-array",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "light-verifier"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "groth16-solana",
  "light-compressed-account",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "light-zero-copy"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "borsh 0.10.4",
  "light-zero-copy-derive",
@@ -3976,7 +3976,7 @@ dependencies = [
 
 [[package]]
 name = "light-zero-copy-derive"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "lazy_static",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,25 +154,25 @@ ark-std = "0.5"
 
 
 # Light Protocol
-light-hash-set = { version = "2.1.0", path = "program-libs/hash-set" }
-light-indexed-merkle-tree = { version = "2.1.0", path = "program-libs/indexed-merkle-tree" }
-light-concurrent-merkle-tree = { version = "2.1.0", path = "program-libs/concurrent-merkle-tree" }
+light-hash-set = { version = "3.0.0", path = "program-libs/hash-set" }
+light-indexed-merkle-tree = { version = "3.0.0", path = "program-libs/indexed-merkle-tree" }
+light-concurrent-merkle-tree = { version = "3.0.0", path = "program-libs/concurrent-merkle-tree" }
 light-sparse-merkle-tree = { version = "0.1.0", path = "sparse-merkle-tree" }
 light-client = { path = "sdk-libs/client", version = "0.14.0" }
-light-hasher = { path = "program-libs/hasher", version = "3.1.0" }
+light-hasher = { path = "program-libs/hasher", version = "4.0.0" }
 light-macros = { path = "program-libs/macros", version = "2.1.0" }
-light-merkle-tree-reference = { path = "program-tests/merkle-tree", version = "2.0.0" }
+light-merkle-tree-reference = { path = "program-tests/merkle-tree", version = "3.0.0" }
 light-heap = { path = "program-libs/heap", version = "2.0.0" }
 light-prover-client = { path = "prover/client", version = "2.0.0" }
 light-sdk = { path = "sdk-libs/sdk", version = "0.13.0" }
 light-sdk-pinocchio = { path = "sdk-libs/sdk-pinocchio", version = "0.13.0" }
 light-sdk-macros = { path = "sdk-libs/macros", version = "0.13.0" }
 light-sdk-types = { path = "sdk-libs/sdk-types", version = "0.13.0" }
-light-compressed-account = { path = "program-libs/compressed-account", version = "0.4.0" }
-light-account-checks = { path = "program-libs/account-checks", version = "0.3.0" }
-light-verifier = { path = "program-libs/verifier", version = "3.0.0" }
-light-zero-copy = { path = "program-libs/zero-copy", version = "0.3.0" }
-light-zero-copy-derive = { path = "program-libs/zero-copy-derive", version = "0.3.0" }
+light-compressed-account = { path = "program-libs/compressed-account", version = "0.5.0" }
+light-account-checks = { path = "program-libs/account-checks", version = "0.4.0" }
+light-verifier = { path = "program-libs/verifier", version = "4.0.0" }
+light-zero-copy = { path = "program-libs/zero-copy", version = "0.4.0" }
+light-zero-copy-derive = { path = "program-libs/zero-copy-derive", version = "0.4.0" }
 photon-api = { path = "sdk-libs/photon-api", version = "0.51.0" }
 forester-utils = { path = "forester-utils", version = "2.0.0" }
 account-compression = { path = "programs/account-compression", version = "2.0.0", features = [
@@ -192,10 +192,10 @@ create-address-test-program = { path = "program-tests/create-address-test-progra
     "cpi",
 ] }
 light-program-test = { path = "sdk-libs/program-test", version = "0.14.0" }
-light-batched-merkle-tree = { path = "program-libs/batched-merkle-tree", version = "0.4.2" }
-light-merkle-tree-metadata = { path = "program-libs/merkle-tree-metadata", version = "0.4.0" }
+light-batched-merkle-tree = { path = "program-libs/batched-merkle-tree", version = "0.5.0" }
+light-merkle-tree-metadata = { path = "program-libs/merkle-tree-metadata", version = "0.5.0" }
 aligned-sized = { path = "program-libs/aligned-sized", version = "1.1.0" }
-light-bloom-filter = { path = "program-libs/bloom-filter", version = "0.3.0" }
+light-bloom-filter = { path = "program-libs/bloom-filter", version = "0.4.0" }
 light-bounded-vec = { version = "2.0.0" }
 light-poseidon = { version = "0.3.0" }
 light-test-utils = { path = "program-tests/utils", version = "1.2.1" }
@@ -248,7 +248,3 @@ dependent-version = "upgrade"
 consolidate-commits = false
 # Don't verify (skip tests/build checks)
 verify = false
-
-[workspace.metadata.release.rate-limit]
-new-packages = 5
-existing-packages = 5

--- a/program-libs/account-checks/Cargo.toml
+++ b/program-libs/account-checks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-account-checks"
-version = "0.3.0"
+version = "0.4.0"
 description = "Checks for solana accounts."
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/batched-merkle-tree/Cargo.toml
+++ b/program-libs/batched-merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-batched-merkle-tree"
-version = "0.4.2"
+version = "0.5.0"
 description = "Batch Merkle tree implementation."
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/bloom-filter/Cargo.toml
+++ b/program-libs/bloom-filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-bloom-filter"
-version = "0.3.0"
+version = "0.4.0"
 description = "Experimental bloom filter."
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/compressed-account/Cargo.toml
+++ b/program-libs/compressed-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-compressed-account"
-version = "0.4.0"
+version = "0.5.0"
 description = "Compressed account struct and common utility functions used in Light Protocol."
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/concurrent-merkle-tree/Cargo.toml
+++ b/program-libs/concurrent-merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-concurrent-merkle-tree"
-version = "2.1.0"
+version = "3.0.0"
 edition = "2021"
 description = "Concurrent Merkle tree implementation"
 repository = "https://github.com/Lightprotocol/light-protocol"

--- a/program-libs/hash-set/Cargo.toml
+++ b/program-libs/hash-set/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-hash-set"
-version = "2.1.0"
+version = "3.0.0"
 description = "Hash set which can be stored on a Solana account"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/hasher/Cargo.toml
+++ b/program-libs/hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-hasher"
-version = "3.1.0"
+version = "4.0.0"
 description = "Trait for generic usage of hash functions on Solana"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/indexed-merkle-tree/Cargo.toml
+++ b/program-libs/indexed-merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-indexed-merkle-tree"
-version = "2.1.0"
+version = "3.0.0"
 description = "Implementation of indexed (and concurrent) Merkle tree in Rust"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/merkle-tree-metadata/Cargo.toml
+++ b/program-libs/merkle-tree-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-merkle-tree-metadata"
-version = "0.4.0"
+version = "0.5.0"
 description = "Merkle tree metadata for light-concurrent-merkle-tree, light-indexed-merkle-tree, light-batched-merkle-tree."
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/verifier/Cargo.toml
+++ b/program-libs/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-verifier"
-version = "3.0.0"
+version = "4.0.0"
 description = "ZKP proof verifier used in Light Protocol"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/zero-copy-derive/Cargo.toml
+++ b/program-libs/zero-copy-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-zero-copy-derive"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Proc macro for zero-copy deserialization"

--- a/program-libs/zero-copy/Cargo.toml
+++ b/program-libs/zero-copy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-zero-copy"
-version = "0.3.0"
+version = "0.4.0"
 description = "Zero copy vector and utils for Solana programs."
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-tests/merkle-tree/Cargo.toml
+++ b/program-tests/merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-merkle-tree-reference"
-version = "2.0.0"
+version = "3.0.0"
 description = "Non-sparse reference Merkle tree implementation"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"


### PR DESCRIPTION
## Program-libs Release

This PR bumps versions for program-libs crates.

### Version Bumps

```
  light-account-checks: 0.3.0 → 0.4.0
  light-batched-merkle-tree: 0.4.2 → 0.5.0
  light-bloom-filter: 0.3.0 → 0.4.0
  light-compressed-account: 0.4.0 → 0.5.0
  light-concurrent-merkle-tree: 2.1.0 → 3.0.0
  light-hash-set: 2.1.0 → 3.0.0
  light-hasher: 3.1.0 → 4.0.0
  light-indexed-merkle-tree: 2.1.0 → 3.0.0
  light-merkle-tree-metadata: 0.4.0 → 0.5.0
  light-verifier: 3.0.0 → 4.0.0
  light-zero-copy-derive: 0.3.0 → 0.4.0
  light-zero-copy: 0.3.0 → 0.4.0
  light-merkle-tree-reference: 2.0.0 → 3.0.0
```

### Release Process
1. Versions bumped in Cargo.toml files
2. PR validation (dry-run) will run automatically
3. After merge, GitHub Action will publish each crate individually to crates.io and create releases

---
*Generated by `scripts/create-release-pr.sh program-libs`*