### PR TITLE
feat:  `--grpc-port` cli flag

### DIFF
--- a/cli/src/commands/test-validator/index.ts
+++ b/cli/src/commands/test-validator/index.ts
@@ -69,6 +69,12 @@ class SetupCommand extends Command {
       default: 8784,
       exclusive: ["skip-indexer"],
     }),
+    "grpc-port": Flags.integer({
+      description: "Enable Photon indexer gRPC on this port.",
+      required: false,
+      default: 50051,
+      exclusive: ["skip-indexer"],
+    }),
     "prover-port": Flags.integer({
       description: "Enable Light Prover server on this port.",
       required: false,

--- a/cli/src/utils/initTestEnv.ts
+++ b/cli/src/utils/initTestEnv.ts
@@ -1,4 +1,3 @@
-import { airdropSol } from "@lightprotocol/stateless.js";
 import { getConfig, getPayer, setAnchorProvider, setConfig } from "./utils";
 import {
   BASE_PATH,
@@ -131,6 +130,7 @@ export async function initTestEnv({
     await startIndexer(
       `http://127.0.0.1:${rpcPort}`,
       indexerPort,
+      grpcPort,
       checkPhotonVersion,
       photonDatabaseUrl,
       grpcPort,

--- a/cli/src/utils/process.ts
+++ b/cli/src/utils/process.ts
@@ -212,6 +212,10 @@ export function spawnBinary(command: string, args: string[] = []) {
       stdio: ["ignore", out, err],
       shell: false,
       detached: true,
+      env: {
+        ...process.env,
+        RUST_LOG: process.env.RUST_LOG || "debug",
+      },
     });
 
     spawnedProcess.on("close", async (code) => {

--- a/cli/src/utils/processPhotonIndexer.ts
+++ b/cli/src/utils/processPhotonIndexer.ts
@@ -39,6 +39,7 @@ function getPhotonInstallMessage(): string {
 export async function startIndexer(
   rpcUrl: string,
   indexerPort: number,
+  grpcPort: number = 50051,
   checkPhotonVersion: boolean = true,
   photonDatabaseUrl?: string,
   grpcPort: number = 50051,
@@ -56,6 +57,8 @@ export async function startIndexer(
     const args: string[] = [
       "--port",
       indexerPort.toString(),
+      "--grpc-port",
+      grpcPort.toString(),
       "--rpc-url",
       rpcUrl,
       "--grpc-port",


### PR DESCRIPTION
- add `--grpc-port` flag for test-validator CLI command.
- enabled configurable logging via `RUST_LOG` for spawned processes.