### PR TITLE
fix: use >= 40 bounds check for transfer_map array access

### DIFF
--- a/programs/compressed-token/program/src/transfer2/compression/mod.rs
+++ b/programs/compressed-token/program/src/transfer2/compression/mod.rs
@@ -91,7 +91,7 @@ pub fn process_token_compression(
 
             // Accumulate transfer amount if present
             if let Some((account_index, amount)) = transfer {
-                if account_index > 40 {
+                if account_index >= 40 {
                     msg!(
                         "Too many compression transfers: {}, max 40 allowed",
                         account_index


### PR DESCRIPTION
The transfer_map array has size 40 (valid indices 0-39), but the bounds check used > 40 which allowed index 40 to pass through, causing an out-of-bounds panic on array access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boundary validation for compressed token transfers by enforcing stricter account index limits. The system now correctly rejects transfer operations when they reach or exceed the maximum allowed index, preventing edge-case scenarios that could previously result in invalid states. This enhancement strengthens error detection and system reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->