### PR TITLE
chore: bump program-libs versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-merkle-tree"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "light-bounded-vec",
  "light-concurrent-merkle-tree",
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "photon-api"
-version = "0.16.0"
+version = "0.52.0"
 dependencies = [
  "reqwest 0.12.24",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ ark-std = "0.5"
 
 # Light Protocol
 light-hash-set = { version = "4.0.0", path = "program-libs/hash-set" }
-light-indexed-merkle-tree = { version = "4.0.0", path = "program-libs/indexed-merkle-tree" }
+light-indexed-merkle-tree = { version = "4.0.1", path = "program-libs/indexed-merkle-tree" }
 light-concurrent-merkle-tree = { version = "4.0.0", path = "program-libs/concurrent-merkle-tree" }
 light-sparse-merkle-tree = { version = "0.3.0", path = "sparse-merkle-tree" }
 light-client = { path = "sdk-libs/client", version = "0.16.0" }

--- a/program-libs/indexed-merkle-tree/Cargo.toml
+++ b/program-libs/indexed-merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-indexed-merkle-tree"
-version = "4.0.0"
+version = "4.0.1"
 description = "Implementation of indexed (and concurrent) Merkle tree in Rust"
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"


### PR DESCRIPTION
## Program-libs Release

This PR bumps versions for program-libs crates.

### Version Bumps

```
  light-indexed-merkle-tree: 4.0.0 → 4.0.1
```

### Release Process
1. Versions bumped in Cargo.toml files
2. PR validation (dry-run) will run automatically
3. After merge, GitHub Action will publish each crate individually to crates.io and create releases

---
*Generated by `scripts/create-release-pr.sh program-libs`*