### PR TITLE
fix: import sys_hash for SBPF v3 static syscalls in light-hasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4011,6 +4011,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.10.9",
  "sha3",
+ "solana-define-syscall 2.3.0",
  "solana-program-error",
  "solana-pubkey",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ solana-bn254 = "3.2.1"
 solana-sysvar = { version = "2.2" }
 solana-rent = { version = "2.2" }
 solana-program-error = { version = "2.2" }
+solana-define-syscall = { version = "2.3" }
 solana-account-info = { version = "2.2" }
 solana-transaction = { version = "2.2" }
 solana-transaction-error = { version = "2.2" }

--- a/program-libs/hasher/Cargo.toml
+++ b/program-libs/hasher/Cargo.toml
@@ -27,6 +27,7 @@ num-bigint = { workspace = true }
 
 # Optional import for ProgramError conversion
 solana-program-error = { workspace = true, optional = true }
+solana-define-syscall = { workspace = true }
 pinocchio = { workspace = true, optional = true }
 zerocopy = { workspace = true, optional = true }
 borsh = { workspace = true, optional = true }

--- a/program-libs/hasher/src/syscalls/definitions.rs
+++ b/program-libs/hasher/src/syscalls/definitions.rs
@@ -35,6 +35,9 @@ macro_rules! define_syscall {
 	}
 }
 
+#[cfg(target_feature = "static-syscalls")]
+pub use solana_define_syscall::sys_hash;
+
 define_syscall!(fn sol_sha256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_keccak256(vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_poseidon(parameters: u64, endianness: u64, vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);


### PR DESCRIPTION
## Summary

- `light-hasher` 5.0.0 copies Solana's `define_syscall!` macro for static syscalls but never defines or imports `sys_hash`, causing compile failures when building with SBPF v3 (`--arch v3`, required for new deploys under SIMD-0500).
- Adds `solana-define-syscall` and re-exports `sys_hash` under `#[cfg(target_feature = "static-syscalls")]`, matching `solana-program` 2.3.

## Reproduction

Before this fix, building with SBPF v3 fails:

```
error[E0425]: cannot find function `sys_hash` in this scope
  --> program-libs/hasher/src/syscalls/definitions.rs:13:12
```

## Test plan

- [x] `cargo build-sbf --arch v3` in `program-libs/hasher` succeeds locally
- [ ] CI passes
- [ ] Request patch release of `light-hasher` on crates.io (e.g. 5.0.1) so downstream crates like `light-sdk` consumers can build with SBPF v3 without `[patch.crates-io]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Added new workspace dependency to improve syscall handling capabilities.
* Updated syscall definitions to support static-syscalls build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->