### PR TITLE
fix: add missing field comparisons in ZCToken PartialEq

### DIFF
--- a/program-libs/ctoken-types/src/state/ctoken/zero_copy.rs
+++ b/program-libs/ctoken-types/src/state/ctoken/zero_copy.rs
@@ -294,6 +294,16 @@ impl PartialEq<CToken> for ZCToken<'_> {
                                 return false;
                             }
 
+                            // Compare compress_to_pubkey
+                            if zc_comp.compress_to_pubkey != regular_comp.compress_to_pubkey {
+                                return false;
+                            }
+
+                            // Compare account_version
+                            if zc_comp.account_version != regular_comp.account_version {
+                                return false;
+                            }
+
                             // Compare last_claimed_slot
                             if u64::from(zc_comp.last_claimed_slot)
                                 != regular_comp.last_claimed_slot


### PR DESCRIPTION
The eq() implementation for the Compressible extension was missing comparisons for compress_to_pubkey and account_version fields. This could cause two CToken instances to be considered equal even when these fields differed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced token comparison accuracy by validating additional configuration fields during equality checks.

* **Tests**
  * Added test coverage for token equality comparisons with compressed extensions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->