### PR TITLE
chore: bump program-libs versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3473,7 +3473,7 @@ dependencies = [
 
 [[package]]
 name = "light-compressed-account"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anchor-lang",
  "ark-bn254 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ light-sdk = { path = "sdk-libs/sdk", version = "0.15.0" }
 light-sdk-pinocchio = { path = "sdk-libs/sdk-pinocchio", version = "0.13.0" }
 light-sdk-macros = { path = "sdk-libs/macros", version = "0.15.0" }
 light-sdk-types = { path = "sdk-libs/sdk-types", version = "0.15.0", default-features = false }
-light-compressed-account = { path = "program-libs/compressed-account", version = "0.6.0", default-features = false }
+light-compressed-account = { path = "program-libs/compressed-account", version = "0.6.1", default-features = false }
 light-compressible = { path = "program-libs/compressible", version = "0.1.0" }
 light-ctoken-types = { path = "program-libs/ctoken-types", version = "0.1.0" }
 light-account-checks = { path = "program-libs/account-checks", version = "0.5.0", default-features = false }

--- a/program-libs/compressed-account/Cargo.toml
+++ b/program-libs/compressed-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-compressed-account"
-version = "0.6.0"
+version = "0.6.1"
 description = "Compressed account struct and common utility functions used in Light Protocol."
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"


### PR DESCRIPTION
## Program-libs Release

This PR bumps versions for program-libs crates.

### Version Bumps

```
  light-compressed-account: 0.6.0 → 0.6.1
```

### Release Process
1. Versions bumped in Cargo.toml files
2. PR validation (dry-run) will run automatically
3. After merge, GitHub Action will publish each crate individually to crates.io and create releases

---
*Generated by `scripts/create-release-pr.sh program-libs`*