### PR TITLE
refactor: remove bump from create mint instruction data

### DIFF
--- a/program-libs/ctoken-types/src/instructions/mint_action/instruction_data.rs
+++ b/program-libs/ctoken-types/src/instructions/mint_action/instruction_data.rs
@@ -67,8 +67,6 @@ pub struct MintActionCompressedInstructionData {
 #[repr(C)]
 #[derive(Debug, Clone, AnchorSerialize, Default, AnchorDeserialize, ZeroCopy)]
 pub struct CreateMint {
-    /// Only used if create mint
-    pub mint_bump: u8,
     /// Placeholder to enable cmints in multiple address trees.
     /// Currently set to 0.
     pub read_only_address_trees: [u8; 4],

--- a/program-tests/compressed-token-test/tests/mint/cpi_context.rs
+++ b/program-tests/compressed-token-test/tests/mint/cpi_context.rs
@@ -59,7 +59,7 @@ async fn test_setup() -> TestSetup {
     // Derive addresses
     let compressed_mint_address =
         derive_compressed_mint_address(&mint_seed.pubkey(), &address_tree);
-    let (spl_mint_pda, mint_bump) = find_spl_mint_address(&mint_seed.pubkey());
+    let (spl_mint_pda, _) = find_spl_mint_address(&mint_seed.pubkey());
 
     // 3. Build mint action instruction using SDK
     let compressed_mint_inputs = CompressedMintWithContext {
@@ -84,7 +84,6 @@ async fn test_setup() -> TestSetup {
     let create_mint_inputs = CreateMintCpiWriteInputs {
         compressed_mint_inputs,
         mint_seed: mint_seed.pubkey(),
-        mint_bump,
         authority: mint_authority.pubkey(),
         payer: payer.pubkey(),
         cpi_context_pubkey,
@@ -336,7 +335,7 @@ async fn test_execute_cpi_context_invalid_tree_index() {
     let execute_inputs = MintActionInputs {
         compressed_mint_inputs: mint_action_inputs.compressed_mint_inputs.clone(),
         mint_seed: mint_seed.pubkey(),
-        mint_bump: mint_action_inputs.mint_bump,
+        mint_bump: None,
         create_mint: true,
         authority: mint_action_inputs.authority,
         payer: mint_action_inputs.payer,

--- a/programs/compressed-token/program/tests/mint_action.rs
+++ b/programs/compressed-token/program/tests/mint_action.rs
@@ -161,10 +161,7 @@ fn generate_random_instruction_data(
 ) -> MintActionCompressedInstructionData {
     let create_mint = force_create_mint.unwrap_or_else(|| rng.gen_bool(0.3));
     let create_mint = if create_mint {
-        Some(CreateMint {
-            mint_bump: rng.gen(),
-            ..Default::default()
-        })
+        Some(CreateMint::default())
     } else {
         None
     };

--- a/sdk-libs/compressed-token-sdk/src/instructions/create_compressed_mint/instruction.rs
+++ b/sdk-libs/compressed-token-sdk/src/instructions/create_compressed_mint/instruction.rs
@@ -28,7 +28,6 @@ pub struct CreateCompressedMintInputs {
     pub mint_authority: Pubkey,
     pub freeze_authority: Option<Pubkey>,
     pub proof: CompressedProof,
-    pub mint_bump: u8,
     pub address_merkle_tree_root_index: u16,
     pub mint_signer: Pubkey,
     pub payer: Pubkey,
@@ -87,7 +86,7 @@ pub fn create_compressed_mint_cpi(
         compressed_mint_inputs: compressed_mint_with_context,
         mint_seed: input.mint_signer,
         create_mint: true, // Key difference - we're creating a new compressed mint
-        mint_bump: Some(input.mint_bump),
+        mint_bump: None,
         authority: input.mint_authority,
         payer: input.payer,
         proof: Some(input.proof),
@@ -112,7 +111,6 @@ pub struct CreateCompressedMintInputsCpiWrite {
     pub decimals: u8,
     pub mint_authority: Pubkey,
     pub freeze_authority: Option<Pubkey>,
-    pub mint_bump: u8,
     pub address_merkle_tree_root_index: u16,
     pub mint_signer: Pubkey,
     pub payer: Pubkey,
@@ -172,7 +170,7 @@ pub fn create_compressed_mint_cpi_write(
     let mint_action_inputs = MintActionInputsCpiWrite {
         compressed_mint_inputs: compressed_mint_with_context,
         mint_seed: Some(input.mint_signer),
-        mint_bump: Some(input.mint_bump),
+        mint_bump: None,
         create_mint: true, // Key difference - we're creating a new compressed mint
         authority: input.mint_authority,
         payer: input.payer,

--- a/sdk-libs/compressed-token-sdk/src/instructions/mint_action/instruction.rs
+++ b/sdk-libs/compressed-token-sdk/src/instructions/mint_action/instruction.rs
@@ -30,7 +30,6 @@ pub const MINT_ACTION_DISCRIMINATOR: u8 = 103;
 pub struct CreateMintInputs {
     pub compressed_mint_inputs: CompressedMintWithContext,
     pub mint_seed: Pubkey,
-    pub mint_bump: u8,
     pub authority: Pubkey,
     pub payer: Pubkey,
     pub proof: Option<CompressedProof>,
@@ -77,7 +76,7 @@ impl MintActionInputs {
             compressed_mint_inputs: inputs.compressed_mint_inputs,
             mint_seed: inputs.mint_seed,
             create_mint: true,
-            mint_bump: Some(inputs.mint_bump),
+            mint_bump: None,
             authority: inputs.authority,
             payer: inputs.payer,
             proof: inputs.proof,
@@ -261,12 +260,8 @@ pub fn create_mint_action_cpi(
 ) -> Result<Instruction> {
     // Convert high-level actions to program-level actions
     let mut program_actions = Vec::new();
-    let mint_bump = input.mint_bump.unwrap_or(0u8);
     let create_mint = if input.create_mint {
-        Some(CreateMint {
-            mint_bump,
-            ..Default::default()
-        })
+        Some(CreateMint::default())
     } else {
         None
     };
@@ -472,7 +467,6 @@ pub struct CreateMintCpiWriteInputs {
     pub compressed_mint_inputs:
         light_ctoken_types::instructions::mint_action::CompressedMintWithContext,
     pub mint_seed: Pubkey,
-    pub mint_bump: u8,
     pub authority: Pubkey,
     pub payer: Pubkey,
     pub cpi_context_pubkey: Pubkey,
@@ -515,7 +509,7 @@ impl MintActionInputsCpiWrite {
         Self {
             compressed_mint_inputs: inputs.compressed_mint_inputs,
             mint_seed: Some(inputs.mint_seed),
-            mint_bump: Some(inputs.mint_bump),
+            mint_bump: None,
             create_mint: true,
             authority: inputs.authority,
             payer: inputs.payer,
@@ -662,12 +656,8 @@ pub fn mint_action_cpi_write(input: MintActionInputsCpiWrite) -> Result<Instruct
 
     // Convert high-level actions to program-level actions
     let mut program_actions = Vec::new();
-    let mint_bump = input.mint_bump.unwrap_or(0u8);
     let create_mint = if input.create_mint {
-        Some(CreateMint {
-            mint_bump,
-            ..Default::default()
-        })
+        Some(CreateMint::default())
     } else {
         None
     };

--- a/sdk-libs/token-client/src/instructions/create_mint.rs
+++ b/sdk-libs/token-client/src/instructions/create_mint.rs
@@ -5,11 +5,8 @@ use light_client::{
 use light_compressed_token_sdk::instructions::create_compressed_mint::{
     create_compressed_mint, derive_compressed_mint_address, CreateCompressedMintInputs,
 };
-use light_ctoken_types::{
-    instructions::extensions::{
-        token_metadata::TokenMetadataInstructionData, ExtensionInstructionData,
-    },
-    COMPRESSED_MINT_SEED,
+use light_ctoken_types::instructions::extensions::{
+    token_metadata::TokenMetadataInstructionData, ExtensionInstructionData,
 };
 use solana_instruction::Instruction;
 use solana_keypair::Keypair;
@@ -46,12 +43,6 @@ pub async fn create_compressed_mint_instruction<R: Rpc + Indexer>(
     let compressed_mint_address =
         derive_compressed_mint_address(&mint_seed.pubkey(), &address_tree_pubkey);
 
-    // Find mint bump for the instruction
-    let (_, mint_bump) = Pubkey::find_program_address(
-        &[COMPRESSED_MINT_SEED, mint_seed.pubkey().as_ref()],
-        &Pubkey::new_from_array(light_ctoken_types::COMPRESSED_TOKEN_PROGRAM_ID),
-    );
-
     // Create extensions if metadata is provided
     let extensions = metadata.map(|meta| vec![ExtensionInstructionData::TokenMetadata(meta)]);
 
@@ -76,7 +67,6 @@ pub async fn create_compressed_mint_instruction<R: Rpc + Indexer>(
         mint_authority,
         freeze_authority,
         proof: rpc_result.proof.0.unwrap(),
-        mint_bump,
         address_merkle_tree_root_index,
         mint_signer: mint_seed.pubkey(),
         payer,

--- a/sdk-tests/sdk-token-test/src/ctoken_pda/mint.rs
+++ b/sdk-tests/sdk-token-test/src/ctoken_pda/mint.rs
@@ -26,7 +26,7 @@ pub fn process_mint_action<'a, 'info>(
     let mint_action_inputs = MintActionInputsCpiWrite {
         compressed_mint_inputs: input.compressed_mint_with_context.clone(),
         mint_seed: Some(ctx.accounts.mint_seed.key()),
-        mint_bump: Some(input.mint_bump),
+        mint_bump: None,
         create_mint: true,
         authority: ctx.accounts.mint_authority.key(),
         payer: ctx.accounts.payer.key(),
@@ -48,7 +48,6 @@ pub fn process_mint_action<'a, 'info>(
     let mint_action_inputs2 = MintActionInputsCpiWrite::new_create_mint(CreateMintCpiWriteInputs {
         compressed_mint_inputs: input.compressed_mint_with_context.clone(),
         mint_seed: ctx.accounts.mint_seed.key(),
-        mint_bump: input.mint_bump,
         authority: ctx.accounts.mint_authority.key(),
         payer: ctx.accounts.payer.key(),
         cpi_context_pubkey: *cpi_accounts.cpi_context().unwrap().key,

--- a/sdk-tests/sdk-token-test/src/pda_ctoken/mint.rs
+++ b/sdk-tests/sdk-token-test/src/pda_ctoken/mint.rs
@@ -19,7 +19,6 @@ pub fn process_mint_action<'a, 'info>(
     let mint_action_inputs = MintActionInputs::new_create_mint(CreateMintInputs {
         compressed_mint_inputs: input.compressed_mint_with_context.clone(),
         mint_seed: ctx.accounts.mint_seed.key(),
-        mint_bump: input.mint_bump,
         authority: ctx.accounts.mint_authority.key(),
         payer: ctx.accounts.payer.key(),
         proof: input.pda_creation.proof.into(),

--- a/sdk-tests/sdk-token-test/src/pda_ctoken/processor.rs
+++ b/sdk-tests/sdk-token-test/src/pda_ctoken/processor.rs
@@ -8,7 +8,6 @@ use super::{
 #[derive(Debug, Clone, AnchorDeserialize, AnchorSerialize)]
 pub struct ChainedCtokenInstructionData {
     pub compressed_mint_with_context: CompressedMintWithContext,
-    pub mint_bump: u8,
     pub token_recipients: Vec<MintToRecipient>,
     pub final_mint_authority: Option<Pubkey>,
     pub pda_creation: PdaCreationData,

--- a/sdk-tests/sdk-token-test/tests/ctoken_pda.rs
+++ b/sdk-tests/sdk-token-test/tests/ctoken_pda.rs
@@ -152,7 +152,7 @@ pub async fn create_mint<R: Rpc + Indexer>(
         derive_compressed_mint_address(&mint_seed.pubkey(), &address_tree_pubkey);
 
     // Find mint bump for the instruction
-    let (mint, mint_bump) = find_spl_mint_address(&mint_seed.pubkey());
+    let (mint, _) = find_spl_mint_address(&mint_seed.pubkey());
 
     let pda_address_seed = hash_to_bn254_field_size_be(
         [b"escrow", payer.pubkey().to_bytes().as_ref()]
@@ -249,7 +249,6 @@ pub async fn create_mint<R: Rpc + Indexer>(
     let instruction_data = sdk_token_test::instruction::CtokenPda {
         input: ChainedCtokenInstructionData {
             compressed_mint_with_context,
-            mint_bump,
             token_recipients,
             final_mint_authority: None, // Revoke mint authority (set to None)
             pda_creation,

--- a/sdk-tests/sdk-token-test/tests/pda_ctoken.rs
+++ b/sdk-tests/sdk-token-test/tests/pda_ctoken.rs
@@ -202,7 +202,7 @@ pub async fn create_mint(
         derive_compressed_mint_address(&mint_seed.pubkey(), &address_tree_pubkey);
 
     // Find mint bump for the instruction
-    let (mint, mint_bump) = find_spl_mint_address(&mint_seed.pubkey());
+    let (mint, _) = find_spl_mint_address(&mint_seed.pubkey());
 
     // Create compressed token associated token account for the mint authority
     let (token_account, _) = derive_ctoken_ata(&mint_authority.pubkey(), &mint);
@@ -322,7 +322,6 @@ pub async fn create_mint(
     let instruction_data = sdk_token_test::instruction::PdaCtoken {
         input: ChainedCtokenInstructionData {
             compressed_mint_with_context,
-            mint_bump,
             token_recipients,
             final_mint_authority: None, // Revoke mint authority (set to None)
             pda_creation,

--- a/sdk-tests/sdk-token-test/tests/test_4_transfer2.rs
+++ b/sdk-tests/sdk-token-test/tests/test_4_transfer2.rs
@@ -155,7 +155,7 @@ async fn create_compressed_mint_helper(
     // Find mint PDA
     let compressed_token_program_id =
         Pubkey::new_from_array(light_ctoken_types::COMPRESSED_TOKEN_PROGRAM_ID);
-    let (mint_pda, mint_bump) = Pubkey::find_program_address(
+    let (mint_pda, _) = Pubkey::find_program_address(
         &[COMPRESSED_MINT_SEED, mint_signer.pubkey().as_ref()],
         &compressed_token_program_id,
     );
@@ -189,7 +189,6 @@ async fn create_compressed_mint_helper(
         mint_authority,
         freeze_authority: None,
         proof: rpc_result.proof.0.unwrap(),
-        mint_bump,
         address_merkle_tree_root_index: rpc_result.addresses[0].root_index,
         mint_signer: mint_signer.pubkey(),
         payer: payer.pubkey(),

--- a/sdk-tests/sdk-token-test/tests/test_compress_full_and_close.rs
+++ b/sdk-tests/sdk-token-test/tests/test_compress_full_and_close.rs
@@ -45,7 +45,7 @@ async fn test_compress_full_and_close() {
 
     let compressed_token_program_id =
         Pubkey::new_from_array(light_ctoken_types::COMPRESSED_TOKEN_PROGRAM_ID);
-    let (mint_pda, mint_bump) = Pubkey::find_program_address(
+    let (mint_pda, _) = Pubkey::find_program_address(
         &[COMPRESSED_MINT_SEED, mint_signer.pubkey().as_ref()],
         &compressed_token_program_id,
     );
@@ -78,7 +78,6 @@ async fn test_compress_full_and_close() {
         mint_authority,
         freeze_authority: Some(freeze_authority),
         proof: rpc_result.proof.0.unwrap(),
-        mint_bump,
         address_merkle_tree_root_index,
         mint_signer: mint_signer.pubkey(),
         payer: payer.pubkey(),


### PR DESCRIPTION
Issue:
- create mint passes a bump which allows to create multiple cmint accounts from a single seed provided multiple bumps that result in an offcurve pda exist.

Changes:
- remove `mint_bump` from create mint instruction data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified compressed token mint creation by removing mint bump parameters from creation inputs.
  * Updated program-derived address derivation mechanism for token mints.
  * Streamlined internal token creation instruction data structures for improved clarity and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->