### PR TITLE
chore: bump program-libs versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-array"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "light-hasher",
  "num-bigint 0.4.6",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-reference"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "light-hasher",
  "light-indexed-array",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "light-sparse-merkle-tree"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "light-hasher",
  "light-indexed-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,11 +157,11 @@ ark-std = "0.5"
 light-hash-set = { version = "3.0.0", path = "program-libs/hash-set" }
 light-indexed-merkle-tree = { version = "3.0.0", path = "program-libs/indexed-merkle-tree" }
 light-concurrent-merkle-tree = { version = "3.0.0", path = "program-libs/concurrent-merkle-tree" }
-light-sparse-merkle-tree = { version = "0.1.0", path = "sparse-merkle-tree" }
+light-sparse-merkle-tree = { version = "0.2.0", path = "sparse-merkle-tree" }
 light-client = { path = "sdk-libs/client", version = "0.14.0" }
 light-hasher = { path = "program-libs/hasher", version = "4.0.0" }
 light-macros = { path = "program-libs/macros", version = "2.1.0" }
-light-merkle-tree-reference = { path = "program-tests/merkle-tree", version = "3.0.0" }
+light-merkle-tree-reference = { path = "program-tests/merkle-tree", version = "3.0.1" }
 light-heap = { path = "program-libs/heap", version = "2.0.0" }
 light-prover-client = { path = "prover/client", version = "2.0.0" }
 light-sdk = { path = "sdk-libs/sdk", version = "0.13.0" }
@@ -199,7 +199,7 @@ light-bloom-filter = { path = "program-libs/bloom-filter", version = "0.4.0" }
 light-bounded-vec = { version = "2.0.0" }
 light-poseidon = { version = "0.3.0" }
 light-test-utils = { path = "program-tests/utils", version = "1.2.1" }
-light-indexed-array = { path = "program-libs/indexed-array", version = "0.1.0" }
+light-indexed-array = { path = "program-libs/indexed-array", version = "0.2.0" }
 light-program-profiler = { version = "0.1.0" }
 create-address-program-test = { path = "program-tests/create-address-test-program", version = "1.0.0" }
 groth16-solana = { version = "0.2.0" }

--- a/program-libs/indexed-array/Cargo.toml
+++ b/program-libs/indexed-array/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-indexed-array"
-version = "0.1.0"
+version = "0.2.0"
 description = "Implementation of indexed (and concurrent) Merkle tree in Rust"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-tests/merkle-tree/Cargo.toml
+++ b/program-tests/merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-merkle-tree-reference"
-version = "3.0.0"
+version = "3.0.1"
 description = "Non-sparse reference Merkle tree implementation"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/scripts/detect-version-changes.sh
+++ b/scripts/detect-version-changes.sh
@@ -29,8 +29,8 @@ else
   DIFF_ARGS=("$BASE_REF...$HEAD_REF")
 fi
 
-# Get list of changed Cargo.toml files in program-libs, sdk-libs, and program-tests/merkle-tree
-for file in $(git diff "${DIFF_ARGS[@]}" --name-only -- '**/Cargo.toml' | grep -E '(program-libs|sdk-libs|program-tests/merkle-tree)/'); do
+# Get list of changed Cargo.toml files in program-libs, sdk-libs, program-tests/merkle-tree, and sparse-merkle-tree
+for file in $(git diff "${DIFF_ARGS[@]}" --name-only -- '**/Cargo.toml' | grep -E '(program-libs|sdk-libs|program-tests/merkle-tree|sparse-merkle-tree)/'); do
   # Extract old and new version from the diff
   versions=$(git diff "${DIFF_ARGS[@]}" -- "$file" | grep -E '^\+version|^-version' | grep -v '+++\|---')
   old_ver=$(echo "$versions" | grep '^-version' | head -1 | awk -F'"' '{print $2}')

--- a/sparse-merkle-tree/Cargo.toml
+++ b/sparse-merkle-tree/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "light-sparse-merkle-tree"
-version = "0.1.0"
+version = "0.2.0"
 description = "Implementation of a sparse indexed (and concurrent) Merkle tree in Rust"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"
 edition = "2021"
-publish = false
 
 [dependencies]
 light-hasher = { workspace = true }


### PR DESCRIPTION
## Program-libs Release

This PR bumps versions for program-libs crates.

### Version Bumps

```
  light-indexed-array: 0.1.0 → 0.2.0
  light-merkle-tree-reference: 3.0.0 → 3.0.1
```

### Release Process
1. Versions bumped in Cargo.toml files
2. PR validation (dry-run) will run automatically
3. After merge, GitHub Action will publish each crate individually to crates.io and create releases

---
*Generated by `scripts/create-release-pr.sh program-libs`*