### PR TITLE
chore: bump sdk-libs versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "light-client"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "light-program-test"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "account-compression",
  "anchor-lang",
@@ -3742,7 +3742,7 @@ dependencies = [
 
 [[package]]
 name = "light-prover-client"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-serialize 0.5.0",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "light-sdk"
-version = "0.13.0"
+version = "0.15.0"
 dependencies = [
  "anchor-lang",
  "borsh 0.10.4",
@@ -3804,7 +3804,7 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-macros"
-version = "0.13.0"
+version = "0.15.0"
 dependencies = [
  "borsh 0.10.4",
  "light-account-checks",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-types"
-version = "0.13.0"
+version = "0.15.0"
 dependencies = [
  "anchor-lang",
  "borsh 0.10.4",
@@ -4596,7 +4596,7 @@ dependencies = [
 
 [[package]]
 name = "photon-api"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "reqwest 0.12.23",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,22 +158,22 @@ light-hash-set = { version = "3.0.0", path = "program-libs/hash-set" }
 light-indexed-merkle-tree = { version = "3.0.0", path = "program-libs/indexed-merkle-tree" }
 light-concurrent-merkle-tree = { version = "3.0.0", path = "program-libs/concurrent-merkle-tree" }
 light-sparse-merkle-tree = { version = "0.2.0", path = "sparse-merkle-tree" }
-light-client = { path = "sdk-libs/client", version = "0.14.0" }
+light-client = { path = "sdk-libs/client", version = "0.15.0" }
 light-hasher = { path = "program-libs/hasher", version = "4.0.0" }
 light-macros = { path = "program-libs/macros", version = "2.1.0" }
 light-merkle-tree-reference = { path = "program-tests/merkle-tree", version = "3.0.1" }
 light-heap = { path = "program-libs/heap", version = "2.0.0" }
-light-prover-client = { path = "prover/client", version = "2.0.0" }
-light-sdk = { path = "sdk-libs/sdk", version = "0.13.0" }
+light-prover-client = { path = "prover/client", version = "3.0.0" }
+light-sdk = { path = "sdk-libs/sdk", version = "0.15.0" }
 light-sdk-pinocchio = { path = "sdk-libs/sdk-pinocchio", version = "0.13.0" }
-light-sdk-macros = { path = "sdk-libs/macros", version = "0.13.0" }
-light-sdk-types = { path = "sdk-libs/sdk-types", version = "0.13.0" }
+light-sdk-macros = { path = "sdk-libs/macros", version = "0.15.0" }
+light-sdk-types = { path = "sdk-libs/sdk-types", version = "0.15.0" }
 light-compressed-account = { path = "program-libs/compressed-account", version = "0.5.0" }
 light-account-checks = { path = "program-libs/account-checks", version = "0.4.0" }
 light-verifier = { path = "program-libs/verifier", version = "4.0.0" }
 light-zero-copy = { path = "program-libs/zero-copy", version = "0.4.0" }
 light-zero-copy-derive = { path = "program-libs/zero-copy-derive", version = "0.4.0" }
-photon-api = { path = "sdk-libs/photon-api", version = "0.51.0" }
+photon-api = { path = "sdk-libs/photon-api", version = "0.52.0" }
 forester-utils = { path = "forester-utils", version = "2.0.0" }
 account-compression = { path = "programs/account-compression", version = "2.0.0", features = [
     "cpi",
@@ -191,7 +191,7 @@ light-registry = { path = "programs/registry", version = "2.0.0", features = [
 create-address-test-program = { path = "program-tests/create-address-test-program", version = "1.0.0", features = [
     "cpi",
 ] }
-light-program-test = { path = "sdk-libs/program-test", version = "0.14.0" }
+light-program-test = { path = "sdk-libs/program-test", version = "0.15.0" }
 light-batched-merkle-tree = { path = "program-libs/batched-merkle-tree", version = "0.5.0" }
 light-merkle-tree-metadata = { path = "program-libs/merkle-tree-metadata", version = "0.5.0" }
 aligned-sized = { path = "program-libs/aligned-sized", version = "1.1.0" }

--- a/prover/client/Cargo.toml
+++ b/prover/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-prover-client"
-version = "2.0.0"
+version = "3.0.0"
 description = "Crate for interacting with Light Protocol circuits"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -44,7 +44,7 @@ get_version_changes() {
         diff_args=("$base_ref...$head_ref")
     fi
 
-    # Get list of changed Cargo.toml files in program-libs, sdk-libs, and program-tests/merkle-tree
+    # Get list of changed Cargo.toml files in program-libs, sdk-libs, program-tests/merkle-tree, sparse-merkle-tree, and prover
     while IFS= read -r file; do
         # Extract old and new version from the diff
         local versions=$(git diff "${diff_args[@]}" -- "$file" | grep -E '^\+version|^-version' | grep -v '+++\|---')
@@ -60,7 +60,7 @@ get_version_changes() {
                 echo "$pkg_name $old_ver $new_ver"
             fi
         fi
-    done < <(git diff "${diff_args[@]}" --name-only -- '**/Cargo.toml' | grep -E '(program-libs|sdk-libs|program-tests/merkle-tree)/')
+    done < <(git diff "${diff_args[@]}" --name-only -- '**/Cargo.toml' | grep -E '(program-libs|sdk-libs|program-tests/merkle-tree|sparse-merkle-tree|prover)/')
 }
 
 # Check if there are changes

--- a/scripts/detect-version-changes.sh
+++ b/scripts/detect-version-changes.sh
@@ -29,8 +29,8 @@ else
   DIFF_ARGS=("$BASE_REF...$HEAD_REF")
 fi
 
-# Get list of changed Cargo.toml files in program-libs, sdk-libs, program-tests/merkle-tree, and sparse-merkle-tree
-for file in $(git diff "${DIFF_ARGS[@]}" --name-only -- '**/Cargo.toml' | grep -E '(program-libs|sdk-libs|program-tests/merkle-tree|sparse-merkle-tree)/'); do
+# Get list of changed Cargo.toml files in program-libs, sdk-libs, program-tests/merkle-tree, sparse-merkle-tree, and prover
+for file in $(git diff "${DIFF_ARGS[@]}" --name-only -- '**/Cargo.toml' | grep -E '(program-libs|sdk-libs|program-tests/merkle-tree|sparse-merkle-tree|prover)/'); do
   # Extract old and new version from the diff
   versions=$(git diff "${DIFF_ARGS[@]}" -- "$file" | grep -E '^\+version|^-version' | grep -v '+++\|---')
   old_ver=$(echo "$versions" | grep '^-version' | head -1 | awk -F'"' '{print $2}')

--- a/scripts/validate-packages.sh
+++ b/scripts/validate-packages.sh
@@ -61,7 +61,7 @@ echo ""
 echo "Running compilation check..."
 for pkg in "${PACKAGES[@]}"; do
   echo "  Checking $pkg..."
-  if ! cargo check -p "$pkg" --all-features 2>&1 | tail -20; then
+  if ! cargo test -p "$pkg" --all-features --no-run 2>&1 | tail -20; then
     echo "Error: Compilation check failed for $pkg"
     exit 1
   fi

--- a/sdk-libs/client/Cargo.toml
+++ b/sdk-libs/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-client"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/lightprotocol/light-protocol"
@@ -44,7 +44,6 @@ light-sdk = { workspace = true }
 light-hasher = { workspace = true }
 light-compressed-account = { workspace = true, features = ["solana"] }
 
-# unrelased
 photon-api = { workspace = true }
 light-prover-client = { workspace = true }
 litesvm = { workspace = true, optional = true }

--- a/sdk-libs/macros/Cargo.toml
+++ b/sdk-libs/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-sdk-macros"
-version = "0.13.0"
+version = "0.15.0"
 description = "Macros for Programs using the Light SDK for ZK Compression "
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/sdk-libs/photon-api/Cargo.toml
+++ b/sdk-libs/photon-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "photon-api"
-version = "0.51.0"
+version = "0.52.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "Solana indexer for general compression"
 license = "Apache-2.0"

--- a/sdk-libs/program-test/Cargo.toml
+++ b/sdk-libs/program-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-program-test"
-version = "0.14.0"
+version = "0.15.0"
 description = "A fast local test environment for Solana programs using compressed accounts and tokens."
 license = "MIT"
 edition = "2021"

--- a/sdk-libs/sdk-types/Cargo.toml
+++ b/sdk-libs/sdk-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-sdk-types"
-version = "0.13.0"
+version = "0.15.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/lightprotocol/light-protocol"

--- a/sdk-libs/sdk/Cargo.toml
+++ b/sdk-libs/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-sdk"
-version = "0.13.0"
+version = "0.15.0"
 description = "Rust SDK for ZK Compression on Solana"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"


### PR DESCRIPTION
## Sdk-libs Release

This PR bumps versions for sdk-libs crates.

### Version Bumps

```
  light-prover-client: 2.0.0 → 3.0.0
  light-client: 0.14.0 → 0.15.0
  light-sdk-macros: 0.13.0 → 0.15.0
  photon-api: 0.51.0 → 0.52.0
  light-program-test: 0.14.0 → 0.15.0
  light-sdk-types: 0.13.0 → 0.15.0
  light-sdk: 0.13.0 → 0.15.0
```

### Release Process
1. Versions bumped in Cargo.toml files
2. PR validation (dry-run) will run automatically
3. After merge, GitHub Action will publish each crate individually to crates.io and create releases

---
*Generated by `scripts/create-release-pr.sh sdk-libs`*