### PR TITLE
chore: bump program-libs versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3352,10 +3352,9 @@ dependencies = [
 
 [[package]]
 name = "light-account-checks"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "borsh 0.10.4",
- "light-account-checks",
  "pinocchio",
  "rand 0.8.5",
  "solana-account-info",
@@ -3375,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "light-batched-merkle-tree"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aligned-sized",
  "borsh 0.10.4",
@@ -3401,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "light-bloom-filter"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitvec",
  "light-hasher",
@@ -3474,14 +3473,13 @@ dependencies = [
 
 [[package]]
 name = "light-compressed-account"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anchor-lang",
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
  "borsh 0.10.4",
  "bytemuck",
- "light-compressed-account",
  "light-hasher",
  "light-heap",
  "light-macros",
@@ -3608,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "light-concurrent-merkle-tree"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
@@ -3676,7 +3674,7 @@ dependencies = [
 
 [[package]]
 name = "light-hash-set"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
@@ -3690,12 +3688,11 @@ dependencies = [
 
 [[package]]
 name = "light-hasher"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
  "borsh 0.10.4",
- "light-hasher",
  "light-poseidon 0.3.0",
  "num-bigint 0.4.6",
  "pinocchio",
@@ -3718,7 +3715,7 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-array"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "light-hasher",
  "num-bigint 0.4.6",
@@ -3729,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-merkle-tree"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "light-bounded-vec",
  "light-concurrent-merkle-tree",
@@ -3746,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "light-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -3757,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-metadata"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anchor-lang",
  "borsh 0.10.4",
@@ -4120,7 +4117,7 @@ dependencies = [
 
 [[package]]
 name = "light-verifier"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "groth16-solana",
  "light-compressed-account",
@@ -4132,10 +4129,9 @@ dependencies = [
 
 [[package]]
 name = "light-zero-copy"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "borsh 0.10.4",
- "light-zero-copy",
  "light-zero-copy-derive",
  "pinocchio",
  "rand 0.8.5",
@@ -4146,7 +4142,7 @@ dependencies = [
 
 [[package]]
 name = "light-zero-copy-derive"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "lazy_static",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,14 +163,14 @@ ark-std = "0.5"
 
 
 # Light Protocol
-light-hash-set = { version = "3.0.0", path = "program-libs/hash-set" }
-light-indexed-merkle-tree = { version = "3.0.0", path = "program-libs/indexed-merkle-tree" }
-light-concurrent-merkle-tree = { version = "3.0.0", path = "program-libs/concurrent-merkle-tree" }
+light-hash-set = { version = "4.0.0", path = "program-libs/hash-set" }
+light-indexed-merkle-tree = { version = "4.0.0", path = "program-libs/indexed-merkle-tree" }
+light-concurrent-merkle-tree = { version = "4.0.0", path = "program-libs/concurrent-merkle-tree" }
 light-sparse-merkle-tree = { version = "0.2.0", path = "sparse-merkle-tree" }
 light-client = { path = "sdk-libs/client", version = "0.15.0" }
 light-event = { path = "sdk-libs/event", version = "0.1.0" }
-light-hasher = { path = "program-libs/hasher", version = "4.0.0", default-features = false }
-light-macros = { path = "program-libs/macros", version = "2.1.0" }
+light-hasher = { path = "program-libs/hasher", version = "5.0.0", default-features = false }
+light-macros = { path = "program-libs/macros", version = "2.2.0" }
 light-merkle-tree-reference = { path = "program-tests/merkle-tree", version = "3.0.1" }
 light-heap = { path = "program-libs/heap", version = "2.0.0" }
 light-prover-client = { path = "prover/client", version = "3.0.0" }
@@ -178,13 +178,13 @@ light-sdk = { path = "sdk-libs/sdk", version = "0.15.0" }
 light-sdk-pinocchio = { path = "sdk-libs/sdk-pinocchio", version = "0.13.0" }
 light-sdk-macros = { path = "sdk-libs/macros", version = "0.15.0" }
 light-sdk-types = { path = "sdk-libs/sdk-types", version = "0.15.0", default-features = false }
-light-compressed-account = { path = "program-libs/compressed-account", version = "0.5.0", default-features = false }
+light-compressed-account = { path = "program-libs/compressed-account", version = "0.6.0", default-features = false }
 light-compressible = { path = "program-libs/compressible", version = "0.1.0" }
 light-ctoken-types = { path = "program-libs/ctoken-types", version = "0.1.0" }
-light-account-checks = { path = "program-libs/account-checks", version = "0.4.0", default-features = false }
-light-verifier = { path = "program-libs/verifier", version = "4.0.0" }
-light-zero-copy = { path = "program-libs/zero-copy", version = "0.4.0", default-features = false }
-light-zero-copy-derive = { path = "program-libs/zero-copy-derive", version = "0.4.0" }
+light-account-checks = { path = "program-libs/account-checks", version = "0.5.0", default-features = false }
+light-verifier = { path = "program-libs/verifier", version = "5.0.0" }
+light-zero-copy = { path = "program-libs/zero-copy", version = "0.5.0", default-features = false }
+light-zero-copy-derive = { path = "program-libs/zero-copy-derive", version = "0.5.0" }
 photon-api = { path = "sdk-libs/photon-api", version = "0.52.0" }
 forester-utils = { path = "forester-utils", version = "2.0.0" }
 account-compression = { path = "programs/account-compression", version = "2.0.0", features = [
@@ -206,14 +206,14 @@ create-address-test-program = { path = "program-tests/create-address-test-progra
     "cpi",
 ] }
 light-program-test = { path = "sdk-libs/program-test", version = "0.15.0" }
-light-batched-merkle-tree = { path = "program-libs/batched-merkle-tree", version = "0.5.0" }
-light-merkle-tree-metadata = { path = "program-libs/merkle-tree-metadata", version = "0.5.0" }
+light-batched-merkle-tree = { path = "program-libs/batched-merkle-tree", version = "0.6.0" }
+light-merkle-tree-metadata = { path = "program-libs/merkle-tree-metadata", version = "0.6.0" }
 aligned-sized = { path = "program-libs/aligned-sized", version = "1.1.0" }
-light-bloom-filter = { path = "program-libs/bloom-filter", version = "0.4.0" }
+light-bloom-filter = { path = "program-libs/bloom-filter", version = "0.5.0" }
 light-bounded-vec = { version = "2.0.0" }
 light-poseidon = { version = "0.3.0" }
 light-test-utils = { path = "program-tests/utils", version = "1.2.1" }
-light-indexed-array = { path = "program-libs/indexed-array", version = "0.2.0" }
+light-indexed-array = { path = "program-libs/indexed-array", version = "0.3.0" }
 light-array-map = { path = "program-libs/array-map", version = "0.1.0" }
 light-program-profiler = { version = "0.1.0" }
 create-address-program-test = { path = "program-tests/create-address-test-program", version = "1.0.0" }

--- a/program-libs/account-checks/Cargo.toml
+++ b/program-libs/account-checks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-account-checks"
-version = "0.4.0"
+version = "0.5.0"
 description = "Checks for solana accounts."
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"
@@ -35,7 +35,6 @@ rand = { workspace = true, optional = true }
 pinocchio = { workspace = true }
 borsh = { workspace = true }
 solana-pubkey = { workspace = true, features = ["curve25519", "sha2"] }
-light-account-checks = { workspace = true, features = ["solana", "pinocchio", "test-only", "std"] }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/program-libs/batched-merkle-tree/Cargo.toml
+++ b/program-libs/batched-merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-batched-merkle-tree"
-version = "0.5.0"
+version = "0.6.0"
 description = "Batch Merkle tree implementation."
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/bloom-filter/Cargo.toml
+++ b/program-libs/bloom-filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-bloom-filter"
-version = "0.4.0"
+version = "0.5.0"
 description = "Experimental bloom filter."
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/compressed-account/Cargo.toml
+++ b/program-libs/compressed-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-compressed-account"
-version = "0.5.0"
+version = "0.6.0"
 description = "Compressed account struct and common utility functions used in Light Protocol."
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"
@@ -46,4 +46,3 @@ borsh = { workspace = true }
 ark-ff = { workspace = true }
 ark-bn254 = { workspace = true }
 num-bigint = { workspace = true, features = ["rand"] }
-light-compressed-account = { workspace = true, features = ["new-unique", "std"] }

--- a/program-libs/concurrent-merkle-tree/Cargo.toml
+++ b/program-libs/concurrent-merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-concurrent-merkle-tree"
-version = "3.0.0"
+version = "4.0.0"
 edition = "2021"
 description = "Concurrent Merkle tree implementation"
 repository = "https://github.com/Lightprotocol/light-protocol"

--- a/program-libs/hash-set/Cargo.toml
+++ b/program-libs/hash-set/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-hash-set"
-version = "3.0.0"
+version = "4.0.0"
 description = "Hash set which can be stored on a Solana account"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/hasher/Cargo.toml
+++ b/program-libs/hasher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-hasher"
-version = "4.0.0"
+version = "5.0.0"
 description = "Trait for generic usage of hash functions on Solana"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"
@@ -48,4 +48,3 @@ rand = { workspace = true }
 num-bigint = { workspace = true, features = ["rand"] }
 light-poseidon = { workspace = true }
 solana-pubkey = { workspace = true }
-light-hasher = { workspace = true, features = ["poseidon", "std", "keccak"] }

--- a/program-libs/hasher/tests/data_hasher.rs
+++ b/program-libs/hasher/tests/data_hasher.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "poseidon")]
+
 use std::vec::Vec;
 
 use light_hasher::{DataHasher, Hasher, HasherError, Poseidon};

--- a/program-libs/hasher/tests/hash_chain.rs
+++ b/program-libs/hasher/tests/hash_chain.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "poseidon")]
+
 use light_hasher::{
     hash_chain::{create_hash_chain_from_slice, create_two_inputs_hash_chain},
     Hasher, HasherError, Poseidon,

--- a/program-libs/hasher/tests/hash_to_field_size.rs
+++ b/program-libs/hasher/tests/hash_to_field_size.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "poseidon")]
+
 use ark_ff::PrimeField;
 use borsh::{BorshDeserialize, BorshSerialize};
 use light_hasher::{

--- a/program-libs/indexed-array/Cargo.toml
+++ b/program-libs/indexed-array/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-indexed-array"
-version = "0.2.0"
+version = "0.3.0"
 description = "Implementation of indexed (and concurrent) Merkle tree in Rust"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/indexed-merkle-tree/Cargo.toml
+++ b/program-libs/indexed-merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-indexed-merkle-tree"
-version = "3.0.0"
+version = "4.0.0"
 description = "Implementation of indexed (and concurrent) Merkle tree in Rust"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/macros/Cargo.toml
+++ b/program-libs/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-macros"
-version = "2.1.0"
+version = "2.2.0"
 description = "Macros used in Light Protocol on-chain programs"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/merkle-tree-metadata/Cargo.toml
+++ b/program-libs/merkle-tree-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-merkle-tree-metadata"
-version = "0.5.0"
+version = "0.6.0"
 description = "Merkle tree metadata for light-concurrent-merkle-tree, light-indexed-merkle-tree, light-batched-merkle-tree."
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/verifier/Cargo.toml
+++ b/program-libs/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-verifier"
-version = "4.0.0"
+version = "5.0.0"
 description = "ZKP proof verifier used in Light Protocol"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/zero-copy-derive/Cargo.toml
+++ b/program-libs/zero-copy-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-zero-copy-derive"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Proc macro for zero-copy deserialization"

--- a/program-libs/zero-copy/Cargo.toml
+++ b/program-libs/zero-copy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-zero-copy"
-version = "0.4.0"
+version = "0.5.0"
 description = "Zero copy vector and utils for Solana programs."
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"
@@ -27,4 +27,3 @@ zerocopy = { workspace = true, features = ["derive"] }
 borsh = { workspace = true }
 trybuild = "1.0"
 light-zero-copy-derive = { workspace = true }
-light-zero-copy = { workspace = true, features = ["std", "derive", "mut"] }


### PR DESCRIPTION
## Program-libs Release

This PR bumps versions for program-libs crates.

### Version Bumps

```
  light-account-checks: 0.4.0 → 0.5.0
  light-batched-merkle-tree: 0.5.0 → 0.6.0
  light-bloom-filter: 0.4.0 → 0.5.0
  light-compressed-account: 0.5.0 → 0.6.0
  light-concurrent-merkle-tree: 3.0.0 → 4.0.0
  light-hash-set: 3.0.0 → 4.0.0
  light-hasher: 4.0.0 → 5.0.0
  light-indexed-array: 0.2.0 → 0.3.0
  light-indexed-merkle-tree: 3.0.0 → 4.0.0
  light-macros: 2.1.0 → 2.2.0
  light-merkle-tree-metadata: 0.5.0 → 0.6.0
  light-verifier: 4.0.0 → 5.0.0
  light-zero-copy-derive: 0.4.0 → 0.5.0
  light-zero-copy: 0.4.0 → 0.5.0
```

### Release Process
1. Versions bumped in Cargo.toml files
2. PR validation (dry-run) will run automatically
3. After merge, GitHub Action will publish each crate individually to crates.io and create releases

---
*Generated by `scripts/create-release-pr.sh program-libs`*