### PR TITLE
Wrap unsafe array numbers in RPC responses

### DIFF
--- a/js/stateless.js/src/rpc.ts
+++ b/js/stateless.js/src/rpc.ts
@@ -289,13 +289,22 @@ export function createRpc(
  * @returns {string} - The preprocessed JSON string with numbers wrapped as strings
  */
 export function wrapBigNumbersAsStrings(text: string): string {
-    return text.replace(/(":\s*)(-?\d+)(\s*[},])/g, (match, p1, p2, p3) => {
-        const num = Number(p2);
+    return text.replace(/-?\d+(?=\s*[,}\]])/g, (match, offset) => {
+        let prefixIndex = offset - 1;
+        while (prefixIndex >= 0 && /\s/.test(text[prefixIndex])) {
+            prefixIndex--;
+        }
+
+        if (prefixIndex < 0 || !':[,'.includes(text[prefixIndex])) {
+            return match;
+        }
+
+        const num = Number(match);
         if (
             !Number.isNaN(num) &&
             (num > Number.MAX_SAFE_INTEGER || num < Number.MIN_SAFE_INTEGER)
         ) {
-            return `${p1}"${p2}"${p3}`;
+            return `"${match}"`;
         }
         return match;
     });

--- a/js/stateless.js/tests/e2e/safe-conversion.test.ts
+++ b/js/stateless.js/tests/e2e/safe-conversion.test.ts
@@ -134,6 +134,15 @@ describe('safely convert json response', async () => {
         });
     });
 
+    it('wraps unsafe numbers inside arrays', () => {
+        const input = '{"values": [1, 9007199254740992, -9007199254740993]}';
+        const output = wrapBigNumbersAsStrings(input);
+
+        expect(output).to.equal(
+            '{"values": [1, "9007199254740992", "-9007199254740993"]}',
+        );
+    });
+
     it('should convert unsafe integer responses safely', async () => {
         const rawResponse = `{
                 "jsonrpc": "2.0",


### PR DESCRIPTION
Handle unsafe integer values inside JSON arrays when preprocessing RPC responses.

The existing helper only wrapped large object property values, so unsafe integers in arrays could still be parsed as JavaScript numbers and lose precision.