### PR TITLE
fix: handle empty String fields in to_byte_array

### DIFF
--- a/program-libs/hasher/src/to_byte_array.rs
+++ b/program-libs/hasher/src/to_byte_array.rs
@@ -180,12 +180,21 @@ impl ToByteArray for String {
 
     /// Max allowed String length is 31 bytes.
     /// For longer strings hash to field size or provide a custom implementation.
+    ///
+    /// Empty strings are represented with a leading 1 byte at index 0 to avoid
+    /// an all-zero `[0u8; 32]` representation, which can cause errors in the
+    /// Poseidon hasher on Solana (see issue #1272).
     fn to_byte_array(&self) -> Result<[u8; 32], HasherError> {
         let bytes = self.as_bytes();
         let mut result = [0u8; 32];
         let byte_len = bytes.len();
         if byte_len > 31 {
             return Err(HasherError::InvalidInputLength(31, bytes.len()));
+        }
+        if byte_len == 0 {
+            // Use a non-zero sentinel to avoid all-zero representation.
+            // This prevents Poseidon syscall errors on Solana (issue #1272).
+            result[0] = 1;
         }
         result[32 - byte_len..].copy_from_slice(bytes);
         Ok(result)

--- a/program-libs/hasher/tests/to_byte_array.rs
+++ b/program-libs/hasher/tests/to_byte_array.rs
@@ -216,11 +216,15 @@ fn test_to_byte_array_u8_arrays() {
 
 #[test]
 fn test_to_byte_array_string() {
-    // Test with empty string
+    // Test with empty string - should produce a non-zero representation
+    // to avoid Poseidon errors (issue #1272)
     let empty_string = "".to_string();
     let result = empty_string.to_byte_array().unwrap();
-    let expected = [0u8; 32];
+    let mut expected = [0u8; 32];
+    expected[0] = 1; // non-zero sentinel for empty strings
     assert_eq!(result, expected);
+    // Ensure it's not all zeros
+    assert_ne!(result, [0u8; 32]);
 
     // Test with short string
     let short_string = "foobar".to_string();


### PR DESCRIPTION
## Problem

When a Light Protocol account has a String field with length 0 (empty string `""`), the serialization/hashing throws a **custom program error 1** on-chain.

## Root Cause

In `program-libs/hasher/src/to_byte_array.rs`, the `ToByteArray` impl for `String` returns `[0u8; 32]` (all zeros) for empty strings. When this all-zero array flows into the Poseidon hasher via `DataHasher::hash()` → `Poseidon::hashv()` → Solana `sol_poseidon` syscall, the syscall returns error code 1 (`InvalidParameters`), which maps to `ProgramError::Custom(1)`.

## Fix

Added a non-zero sentinel byte (`result[0] = 1`) for empty strings in `String::to_byte_array()`. This produces a distinct, deterministic, non-zero `[u8; 32]` representation that avoids the Poseidon syscall error while remaining consistent across calls.

### Files Changed
- `program-libs/hasher/src/to_byte_array.rs` — Empty string now returns non-zero representation
- `program-libs/hasher/tests/to_byte_array.rs` — Updated test to verify new behavior

### Testing
All 10 hasher tests pass with `--features "poseidon,keccak,alloc"`.

Fixes #1272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated empty string handling in byte array conversion to produce a non-zero sentinel value, ensuring empty strings no longer result in all-zero output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->