### PR TITLE
chore: remove proving keys and programs dependency from CI

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -112,19 +112,6 @@ runs:
       shell: bash
       run: bash scripts/devenv/install-photon.sh
 
-    - name: Cache proving keys
-      if: "!contains(inputs.skip-components, 'proving-keys')"
-      id: cache-keys
-      uses: actions/cache@v4
-      with:
-        path: prover/server/proving-keys
-        key: ${{ runner.os }}-proving-keys-${{ inputs.cache-suffix }}${{ inputs.cache-suffix && '-' || '' }}${{ hashFiles('prover/server/prover/common/key_downloader.go', 'prover/server/prover/common/proving_keys_utils.go') }}
-
-    - name: Download proving keys
-      if: "!contains(inputs.skip-components, 'proving-keys') && steps.cache-keys.outputs.cache-hit != 'true'"
-      shell: bash
-      run: bash scripts/devenv/download-gnark-keys.sh
-
     - name: Set Light Protocol environment variables
       shell: bash
       run: |

--- a/cli/package.json
+++ b/cli/package.json
@@ -54,7 +54,6 @@
   },
   "devDependencies": {
     "@eslint/js": "9.36.0",
-    "@lightprotocol/programs": "workspace:*",
     "@oclif/test": "^4.1.14",
     "@solana/spl-token": "^0.3.11",
     "@types/bn.js": "^5.1.5",

--- a/js/compressed-token/package.json
+++ b/js/compressed-token/package.json
@@ -43,7 +43,6 @@
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
         "@eslint/js": "9.36.0",
         "@lightprotocol/hasher.rs": "0.2.1",
-        "@lightprotocol/programs": "workspace:*",
         "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^26.0.1",

--- a/js/stateless.js/package.json
+++ b/js/stateless.js/package.json
@@ -54,7 +54,6 @@
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
         "@eslint/js": "9.36.0",
         "@lightprotocol/hasher.rs": "0.2.1",
-        "@lightprotocol/programs": "workspace:*",
         "@playwright/test": "^1.47.1",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^26.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,9 +105,6 @@ importers:
       '@eslint/js':
         specifier: 9.36.0
         version: 9.36.0
-      '@lightprotocol/programs':
-        specifier: workspace:*
-        version: link:../programs
       '@oclif/test':
         specifier: ^4.1.14
         version: 4.1.14(@oclif/core@4.5.4)
@@ -211,9 +208,6 @@ importers:
       '@lightprotocol/hasher.rs':
         specifier: 0.2.1
         version: 0.2.1
-      '@lightprotocol/programs':
-        specifier: workspace:*
-        version: link:../../programs
       '@rollup/plugin-alias':
         specifier: ^5.1.0
         version: 5.1.0(rollup@4.21.3)
@@ -353,9 +347,6 @@ importers:
       '@lightprotocol/hasher.rs':
         specifier: 0.2.1
         version: 0.2.1
-      '@lightprotocol/programs':
-        specifier: workspace:*
-        version: link:../../programs
       '@playwright/test':
         specifier: ^1.47.1
         version: 1.47.1


### PR DESCRIPTION
- Remove proving keys caching and download from setup-and-build action
- Remove @lightprotocol/programs from devDependencies in stateless.js, compressed-token, and CLI packages

This simplifies the CI workflow and removes unnecessary build dependencies.