### PR TITLE
fix: don't expect tokens out queue for mint to ctoken

### DIFF
--- a/programs/compressed-token/program/src/mint_action/accounts.rs
+++ b/programs/compressed-token/program/src/mint_action/accounts.rs
@@ -449,14 +449,11 @@ impl AccountsConfig {
                 create_mint: parsed_instruction_data.create_mint.is_some(),
             })
         } else {
-            // For MintTo or MintToCToken actions
-            // - needed for tokens_out_queue and authority validation
-            let has_mint_to_actions = parsed_instruction_data.actions.iter().any(|action| {
-                matches!(
-                    action,
-                    ZAction::MintToCompressed(_) | ZAction::MintToCToken(_)
-                )
-            });
+            // Used to expect tokens_out_queue for MintToCompressed action.
+            let has_mint_to_actions = parsed_instruction_data
+                .actions
+                .iter()
+                .any(|action| matches!(action, ZAction::MintToCompressed(_)));
 
             Ok(AccountsConfig {
                 with_cpi_context,


### PR DESCRIPTION
Issue:
- mint_action instruction expects tokens out queue when minting to ctoken accounts but minting to ctoken accounts don't create compressed accounts thus doesn't use the tokens out queue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined token handling logic in the mint action configuration to improve accuracy in processing compressed token transactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->