### PR TITLE
chore: bump program-libs versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "light-account-checks"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "borsh 0.10.4",
  "pinocchio",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "light-batched-merkle-tree"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aligned-sized",
  "borsh 0.10.4",
@@ -3473,7 +3473,7 @@ dependencies = [
 
 [[package]]
 name = "light-compressed-account"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anchor-lang",
  "ark-bn254 0.5.0",
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "light-concurrent-merkle-tree"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ ark-std = "0.5"
 # Light Protocol
 light-hash-set = { version = "4.0.0", path = "program-libs/hash-set" }
 light-indexed-merkle-tree = { version = "4.0.1", path = "program-libs/indexed-merkle-tree" }
-light-concurrent-merkle-tree = { version = "4.0.0", path = "program-libs/concurrent-merkle-tree" }
+light-concurrent-merkle-tree = { version = "4.0.1", path = "program-libs/concurrent-merkle-tree" }
 light-sparse-merkle-tree = { version = "0.3.0", path = "sparse-merkle-tree" }
 light-client = { path = "sdk-libs/client", version = "0.16.0" }
 light-event = { path = "sdk-libs/event", version = "0.1.1" }
@@ -178,10 +178,10 @@ light-sdk = { path = "sdk-libs/sdk", version = "0.16.0" }
 light-sdk-pinocchio = { path = "sdk-libs/sdk-pinocchio", version = "0.16.0" }
 light-sdk-macros = { path = "sdk-libs/macros", version = "0.16.0" }
 light-sdk-types = { path = "sdk-libs/sdk-types", version = "0.16.0", default-features = false }
-light-compressed-account = { path = "program-libs/compressed-account", version = "0.6.1", default-features = false }
+light-compressed-account = { path = "program-libs/compressed-account", version = "0.6.2", default-features = false }
 light-compressible = { path = "program-libs/compressible", version = "0.1.0" }
 light-ctoken-types = { path = "program-libs/ctoken-types", version = "0.1.0" }
-light-account-checks = { path = "program-libs/account-checks", version = "0.5.0", default-features = false }
+light-account-checks = { path = "program-libs/account-checks", version = "0.5.1", default-features = false }
 light-verifier = { path = "program-libs/verifier", version = "5.0.0" }
 light-zero-copy = { path = "program-libs/zero-copy", version = "0.5.0", default-features = false }
 light-zero-copy-derive = { path = "program-libs/zero-copy-derive", version = "0.5.0" }
@@ -206,7 +206,7 @@ create-address-test-program = { path = "program-tests/create-address-test-progra
     "cpi",
 ] }
 light-program-test = { path = "sdk-libs/program-test", version = "0.16.0" }
-light-batched-merkle-tree = { path = "program-libs/batched-merkle-tree", version = "0.6.0" }
+light-batched-merkle-tree = { path = "program-libs/batched-merkle-tree", version = "0.6.1" }
 light-merkle-tree-metadata = { path = "program-libs/merkle-tree-metadata", version = "0.6.0" }
 aligned-sized = { path = "program-libs/aligned-sized", version = "1.1.0" }
 light-bloom-filter = { path = "program-libs/bloom-filter", version = "0.5.0" }

--- a/program-libs/account-checks/Cargo.toml
+++ b/program-libs/account-checks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-account-checks"
-version = "0.5.0"
+version = "0.5.1"
 description = "Checks for solana accounts."
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/batched-merkle-tree/Cargo.toml
+++ b/program-libs/batched-merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-batched-merkle-tree"
-version = "0.6.0"
+version = "0.6.1"
 description = "Batch Merkle tree implementation."
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/compressed-account/Cargo.toml
+++ b/program-libs/compressed-account/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-compressed-account"
-version = "0.6.1"
+version = "0.6.2"
 description = "Compressed account struct and common utility functions used in Light Protocol."
 repository = "https://github.com/Lightprotocol/light-protocol"
 license = "Apache-2.0"

--- a/program-libs/concurrent-merkle-tree/Cargo.toml
+++ b/program-libs/concurrent-merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-concurrent-merkle-tree"
-version = "4.0.0"
+version = "4.0.1"
 edition = "2021"
 description = "Concurrent Merkle tree implementation"
 repository = "https://github.com/Lightprotocol/light-protocol"


### PR DESCRIPTION
## Program-libs Release

This PR bumps versions for program-libs crates.

### Version Bumps

```
  light-account-checks: 0.5.0 → 0.5.1
  light-batched-merkle-tree: 0.6.0 → 0.6.1
  light-compressed-account: 0.6.1 → 0.6.2
  light-concurrent-merkle-tree: 4.0.0 → 4.0.1
```

### Release Process
1. Versions bumped in Cargo.toml files
2. PR validation (dry-run) will run automatically
3. After merge, GitHub Action will publish each crate individually to crates.io and create releases

---
*Generated by `scripts/create-release-pr.sh program-libs`*