### PR TITLE
refactor: remove redundant lamports_per_write parameter from calculate_top_up_lamports

### DIFF
--- a/program-libs/compressible/src/compression_info.rs
+++ b/program-libs/compressible/src/compression_info.rs
@@ -94,9 +94,9 @@ macro_rules! impl_is_compressible {
                 num_bytes: u64,
                 current_slot: u64,
                 current_lamports: u64,
-                lamports_per_write: u32,
                 rent_exemption_lamports: u64,
             ) -> Result<u64, CompressibleError> {
+                let lamports_per_write: u32 = self.lamports_per_write.into();
                 // Calculate rent status using AccountRentState
                 let state = crate::rent::AccountRentState {
                     num_bytes,

--- a/program-libs/compressible/tests/compression_info.rs
+++ b/program-libs/compressible/tests/compression_info.rs
@@ -550,7 +550,6 @@ fn test_calculate_top_up_lamports() {
                 TEST_BYTES,
                 test_case.current_slot,
                 test_case.current_lamports,
-                test_case.lamports_per_write,
                 rent_exemption_lamports,
             )
             .unwrap();

--- a/program-tests/utils/src/assert_ctoken_transfer.rs
+++ b/program-tests/utils/src/assert_ctoken_transfer.rs
@@ -105,7 +105,6 @@ pub async fn assert_compressible_for_account(
                         260,
                         current_slot,
                         lamports_before,
-                        compressible_before.lamports_per_write.into(),
                         light_ctoken_types::COMPRESSIBLE_TOKEN_RENT_EXEMPTION,
                     )
                     .unwrap();

--- a/program-tests/utils/src/assert_mint_action.rs
+++ b/program-tests/utils/src/assert_mint_action.rs
@@ -186,7 +186,6 @@ pub async fn assert_mint_action(
                         account_size,
                         current_slot,
                         pre_lamports,
-                        compressible.lamports_per_write,
                         light_ctoken_types::COMPRESSIBLE_TOKEN_RENT_EXEMPTION,
                     )
                     .unwrap();

--- a/programs/compressed-token/program/src/ctoken_transfer.rs
+++ b/programs/compressed-token/program/src/ctoken_transfer.rs
@@ -75,7 +75,6 @@ fn calculate_and_execute_top_up_transfers(
                                 transfer.account.data_len() as u64,
                                 current_slot,
                                 transfer.account.lamports(),
-                                compressible_extension.lamports_per_write.into(),
                                 light_ctoken_types::COMPRESSIBLE_TOKEN_RENT_EXEMPTION,
                             )
                             .map_err(|_| CTokenError::InvalidAccountData)?;

--- a/programs/compressed-token/program/src/transfer2/compression/ctoken/compress_or_decompress_ctokens.rs
+++ b/programs/compressed-token/program/src/transfer2/compression/ctoken/compress_or_decompress_ctokens.rs
@@ -124,7 +124,6 @@ fn process_compressible_extension(
                         token_account_info.data_len() as u64,
                         *current_slot,
                         token_account_info.lamports(),
-                        compressible_extension.lamports_per_write.into(),
                         light_ctoken_types::COMPRESSIBLE_TOKEN_RENT_EXEMPTION,
                     )
                     .map_err(|_| CTokenError::InvalidAccountData)?;


### PR DESCRIPTION
The function now reads lamports_per_write from self instead of requiring it as a parameter, since it's already stored in the CompressionInfo struct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified compression rent calculation by refactoring internal parameter handling to improve code maintainability while preserving existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->