### PR TITLE
fix: conditionally include discriminator in CPI context account hashing

### DIFF
--- a/programs/system/src/cpi_context/account.rs
+++ b/programs/system/src/cpi_context/account.rs
@@ -102,7 +102,11 @@ impl InputAccount<'_> for CpiContextInAccount {
         hash_with_hashed_values(
             &self.lamports.get(),
             self.address().as_ref().map(|x| x.as_slice()),
-            Some((self.discriminator.as_slice(), self.data_hash.as_slice())),
+            if self.has_data() {
+                Some((self.discriminator.as_slice(), self.data_hash.as_slice()))
+            } else {
+                None
+            },
             owner_hashed,
             merkle_tree_hashed,
             leaf_index,
@@ -166,7 +170,11 @@ impl OutputAccount<'_> for CpiContextOutAccount {
         hash_with_hashed_values(
             &self.lamports.get(),
             self.address().as_ref().map(|x| x.as_slice()),
-            Some((self.discriminator.as_slice(), self.data_hash.as_slice())),
+            if self.has_data() {
+                Some((self.discriminator.as_slice(), self.data_hash.as_slice()))
+            } else {
+                None
+            },
             owner_hashed,
             merkle_tree_hashed,
             leaf_index,


### PR DESCRIPTION
CpiContextInAccount and CpiContextOutAccount always passed
Some((discriminator, data_hash)) to hash_with_hashed_values, even when
has_data() was false. This caused hash mismatches for no-data compressed
accounts, as the regular account hashing correctly passes None when there
is no data. Now both implementations check has_data() before including
discriminator/data_hash in the hash, matching the behavior of the
non-CPI-context account hashing.

Forester is not affected - it uses pre-computed hashes from the indexer
and never calls hash_with_hashed_values directly.

https://claude.ai/code/session_01GEhytcJ5GZXB2ZZMH1ouS3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed state validation for cross-program invocation operations with certain account configurations, improving the accuracy of contract interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->