### PR TITLE
Finalize single-expression light handlers

### DIFF
--- a/sdk-libs/macros/src/light_pdas/program/parsing.rs
+++ b/sdk-libs/macros/src/light_pdas/program/parsing.rs
@@ -617,13 +617,36 @@ fn is_delegation_body(block: &syn::Block, ctx_name: &str) -> bool {
         syn::Stmt::Expr(expr, _) => {
             // Check if it's a function call that takes ctx as an argument
             match expr {
-                syn::Expr::Call(call) => call_has_ctx_arg(&call.args, ctx_name),
-                syn::Expr::MethodCall(call) => call_has_ctx_arg(&call.args, ctx_name),
+                syn::Expr::Call(call) => call_moves_ctx_arg(&call.args, ctx_name),
+                syn::Expr::MethodCall(call) => call_moves_ctx_arg(&call.args, ctx_name),
                 _ => false,
             }
         }
         _ => false,
     }
+}
+
+/// Check if any argument consumes the context param.
+///
+/// Passing `&ctx` or `&mut ctx` lets the wrapper continue using `ctx` for
+/// finalization after the handler returns, so those are intentionally excluded.
+fn call_moves_ctx_arg(
+    args: &syn::punctuated::Punctuated<syn::Expr, syn::token::Comma>,
+    ctx_name: &str,
+) -> bool {
+    for arg in args {
+        match arg {
+            syn::Expr::Path(path) if path.path.is_ident(ctx_name) => return true,
+            syn::Expr::MethodCall(method_call)
+                if method_call.method == "into"
+                    && matches!(&*method_call.receiver, syn::Expr::Path(path) if path.path.is_ident(ctx_name)) =>
+            {
+                return true;
+            }
+            _ => {}
+        }
+    }
+    false
 }
 
 /// Check if any argument in the call is the context param (moving the context).

--- a/sdk-libs/macros/src/light_pdas_tests/parsing_tests.rs
+++ b/sdk-libs/macros/src/light_pdas_tests/parsing_tests.rs
@@ -2,10 +2,11 @@
 //!
 //! Extracted from `light_pdas/program/parsing.rs`.
 
+use quote::quote;
 use syn::punctuated::Punctuated;
 
 use crate::light_pdas::program::parsing::{
-    call_has_ctx_arg, extract_context_and_params, ExtractResult,
+    call_has_ctx_arg, extract_context_and_params, wrap_function_with_light, ExtractResult,
 };
 
 fn parse_args(code: &str) -> Punctuated<syn::Expr, syn::token::Comma> {
@@ -215,4 +216,38 @@ fn test_extract_context_and_params_multiple_args_detected() {
         }
         _ => panic!("Expected ExtractResult::MultipleParams"),
     }
+}
+
+#[test]
+fn test_wrap_single_expression_mut_context_runs_finalize() {
+    let fn_item: syn::ItemFn = syn::parse_quote! {
+        pub fn handler(ctx: Context<MyAccounts>, params: Params) -> Result<()> {
+            instructions::handler(&mut ctx)
+        }
+    };
+    let params_ident: syn::Ident = syn::parse_quote!(params);
+    let ctx_ident: syn::Ident = syn::parse_quote!(ctx);
+
+    let wrapped = wrap_function_with_light(&fn_item, &params_ident, &ctx_ident);
+    let wrapped_tokens = quote!(#wrapped).to_string();
+
+    assert!(wrapped_tokens.contains("__user_result"));
+    assert!(wrapped_tokens.contains("light_finalize"));
+}
+
+#[test]
+fn test_wrap_moved_context_delegation_skips_finalize() {
+    let fn_item: syn::ItemFn = syn::parse_quote! {
+        pub fn handler(ctx: Context<MyAccounts>, params: Params) -> Result<()> {
+            instructions::handler(ctx)
+        }
+    };
+    let params_ident: syn::Ident = syn::parse_quote!(params);
+    let ctx_ident: syn::Ident = syn::parse_quote!(ctx);
+
+    let wrapped = wrap_function_with_light(&fn_item, &params_ident, &ctx_ident);
+    let wrapped_tokens = quote!(#wrapped).to_string();
+
+    assert!(!wrapped_tokens.contains("__user_result"));
+    assert!(!wrapped_tokens.contains("light_finalize"));
 }


### PR DESCRIPTION
Closes #1290.

## Summary
- Treat a single-expression light handler as delegated only when the context is actually moved into the inner call.
- Keep &ctx / &mut ctx handlers on the wrapper path so __user_result and light_finalize are emitted.
- Add regression coverage for both the borrowed-context finalize path and the moved-context delegation path.

## Validation
- cargo fmt --package light-sdk-macros --check
- cargo test -p light-sdk-macros test_wrap_single_expression_mut_context_runs_finalize
- cargo test -p light-sdk-macros test_wrap_moved_context_delegation_skips_finalize
- cargo test -p light-sdk-macros light_pdas_tests::parsing_tests
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context argument detection in program handlers to accurately determine whether context is borrowed or moved, ensuring the wrapper applies proper finalization logic only when appropriate.

* **Tests**
  * Added test cases validating correct behavior when context is passed by reference versus moved into handler functions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lightprotocol/light-protocol/pull/2381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->